### PR TITLE
组网后端能力模型、资源冲突检测与托管进程生命周期

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Added
 
+- 组网后端能力/附件模型、冻结 descriptor、强类型宿主资源声明与语义化系统资源冲突预检；
+- 带阶段超时、调用方取消安全、逆序回滚、后台状态监控和 fail-closed 隔离的事务监督器；
+- 基于 Unix process group/Windows Job 的托管 daemon、显式 readiness、后台退出监控、有界自动重启、脱敏日志与显式 `close` 契约；
+- Linux、Android、Windows、macOS capture 与 DNS/Mixed/API 固定监听的实际资源声明，以及纯快照读取、URL/诊断/共享密钥安全投影的 `/v1/mesh/status`；
+- 本阶段只交付通用组网基础设施，不包含 Tailscale、Cloudflare 等具体产品适配器，也不修改代理协议；
 - 仓库文档中心、功能矩阵、架构、配置、API、排错和路线图；
 - 结构化 Issue 表单、Pull Request 模板和 CODEOWNERS；
 - Dependabot、依赖变更审查、CodeQL 与私密漏洞报告；

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio-util = { version = "0.7", features = ["full"] }
 futures = "0.3"
 async-trait = "0.1"
 pin-project-lite = "0.2"
+command-group = { version = "5.0.1", features = ["with-tokio"] }
 
 # 序列化与配置
 serde = { version = "1", features = ["derive"] }
@@ -132,6 +133,8 @@ percent-encoding = "2"
 base64 = "0.22"
 rand = "0.8"
 hex = "0.4"
+tempfile = "3"
+libc = "0.2"
 
 # 内部 crate
 core-config   = { path = "crates/core-config" }

--- a/crates/core-api/Cargo.toml
+++ b/crates/core-api/Cargo.toml
@@ -10,6 +10,7 @@ core-smart   = { workspace = true }
 core-runtime = { workspace = true }
 core-route   = { workspace = true }
 core-capture = { workspace = true }
+core-mesh    = { workspace = true }
 core-feeds   = { workspace = true }
 core-observe = { workspace = true }
 tokio        = { workspace = true }
@@ -27,4 +28,5 @@ bytes        = { workspace = true }
 dashmap      = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 http-body-util = "0.1"

--- a/crates/core-api/src/native.rs
+++ b/crates/core-api/src/native.rs
@@ -20,6 +20,8 @@ pub struct NativeState {
     pub urltest: Arc<UrlTester>,
     /// 由 main.rs 在 capture 启动后注入；为空时 /v1/capture/state 仅回静态配置。
     pub capture: Option<Arc<core_capture::CaptureSupervisor>>,
+    /// 统一组网监督器；`/v1/mesh/status` 只返回脱敏后的结构化快照。
+    pub mesh: Option<Arc<core_mesh::MeshSupervisor>>,
     /// 订阅管理器（始终注入，可能 idle）—— `/providers/proxies` 端点使用。
     pub feeds: Option<Arc<core_feeds::FeedManager>>,
     /// 端点级响应缓存（singleflight + TTL）。
@@ -45,6 +47,7 @@ impl NativeState {
             secret: None,
             urltest,
             capture: None,
+            mesh: None,
             feeds,
             caches: crate::compat_cache::Caches::new(),
             ws_hubs,
@@ -64,6 +67,7 @@ pub fn router(state: NativeState) -> Router {
         .route("/resolver/query", get(resolver_query))
         .route("/route/check", get(route_check))
         .route("/capture/state", get(capture_state))
+        .route("/mesh/status", get(mesh_status))
         .route("/smart/why", get(smart_why))
         .route("/smart/pin", post(smart_pin))
         .route("/smart/avoid", post(smart_avoid))
@@ -279,6 +283,23 @@ async fn capture_state(State(s): State<NativeState>) -> impl IntoResponse {
         }
     }
     Json(body)
+}
+
+async fn mesh_status(State(s): State<NativeState>) -> impl IntoResponse {
+    match &s.mesh {
+        // Monitoring and fail-closed isolation belong to MeshSupervisor's
+        // background lifecycle. A GET must neither invoke an external daemon
+        // nor change a snapshot generation.
+        Some(mesh) => Json(mesh.snapshot().public_view()).into_response(),
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "error": "mesh supervisor unavailable",
+                "code": "mesh_supervisor_unavailable"
+            })),
+        )
+            .into_response(),
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/core-api/src/server.rs
+++ b/crates/core-api/src/server.rs
@@ -57,6 +57,8 @@ pub struct ApiServer {
     pub clash_compat: bool,
     pub urltest: Arc<UrlTester>,
     pub capture: Option<Arc<core_capture::CaptureSupervisor>>,
+    /// 统一组网监督器；提供只读运行状态，不暴露认证材料。
+    pub mesh: Option<Arc<core_mesh::MeshSupervisor>>,
     pub feeds: Option<Arc<core_feeds::FeedManager>>,
     /// CORS 允许 origin 列表。空 = 仅本机；`["*"]` = Any。
     /// 来自 `ui.cors` 配置。
@@ -76,6 +78,7 @@ impl ApiServer {
             secret: self.secret.clone(),
             urltest: self.urltest.clone(),
             capture: self.capture.clone(),
+            mesh: self.mesh.clone(),
             feeds: self.feeds.clone(),
             caches: caches.clone(),
             ws_hubs: ws_hubs.clone(),

--- a/crates/core-api/tests/compat_smoke.rs
+++ b/crates/core-api/tests/compat_smoke.rs
@@ -1,7 +1,14 @@
 //! Clash 兼容层关键端点的 smoke 测试 —— 直接打 axum router 验证响应形状。
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
+use async_trait::async_trait;
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -37,6 +44,110 @@ async fn body_json(resp: axum::response::Response) -> Value {
     serde_json::from_slice(&bytes).unwrap_or(Value::Null)
 }
 
+struct AdversarialMeshBackend {
+    descriptor: core_mesh::BackendDescriptor,
+    calls: Arc<AtomicUsize>,
+}
+
+impl AdversarialMeshBackend {
+    fn new(calls: Arc<AtomicUsize>) -> Self {
+        Self {
+            descriptor: core_mesh::BackendDescriptor::new(
+                core_mesh::BackendId::new("malicious-backend").unwrap(),
+                core_mesh::BackendKind::Other("vendor\ncontrolled".to_owned()),
+                core_mesh::BackendOwnership::AttachExternal,
+            ),
+            calls,
+        }
+    }
+
+    fn status_value(&self) -> core_mesh::BackendStatus {
+        let mut status = core_mesh::BackendStatus::new(
+            self.descriptor.id().clone(),
+            self.descriptor.kind().clone(),
+            self.descriptor.ownership(),
+        );
+        status.phase = core_mesh::BackendPhase::Ready;
+        status.version = Some(format!("v1\r\n{}", "版".repeat(100)));
+        status.attachments = vec![
+            core_mesh::Attachment::Endpoint(core_mesh::EndpointAttachment {
+                purpose: core_mesh::EndpointPurpose::Health,
+                address: core_mesh::EndpointAddress::Url(
+                    "https://example.com:8443/health/check".to_owned(),
+                ),
+            }),
+            core_mesh::Attachment::Endpoint(core_mesh::EndpointAttachment {
+                purpose: core_mesh::EndpointPurpose::Control,
+                address: core_mesh::EndpointAddress::Url(
+                    "https://alice:password-secret@example.com:9443/private/path\
+                     ?token=query-secret#fragment-secret"
+                        .replace(' ', ""),
+                ),
+            }),
+            core_mesh::Attachment::Endpoint(core_mesh::EndpointAttachment {
+                purpose: core_mesh::EndpointPurpose::Other("invalid\nurl".to_owned()),
+                address: core_mesh::EndpointAddress::Url("not a url invalid-url-secret".to_owned()),
+            }),
+            core_mesh::Attachment::Endpoint(core_mesh::EndpointAttachment {
+                purpose: core_mesh::EndpointPurpose::Management,
+                address: core_mesh::EndpointAddress::Opaque("opaque-secret".to_owned()),
+            }),
+        ];
+        status.resource_claims.push(
+            core_mesh::ResourceClaim::coordinated(
+                core_mesh::SystemResource::Interface {
+                    name: "mesh\ninterface".to_owned(),
+                },
+                "coordination-secret",
+            )
+            .unwrap(),
+        );
+        status.diagnostics.push(core_mesh::Diagnostic::new(
+            core_mesh::DiagnosticLevel::Error,
+            "unsafe\ncode",
+            "diagnostic-secret",
+        ));
+        status
+    }
+
+    fn record_call(&self) {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl core_mesh::NetworkBackend for AdversarialMeshBackend {
+    fn descriptor(&self) -> core_mesh::BackendDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn probe(&self) -> core_mesh::BackendResult<core_mesh::BackendObservation> {
+        self.record_call();
+        Ok(self.status_value())
+    }
+
+    async fn reconcile(
+        &self,
+        _observation: &core_mesh::BackendObservation,
+    ) -> core_mesh::BackendResult<core_mesh::BackendStatus> {
+        self.record_call();
+        Ok(self.status_value())
+    }
+
+    async fn status(&self) -> core_mesh::BackendResult<core_mesh::BackendStatus> {
+        self.record_call();
+        Ok(self.status_value())
+    }
+}
+
+#[async_trait]
+impl core_mesh::ExternalNetworkBackend for AdversarialMeshBackend {
+    async fn detach(&self) -> core_mesh::BackendResult<()> {
+        self.record_call();
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn version_advertises_meta() {
     let app = core_api::compat::router(build_state());
@@ -53,6 +164,133 @@ async fn version_advertises_meta() {
     let v = body_json(resp).await;
     assert_eq!(v["meta"], Value::Bool(true));
     assert_eq!(v["premium"], Value::Bool(true));
+}
+
+#[tokio::test]
+async fn mesh_status_is_explicit_when_supervisor_is_not_injected() {
+    let app = core_api::native::router(build_state());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/mesh/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let value = body_json(resp).await;
+    assert_eq!(value["code"], "mesh_supervisor_unavailable");
+}
+
+#[tokio::test]
+async fn mesh_status_returns_a_redacted_snapshot_without_backend_calls() {
+    let mut state = build_state();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut registry = core_mesh::BackendRegistry::new();
+    registry
+        .register_external(Arc::new(AdversarialMeshBackend::new(calls.clone())))
+        .expect("backend registration");
+    let mesh = Arc::new(core_mesh::MeshSupervisor::with_options(
+        registry,
+        Vec::new(),
+        core_mesh::SupervisorOptions {
+            monitor_interval: Duration::ZERO,
+            ..core_mesh::SupervisorOptions::default()
+        },
+    ));
+    mesh.start().await.expect("supervisor starts");
+    let calls_after_start = calls.load(Ordering::SeqCst);
+    assert_eq!(calls_after_start, 2, "start must probe and reconcile once");
+    state.mesh = Some(mesh.clone());
+
+    let app = core_api::native::router(state);
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/mesh/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let value = body_json(resp).await;
+    assert_eq!(value["running"], true);
+    assert_eq!(value["supervisor_phase"], "running");
+    let generation = value["generation"].clone();
+    let status = &value["statuses"]["malicious-backend"];
+    assert_eq!(status["kind"]["other"], "vendor controlled");
+    let version = status["version"].as_str().expect("public version");
+    assert!(version.len() <= 128);
+    assert!(!version.chars().any(char::is_control));
+
+    let attachments = status["attachments"].as_array().expect("attachments");
+    assert_eq!(
+        attachments[0]["details"]["address"]["value"],
+        "https://example.com:8443/"
+    );
+    assert_eq!(
+        attachments[1]["details"]["address"]["value"],
+        "https://example.com:9443/"
+    );
+    for hidden in [&attachments[2], &attachments[3]] {
+        assert_eq!(hidden["details"]["address"]["type"], "hidden");
+        assert!(hidden["details"]["address"].get("value").is_none());
+    }
+    assert_eq!(status["diagnostics"][0]["code"], "mesh.backend_diagnostic");
+    assert_eq!(
+        status["diagnostics"][0]["message"],
+        "diagnostic details are available in local process logs"
+    );
+
+    let serialized = serde_json::to_string(&value).unwrap();
+    for secret in [
+        "alice",
+        "password-secret",
+        "query-secret",
+        "fragment-secret",
+        "health/check",
+        "private/path",
+        "invalid-url-secret",
+        "opaque-secret",
+        "coordination-secret",
+        "coordination_key",
+        "diagnostic-secret",
+    ] {
+        assert!(
+            !serialized.contains(secret),
+            "mesh API leaked {secret}: {serialized}"
+        );
+    }
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        calls_after_start,
+        "GET must not invoke a backend"
+    );
+
+    let second = app
+        .oneshot(
+            Request::builder()
+                .uri("/mesh/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::OK);
+    assert_eq!(
+        body_json(second).await["generation"],
+        generation,
+        "read-only status requests must not publish a new generation"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        calls_after_start,
+        "repeated GET must remain snapshot-only"
+    );
+    mesh.stop().await.expect("supervisor stops");
 }
 
 #[tokio::test]

--- a/crates/core-capture/Cargo.toml
+++ b/crates/core-capture/Cargo.toml
@@ -11,6 +11,7 @@ core-route    = { workspace = true }
 core-runtime  = { workspace = true }
 core-outbound = { workspace = true }
 core-observe  = { workspace = true }
+core-mesh     = { workspace = true }
 compact_str   = { workspace = true }
 async-trait   = { workspace = true }
 anyhow        = { workspace = true }

--- a/crates/core-capture/src/android_vpn_config.rs
+++ b/crates/core-capture/src/android_vpn_config.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 
 use crate::engine::CapturePlan;
 
+const VPN_SERVICE_DEFAULT_ROUTE_V4: &str = "0.0.0.0/0";
+const VPN_SERVICE_DEFAULT_ROUTE_V6: &str = "::/0";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AndroidIpPrefix {
     pub address: IpAddr,
@@ -40,30 +43,15 @@ pub fn build_vpn_service_config(plan: &CapturePlan) -> AndroidVpnServiceConfig {
     }
     addresses.sort_by_key(prefix_sort_key);
 
-    let mut base_routes = if !plan.route_addresses.is_empty() {
-        plan.route_addresses.clone()
-    } else if plan.auto_route {
-        let mut r = vec!["0.0.0.0/0".parse::<IpNet>().unwrap()];
-        if plan.tun_v6_cidr.is_some() {
-            r.push("::/0".parse::<IpNet>().unwrap());
-        }
-        r
-    } else {
+    if plan.route_addresses.is_empty() && !plan.auto_route {
         warnings.push(
             "auto_route=false 且 route_address 为空；VpnService.Builder 不会添加接管路由".into(),
         );
-        Vec::new()
-    };
-    base_routes.sort_by_key(net_sort_key);
-
-    let mut static_excludes = plan.exclude_cidrs.clone();
-    static_excludes.extend(plan.route_exclude_addresses.iter().copied());
-
-    let mut routes = subtract_routes(&base_routes, &static_excludes)
+    }
+    let routes = vpn_service_route_nets(plan)
         .into_iter()
         .map(AndroidIpPrefix::from_net)
         .collect::<Vec<_>>();
-    routes.sort_by_key(prefix_sort_key);
 
     let mut dns_servers = Vec::new();
     if plan.hijack_dns {
@@ -126,6 +114,41 @@ pub fn build_vpn_service_config(plan: &CapturePlan) -> AndroidVpnServiceConfig {
         disallowed_applications,
         warnings,
     }
+}
+
+/// Return the exact static routes exported to `VpnService.Builder`.
+///
+/// This function is deliberately pure and shared with host-resource preflight:
+/// declaring the Android framework fallback must never probe root capabilities,
+/// and it must stay in lock-step with the routes the embedding app installs.
+pub(crate) fn vpn_service_route_nets(plan: &CapturePlan) -> Vec<IpNet> {
+    let mut base_routes = if !plan.route_addresses.is_empty() {
+        plan.route_addresses.clone()
+    } else if plan.auto_route {
+        let mut routes = vec![
+            VPN_SERVICE_DEFAULT_ROUTE_V4
+                .parse::<IpNet>()
+                .expect("Android VpnService IPv4 default route must be valid"),
+        ];
+        if plan.tun_v6_cidr.is_some() {
+            routes.push(
+                VPN_SERVICE_DEFAULT_ROUTE_V6
+                    .parse::<IpNet>()
+                    .expect("Android VpnService IPv6 default route must be valid"),
+            );
+        }
+        routes
+    } else {
+        Vec::new()
+    };
+    base_routes.sort_by_key(net_sort_key);
+
+    let mut static_excludes = plan.exclude_cidrs.clone();
+    static_excludes.extend(plan.route_exclude_addresses.iter().copied());
+
+    let mut routes = subtract_routes(&base_routes, &static_excludes);
+    routes.sort_by_key(net_sort_key);
+    routes
 }
 
 pub fn build_vpn_service_config_json(plan: &CapturePlan) -> Result<String, serde_json::Error> {

--- a/crates/core-capture/src/capture_dns.rs
+++ b/crates/core-capture/src/capture_dns.rs
@@ -1,0 +1,33 @@
+//! Pure capture-private DNS listener selection shared by startup and resource
+//! arbitration.
+
+const WINDOWS_FAKE_DNS_LISTEN_ADDRS: &[&str] = &["127.0.0.1:53", "[::1]:53"];
+const UNIX_FAKE_DNS_LISTEN_ADDRS: &[&str] = &["127.0.0.1:5454"];
+
+pub(crate) fn fake_dns_listen_addrs() -> &'static [&'static str] {
+    fake_dns_listen_addrs_for_windows(cfg!(target_os = "windows"))
+}
+
+pub(crate) fn fake_dns_listen_addrs_for_windows(windows: bool) -> &'static [&'static str] {
+    if windows {
+        // WindowsTun redirects both IPv4 and IPv6 resolver families here.
+        WINDOWS_FAKE_DNS_LISTEN_ADDRS
+    } else {
+        // Unix capture keeps the private listener away from privileged port 53.
+        UNIX_FAKE_DNS_LISTEN_ADDRS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_listener_sets_are_explicit_and_stable() {
+        assert_eq!(
+            fake_dns_listen_addrs_for_windows(true),
+            ["127.0.0.1:53", "[::1]:53"]
+        );
+        assert_eq!(fake_dns_listen_addrs_for_windows(false), ["127.0.0.1:5454"]);
+    }
+}

--- a/crates/core-capture/src/lib.rs
+++ b/crates/core-capture/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod android_caps;
 pub mod android_vpn_config;
+mod capture_dns;
 pub mod default_iface;
 pub mod dial_meta;
 pub mod doctor;
@@ -36,6 +37,7 @@ pub mod net_monitor_event;
 pub mod netstack_dispatch;
 pub mod packet;
 pub mod platform;
+mod resource_claims;
 pub mod route_table;
 pub mod stack;
 pub mod stack_system;
@@ -70,6 +72,7 @@ pub use engine::{
 pub use ipset::{IpSetProvider, NoopIpSetProvider, noop as noop_ipset_provider};
 pub use nat::{FlowKey, HostPin, NatEntry, NatTable};
 pub use packet::{IpHeader, IpVersion, L4, ParsedPacket, TcpFlags, TcpSummary, UdpSummary};
+pub use resource_claims::host_resource_claims;
 pub use route_table::{ManagedRoute, RouteBackend, RouteTable, SystemBackend};
 pub use stack::{
     AcceptedTcp, DEFAULT_LISTENER_POOL, SharedStack, SmolStream, SpliceManager, StackNotify,

--- a/crates/core-capture/src/platform/android.rs
+++ b/crates/core-capture/src/platform/android.rs
@@ -177,6 +177,12 @@ fn tier_label(tier: Option<AndroidTier>) -> &'static str {
 Capability 探测（通过 su -c 执行命令）
 ============================================================ */
 
+/// Detect the runtime transparent-capture tier.
+///
+/// This is an activation-time probe, not a read-only preflight: when TPROXY is
+/// not already visible it may load `nf_tproxy_ipv4`/`nf_tproxy_ipv6`. Host
+/// resource arbitration must use the capability-independent conservative union
+/// in `resource_claims` before constructing `AndroidCapture`.
 #[cfg(target_os = "android")]
 pub fn detect_capability() -> AndroidCapability {
     let mut c = AndroidCapability::default();
@@ -259,6 +265,9 @@ Per-Tier 安装/撤销（Android target 才真执行）
 
 const NFT_TABLE: &str = "wuthercore";
 const IPT_CHAIN: &str = "WUTHERCORE";
+pub(crate) const TRANSPARENT_FWMARK: u32 = 1;
+pub(crate) const TRANSPARENT_ROUTE_TABLE: u32 = 100;
+const TRANSPARENT_PORT: u16 = 7894;
 
 fn install_nft_full(plan: &CapturePlan) -> Result<(), CaptureError> {
     info!(target: "capture::android", "Tier=NftablesFull installing");
@@ -270,27 +279,43 @@ fn install_nft_full(plan: &CapturePlan) -> Result<(), CaptureError> {
     ))?;
     // 3. mark fwmark 1（与 ip rule 路由表配合）
     run_su_must(&format!(
-        "nft 'add rule inet {NFT_TABLE} prerouting meta l4proto tcp tproxy ip to 127.0.0.1:7894 meta mark set 1 accept'"
+        "nft 'add rule inet {NFT_TABLE} prerouting meta l4proto tcp tproxy ip to 127.0.0.1:{TRANSPARENT_PORT} meta mark set {TRANSPARENT_FWMARK} accept'"
     ))?;
     if plan.kind == EngineKind::Tproxy {
         run_su_must(&format!(
-            "nft 'add rule inet {NFT_TABLE} prerouting meta l4proto tcp tproxy ip6 to [::1]:7894 meta mark set 1 accept'"
+            "nft 'add rule inet {NFT_TABLE} prerouting meta l4proto tcp tproxy ip6 to [::1]:{TRANSPARENT_PORT} meta mark set {TRANSPARENT_FWMARK} accept'"
         ))?;
     }
     // 4. ip rule fwmark 1 lookup 100
-    run_su_must("ip rule add fwmark 1 lookup 100")?;
-    run_su_must("ip route add local default dev lo table 100")?;
-    run_su_must("ip -6 rule add fwmark 1 lookup 100")?;
-    run_su_must("ip -6 route add local default dev lo table 100")?;
+    run_su_must(&format!(
+        "ip rule add fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
+    run_su_must(&format!(
+        "ip route add local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
+    run_su_must(&format!(
+        "ip -6 rule add fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
+    run_su_must(&format!(
+        "ip -6 route add local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
     Ok(())
 }
 
 fn revert_nft_full() {
     let _ = run_su_must(&format!("nft delete table inet {NFT_TABLE}"));
-    let _ = run_su_must("ip rule del fwmark 1 lookup 100");
-    let _ = run_su_must("ip route del local default dev lo table 100");
-    let _ = run_su_must("ip -6 rule del fwmark 1 lookup 100");
-    let _ = run_su_must("ip -6 route del local default dev lo table 100");
+    let _ = run_su_must(&format!(
+        "ip rule del fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ));
+    let _ = run_su_must(&format!(
+        "ip route del local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ));
+    let _ = run_su_must(&format!(
+        "ip -6 rule del fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ));
+    let _ = run_su_must(&format!(
+        "ip -6 route del local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ));
 }
 
 fn install_iptables_v4v6_tproxy(_plan: &CapturePlan) -> Result<(), CaptureError> {
@@ -298,20 +323,28 @@ fn install_iptables_v4v6_tproxy(_plan: &CapturePlan) -> Result<(), CaptureError>
     // v4
     run_su_must(&format!("iptables -t mangle -N {IPT_CHAIN}"))?;
     run_su_must(&format!(
-        "iptables -t mangle -A {IPT_CHAIN} -p tcp -j TPROXY --on-port 7894 --tproxy-mark 1"
+        "iptables -t mangle -A {IPT_CHAIN} -p tcp -j TPROXY --on-port {TRANSPARENT_PORT} --tproxy-mark {TRANSPARENT_FWMARK}"
     ))?;
     run_su_must(&format!("iptables -t mangle -A PREROUTING -j {IPT_CHAIN}"))?;
     // v6
     run_su_must(&format!("ip6tables -t mangle -N {IPT_CHAIN}"))?;
     run_su_must(&format!(
-        "ip6tables -t mangle -A {IPT_CHAIN} -p tcp -j TPROXY --on-port 7894 --tproxy-mark 1"
+        "ip6tables -t mangle -A {IPT_CHAIN} -p tcp -j TPROXY --on-port {TRANSPARENT_PORT} --tproxy-mark {TRANSPARENT_FWMARK}"
     ))?;
     run_su_must(&format!("ip6tables -t mangle -A PREROUTING -j {IPT_CHAIN}"))?;
     // route table
-    run_su_must("ip rule add fwmark 1 lookup 100")?;
-    run_su_must("ip route add local default dev lo table 100")?;
-    run_su_must("ip -6 rule add fwmark 1 lookup 100")?;
-    run_su_must("ip -6 route add local default dev lo table 100")?;
+    run_su_must(&format!(
+        "ip rule add fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
+    run_su_must(&format!(
+        "ip route add local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
+    run_su_must(&format!(
+        "ip -6 rule add fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
+    run_su_must(&format!(
+        "ip -6 route add local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ))?;
     Ok(())
 }
 
@@ -319,12 +352,12 @@ fn install_iptables_v4v6_redirect(_plan: &CapturePlan) -> Result<(), CaptureErro
     info!(target: "capture::android", "Tier=IptablesV4V6Redirect installing");
     run_su_must(&format!("iptables -t nat -N {IPT_CHAIN}"))?;
     run_su_must(&format!(
-        "iptables -t nat -A {IPT_CHAIN} -p tcp -j REDIRECT --to-ports 7894"
+        "iptables -t nat -A {IPT_CHAIN} -p tcp -j REDIRECT --to-ports {TRANSPARENT_PORT}"
     ))?;
     run_su_must(&format!("iptables -t nat -A PREROUTING -j {IPT_CHAIN}"))?;
     run_su_must(&format!("ip6tables -t nat -N {IPT_CHAIN}"))?;
     run_su_must(&format!(
-        "ip6tables -t nat -A {IPT_CHAIN} -p tcp -j REDIRECT --to-ports 7894"
+        "ip6tables -t nat -A {IPT_CHAIN} -p tcp -j REDIRECT --to-ports {TRANSPARENT_PORT}"
     ))?;
     run_su_must(&format!("ip6tables -t nat -A PREROUTING -j {IPT_CHAIN}"))?;
     Ok(())
@@ -334,7 +367,7 @@ fn install_iptables_v4_only(_plan: &CapturePlan) -> Result<(), CaptureError> {
     info!(target: "capture::android", "Tier=IptablesV4Only installing (IPv6 traffic will go direct)");
     run_su_must(&format!("iptables -t nat -N {IPT_CHAIN}"))?;
     run_su_must(&format!(
-        "iptables -t nat -A {IPT_CHAIN} -p tcp -j REDIRECT --to-ports 7894"
+        "iptables -t nat -A {IPT_CHAIN} -p tcp -j REDIRECT --to-ports {TRANSPARENT_PORT}"
     ))?;
     run_su_must(&format!("iptables -t nat -A PREROUTING -j {IPT_CHAIN}"))?;
     Ok(())
@@ -348,8 +381,16 @@ fn revert_iptables_all() {
             let _ = run_su_must(&format!("{ipt} -t {table} -X {IPT_CHAIN}"));
         }
     }
-    let _ = run_su_must("ip rule del fwmark 1 lookup 100");
-    let _ = run_su_must("ip route del local default dev lo table 100");
-    let _ = run_su_must("ip -6 rule del fwmark 1 lookup 100");
-    let _ = run_su_must("ip -6 route del local default dev lo table 100");
+    let _ = run_su_must(&format!(
+        "ip rule del fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ));
+    let _ = run_su_must(&format!(
+        "ip route del local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ));
+    let _ = run_su_must(&format!(
+        "ip -6 rule del fwmark {TRANSPARENT_FWMARK} lookup {TRANSPARENT_ROUTE_TABLE}"
+    ));
+    let _ = run_su_must(&format!(
+        "ip -6 route del local default dev lo table {TRANSPARENT_ROUTE_TABLE}"
+    ));
 }

--- a/crates/core-capture/src/platform/linux.rs
+++ b/crates/core-capture/src/platform/linux.rs
@@ -779,9 +779,9 @@ fn install_auto_route(routes: &RouteTable, plan: &CapturePlan) {
     // 避免与已有 0.0.0.0/0 互相覆盖；同时统一使用自定义路由表 + ip rule。
     let table = plan.iproute2_table_index;
     let rule_idx = plan.iproute2_rule_index;
-    let mut cidrs: Vec<&str> = vec!["0.0.0.0/1", "128.0.0.0/1"];
+    let mut cidrs: Vec<&str> = crate::resource_claims::LINUX_TUN_SPLIT_DEFAULT_V4.to_vec();
     if plan.tun_v6_cidr.is_some() && is_ipv6_available(&plan.interface_name) {
-        cidrs.extend_from_slice(&["::/1", "8000::/1"]);
+        cidrs.extend_from_slice(&crate::resource_claims::LINUX_TUN_SPLIT_DEFAULT_V6);
     }
     for cidr in cidrs {
         if let Ok(net) = cidr.parse() {
@@ -948,9 +948,7 @@ fn install_auto_route(routes: &RouteTable, plan: &CapturePlan) {
 }
 
 fn tun_outbound_mark(plan: &CapturePlan) -> u32 {
-    plan.auto_redirect_marks
-        .output
-        .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK)
+    crate::resource_claims::tun_outbound_mark(plan)
 }
 
 fn outbound_bypass_rule_priority(rule_idx: u32) -> u32 {
@@ -1049,7 +1047,7 @@ fn route_rule_family(net: &ipnet::IpNet) -> &'static str {
 }
 
 fn auto_route_uses_catch_all_rule(plan: &CapturePlan) -> bool {
-    plan.route_addresses.is_empty() || !plan.route_address_set.is_empty()
+    crate::resource_claims::linux_auto_route_is_catch_all(plan)
 }
 
 fn should_cleanup_legacy_catch_all_rule(plan: &CapturePlan) -> bool {
@@ -1340,9 +1338,13 @@ const NFT_REDIRECT_TABLE: &str = "wuthercore_redirect";
 
 fn install_auto_redirect(plan: &CapturePlan) -> Result<(), CaptureError> {
     let marks = &plan.auto_redirect_marks;
-    let in_mark = marks.input.unwrap_or(0x2023);
+    let in_mark = marks
+        .input
+        .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_INPUT_MARK);
     let out_mark = tun_outbound_mark(plan);
-    let reset_mark = marks.reset.unwrap_or(0x2025);
+    let reset_mark = marks
+        .reset
+        .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_RESET_MARK);
 
     let mut script = String::new();
     use std::fmt::Write;
@@ -2008,7 +2010,12 @@ fn revert_auto_redirect(plan: &CapturePlan) {
     // ip rule 撤销
     if ip_rule_supported() {
         let table_s = plan.iproute2_table_index.to_string();
-        let mark_s = format!("{:#x}", plan.auto_redirect_marks.input.unwrap_or(0x2023));
+        let mark_s = format!(
+            "{:#x}",
+            plan.auto_redirect_marks
+                .input
+                .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_INPUT_MARK)
+        );
         for fam in ["", "-6"] {
             let _ = run_ip_quiet(fam, &["rule", "del", "fwmark", &mark_s, "lookup", &table_s]);
         }

--- a/crates/core-capture/src/platform/linux_identity_bypass.rs
+++ b/crates/core-capture/src/platform/linux_identity_bypass.rs
@@ -131,17 +131,8 @@ pub fn revert(plan: &CapturePlan) {
     }
 }
 
-fn has_identity_filters(f: &CaptureFilters) -> bool {
-    !f.include_uid.is_empty()
-        || !f.include_uid_range.is_empty()
-        || !f.exclude_uid.is_empty()
-        || !f.exclude_uid_range.is_empty()
-        || !f.include_gid.is_empty()
-        || !f.include_gid_range.is_empty()
-        || !f.exclude_gid.is_empty()
-        || !f.exclude_gid_range.is_empty()
-        || !f.include_package.is_empty()
-        || !f.exclude_package.is_empty()
+fn has_identity_filters(filters: &CaptureFilters) -> bool {
+    crate::resource_claims::has_linux_identity_filters(filters)
 }
 
 fn install_for_family(

--- a/crates/core-capture/src/platform/macos.rs
+++ b/crates/core-capture/src/platform/macos.rs
@@ -151,7 +151,7 @@ impl CaptureEngine for MacUtun {
         Self::configure(&self.plan, &real_name)?;
 
         // 默认路由 → utunN
-        if let Ok(default4) = "0.0.0.0/0".parse() {
+        if let Ok(default4) = crate::resource_claims::DEFAULT_ROUTE_V4.parse() {
             let _ = self.routes.add(ManagedRoute {
                 dest: default4,
                 gateway: None,

--- a/crates/core-capture/src/platform/windows.rs
+++ b/crates/core-capture/src/platform/windows.rs
@@ -143,7 +143,7 @@ impl CaptureEngine for WindowsTun {
                 })?;
             }
 
-            for dest in desired_tun_routes(&self.plan) {
+            for dest in crate::resource_claims::windows_tun_route_nets(&self.plan) {
                 self.routes
                     .add(ManagedRoute {
                         dest,
@@ -233,36 +233,6 @@ impl CaptureEngine for WindowsTun {
         info!(target: "capture", iface = %self.plan.interface_name, "windows tun stopped");
         Ok(())
     }
-}
-
-fn desired_tun_routes(plan: &CapturePlan) -> Vec<ipnet::IpNet> {
-    if !plan.auto_route {
-        return Vec::new();
-    }
-
-    let mut routes = if plan.route_addresses.is_empty() || !plan.route_address_set.is_empty() {
-        let mut defaults = vec![
-            "0.0.0.0/0"
-                .parse::<ipnet::IpNet>()
-                .expect("constant IPv4 default route"),
-        ];
-        if plan.ipv6_enabled && plan.tun_v6_cidr.is_some() {
-            defaults.push(
-                "::/0"
-                    .parse::<ipnet::IpNet>()
-                    .expect("constant IPv6 default route"),
-            );
-        }
-        defaults
-    } else {
-        plan.route_addresses.clone()
-    };
-    routes.retain(|route| {
-        route.addr().is_ipv4() || (plan.ipv6_enabled && plan.tun_v6_cidr.is_some())
-    });
-    let mut seen = HashSet::with_capacity(routes.len());
-    routes.retain(|route| seen.insert(*route));
-    routes
 }
 
 /* ---------------- DNS hijack helpers ---------------- */
@@ -636,9 +606,11 @@ mod tests {
 
     #[test]
     fn desired_routes_respect_auto_route_ipv6_and_explicit_prefixes() {
-        assert!(desired_tun_routes(&route_plan(false, true)).is_empty());
+        assert!(
+            crate::resource_claims::windows_tun_route_nets(&route_plan(false, true)).is_empty()
+        );
         assert_eq!(
-            desired_tun_routes(&route_plan(true, true)),
+            crate::resource_claims::windows_tun_route_nets(&route_plan(true, true)),
             [
                 "0.0.0.0/0".parse::<ipnet::IpNet>().unwrap(),
                 "::/0".parse::<ipnet::IpNet>().unwrap(),
@@ -648,7 +620,7 @@ mod tests {
         let mut ipv4_only = route_plan(true, true);
         ipv4_only.ipv6_enabled = false;
         assert_eq!(
-            desired_tun_routes(&ipv4_only),
+            crate::resource_claims::windows_tun_route_nets(&ipv4_only),
             ["0.0.0.0/0".parse::<ipnet::IpNet>().unwrap()]
         );
 
@@ -659,7 +631,7 @@ mod tests {
             "2001:db8::/32".parse().unwrap(),
         ];
         assert_eq!(
-            desired_tun_routes(&explicit),
+            crate::resource_claims::windows_tun_route_nets(&explicit),
             [
                 "10.0.0.0/8".parse::<ipnet::IpNet>().unwrap(),
                 "2001:db8::/32".parse::<ipnet::IpNet>().unwrap(),

--- a/crates/core-capture/src/resource_claims.rs
+++ b/crates/core-capture/src/resource_claims.rs
@@ -1,0 +1,968 @@
+//! Capture-owned host resource declarations for mesh conflict arbitration.
+//!
+//! The public API deliberately returns unowned [`ResourceClaim`] values. The
+//! process that embeds `core-capture` supplies the host owner identity; all
+//! knowledge about platform routes, marks, interfaces, DNS, and firewall
+//! mutations remains beside the implementations that perform those mutations.
+
+use std::{
+    collections::{BTreeSet, HashSet},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+};
+
+use core_mesh::{FwmarkRange, ResourceClaim, SocketTransport, SystemResource};
+
+use crate::engine::{CaptureFilters, CapturePlan, EngineKind};
+
+pub(crate) const DEFAULT_ROUTE_V4: &str = "0.0.0.0/0";
+pub(crate) const DEFAULT_ROUTE_V6: &str = "::/0";
+pub(crate) const LINUX_TUN_SPLIT_DEFAULT_V4: [&str; 2] = ["0.0.0.0/1", "128.0.0.0/1"];
+pub(crate) const LINUX_TUN_SPLIT_DEFAULT_V6: [&str; 2] = ["::/1", "8000::/1"];
+
+/// Return every host resource that the selected capture implementation can
+/// reserve on the current platform.
+///
+/// Route declarations intentionally contain two complementary views:
+///
+/// - [`SystemResource::RoutePrefix`] names the concrete kernel route object,
+///   including its policy table.
+/// - [`SystemResource::DefaultRouteV4`] / [`SystemResource::DefaultRouteV6`]
+///   name logical ownership of effective catch-all traffic.
+///
+/// All claims are exclusive, sorted, and deduplicated. Android declarations
+/// never execute capability probes: TUN declares the conservative union of the
+/// root Linux path and the framework-preconfigured VpnService fallback, while
+/// transparent capture declares the fail-closed union of every runtime tier.
+/// Linux auto-redirect is likewise a fail-closed union because its
+/// nftables/TPROXY/NAT fallback is selected only while installing rules.
+pub fn host_resource_claims(plan: &CapturePlan) -> Vec<ResourceClaim> {
+    // Keep this guard ahead of even compile-time platform selection. More
+    // importantly, Android capability detection is intentionally absent from
+    // this declaration path: it may run `modprobe` during later activation.
+    if !plan.on || matches!(plan.kind, EngineKind::None) {
+        return Vec::new();
+    }
+    claims_for_platform(plan, current_platform())
+}
+
+#[allow(dead_code)] // Every variant is constructed by a different target cfg.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostPlatform {
+    Linux,
+    Android,
+    Windows,
+    Macos,
+    Ios,
+    Other,
+}
+
+/// Compile-time-only platform selection for the pure declaration boundary.
+///
+/// This is a `const fn` so Android preflight cannot accidentally grow a
+/// command-based capability probe.
+const fn current_platform() -> HostPlatform {
+    #[cfg(target_os = "linux")]
+    {
+        return HostPlatform::Linux;
+    }
+    #[cfg(target_os = "android")]
+    {
+        return HostPlatform::Android;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return HostPlatform::Windows;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return HostPlatform::Macos;
+    }
+    #[cfg(target_os = "ios")]
+    {
+        // iOS uses a NetworkExtension-preconfigured fd; the host application,
+        // not this crate's platform backend, owns its interface and routes.
+        // CaptureSupervisor still owns its private DNS listener.
+        return HostPlatform::Ios;
+    }
+    #[allow(unreachable_code)]
+    HostPlatform::Other
+}
+
+fn claims_for_platform(plan: &CapturePlan, platform: HostPlatform) -> Vec<ResourceClaim> {
+    if !plan.on || matches!(plan.kind, EngineKind::None) {
+        return Vec::new();
+    }
+
+    let mut claims = BTreeSet::new();
+    let supported = match (platform, plan.kind) {
+        (HostPlatform::Linux, EngineKind::Tun) => {
+            linux_tun_claims(plan, &mut claims);
+            true
+        }
+        (HostPlatform::Android, EngineKind::Tun) => {
+            android_tun_claims(plan, &mut claims);
+            true
+        }
+        (HostPlatform::Linux, EngineKind::Tproxy) => {
+            linux_tproxy_claims(plan, &mut claims);
+            true
+        }
+        (HostPlatform::Linux, EngineKind::Redirect) => {
+            claim(&mut claims, SystemResource::FirewallManager);
+            true
+        }
+        (HostPlatform::Android, EngineKind::Tproxy | EngineKind::Redirect) => {
+            android_transparent_claims(&mut claims);
+            true
+        }
+        (HostPlatform::Windows, EngineKind::Tun) => {
+            windows_tun_claims(plan, &mut claims);
+            if plan.hijack_dns {
+                claim(&mut claims, SystemResource::DnsManager);
+            }
+            true
+        }
+        (HostPlatform::Macos, EngineKind::Tun) => {
+            // macOS chooses the final utunN name only while opening the
+            // device. Reserve the namespace before activation instead of
+            // pretending that the requested plan name is the real interface.
+            claim(&mut claims, SystemResource::InterfaceManager);
+            address_prefixes(plan, &mut claims);
+            default_route(
+                &mut claims,
+                DEFAULT_ROUTE_V4,
+                SystemResource::DefaultRouteV4,
+            );
+            true
+        }
+        // NetworkExtension owns the iOS interface and routes, but the common
+        // supervisor still starts its private DNS listener when requested.
+        (HostPlatform::Ios, EngineKind::Tun) => true,
+        _ => false,
+    };
+
+    if supported && plan.hijack_dns {
+        capture_dns_listener_claims(platform, &mut claims);
+    }
+
+    claims.into_iter().collect()
+}
+
+fn windows_tun_claims(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
+    interface_and_addresses(plan, claims);
+    let routes = windows_tun_route_nets(plan);
+    if !routes.is_empty() {
+        claim(claims, SystemResource::RouteManager);
+    }
+    for prefix in routes {
+        route_prefix_net(claims, None, prefix);
+        if prefix.prefix_len() == 0 {
+            claim(
+                claims,
+                if prefix.addr().is_ipv4() {
+                    SystemResource::DefaultRouteV4
+                } else {
+                    SystemResource::DefaultRouteV6
+                },
+            );
+        }
+    }
+}
+
+fn capture_dns_listener_claims(platform: HostPlatform, claims: &mut BTreeSet<ResourceClaim>) {
+    let windows = matches!(platform, HostPlatform::Windows);
+    for listen in crate::capture_dns::fake_dns_listen_addrs_for_windows(windows) {
+        let address = listen
+            .parse()
+            .expect("capture DNS listen constants must be valid socket addresses");
+        listen_socket_pair(claims, address);
+    }
+}
+
+fn android_tun_claims(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
+    // Android opens root /dev/net/tun first and falls back to a fd whose
+    // interface, addresses, routes, and DNS were preconfigured by
+    // VpnService.Builder. Preflight cannot know which open will succeed, so it
+    // reserves the union of both real installation paths.
+    linux_tun_claims(plan, claims);
+    claim(claims, SystemResource::InterfaceManager);
+
+    let vpn_routes = crate::android_vpn_config::vpn_service_route_nets(plan);
+    if !vpn_routes.is_empty() {
+        claim(claims, SystemResource::RouteManager);
+        for prefix in vpn_routes {
+            // Android's framework owns table selection. `None` deliberately
+            // means unknown table scope and therefore conflicts conservatively
+            // with an overlapping route in any backend-declared table.
+            route_prefix_net(claims, None, prefix);
+        }
+    }
+    if plan.hijack_dns {
+        // VpnService.Builder.addDnsServer changes the VPN DNS namespace even
+        // though the preconfigured device skips Linux DNS management.
+        claim(claims, SystemResource::DnsManager);
+    }
+}
+
+fn linux_tun_claims(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
+    interface_and_addresses(plan, claims);
+
+    if plan.auto_route {
+        claim(claims, SystemResource::RouteManager);
+        claim(
+            claims,
+            SystemResource::RouteTable {
+                table: plan.iproute2_table_index,
+            },
+        );
+        for prefix in LINUX_TUN_SPLIT_DEFAULT_V4 {
+            route_prefix(claims, Some(plan.iproute2_table_index), prefix);
+        }
+        if plan.tun_v6_cidr.is_some() {
+            for prefix in LINUX_TUN_SPLIT_DEFAULT_V6 {
+                route_prefix(claims, Some(plan.iproute2_table_index), prefix);
+            }
+        }
+
+        // A static route_address-only policy does not own effective default
+        // traffic, even though the custom table still contains split defaults.
+        if linux_auto_route_is_catch_all(plan) {
+            claim(claims, SystemResource::DefaultRouteV4);
+            if plan.tun_v6_cidr.is_some() {
+                claim(claims, SystemResource::DefaultRouteV6);
+            }
+        }
+
+        fwmark(claims, tun_outbound_mark(plan));
+        if has_linux_identity_filters(&plan.filters) {
+            claim(claims, SystemResource::FirewallManager);
+        }
+    }
+
+    if plan.strict_route {
+        // install_strict_route writes IPv4 and IPv6 blackhole ip rules. It does
+        // not install a firewall rule.
+        claim(claims, SystemResource::RouteManager);
+        claim(claims, SystemResource::DefaultRouteV4);
+        claim(claims, SystemResource::DefaultRouteV6);
+    }
+
+    if plan.auto_redirect {
+        // nftables and TPROXY fallbacks install fwmark policy rules into the
+        // configured TUN table. They do not create a local-default route (the
+        // exact split-default RoutePrefix objects above come only from
+        // install_auto_route). NAT REDIRECT may use only the firewall, hence
+        // this is the safe union of all successful runtime backends.
+        claim(claims, SystemResource::FirewallManager);
+        claim(claims, SystemResource::RouteManager);
+        claim(
+            claims,
+            SystemResource::RouteTable {
+                table: plan.iproute2_table_index,
+            },
+        );
+        fwmark(
+            claims,
+            plan.auto_redirect_marks
+                .input
+                .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_INPUT_MARK),
+        );
+        fwmark(claims, tun_outbound_mark(plan));
+        fwmark(
+            claims,
+            plan.auto_redirect_marks
+                .reset
+                .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_RESET_MARK),
+        );
+    }
+}
+
+fn linux_tproxy_claims(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
+    let table = crate::tproxy_rules::TPROXY_ROUTE_TABLE;
+    claim(claims, SystemResource::RouteManager);
+    claim(claims, SystemResource::FirewallManager);
+    claim(claims, SystemResource::DefaultRouteV4);
+    claim(claims, SystemResource::RouteTable { table });
+    route_prefix(claims, Some(table), DEFAULT_ROUTE_V4);
+    fwmark(claims, crate::tproxy_rules::TPROXY_FWMARK);
+    fwmark(
+        claims,
+        plan.auto_redirect_marks
+            .output
+            .unwrap_or(crate::tproxy_rules::TPROXY_FWMARK),
+    );
+
+    let address = SocketAddr::V4(SocketAddrV4::new(
+        Ipv4Addr::UNSPECIFIED,
+        crate::tproxy_rules::TPROXY_PORT,
+    ));
+    listen_socket_pair(claims, address);
+
+    if plan.ipv6_enabled {
+        claim(claims, SystemResource::DefaultRouteV6);
+        route_prefix(claims, Some(table), DEFAULT_ROUTE_V6);
+        let address = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::UNSPECIFIED,
+            crate::tproxy_rules::TPROXY_PORT,
+            0,
+            0,
+        ));
+        listen_socket_pair(claims, address);
+    }
+}
+
+fn android_transparent_claims(claims: &mut BTreeSet<ResourceClaim>) {
+    // Runtime capability selection happens only after mesh preflight and may
+    // load nf_tproxy modules. A read-only snapshot cannot prove that currently
+    // absent modules are not loadable, so reserve the union of all tiers:
+    // REDIRECT owns only the firewall, while either TPROXY tier additionally
+    // owns both policy-route families, table 100, and mark 1.
+    claim(claims, SystemResource::FirewallManager);
+    android_tproxy_route_claims(claims);
+    claim(claims, SystemResource::DefaultRouteV4);
+    claim(claims, SystemResource::DefaultRouteV6);
+}
+
+fn android_tproxy_route_claims(claims: &mut BTreeSet<ResourceClaim>) {
+    let table = crate::platform::android::TRANSPARENT_ROUTE_TABLE;
+    claim(claims, SystemResource::RouteManager);
+    claim(claims, SystemResource::RouteTable { table });
+    route_prefix(claims, Some(table), DEFAULT_ROUTE_V4);
+    route_prefix(claims, Some(table), DEFAULT_ROUTE_V6);
+    fwmark(claims, crate::platform::android::TRANSPARENT_FWMARK);
+}
+
+fn interface_and_addresses(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
+    claim(
+        claims,
+        SystemResource::Interface {
+            name: plan.interface_name.clone(),
+        },
+    );
+    address_prefixes(plan, claims);
+}
+
+fn address_prefixes(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
+    claim(
+        claims,
+        SystemResource::AddressPrefix {
+            prefix: plan.tun_v4_cidr.into(),
+        },
+    );
+    if let Some(prefix) = plan.tun_v6_cidr {
+        // Platform setup reads tun_v6_cidr directly. ipv6_enabled only affects
+        // packet classification and must not hide an address actually created.
+        claim(
+            claims,
+            SystemResource::AddressPrefix {
+                prefix: prefix.into(),
+            },
+        );
+    }
+}
+
+fn default_route(claims: &mut BTreeSet<ResourceClaim>, prefix: &str, logical: SystemResource) {
+    claim(claims, SystemResource::RouteManager);
+    route_prefix(claims, None, prefix);
+    claim(claims, logical);
+}
+
+fn route_prefix(claims: &mut BTreeSet<ResourceClaim>, table: Option<u32>, prefix: &str) {
+    route_prefix_net(
+        claims,
+        table,
+        prefix
+            .parse()
+            .expect("capture route constants must be valid prefixes"),
+    );
+}
+
+fn route_prefix_net(
+    claims: &mut BTreeSet<ResourceClaim>,
+    table: Option<u32>,
+    prefix: ipnet::IpNet,
+) {
+    claim(claims, SystemResource::RoutePrefix { table, prefix });
+}
+
+fn listen_socket_pair(claims: &mut BTreeSet<ResourceClaim>, address: SocketAddr) {
+    for transport in [SocketTransport::Tcp, SocketTransport::Udp] {
+        claim(claims, SystemResource::ListenSocket { transport, address });
+    }
+}
+
+fn fwmark(claims: &mut BTreeSet<ResourceClaim>, mark: u32) {
+    claim(
+        claims,
+        SystemResource::FwmarkRange {
+            range: FwmarkRange::new(mark, mark)
+                .expect("a single capture fwmark is always a valid range"),
+        },
+    );
+}
+
+fn claim(claims: &mut BTreeSet<ResourceClaim>, resource: SystemResource) {
+    claims.insert(ResourceClaim::exclusive(resource));
+}
+
+pub(crate) fn tun_outbound_mark(plan: &CapturePlan) -> u32 {
+    plan.auto_redirect_marks
+        .output
+        .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK)
+}
+
+pub(crate) fn linux_auto_route_is_catch_all(plan: &CapturePlan) -> bool {
+    plan.route_addresses.is_empty() || !plan.route_address_set.is_empty()
+}
+
+/// Exact route set installed by the Windows TUN backend.
+///
+/// Keep this target-independent so resource arbitration and Windows startup
+/// cannot drift even when tests run on a non-Windows host.
+pub(crate) fn windows_tun_route_nets(plan: &CapturePlan) -> Vec<ipnet::IpNet> {
+    if !plan.auto_route {
+        return Vec::new();
+    }
+
+    let mut routes = if plan.route_addresses.is_empty() || !plan.route_address_set.is_empty() {
+        let mut defaults = vec![
+            DEFAULT_ROUTE_V4
+                .parse()
+                .expect("constant IPv4 default route"),
+        ];
+        if plan.ipv6_enabled && plan.tun_v6_cidr.is_some() {
+            defaults.push(
+                DEFAULT_ROUTE_V6
+                    .parse()
+                    .expect("constant IPv6 default route"),
+            );
+        }
+        defaults
+    } else {
+        plan.route_addresses.clone()
+    };
+    routes.retain(|route| {
+        route.addr().is_ipv4() || (plan.ipv6_enabled && plan.tun_v6_cidr.is_some())
+    });
+    let mut seen = HashSet::with_capacity(routes.len());
+    routes.retain(|route| seen.insert(*route));
+    routes
+}
+
+pub(crate) fn has_linux_identity_filters(filters: &CaptureFilters) -> bool {
+    !filters.include_uid.is_empty()
+        || !filters.include_uid_range.is_empty()
+        || !filters.exclude_uid.is_empty()
+        || !filters.exclude_uid_range.is_empty()
+        || !filters.include_gid.is_empty()
+        || !filters.include_gid_range.is_empty()
+        || !filters.exclude_gid.is_empty()
+        || !filters.exclude_gid_range.is_empty()
+        || !filters.include_package.is_empty()
+        || !filters.exclude_package.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use core_config::model::{Capture, CaptureMethod};
+
+    use super::*;
+
+    fn plan(kind: EngineKind) -> CapturePlan {
+        let mut capture = Capture {
+            on: true,
+            method: CaptureMethod::VirtualNic,
+            ..Capture::default()
+        };
+        capture.tun.interface_name = Some("claims-test0".into());
+        capture.tun.address = vec!["198.19.0.0/30".into(), "fd00:1234::/126".into()];
+        capture.tun.inet6 = true;
+        let mut plan = CapturePlan::from_config(&capture).unwrap();
+        plan.kind = kind;
+        plan.auto_route = false;
+        plan.strict_route = false;
+        plan.auto_redirect = false;
+        plan.hijack_dns = false;
+        plan
+    }
+
+    fn resources(plan: &CapturePlan, platform: HostPlatform) -> BTreeSet<SystemResource> {
+        claims_for_platform(plan, platform)
+            .into_iter()
+            .map(|claim| {
+                assert_eq!(claim.mode, core_mesh::ClaimMode::Exclusive);
+                claim.resource
+            })
+            .collect()
+    }
+
+    fn contains_prefix(
+        resources: &BTreeSet<SystemResource>,
+        table: Option<u32>,
+        prefix: &str,
+    ) -> bool {
+        resources.contains(&SystemResource::RoutePrefix {
+            table,
+            prefix: prefix.parse().unwrap(),
+        })
+    }
+
+    fn contains_listener_pair(resources: &BTreeSet<SystemResource>, address: SocketAddr) -> bool {
+        [SocketTransport::Tcp, SocketTransport::Udp]
+            .into_iter()
+            .all(|transport| {
+                resources.contains(&SystemResource::ListenSocket { transport, address })
+            })
+    }
+
+    #[test]
+    fn disabled_or_none_capture_has_no_claims() {
+        let mut disabled = plan(EngineKind::Tun);
+        disabled.on = false;
+        for platform in [
+            HostPlatform::Linux,
+            HostPlatform::Android,
+            HostPlatform::Windows,
+            HostPlatform::Macos,
+            HostPlatform::Ios,
+            HostPlatform::Other,
+        ] {
+            assert!(claims_for_platform(&disabled, platform).is_empty());
+            assert!(claims_for_platform(&plan(EngineKind::None), platform).is_empty());
+        }
+        assert!(host_resource_claims(&disabled).is_empty());
+        assert!(host_resource_claims(&plan(EngineKind::None)).is_empty());
+    }
+
+    #[test]
+    fn platform_selection_is_const_and_cannot_probe_android_capabilities() {
+        // This assignment is evaluated in a const context. Adding su, modprobe,
+        // filesystem, or process probing to current_platform() would make this
+        // test fail to compile.
+        const SELECTED: HostPlatform = current_platform();
+        let _ = SELECTED;
+    }
+
+    #[test]
+    fn linux_tun_claims_exact_split_routes_table_addresses_and_output_mark() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = true;
+        plan.iproute2_table_index = 4242;
+        plan.auto_redirect_marks.output = Some(0x55);
+        plan.ipv6_enabled = false;
+        let resources = resources(&plan, HostPlatform::Linux);
+
+        assert!(resources.contains(&SystemResource::Interface {
+            name: "claims-test0".into()
+        }));
+        assert!(resources.contains(&SystemResource::AddressPrefix {
+            prefix: "198.19.0.0/30".parse().unwrap()
+        }));
+        assert!(resources.contains(&SystemResource::AddressPrefix {
+            prefix: "fd00:1234::/126".parse().unwrap()
+        }));
+        for prefix in LINUX_TUN_SPLIT_DEFAULT_V4
+            .into_iter()
+            .chain(LINUX_TUN_SPLIT_DEFAULT_V6)
+        {
+            assert!(contains_prefix(&resources, Some(4242), prefix));
+        }
+        assert!(resources.contains(&SystemResource::RouteTable { table: 4242 }));
+        assert!(resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(resources.contains(&SystemResource::DefaultRouteV6));
+        assert!(resources.contains(&SystemResource::FwmarkRange {
+            range: FwmarkRange::new(0x55, 0x55).unwrap()
+        }));
+        assert!(!resources.contains(&SystemResource::FirewallManager));
+    }
+
+    #[test]
+    fn linux_static_route_policy_keeps_real_routes_without_logical_default_claims() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = true;
+        plan.route_addresses = vec!["203.0.113.0/24".parse().unwrap()];
+        let resources = resources(&plan, HostPlatform::Linux);
+
+        assert!(contains_prefix(
+            &resources,
+            Some(plan.iproute2_table_index),
+            "0.0.0.0/1"
+        ));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV6));
+    }
+
+    #[test]
+    fn linux_strict_route_owns_policy_routes_not_firewall() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.strict_route = true;
+        plan.tun_v6_cidr = None;
+        plan.ipv6_enabled = false;
+        let resources = resources(&plan, HostPlatform::Linux);
+
+        assert!(resources.contains(&SystemResource::RouteManager));
+        assert!(resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(resources.contains(&SystemResource::DefaultRouteV6));
+        assert!(!resources.contains(&SystemResource::FirewallManager));
+    }
+
+    #[test]
+    fn linux_identity_bypass_makes_auto_route_a_firewall_owner() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = true;
+        plan.filters.exclude_uid.push(1000);
+        let resources = resources(&plan, HostPlatform::Linux);
+
+        assert!(resources.contains(&SystemResource::FirewallManager));
+    }
+
+    #[test]
+    fn linux_auto_redirect_claims_configured_table_firewall_and_all_marks() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_redirect = true;
+        plan.iproute2_table_index = 5353;
+        plan.auto_redirect_marks.input = Some(0x31);
+        plan.auto_redirect_marks.output = Some(0x32);
+        plan.auto_redirect_marks.reset = Some(0x33);
+        let resources = resources(&plan, HostPlatform::Linux);
+
+        assert!(resources.contains(&SystemResource::RouteManager));
+        assert!(resources.contains(&SystemResource::RouteTable { table: 5353 }));
+        assert!(resources.contains(&SystemResource::FirewallManager));
+        for mark in [0x31, 0x32, 0x33] {
+            assert!(resources.contains(&SystemResource::FwmarkRange {
+                range: FwmarkRange::new(mark, mark).unwrap()
+            }));
+        }
+    }
+
+    #[test]
+    fn linux_tproxy_claims_dual_stack_routes_marks_and_listener_set() {
+        let mut plan = plan(EngineKind::Tproxy);
+        plan.iproute2_table_index = 9999;
+        plan.auto_redirect_marks.output = Some(0x2024);
+        plan.ipv6_enabled = true;
+        let resources = resources(&plan, HostPlatform::Linux);
+        let table = crate::tproxy_rules::TPROXY_ROUTE_TABLE;
+        let ipv4 = SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::UNSPECIFIED,
+            crate::tproxy_rules::TPROXY_PORT,
+        ));
+        let ipv6 = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::UNSPECIFIED,
+            crate::tproxy_rules::TPROXY_PORT,
+            0,
+            0,
+        ));
+
+        assert!(resources.contains(&SystemResource::RouteTable { table }));
+        assert!(!resources.contains(&SystemResource::RouteTable { table: 9999 }));
+        assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V4));
+        assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V6));
+        assert!(resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(resources.contains(&SystemResource::DefaultRouteV6));
+        for mark in [crate::tproxy_rules::TPROXY_FWMARK, 0x2024] {
+            assert!(resources.contains(&SystemResource::FwmarkRange {
+                range: FwmarkRange::new(mark, mark).unwrap()
+            }));
+        }
+        assert!(contains_listener_pair(&resources, ipv4));
+        assert!(contains_listener_pair(&resources, ipv6));
+    }
+
+    #[test]
+    fn linux_tproxy_omits_every_ipv6_claim_when_ipv6_is_disabled() {
+        let mut plan = plan(EngineKind::Tproxy);
+        plan.ipv6_enabled = false;
+        let resources = resources(&plan, HostPlatform::Linux);
+        let table = crate::tproxy_rules::TPROXY_ROUTE_TABLE;
+        let ipv6 = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::UNSPECIFIED,
+            crate::tproxy_rules::TPROXY_PORT,
+            0,
+            0,
+        ));
+
+        assert!(!contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V6));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV6));
+        assert!(!contains_listener_pair(&resources, ipv6));
+    }
+
+    #[test]
+    fn linux_redirect_only_mutates_firewall() {
+        let resources = resources(&plan(EngineKind::Redirect), HostPlatform::Linux);
+        assert_eq!(resources, BTreeSet::from([SystemResource::FirewallManager]));
+    }
+
+    #[test]
+    fn android_tun_reserves_root_and_vpnservice_route_union() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = true;
+        plan.hijack_dns = true;
+        plan.iproute2_table_index = 6161;
+        let vpn_routes = crate::android_vpn_config::vpn_service_route_nets(&plan);
+        let resources = resources(&plan, HostPlatform::Android);
+
+        // Root /dev/net/tun path.
+        assert!(resources.contains(&SystemResource::RouteTable { table: 6161 }));
+        assert!(resources.contains(&SystemResource::InterfaceManager));
+        assert!(resources.contains(&SystemResource::Interface {
+            name: "claims-test0".into()
+        }));
+        for prefix in LINUX_TUN_SPLIT_DEFAULT_V4
+            .into_iter()
+            .chain(LINUX_TUN_SPLIT_DEFAULT_V6)
+        {
+            assert!(contains_prefix(&resources, Some(6161), prefix));
+        }
+
+        // VpnService.Builder fallback path. Its table is selected by Android,
+        // so every exact Builder route is declared with unknown table scope.
+        assert!(!vpn_routes.is_empty());
+        for prefix in vpn_routes {
+            assert!(resources.contains(&SystemResource::RoutePrefix {
+                table: None,
+                prefix,
+            }));
+        }
+        assert!(resources.contains(&SystemResource::DnsManager));
+    }
+
+    #[test]
+    fn android_vpnservice_static_route_is_claimed_when_auto_route_is_false() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = false;
+        plan.route_addresses = vec!["203.0.113.0/24".parse().unwrap()];
+        let resources = resources(&plan, HostPlatform::Android);
+
+        assert!(resources.contains(&SystemResource::RouteManager));
+        assert!(contains_prefix(&resources, None, "203.0.113.0/24"));
+        assert!(!resources.contains(&SystemResource::RouteTable {
+            table: plan.iproute2_table_index,
+        }));
+    }
+
+    #[test]
+    fn android_transparent_preflight_is_pure_fail_closed_union() {
+        for kind in [EngineKind::Tproxy, EngineKind::Redirect] {
+            // HostPlatform::Android carries no detected capability. This pure
+            // boundary therefore cannot run su/modprobe, and the result still
+            // covers a TPROXY tier that runtime activation may unlock later.
+            let mut plan = plan(kind);
+            plan.iproute2_table_index = 9999;
+            let resources = resources(&plan, HostPlatform::Android);
+            let table = crate::platform::android::TRANSPARENT_ROUTE_TABLE;
+
+            assert!(resources.contains(&SystemResource::FirewallManager));
+            assert!(resources.contains(&SystemResource::RouteTable { table }));
+            assert!(!resources.contains(&SystemResource::RouteTable { table: 9999 }));
+            assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V4));
+            assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V6));
+            assert!(resources.contains(&SystemResource::DefaultRouteV4));
+            assert!(resources.contains(&SystemResource::DefaultRouteV6));
+            assert!(
+                resources.contains(&SystemResource::FwmarkRange {
+                    range: FwmarkRange::new(
+                        crate::platform::android::TRANSPARENT_FWMARK,
+                        crate::platform::android::TRANSPARENT_FWMARK,
+                    )
+                    .unwrap()
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn android_transparent_uses_shared_runtime_table_and_mark_constants() {
+        let mut plan = plan(EngineKind::Redirect);
+        plan.iproute2_table_index = 9999;
+        let resources = resources(&plan, HostPlatform::Android);
+        let table = crate::platform::android::TRANSPARENT_ROUTE_TABLE;
+
+        assert!(resources.contains(&SystemResource::RouteTable { table }));
+        assert!(!resources.contains(&SystemResource::RouteTable { table: 9999 }));
+        assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V4));
+        assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V6));
+        assert!(resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(resources.contains(&SystemResource::DefaultRouteV6));
+        assert!(
+            resources.contains(&SystemResource::FwmarkRange {
+                range: FwmarkRange::new(
+                    crate::platform::android::TRANSPARENT_FWMARK,
+                    crate::platform::android::TRANSPARENT_FWMARK,
+                )
+                .unwrap()
+            })
+        );
+    }
+
+    #[test]
+    fn windows_tun_without_auto_route_declares_no_route_ownership() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = false;
+        let resources = resources(&plan, HostPlatform::Windows);
+
+        assert!(!resources.contains(&SystemResource::RouteManager));
+        assert!(!contains_prefix(&resources, None, DEFAULT_ROUTE_V4));
+        assert!(!contains_prefix(&resources, None, DEFAULT_ROUTE_V6));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV6));
+        assert!(resources.contains(&SystemResource::AddressPrefix {
+            prefix: "fd00:1234::/126".parse().unwrap()
+        }));
+        assert!(!resources.contains(&SystemResource::FirewallManager));
+    }
+
+    #[test]
+    fn windows_tun_claims_the_shared_default_route_set_with_ipv6_gates() {
+        let mut dual_stack = plan(EngineKind::Tun);
+        dual_stack.auto_route = true;
+        dual_stack.ipv6_enabled = true;
+        let dual_resources = resources(&dual_stack, HostPlatform::Windows);
+        assert!(contains_prefix(&dual_resources, None, DEFAULT_ROUTE_V4));
+        assert!(contains_prefix(&dual_resources, None, DEFAULT_ROUTE_V6));
+        assert!(dual_resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(dual_resources.contains(&SystemResource::DefaultRouteV6));
+
+        dual_stack.ipv6_enabled = false;
+        let ipv4_resources = resources(&dual_stack, HostPlatform::Windows);
+        assert!(contains_prefix(&ipv4_resources, None, DEFAULT_ROUTE_V4));
+        assert!(!contains_prefix(&ipv4_resources, None, DEFAULT_ROUTE_V6));
+        assert!(!ipv4_resources.contains(&SystemResource::DefaultRouteV6));
+
+        dual_stack.ipv6_enabled = true;
+        dual_stack.tun_v6_cidr = None;
+        let no_tun_v6_resources = resources(&dual_stack, HostPlatform::Windows);
+        assert!(!contains_prefix(
+            &no_tun_v6_resources,
+            None,
+            DEFAULT_ROUTE_V6
+        ));
+        assert!(!no_tun_v6_resources.contains(&SystemResource::DefaultRouteV6));
+    }
+
+    #[test]
+    fn windows_tun_claims_filtered_deduplicated_static_routes() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = true;
+        plan.route_addresses = vec![
+            "203.0.113.0/24".parse().unwrap(),
+            "2001:db8::/32".parse().unwrap(),
+            "203.0.113.0/24".parse().unwrap(),
+        ];
+        plan.ipv6_enabled = false;
+        let route_nets = windows_tun_route_nets(&plan);
+        let resources = resources(&plan, HostPlatform::Windows);
+
+        assert_eq!(route_nets, vec!["203.0.113.0/24".parse().unwrap()]);
+        assert!(contains_prefix(&resources, None, "203.0.113.0/24"));
+        assert!(!contains_prefix(&resources, None, "2001:db8::/32"));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV6));
+    }
+
+    #[test]
+    fn windows_route_address_set_forces_catch_all_route_claims() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = true;
+        plan.route_addresses = vec!["203.0.113.0/24".parse().unwrap()];
+        plan.route_address_set = vec!["geoip-cn".into()];
+        let resources = resources(&plan, HostPlatform::Windows);
+
+        assert!(contains_prefix(&resources, None, DEFAULT_ROUTE_V4));
+        assert!(contains_prefix(&resources, None, DEFAULT_ROUTE_V6));
+        assert!(!contains_prefix(&resources, None, "203.0.113.0/24"));
+        assert!(resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(resources.contains(&SystemResource::DefaultRouteV6));
+    }
+
+    #[test]
+    fn capture_private_dns_listeners_match_runtime_platform_selection() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.hijack_dns = true;
+        let unix = "127.0.0.1:5454".parse().unwrap();
+        for kind in [EngineKind::Tun, EngineKind::Tproxy, EngineKind::Redirect] {
+            plan.kind = kind;
+            for platform in [HostPlatform::Linux, HostPlatform::Android] {
+                let resources = resources(&plan, platform);
+                assert!(contains_listener_pair(&resources, unix));
+            }
+        }
+        plan.kind = EngineKind::Tun;
+        for platform in [HostPlatform::Macos, HostPlatform::Ios] {
+            let resources = resources(&plan, platform);
+            assert!(contains_listener_pair(&resources, unix));
+        }
+
+        let windows = resources(&plan, HostPlatform::Windows);
+        assert!(windows.contains(&SystemResource::DnsManager));
+        assert!(contains_listener_pair(
+            &windows,
+            "127.0.0.1:53".parse().unwrap()
+        ));
+        assert!(contains_listener_pair(
+            &windows,
+            "[::1]:53".parse().unwrap()
+        ));
+
+        plan.hijack_dns = false;
+        let resources = resources(&plan, HostPlatform::Windows);
+        assert!(!resources.contains(&SystemResource::DnsManager));
+        assert!(!contains_listener_pair(
+            &resources,
+            "127.0.0.1:53".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn macos_tun_claims_actual_v4_default_without_documented_but_unimplemented_pf() {
+        let mut plan = plan(EngineKind::Tun);
+        plan.auto_route = false;
+        plan.hijack_dns = true;
+        let resources = resources(&plan, HostPlatform::Macos);
+
+        assert!(contains_prefix(&resources, None, DEFAULT_ROUTE_V4));
+        assert!(resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV6));
+        assert!(!resources.contains(&SystemResource::DnsManager));
+        assert!(!resources.contains(&SystemResource::FirewallManager));
+        assert!(resources.contains(&SystemResource::InterfaceManager));
+        assert!(!resources.contains(&SystemResource::Interface {
+            name: "claims-test0".into()
+        }));
+    }
+
+    #[test]
+    fn unsupported_platform_engine_pairs_claim_nothing() {
+        assert!(claims_for_platform(&plan(EngineKind::Tproxy), HostPlatform::Windows).is_empty());
+        assert!(claims_for_platform(&plan(EngineKind::Redirect), HostPlatform::Macos).is_empty());
+        assert!(claims_for_platform(&plan(EngineKind::Tun), HostPlatform::Other).is_empty());
+    }
+
+    #[test]
+    fn public_api_uses_the_cfg_selected_platform() {
+        let plan = plan(EngineKind::Tun);
+        let actual = host_resource_claims(&plan);
+
+        #[cfg(target_os = "linux")]
+        assert_eq!(actual, claims_for_platform(&plan, HostPlatform::Linux));
+        #[cfg(target_os = "android")]
+        assert_eq!(actual, claims_for_platform(&plan, HostPlatform::Android));
+        #[cfg(target_os = "windows")]
+        assert_eq!(actual, claims_for_platform(&plan, HostPlatform::Windows));
+        #[cfg(target_os = "macos")]
+        assert_eq!(actual, claims_for_platform(&plan, HostPlatform::Macos));
+        #[cfg(target_os = "ios")]
+        assert_eq!(actual, claims_for_platform(&plan, HostPlatform::Ios));
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "windows",
+            target_os = "macos",
+            target_os = "ios"
+        )))]
+        assert_eq!(actual, claims_for_platform(&plan, HostPlatform::Other));
+    }
+}

--- a/crates/core-capture/src/supervisor.rs
+++ b/crates/core-capture/src/supervisor.rs
@@ -562,7 +562,7 @@ impl CaptureSupervisor {
                 .with_fake_pool(self.fake_pool.clone()),
         );
         if self.plan.hijack_dns {
-            for &listen_addr in fake_dns_listen_addrs() {
+            for &listen_addr in crate::capture_dns::fake_dns_listen_addrs() {
                 let listener = core_runtime::spawn_dns_listener(listen_addr, dns_service.clone())
                     .await
                     .map_err(|error| {
@@ -843,17 +843,6 @@ impl CaptureSupervisor {
     }
 }
 
-fn fake_dns_listen_addrs() -> &'static [&'static str] {
-    if cfg!(target_os = "windows") {
-        // WindowsTun points both IPv4 and IPv6 resolver families at these
-        // loopback listeners.
-        &["127.0.0.1:53", "[::1]:53"]
-    } else {
-        // Preserve the existing private capture listener on Unix platforms.
-        &["127.0.0.1:5454"]
-    }
-}
-
 /// 工具：把字符串地址解析。
 pub fn first_addr(s: &str) -> Option<SocketAddr> {
     s.to_socket_addrs().ok().and_then(|mut it| it.next())
@@ -1105,9 +1094,15 @@ route:
     #[test]
     fn windows_fake_dns_matches_system_dns_target() {
         if cfg!(target_os = "windows") {
-            assert_eq!(fake_dns_listen_addrs(), ["127.0.0.1:53", "[::1]:53"]);
+            assert_eq!(
+                crate::capture_dns::fake_dns_listen_addrs(),
+                ["127.0.0.1:53", "[::1]:53"]
+            );
         } else {
-            assert_eq!(fake_dns_listen_addrs(), ["127.0.0.1:5454"]);
+            assert_eq!(
+                crate::capture_dns::fake_dns_listen_addrs(),
+                ["127.0.0.1:5454"]
+            );
         }
     }
 

--- a/crates/core-capture/src/tproxy_rules.rs
+++ b/crates/core-capture/src/tproxy_rules.rs
@@ -6,7 +6,7 @@ pub(crate) const TPROXY_FWMARK: u32 = 0x2d0;
 pub(crate) const TPROXY_PORT: u16 = 7894;
 pub(crate) const TPROXY_ROUTE_IFACE: &str = "lo";
 
-const TPROXY_ROUTE_TABLE: u32 = 0x2d0;
+pub(crate) const TPROXY_ROUTE_TABLE: u32 = 0x2d0;
 const TPROXY_PREROUTING_CHAIN: &str = "WUTHERCORE_PREROUTING";
 const TPROXY_OUTPUT_CHAIN: &str = "WUTHERCORE_OUTPUT";
 const TPROXY_DIVERT_CHAIN: &str = "WUTHERCORE_DIVERT";

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -228,31 +228,41 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
             udp: d.udp,
         },
     });
+    if mixed.as_ref().is_some_and(|listener| listener.port == 0) {
+        return Err(ConfigError::invalid(
+            "listen.local 端口不能为 0；删除 local 配置可禁用 Mixed 入站",
+        ));
+    }
 
-    let panel = listen.panel.and_then(|p| match p {
-        PanelBind::Off(false) => None,
-        PanelBind::Off(true) => Some(PanelListen {
+    let panel = match listen.panel {
+        None | Some(PanelBind::Off(false)) => None,
+        Some(PanelBind::Off(true)) => Some(PanelListen {
             host: host_for(share).into(),
             port: 9090,
         }),
-        PanelBind::Port(port) => Some(PanelListen {
+        Some(PanelBind::Port(port)) => Some(PanelListen {
             host: host_for(share).into(),
             port,
         }),
-        PanelBind::Address(addr) => {
-            let parts: Vec<&str> = addr.rsplitn(2, ':').collect();
-            if parts.len() == 2 {
-                let port = parts[0].parse().ok();
-                if let Some(port) = port {
-                    return Some(PanelListen {
-                        host: parts[1].to_string(),
-                        port,
-                    });
-                }
-            }
-            None
+        Some(PanelBind::Address(addr)) => {
+            let socket: SocketAddr = addr
+                .parse()
+                .map_err(|_| ConfigError::invalid(format!("非法 listen.panel 地址: {addr}")))?;
+            let host = match socket.ip() {
+                std::net::IpAddr::V4(ip) => ip.to_string(),
+                std::net::IpAddr::V6(ip) => format!("[{ip}]"),
+            };
+            Some(PanelListen {
+                host,
+                port: socket.port(),
+            })
         }
-    });
+    };
+    if panel.as_ref().is_some_and(|listener| listener.port == 0) {
+        return Err(ConfigError::invalid(
+            "listen.panel 端口不能为 0；设为 false 可禁用 API 入站",
+        ));
+    }
 
     let auth = listen
         .auth
@@ -1000,6 +1010,54 @@ nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#HK"]
         assert!(kinds.iter().any(|m| matches!(m, RouteMatcher::Home)));
         assert!(kinds.iter().any(|m| matches!(m, RouteMatcher::Cn)));
         assert!(kinds.iter().any(|m| matches!(m, RouteMatcher::Any)));
+    }
+
+    #[test]
+    fn fixed_process_listeners_reject_dynamic_port_zero() {
+        for yaml in [
+            r#"
+version: 1
+profile: desktop
+listen:
+  local: 0
+"#,
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 0
+"#,
+        ] {
+            let error = crate::loader::load_from_str(yaml).unwrap_err();
+            assert!(error.to_string().contains("端口不能为 0"));
+        }
+    }
+
+    #[test]
+    fn panel_address_is_validated_and_preserves_ipv6() {
+        let error = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: not-a-socket
+"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("非法 listen.panel 地址"));
+
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: "[::1]:9090"
+"#,
+        );
+        assert_eq!(
+            plan.listen.panel.unwrap().socket_addr().unwrap(),
+            "[::1]:9090".parse().unwrap()
+        );
     }
 
     #[test]

--- a/crates/core-inbound/src/mixed.rs
+++ b/crates/core-inbound/src/mixed.rs
@@ -71,15 +71,16 @@ pub struct MixedListener {
     pub udp: bool,
 }
 
+async fn bind_mixed_listener(listen: SocketAddr) -> io::Result<TcpListener> {
+    TcpListener::bind(listen).await
+}
+
 pub async fn run_mixed(listener: MixedListener, runtime: Arc<Runtime>) -> io::Result<()> {
-    let report = crate::privilege::PrivilegeReport::detect();
-    let l = crate::listener::bind_with_fallback(listener.listen, &report, None).await?;
+    // Host-resource arbitration reserves this exact address. Falling back to a
+    // different port would make the reservation and the live socket diverge.
+    let l = bind_mixed_listener(listener.listen).await?;
     let bound = l.local_addr()?;
-    if bound != listener.listen {
-        info!(want = %listener.listen, got = %bound, "mixed inbound bound to fallback");
-    } else {
-        info!(addr = %bound, "mixed inbound listening");
-    }
+    info!(addr = %bound, "mixed inbound listening");
     serve_mixed(l, listener, runtime).await
 }
 
@@ -2378,6 +2379,18 @@ mod tests {
     fn network_test_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[tokio::test]
+    async fn mixed_bind_is_exact_and_fails_when_requested_port_is_occupied() {
+        let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = occupied.local_addr().unwrap();
+
+        let error = bind_mixed_listener(address)
+            .await
+            .expect_err("must not fall back to an undeclared port");
+
+        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
     }
 
     fn test_runtime() -> Arc<Runtime> {

--- a/crates/core-mesh/Cargo.toml
+++ b/crates/core-mesh/Cargo.toml
@@ -7,8 +7,21 @@ license.workspace = true
 [dependencies]
 core-config = { workspace = true }
 async-trait = { workspace = true }
+command-group = { workspace = true }
 ipnet       = { workspace = true }
 once_cell   = { workspace = true }
 anyhow      = { workspace = true }
 thiserror   = { workspace = true }
 tracing     = { workspace = true }
+serde       = { workspace = true }
+tokio       = { workspace = true }
+tokio-util  = { workspace = true }
+tempfile    = { workspace = true }
+url         = { workspace = true }
+zeroize     = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/core-mesh/src/backend.rs
+++ b/crates/core-mesh/src/backend.rs
@@ -1,0 +1,230 @@
+//! Backend lifecycle contract.
+//!
+//! Concrete provider adapters keep provider-specific configuration and process
+//! details behind these interfaces. Lifecycle release is deliberately split at
+//! the trait level: an external attachment can only be detached, while a
+//! managed or embedded backend can only be terminated.
+
+#![forbid(unsafe_code)]
+
+use std::{error::Error as StdError, fmt};
+
+use async_trait::async_trait;
+
+use crate::model::{BackendId, BackendKind, BackendObservation, BackendOwnership, BackendStatus};
+
+/// Immutable identity and lifecycle class captured by the registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendDescriptor {
+    id: BackendId,
+    kind: BackendKind,
+    ownership: BackendOwnership,
+}
+
+impl BackendDescriptor {
+    pub fn new(id: BackendId, kind: BackendKind, ownership: BackendOwnership) -> Self {
+        Self {
+            id,
+            kind,
+            ownership,
+        }
+    }
+
+    pub fn id(&self) -> &BackendId {
+        &self.id
+    }
+
+    pub fn kind(&self) -> &BackendKind {
+        &self.kind
+    }
+
+    pub fn ownership(&self) -> BackendOwnership {
+        self.ownership
+    }
+}
+
+/// Error returned by one backend lifecycle operation.
+///
+/// Only `code` and `public_message` may flow into API snapshots. The optional
+/// source is sensitive implementation context (for example raw CLI stderr) and
+/// is intentionally omitted from `Display`, `Debug`, and `Error::source`.
+pub struct BackendError {
+    code: String,
+    public_message: String,
+    sensitive_source: Option<Box<dyn StdError + Send + Sync + 'static>>,
+}
+
+impl BackendError {
+    pub fn new(code: impl Into<String>, public_message: impl Into<String>) -> Self {
+        Self {
+            code: sanitize_code(code.into()),
+            public_message: sanitize_public_message(public_message.into()),
+            sensitive_source: None,
+        }
+    }
+
+    pub fn with_sensitive_source<E>(mut self, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        self.sensitive_source = Some(Box::new(source));
+        self
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn public_message(&self) -> &str {
+        &self.public_message
+    }
+
+    pub(crate) fn cancelled(operation: &'static str) -> Self {
+        Self::new("operation_cancelled", format!("{operation} was cancelled"))
+    }
+
+    pub(crate) fn timed_out(operation: &'static str) -> Self {
+        Self::new(
+            "operation_timeout",
+            format!("{operation} exceeded its bounded deadline"),
+        )
+    }
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.public_message)
+    }
+}
+
+impl fmt::Debug for BackendError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackendError")
+            .field("code", &self.code)
+            .field("public_message", &self.public_message)
+            .field(
+                "sensitive_source",
+                &self.sensitive_source.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
+}
+
+impl StdError for BackendError {}
+
+pub type BackendResult<T> = Result<T, BackendError>;
+
+/// Provider-neutral observation and reconciliation operations.
+///
+/// [`Self::probe`] must not acquire a claimed host resource. The registry
+/// captures [`Self::descriptor`] exactly once and the supervisor never trusts
+/// later descriptor changes for identity, lookup, or release decisions.
+#[async_trait]
+pub trait NetworkBackend: Send + Sync + 'static {
+    fn descriptor(&self) -> BackendDescriptor;
+
+    async fn probe(&self) -> BackendResult<BackendObservation>;
+
+    /// Reconcile using the exact observation that passed conflict preflight.
+    ///
+    /// Reconcile may be cancelled or timed out. Implementations must therefore
+    /// tolerate a subsequent lifecycle release after partial startup.
+    async fn reconcile(&self, observation: &BackendObservation) -> BackendResult<BackendStatus>;
+
+    async fn status(&self) -> BackendResult<BackendStatus>;
+}
+
+/// Lifecycle capability for a user- or OS-owned external daemon.
+///
+/// There is no terminate operation on this trait, so a registry entry attached
+/// as external cannot accidentally stop, log out, or uninstall the daemon.
+/// Because detach cannot undo daemon-owned routes, DNS, or firewall state, an
+/// external adapter's resource claims are a conservative envelope for every
+/// state that daemon may enter while attached. The supervisor freezes that
+/// envelope at preflight and rejects later changes.
+#[async_trait]
+pub trait ExternalNetworkBackend: NetworkBackend {
+    /// Release only attachments owned by this process.
+    ///
+    /// This operation has at-least-once semantics: a timeout can make the
+    /// external result unknowable, so implementations must be idempotent and
+    /// safe to retry.
+    async fn detach(&self) -> BackendResult<()>;
+}
+
+/// Lifecycle capability for a managed child or embedded backend owned by this
+/// process.
+///
+/// There is no detach-only operation on this trait. The registry records
+/// whether the frozen descriptor is `ManagedChild` or `Embedded`.
+#[async_trait]
+pub trait OwnedNetworkBackend: NetworkBackend {
+    /// Terminate resources owned by this process.
+    ///
+    /// This operation has at-least-once semantics: a timeout can make the
+    /// external result unknowable, so implementations must be idempotent and
+    /// safe to retry.
+    async fn terminate(&self) -> BackendResult<()>;
+}
+
+fn sanitize_code(code: String) -> String {
+    let code = code.trim();
+    if code.is_empty()
+        || code.len() > 64
+        || !code
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+    {
+        "backend_error".to_owned()
+    } else {
+        code.to_owned()
+    }
+}
+
+fn sanitize_public_message(message: String) -> String {
+    const MAX_CHARS: usize = 512;
+
+    let mut sanitized = String::with_capacity(message.len().min(MAX_CHARS));
+    for character in message.chars().take(MAX_CHARS) {
+        if character.is_control() {
+            sanitized.push(' ');
+        } else {
+            sanitized.push(character);
+        }
+    }
+    let sanitized = sanitized.trim();
+    if sanitized.is_empty() {
+        "backend operation failed".to_owned()
+    } else {
+        sanitized.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn backend_error_debug_and_display_never_expose_sensitive_source() {
+        let secret = "token-super-secret";
+        let error = BackendError::new("auth_failed", "authentication failed")
+            .with_sensitive_source(io::Error::other(format!("raw stderr: {secret}")));
+
+        let rendered = format!("{error} {error:?}");
+        assert!(rendered.contains("auth_failed"));
+        assert!(rendered.contains("authentication failed"));
+        assert!(!rendered.contains(secret));
+        assert!(error.sensitive_source.is_some());
+    }
+
+    #[test]
+    fn public_error_fields_are_log_safe_and_bounded() {
+        let error = BackendError::new("bad\ncode", "first line\nforged line");
+        assert_eq!(error.code(), "backend_error");
+        assert_eq!(error.public_message(), "first line forged line");
+        assert!(error.public_message().len() <= 512);
+    }
+}

--- a/crates/core-mesh/src/conflict.rs
+++ b/crates/core-mesh/src/conflict.rs
@@ -1,0 +1,1217 @@
+//! Deterministic host-resource conflict detection.
+//!
+//! Claims are compared by resource semantics rather than enum equality: address
+//! and route prefixes overlap, wildcard listeners cover concrete addresses, and
+//! firewall mark ranges are inclusive. Only claims from different owners can
+//! conflict.
+
+#![forbid(unsafe_code)]
+
+use std::{
+    borrow::Borrow,
+    fmt,
+    net::{IpAddr, SocketAddr},
+};
+
+use ipnet::IpNet;
+use serde::{Deserialize, Serialize};
+
+use crate::model::{
+    ClaimMode, FwmarkRange, OwnedResourceClaim, PublicOwnedResourceClaim, PublicSocketTransport,
+    SocketTransport, SystemResource, public_custom_string,
+};
+
+/// A deterministic description of two incompatible resource claims.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ResourceConflict {
+    pub kind: ResourceConflictKind,
+    pub incompatibility: ClaimIncompatibility,
+    pub left: OwnedResourceClaim,
+    pub right: OwnedResourceClaim,
+}
+
+/// Resource-specific reason that two claims overlap.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum ResourceConflictKind {
+    Singleton {
+        resource: SingletonResource,
+    },
+    RouteManager {
+        managed_resource: RouteManagedResource,
+    },
+    FirewallManager {
+        range: FwmarkRange,
+    },
+    InterfaceManager {
+        name: String,
+    },
+    Interface {
+        name: String,
+    },
+    ListenSocket {
+        transport: SocketTransport,
+        left: SocketAddr,
+        right: SocketAddr,
+    },
+    AddressPrefix {
+        left: IpNet,
+        right: IpNet,
+    },
+    AddressRoutePrefix {
+        address_prefix: IpNet,
+        route_table: Option<u32>,
+        route_prefix: IpNet,
+    },
+    DefaultRoutePrefix {
+        family: SingletonResource,
+        route_table: Option<u32>,
+        route_prefix: IpNet,
+    },
+    RoutePrefix {
+        left_table: Option<u32>,
+        right_table: Option<u32>,
+        left: IpNet,
+        right: IpNet,
+    },
+    RouteTablePrefix {
+        table: u32,
+        route_prefix: IpNet,
+    },
+    RouteTable {
+        table: u32,
+    },
+    FwmarkRange {
+        left: FwmarkRange,
+        right: FwmarkRange,
+    },
+}
+
+/// Globally unique host facilities represented by singleton claims.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SingletonResource {
+    RouteManager,
+    DefaultRouteV4,
+    DefaultRouteV6,
+    DnsManager,
+    FirewallManager,
+    HostsDatabase,
+    InterfaceManager,
+}
+
+/// Route resource covered by the global route-manager claim.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum RouteManagedResource {
+    DefaultRouteV4,
+    DefaultRouteV6,
+    RoutePrefix { table: Option<u32>, prefix: IpNet },
+    RouteTable { table: u32 },
+}
+
+/// Why coordination modes do not permit an overlapping pair to coexist.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum ClaimIncompatibility {
+    /// At least one claim requests exclusive ownership.
+    Exclusive,
+    /// At least one coordinated claim has an empty or whitespace-only key.
+    MissingCoordinationKey,
+    /// Both claims are coordinated, but their normalized keys differ.
+    ///
+    /// The values themselves are deliberately not retained because coordination
+    /// keys may be credentials or other provider-sensitive material.
+    CoordinationKeyMismatch,
+}
+
+impl fmt::Debug for ClaimIncompatibility {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Exclusive => "Exclusive",
+            Self::MissingCoordinationKey => "MissingCoordinationKey",
+            Self::CoordinationKeyMismatch => "CoordinationKeyMismatch",
+        })
+    }
+}
+
+/// Redacted conflict projection suitable for the public mesh API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicResourceConflict {
+    pub kind: PublicResourceConflictKind,
+    pub incompatibility: PublicClaimIncompatibility,
+    pub left: PublicOwnedResourceClaim,
+    pub right: PublicOwnedResourceClaim,
+}
+
+impl From<&ResourceConflict> for PublicResourceConflict {
+    fn from(value: &ResourceConflict) -> Self {
+        Self {
+            kind: (&value.kind).into(),
+            incompatibility: (&value.incompatibility).into(),
+            left: (&value.left).into(),
+            right: (&value.right).into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum PublicResourceConflictKind {
+    Singleton {
+        resource: PublicSingletonResource,
+    },
+    RouteManager {
+        managed_resource: PublicRouteManagedResource,
+    },
+    FirewallManager {
+        range: FwmarkRange,
+    },
+    InterfaceManager {
+        name: String,
+    },
+    Interface {
+        name: String,
+    },
+    ListenSocket {
+        transport: PublicSocketTransport,
+        left: SocketAddr,
+        right: SocketAddr,
+    },
+    AddressPrefix {
+        left: IpNet,
+        right: IpNet,
+    },
+    AddressRoutePrefix {
+        address_prefix: IpNet,
+        route_table: Option<u32>,
+        route_prefix: IpNet,
+    },
+    DefaultRoutePrefix {
+        family: PublicSingletonResource,
+        route_table: Option<u32>,
+        route_prefix: IpNet,
+    },
+    RoutePrefix {
+        left_table: Option<u32>,
+        right_table: Option<u32>,
+        left: IpNet,
+        right: IpNet,
+    },
+    RouteTablePrefix {
+        table: u32,
+        route_prefix: IpNet,
+    },
+    RouteTable {
+        table: u32,
+    },
+    FwmarkRange {
+        left: FwmarkRange,
+        right: FwmarkRange,
+    },
+}
+
+impl From<&ResourceConflictKind> for PublicResourceConflictKind {
+    fn from(value: &ResourceConflictKind) -> Self {
+        match value {
+            ResourceConflictKind::Singleton { resource } => Self::Singleton {
+                resource: (*resource).into(),
+            },
+            ResourceConflictKind::RouteManager { managed_resource } => Self::RouteManager {
+                managed_resource: managed_resource.into(),
+            },
+            ResourceConflictKind::FirewallManager { range } => {
+                Self::FirewallManager { range: *range }
+            }
+            ResourceConflictKind::InterfaceManager { name } => Self::InterfaceManager {
+                name: public_custom_string(name),
+            },
+            ResourceConflictKind::Interface { name } => Self::Interface {
+                name: public_custom_string(name),
+            },
+            ResourceConflictKind::ListenSocket {
+                transport,
+                left,
+                right,
+            } => Self::ListenSocket {
+                transport: transport.into(),
+                left: *left,
+                right: *right,
+            },
+            ResourceConflictKind::AddressPrefix { left, right } => Self::AddressPrefix {
+                left: *left,
+                right: *right,
+            },
+            ResourceConflictKind::AddressRoutePrefix {
+                address_prefix,
+                route_table,
+                route_prefix,
+            } => Self::AddressRoutePrefix {
+                address_prefix: *address_prefix,
+                route_table: *route_table,
+                route_prefix: *route_prefix,
+            },
+            ResourceConflictKind::DefaultRoutePrefix {
+                family,
+                route_table,
+                route_prefix,
+            } => Self::DefaultRoutePrefix {
+                family: (*family).into(),
+                route_table: *route_table,
+                route_prefix: *route_prefix,
+            },
+            ResourceConflictKind::RoutePrefix {
+                left_table,
+                right_table,
+                left,
+                right,
+            } => Self::RoutePrefix {
+                left_table: *left_table,
+                right_table: *right_table,
+                left: *left,
+                right: *right,
+            },
+            ResourceConflictKind::RouteTablePrefix {
+                table,
+                route_prefix,
+            } => Self::RouteTablePrefix {
+                table: *table,
+                route_prefix: *route_prefix,
+            },
+            ResourceConflictKind::RouteTable { table } => Self::RouteTable { table: *table },
+            ResourceConflictKind::FwmarkRange { left, right } => Self::FwmarkRange {
+                left: *left,
+                right: *right,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicSingletonResource {
+    RouteManager,
+    DefaultRouteV4,
+    DefaultRouteV6,
+    DnsManager,
+    FirewallManager,
+    HostsDatabase,
+    InterfaceManager,
+}
+
+impl From<SingletonResource> for PublicSingletonResource {
+    fn from(value: SingletonResource) -> Self {
+        match value {
+            SingletonResource::RouteManager => Self::RouteManager,
+            SingletonResource::DefaultRouteV4 => Self::DefaultRouteV4,
+            SingletonResource::DefaultRouteV6 => Self::DefaultRouteV6,
+            SingletonResource::DnsManager => Self::DnsManager,
+            SingletonResource::FirewallManager => Self::FirewallManager,
+            SingletonResource::HostsDatabase => Self::HostsDatabase,
+            SingletonResource::InterfaceManager => Self::InterfaceManager,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum PublicRouteManagedResource {
+    DefaultRouteV4,
+    DefaultRouteV6,
+    RoutePrefix { table: Option<u32>, prefix: IpNet },
+    RouteTable { table: u32 },
+}
+
+impl From<&RouteManagedResource> for PublicRouteManagedResource {
+    fn from(value: &RouteManagedResource) -> Self {
+        match value {
+            RouteManagedResource::DefaultRouteV4 => Self::DefaultRouteV4,
+            RouteManagedResource::DefaultRouteV6 => Self::DefaultRouteV6,
+            RouteManagedResource::RoutePrefix { table, prefix } => Self::RoutePrefix {
+                table: *table,
+                prefix: *prefix,
+            },
+            RouteManagedResource::RouteTable { table } => Self::RouteTable { table: *table },
+        }
+    }
+}
+
+/// Public incompatibility reason. Coordination keys are deliberately omitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PublicClaimIncompatibility {
+    Exclusive,
+    MissingCoordination,
+    CoordinationMismatch,
+}
+
+impl From<&ClaimIncompatibility> for PublicClaimIncompatibility {
+    fn from(value: &ClaimIncompatibility) -> Self {
+        match value {
+            ClaimIncompatibility::Exclusive => Self::Exclusive,
+            ClaimIncompatibility::MissingCoordinationKey => Self::MissingCoordination,
+            ClaimIncompatibility::CoordinationKeyMismatch => Self::CoordinationMismatch,
+        }
+    }
+}
+
+/// Detect all conflicts between claims from distinct owners.
+///
+/// Input order and duplicate claims do not affect the result. Overlapping
+/// coordinated claims coexist only when both use the same non-empty key.
+pub fn detect_conflicts<I, C>(claims: I) -> Vec<ResourceConflict>
+where
+    I: IntoIterator<Item = C>,
+    C: Borrow<OwnedResourceClaim>,
+{
+    let mut claims: Vec<_> = claims
+        .into_iter()
+        .map(|claim| claim.borrow().clone())
+        .collect();
+    claims.sort();
+    claims.dedup();
+
+    let mut conflicts = Vec::new();
+    for left_index in 0..claims.len() {
+        for right_index in (left_index + 1)..claims.len() {
+            let left = &claims[left_index];
+            let right = &claims[right_index];
+            if left.owner == right.owner {
+                continue;
+            }
+
+            let Some(kind) = overlapping_kind(&left.claim.resource, &right.claim.resource) else {
+                continue;
+            };
+            let Some(incompatibility) = claim_incompatibility(&left.claim.mode, &right.claim.mode)
+            else {
+                continue;
+            };
+
+            conflicts.push(ResourceConflict {
+                kind,
+                incompatibility,
+                left: left.clone(),
+                right: right.clone(),
+            });
+        }
+    }
+
+    conflicts.sort();
+    conflicts.dedup();
+    conflicts
+}
+
+fn claim_incompatibility(left: &ClaimMode, right: &ClaimMode) -> Option<ClaimIncompatibility> {
+    match (left, right) {
+        (ClaimMode::Exclusive, _) | (_, ClaimMode::Exclusive) => {
+            Some(ClaimIncompatibility::Exclusive)
+        }
+        (
+            ClaimMode::CoordinatedShared {
+                coordination_key: left,
+            },
+            ClaimMode::CoordinatedShared {
+                coordination_key: right,
+            },
+        ) => {
+            let left = left.trim();
+            let right = right.trim();
+            if left.is_empty() || right.is_empty() {
+                Some(ClaimIncompatibility::MissingCoordinationKey)
+            } else if left == right {
+                None
+            } else {
+                Some(ClaimIncompatibility::CoordinationKeyMismatch)
+            }
+        }
+    }
+}
+
+fn overlapping_kind(left: &SystemResource, right: &SystemResource) -> Option<ResourceConflictKind> {
+    use SystemResource::{
+        AddressPrefix, DefaultRouteV4, DefaultRouteV6, DnsManager, FirewallManager, FwmarkRange,
+        HostsDatabase, Interface, InterfaceManager, ListenSocket, RouteManager, RoutePrefix,
+        RouteTable,
+    };
+
+    match (left, right) {
+        (RouteManager, RouteManager) => Some(singleton(SingletonResource::RouteManager)),
+        (RouteManager, DefaultRouteV4) | (DefaultRouteV4, RouteManager) => {
+            Some(ResourceConflictKind::RouteManager {
+                managed_resource: RouteManagedResource::DefaultRouteV4,
+            })
+        }
+        (RouteManager, DefaultRouteV6) | (DefaultRouteV6, RouteManager) => {
+            Some(ResourceConflictKind::RouteManager {
+                managed_resource: RouteManagedResource::DefaultRouteV6,
+            })
+        }
+        (RouteManager, RoutePrefix { table, prefix })
+        | (RoutePrefix { table, prefix }, RouteManager) => {
+            Some(ResourceConflictKind::RouteManager {
+                managed_resource: RouteManagedResource::RoutePrefix {
+                    table: *table,
+                    prefix: *prefix,
+                },
+            })
+        }
+        (RouteManager, RouteTable { table }) | (RouteTable { table }, RouteManager) => {
+            Some(ResourceConflictKind::RouteManager {
+                managed_resource: RouteManagedResource::RouteTable { table: *table },
+            })
+        }
+        (DefaultRouteV4, DefaultRouteV4) => Some(singleton(SingletonResource::DefaultRouteV4)),
+        (DefaultRouteV6, DefaultRouteV6) => Some(singleton(SingletonResource::DefaultRouteV6)),
+        (DefaultRouteV4, RoutePrefix { table, prefix })
+        | (RoutePrefix { table, prefix }, DefaultRouteV4)
+            if prefix.addr().is_ipv4() && prefix.prefix_len() == 0 =>
+        {
+            Some(ResourceConflictKind::DefaultRoutePrefix {
+                family: SingletonResource::DefaultRouteV4,
+                route_table: *table,
+                route_prefix: *prefix,
+            })
+        }
+        (DefaultRouteV6, RoutePrefix { table, prefix })
+        | (RoutePrefix { table, prefix }, DefaultRouteV6)
+            if prefix.addr().is_ipv6() && prefix.prefix_len() == 0 =>
+        {
+            Some(ResourceConflictKind::DefaultRoutePrefix {
+                family: SingletonResource::DefaultRouteV6,
+                route_table: *table,
+                route_prefix: *prefix,
+            })
+        }
+        (DnsManager, DnsManager) => Some(singleton(SingletonResource::DnsManager)),
+        (FirewallManager, FirewallManager) => Some(singleton(SingletonResource::FirewallManager)),
+        (FirewallManager, FwmarkRange { range }) | (FwmarkRange { range }, FirewallManager) => {
+            Some(ResourceConflictKind::FirewallManager { range: *range })
+        }
+        (HostsDatabase, HostsDatabase) => Some(singleton(SingletonResource::HostsDatabase)),
+        (InterfaceManager, InterfaceManager) => {
+            Some(singleton(SingletonResource::InterfaceManager))
+        }
+        (InterfaceManager, Interface { name }) | (Interface { name }, InterfaceManager) => {
+            Some(ResourceConflictKind::InterfaceManager { name: name.clone() })
+        }
+        (Interface { name: left }, Interface { name: right }) if left == right => {
+            Some(ResourceConflictKind::Interface { name: left.clone() })
+        }
+        (
+            ListenSocket {
+                transport: left_transport,
+                address: left_address,
+            },
+            ListenSocket {
+                transport: right_transport,
+                address: right_address,
+            },
+        ) if left_transport == right_transport
+            && listeners_overlap(*left_address, *right_address) =>
+        {
+            Some(ResourceConflictKind::ListenSocket {
+                transport: left_transport.clone(),
+                left: *left_address,
+                right: *right_address,
+            })
+        }
+        (
+            AddressPrefix {
+                prefix: left_prefix,
+            },
+            AddressPrefix {
+                prefix: right_prefix,
+            },
+        ) if prefixes_overlap(left_prefix, right_prefix) => {
+            Some(ResourceConflictKind::AddressPrefix {
+                left: *left_prefix,
+                right: *right_prefix,
+            })
+        }
+        (
+            AddressPrefix {
+                prefix: address_prefix,
+            },
+            RoutePrefix {
+                table,
+                prefix: route_prefix,
+            },
+        )
+        | (
+            RoutePrefix {
+                table,
+                prefix: route_prefix,
+            },
+            AddressPrefix {
+                prefix: address_prefix,
+            },
+        ) if prefixes_overlap(address_prefix, route_prefix) => {
+            Some(ResourceConflictKind::AddressRoutePrefix {
+                address_prefix: *address_prefix,
+                route_table: *table,
+                route_prefix: *route_prefix,
+            })
+        }
+        (
+            RoutePrefix {
+                table: left_table,
+                prefix: left_prefix,
+            },
+            RoutePrefix {
+                table: right_table,
+                prefix: right_prefix,
+            },
+        ) if route_tables_overlap(*left_table, *right_table)
+            && prefixes_overlap(left_prefix, right_prefix) =>
+        {
+            Some(ResourceConflictKind::RoutePrefix {
+                left_table: *left_table,
+                right_table: *right_table,
+                left: *left_prefix,
+                right: *right_prefix,
+            })
+        }
+        (RouteTable { table: left }, RouteTable { table: right }) if left == right => {
+            Some(ResourceConflictKind::RouteTable { table: *left })
+        }
+        (
+            RouteTable { table },
+            RoutePrefix {
+                table: route_table,
+                prefix,
+            },
+        )
+        | (
+            RoutePrefix {
+                table: route_table,
+                prefix,
+            },
+            RouteTable { table },
+        ) if route_table.is_none() || route_table == &Some(*table) => {
+            Some(ResourceConflictKind::RouteTablePrefix {
+                table: *table,
+                route_prefix: *prefix,
+            })
+        }
+        (FwmarkRange { range: left }, FwmarkRange { range: right }) if left.overlaps(*right) => {
+            Some(ResourceConflictKind::FwmarkRange {
+                left: *left,
+                right: *right,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn singleton(resource: SingletonResource) -> ResourceConflictKind {
+    ResourceConflictKind::Singleton { resource }
+}
+
+fn listeners_overlap(left: SocketAddr, right: SocketAddr) -> bool {
+    if left.port() != right.port() {
+        return false;
+    }
+
+    let left = normalized_listener_ip(left.ip());
+    let right = normalized_listener_ip(right.ip());
+
+    if left.is_ipv4() == right.is_ipv4() {
+        return left == right || left.is_unspecified() || right.is_unspecified();
+    }
+
+    // An unspecified IPv6 bind commonly accepts IPv4 through dual-stack
+    // sockets. Treat it conservatively unless the eventual platform adapter
+    // can prove IPV6_V6ONLY is enabled.
+    (left.is_ipv6() && left.is_unspecified()) || (right.is_ipv6() && right.is_unspecified())
+}
+
+fn normalized_listener_ip(address: IpAddr) -> IpAddr {
+    match address {
+        IpAddr::V6(address) => address
+            .to_ipv4_mapped()
+            .map_or(IpAddr::V6(address), IpAddr::V4),
+        address => address,
+    }
+}
+
+fn route_tables_overlap(left: Option<u32>, right: Option<u32>) -> bool {
+    left == right || left.is_none() || right.is_none()
+}
+
+fn prefixes_overlap(left: &IpNet, right: &IpNet) -> bool {
+    match (left, right) {
+        (IpNet::V4(left), IpNet::V4(right)) => {
+            left.contains(&right.network()) || right.contains(&left.network())
+        }
+        (IpNet::V6(left), IpNet::V6(right)) => {
+            left.contains(&right.network()) || right.contains(&left.network())
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use super::*;
+    use crate::model::{BackendId, ResourceClaim};
+
+    fn id(value: &str) -> BackendId {
+        BackendId::new(value).unwrap()
+    }
+
+    fn exclusive(owner: &str, resource: SystemResource) -> OwnedResourceClaim {
+        OwnedResourceClaim::backend(id(owner), ResourceClaim::exclusive(resource))
+    }
+
+    fn coordinated(owner: &str, resource: SystemResource, key: &str) -> OwnedResourceClaim {
+        OwnedResourceClaim::backend(
+            id(owner),
+            ResourceClaim {
+                resource,
+                mode: ClaimMode::CoordinatedShared {
+                    coordination_key: key.to_owned(),
+                },
+            },
+        )
+    }
+
+    fn prefix(value: &str) -> IpNet {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn singleton_claims_conflict_only_between_different_owners() {
+        let first = exclusive("alpha", SystemResource::DnsManager);
+        let duplicate = first.clone();
+        assert!(detect_conflicts([first, duplicate]).is_empty());
+
+        let conflicts = detect_conflicts([
+            exclusive("alpha", SystemResource::DnsManager),
+            exclusive("beta", SystemResource::DnsManager),
+        ]);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0].kind,
+            ResourceConflictKind::Singleton {
+                resource: SingletonResource::DnsManager
+            }
+        );
+    }
+
+    #[test]
+    fn interface_name_is_an_exact_host_resource() {
+        let conflicts = detect_conflicts([
+            exclusive(
+                "alpha",
+                SystemResource::Interface {
+                    name: "mesh0".to_owned(),
+                },
+            ),
+            exclusive(
+                "beta",
+                SystemResource::Interface {
+                    name: "mesh0".to_owned(),
+                },
+            ),
+            exclusive(
+                "gamma",
+                SystemResource::Interface {
+                    name: "mesh1".to_owned(),
+                },
+            ),
+        ]);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0].kind,
+            ResourceConflictKind::Interface {
+                name: "mesh0".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn interface_manager_conflicts_with_managers_and_every_exact_interface() {
+        let conflicts = detect_conflicts([
+            exclusive("manager-alpha", SystemResource::InterfaceManager),
+            exclusive("manager-beta", SystemResource::InterfaceManager),
+            exclusive(
+                "exact-mesh0",
+                SystemResource::Interface {
+                    name: "mesh0".to_owned(),
+                },
+            ),
+            exclusive(
+                "exact-mesh1",
+                SystemResource::Interface {
+                    name: "mesh1".to_owned(),
+                },
+            ),
+        ]);
+
+        assert_eq!(conflicts.len(), 5);
+        assert_eq!(
+            conflicts
+                .iter()
+                .filter(|conflict| matches!(
+                    conflict.kind,
+                    ResourceConflictKind::Singleton {
+                        resource: SingletonResource::InterfaceManager
+                    }
+                ))
+                .count(),
+            1
+        );
+
+        let mut managed_names = conflicts
+            .iter()
+            .filter_map(|conflict| match &conflict.kind {
+                ResourceConflictKind::InterfaceManager { name } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        managed_names.sort_unstable();
+        assert_eq!(managed_names, ["mesh0", "mesh0", "mesh1", "mesh1"]);
+
+        let public = conflicts
+            .iter()
+            .map(PublicResourceConflict::from)
+            .collect::<Vec<_>>();
+        assert!(public.iter().any(|conflict| matches!(
+            conflict.kind,
+            PublicResourceConflictKind::Singleton {
+                resource: PublicSingletonResource::InterfaceManager
+            }
+        )));
+        assert!(public.iter().any(|conflict| matches!(
+            &conflict.kind,
+            PublicResourceConflictKind::InterfaceManager { name } if name == "mesh0"
+        )));
+    }
+
+    #[test]
+    fn wildcard_listeners_overlap_concrete_and_dual_stack_addresses() {
+        let listen = |owner: &str, transport: SocketTransport, address: &str| {
+            exclusive(
+                owner,
+                SystemResource::ListenSocket {
+                    transport,
+                    address: address.parse().unwrap(),
+                },
+            )
+        };
+
+        let conflicts = detect_conflicts([
+            listen("wildcard", SocketTransport::Tcp, "0.0.0.0:8080"),
+            listen("loopback", SocketTransport::Tcp, "127.0.0.1:8080"),
+            listen("other-ip", SocketTransport::Tcp, "192.0.2.1:8080"),
+            listen("udp", SocketTransport::Udp, "0.0.0.0:8080"),
+            listen("ipv6", SocketTransport::Tcp, "[::]:8080"),
+        ]);
+
+        assert_eq!(conflicts.len(), 5);
+        assert!(conflicts.iter().all(|conflict| matches!(
+            conflict.kind,
+            ResourceConflictKind::ListenSocket {
+                transport: SocketTransport::Tcp,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn ipv4_mapped_ipv6_listeners_share_the_ipv4_binding_namespace() {
+        let address = |value: &str| value.parse::<SocketAddr>().unwrap();
+
+        let mapped_loopback = address("[::ffff:127.0.0.1]:8080");
+        let mapped_unspecified = address("[::ffff:0.0.0.0]:8080");
+
+        assert!(listeners_overlap(
+            mapped_loopback,
+            address("127.0.0.1:8080")
+        ));
+        assert!(listeners_overlap(mapped_loopback, address("0.0.0.0:8080")));
+        assert!(listeners_overlap(mapped_loopback, address("[::]:8080")));
+        assert!(listeners_overlap(
+            mapped_unspecified,
+            address("192.0.2.1:8080")
+        ));
+        assert!(listeners_overlap(
+            mapped_unspecified,
+            address("[::ffff:192.0.2.1]:8080")
+        ));
+
+        assert!(!listeners_overlap(
+            mapped_loopback,
+            address("192.0.2.1:8080")
+        ));
+        assert!(!listeners_overlap(
+            mapped_loopback,
+            address("[2001:db8::1]:8080")
+        ));
+    }
+
+    #[test]
+    fn listener_overlap_preserves_port_transport_and_precise_ipv6_boundaries() {
+        let address = |value: &str| value.parse::<SocketAddr>().unwrap();
+
+        assert!(!listeners_overlap(
+            address("[::ffff:127.0.0.1]:8080"),
+            address("127.0.0.1:8081")
+        ));
+        assert!(listeners_overlap(
+            address("[2001:db8::1]:8080"),
+            address("[2001:db8::1]:8080")
+        ));
+        assert!(!listeners_overlap(
+            address("[2001:db8::1]:8080"),
+            address("[2001:db8::2]:8080")
+        ));
+        assert!(!listeners_overlap(
+            address("[2001:db8::1]:8080"),
+            address("0.0.0.0:8080")
+        ));
+
+        let conflicts = detect_conflicts([
+            exclusive(
+                "mapped-tcp",
+                SystemResource::ListenSocket {
+                    transport: SocketTransport::Tcp,
+                    address: address("[::ffff:127.0.0.1]:8080"),
+                },
+            ),
+            exclusive(
+                "native-udp",
+                SystemResource::ListenSocket {
+                    transport: SocketTransport::Udp,
+                    address: address("127.0.0.1:8080"),
+                },
+            ),
+            exclusive(
+                "native-other-port",
+                SystemResource::ListenSocket {
+                    transport: SocketTransport::Tcp,
+                    address: address("127.0.0.1:8081"),
+                },
+            ),
+        ]);
+
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn cloudflare_address_prefix_overlaps_tailscale_route_prefix() {
+        let conflicts = detect_conflicts([
+            exclusive(
+                "cloudflare",
+                SystemResource::AddressPrefix {
+                    prefix: prefix("100.96.0.0/12"),
+                },
+            ),
+            exclusive(
+                "tailscale",
+                SystemResource::RoutePrefix {
+                    table: Some(52),
+                    prefix: prefix("100.64.0.0/10"),
+                },
+            ),
+        ]);
+
+        assert_eq!(conflicts.len(), 1);
+        assert!(matches!(
+            conflicts[0].kind,
+            ResourceConflictKind::AddressRoutePrefix { .. }
+        ));
+    }
+
+    #[test]
+    fn route_manager_conflicts_with_managed_route_resources() {
+        let conflicts = detect_conflicts([
+            exclusive("manager", SystemResource::RouteManager),
+            exclusive("default", SystemResource::DefaultRouteV4),
+            exclusive(
+                "prefix",
+                SystemResource::RoutePrefix {
+                    table: Some(100),
+                    prefix: prefix("10.0.0.0/8"),
+                },
+            ),
+            exclusive("table", SystemResource::RouteTable { table: 254 }),
+        ]);
+
+        assert_eq!(conflicts.len(), 3);
+        assert!(
+            conflicts
+                .iter()
+                .all(|conflict| matches!(conflict.kind, ResourceConflictKind::RouteManager { .. }))
+        );
+    }
+
+    #[test]
+    fn default_routes_and_reserved_tables_conflict_with_equivalent_route_prefixes() {
+        let conflicts = detect_conflicts([
+            exclusive("default-v4", SystemResource::DefaultRouteV4),
+            exclusive("default-v6", SystemResource::DefaultRouteV6),
+            exclusive("table", SystemResource::RouteTable { table: 100 }),
+            exclusive(
+                "route-v4",
+                SystemResource::RoutePrefix {
+                    table: Some(100),
+                    prefix: prefix("0.0.0.0/0"),
+                },
+            ),
+            exclusive(
+                "route-v6",
+                SystemResource::RoutePrefix {
+                    table: Some(200),
+                    prefix: prefix("::/0"),
+                },
+            ),
+        ]);
+
+        assert_eq!(conflicts.len(), 3);
+        assert_eq!(
+            conflicts
+                .iter()
+                .filter(|conflict| matches!(
+                    conflict.kind,
+                    ResourceConflictKind::DefaultRoutePrefix { .. }
+                ))
+                .count(),
+            2
+        );
+        assert!(conflicts.iter().any(|conflict| matches!(
+            conflict.kind,
+            ResourceConflictKind::RouteTablePrefix { table: 100, .. }
+        )));
+    }
+
+    #[test]
+    fn firewall_manager_conflicts_with_fwmark_unless_coordinated() {
+        let range = FwmarkRange::new(0x100, 0x1ff).unwrap();
+        assert_eq!(
+            detect_conflicts([
+                exclusive("manager", SystemResource::FirewallManager),
+                exclusive("marker", SystemResource::FwmarkRange { range }),
+            ])
+            .len(),
+            1
+        );
+
+        assert!(
+            detect_conflicts([
+                coordinated("manager", SystemResource::FirewallManager, "shared-fw"),
+                coordinated("marker", SystemResource::FwmarkRange { range }, "shared-fw",),
+            ])
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn ipv6_prefixes_overlap_but_address_families_do_not() {
+        let ipv6 = detect_conflicts([
+            exclusive(
+                "alpha",
+                SystemResource::AddressPrefix {
+                    prefix: prefix("fd00::/8"),
+                },
+            ),
+            exclusive(
+                "beta",
+                SystemResource::AddressPrefix {
+                    prefix: prefix("fd12:3456::/32"),
+                },
+            ),
+        ]);
+        assert_eq!(ipv6.len(), 1);
+
+        let mixed = detect_conflicts([
+            exclusive(
+                "alpha",
+                SystemResource::AddressPrefix {
+                    prefix: prefix("0.0.0.0/0"),
+                },
+            ),
+            exclusive(
+                "beta",
+                SystemResource::AddressPrefix {
+                    prefix: prefix("::/0"),
+                },
+            ),
+        ]);
+        assert!(mixed.is_empty());
+    }
+
+    #[test]
+    fn route_prefixes_require_overlapping_table_scopes() {
+        let route = |owner: &str, table: Option<u32>, value: &str| {
+            exclusive(
+                owner,
+                SystemResource::RoutePrefix {
+                    table,
+                    prefix: prefix(value),
+                },
+            )
+        };
+
+        assert!(
+            detect_conflicts([
+                route("alpha", Some(100), "10.0.0.0/8"),
+                route("beta", Some(200), "10.1.0.0/16"),
+            ])
+            .is_empty()
+        );
+        assert_eq!(
+            detect_conflicts([
+                route("alpha", None, "10.0.0.0/8"),
+                route("beta", Some(200), "10.1.0.0/16"),
+            ])
+            .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn route_table_and_fwmark_ranges_detect_exact_and_boundary_overlap() {
+        assert_eq!(
+            detect_conflicts([
+                exclusive("alpha", SystemResource::RouteTable { table: 51820 }),
+                exclusive("beta", SystemResource::RouteTable { table: 51820 }),
+            ])
+            .len(),
+            1
+        );
+
+        let range = |owner: &str, start: u32, end: u32| {
+            exclusive(
+                owner,
+                SystemResource::FwmarkRange {
+                    range: FwmarkRange::new(start, end).unwrap(),
+                },
+            )
+        };
+        assert_eq!(
+            detect_conflicts([
+                range("alpha", 0x100, 0x1ff),
+                range("beta", 0x1ff, 0x2ff),
+                range("gamma", 0x300, 0x3ff),
+            ])
+            .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn only_matching_non_empty_coordination_keys_can_share() {
+        assert!(
+            detect_conflicts([
+                coordinated("alpha", SystemResource::FirewallManager, "mesh-fw"),
+                coordinated("beta", SystemResource::FirewallManager, " mesh-fw "),
+            ])
+            .is_empty()
+        );
+
+        let mismatched = detect_conflicts([
+            coordinated("alpha", SystemResource::FirewallManager, "alpha-key"),
+            coordinated("beta", SystemResource::FirewallManager, "beta-key"),
+        ]);
+        assert_eq!(
+            mismatched[0].incompatibility,
+            ClaimIncompatibility::CoordinationKeyMismatch
+        );
+
+        let missing = detect_conflicts([
+            coordinated("alpha", SystemResource::FirewallManager, " "),
+            coordinated("beta", SystemResource::FirewallManager, "mesh-fw"),
+        ]);
+        assert_eq!(
+            missing[0].incompatibility,
+            ClaimIncompatibility::MissingCoordinationKey
+        );
+    }
+
+    #[test]
+    fn coordination_key_mismatch_debug_is_redacted() {
+        let left_secret = "left-secret-coordination-key";
+        let right_secret = "right-secret-coordination-key";
+        let conflicts = detect_conflicts([
+            coordinated("alpha", SystemResource::FirewallManager, left_secret),
+            coordinated("beta", SystemResource::FirewallManager, right_secret),
+        ]);
+        let incompatibility = &conflicts[0].incompatibility;
+
+        let debug = format!("{incompatibility:?}");
+        assert_eq!(debug, "CoordinationKeyMismatch");
+        assert!(!debug.contains(left_secret));
+        assert!(!debug.contains(right_secret));
+
+        let serialized = serde_json::to_string(incompatibility).unwrap();
+        assert!(!serialized.contains(left_secret));
+        assert!(!serialized.contains(right_secret));
+    }
+
+    #[test]
+    fn conflict_output_is_stably_sorted_and_input_order_independent() {
+        let mut claims = vec![
+            exclusive("zeta", SystemResource::DnsManager),
+            exclusive("alpha", SystemResource::DnsManager),
+            exclusive(
+                "middle",
+                SystemResource::ListenSocket {
+                    transport: SocketTransport::Tcp,
+                    address: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 443),
+                },
+            ),
+            exclusive(
+                "beta",
+                SystemResource::ListenSocket {
+                    transport: SocketTransport::Tcp,
+                    address: "127.0.0.1:443".parse().unwrap(),
+                },
+            ),
+        ];
+
+        let expected = detect_conflicts(&claims);
+        claims.reverse();
+        let actual = detect_conflicts(claims);
+
+        assert_eq!(actual, expected);
+        assert_eq!(actual.len(), 2);
+        assert!(actual.windows(2).all(|pair| pair[0] <= pair[1]));
+        assert!(
+            actual
+                .iter()
+                .all(|conflict| conflict.left.owner != conflict.right.owner)
+        );
+    }
+
+    #[test]
+    fn public_conflict_never_exposes_coordination_keys() {
+        let conflict = detect_conflicts([
+            coordinated(
+                "alpha",
+                SystemResource::FirewallManager,
+                "alpha-coordination-secret",
+            ),
+            coordinated(
+                "beta",
+                SystemResource::FirewallManager,
+                "beta-coordination-secret",
+            ),
+        ])
+        .remove(0);
+
+        let public = PublicResourceConflict::from(&conflict);
+        assert_eq!(
+            public.incompatibility,
+            PublicClaimIncompatibility::CoordinationMismatch
+        );
+        let serialized = serde_json::to_string(&public).unwrap();
+        assert!(!serialized.contains("alpha-coordination-secret"));
+        assert!(!serialized.contains("beta-coordination-secret"));
+        assert!(!serialized.contains("coordination_key"));
+        assert!(serialized.contains("coordination_mismatch"));
+    }
+}

--- a/crates/core-mesh/src/lib.rs
+++ b/crates/core-mesh/src/lib.rs
@@ -1,8 +1,9 @@
-//! core-mesh —— Tailscale / WireGuard / 局域网协同。
+//! core-mesh —— 跨后端组网能力、资源仲裁与生命周期监督。
 //!
-//! §9：默认排除 100.64.0.0/10、fd7a:115c:a1e0::/48；
-//! Tailnet 目标默认 direct，不进入 Smart。
-//! MVP：检测本机是否存在 tailscaled / userspace proxy，并产出诊断。
+//! 所有具体组网实现都通过 [`NetworkBackend`] 接入，并在修改系统路由、DNS、
+//! 防火墙、接口或监听端口前，由 [`MeshSupervisor`] 统一检查资源声明。这样既能
+//! 安全附着用户自行管理的系统服务，也能对 WutherCore 创建的子进程做事务启动、
+//! 失败回滚和逆序关闭。
 
 #![forbid(unsafe_code)]
 
@@ -10,6 +11,28 @@ use core_config::model::{Mesh, TailscaleMode};
 use ipnet::IpNet;
 use once_cell::sync::Lazy;
 use tracing::info;
+
+pub mod backend;
+pub mod conflict;
+pub mod model;
+pub mod process;
+pub mod registry;
+pub mod supervisor;
+
+pub use backend::{
+    BackendDescriptor, BackendError, BackendResult, ExternalNetworkBackend, NetworkBackend,
+    OwnedNetworkBackend,
+};
+pub use conflict::{
+    PublicClaimIncompatibility, PublicResourceConflict, PublicResourceConflictKind,
+    PublicRouteManagedResource, PublicSingletonResource, ResourceConflict, detect_conflicts,
+};
+pub use model::*;
+pub use process::*;
+pub use registry::{BackendRegistry, RegistryError};
+pub use supervisor::{
+    BackendCallTimeouts, BackendFailure, MeshError, MeshSupervisor, SupervisorOptions,
+};
 
 pub static TAILNET_CIDRS: Lazy<Vec<IpNet>> = Lazy::new(|| {
     ["100.64.0.0/10", "fd7a:115c:a1e0::/48"]

--- a/crates/core-mesh/src/model.rs
+++ b/crates/core-mesh/src/model.rs
@@ -1,0 +1,1477 @@
+//! Provider-neutral mesh backend model.
+//!
+//! These types deliberately separate backend capabilities, observed data-plane
+//! attachments, and claimed host resources. A backend can therefore expose only
+//! what it actually supports without pretending every mesh product is an L3 VPN.
+
+#![forbid(unsafe_code)]
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    net::SocketAddr,
+    path::PathBuf,
+    str::FromStr,
+};
+
+use ipnet::IpNet;
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use url::Url;
+
+/// Stable, user-visible identity of a configured mesh backend.
+///
+/// Leading and trailing whitespace is removed at construction time. IDs are
+/// limited to 128 bytes and the conservative ASCII set commonly used by
+/// adapters (`A-Z`, `a-z`, `0-9`, `/`, `.`, `_`, `:`, and `-`). This keeps IDs
+/// safe for structured logs, diagnostics, and serialized map keys.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+pub struct BackendId(String);
+
+impl BackendId {
+    pub const MAX_BYTES: usize = 128;
+
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidBackendId> {
+        let value = value.into();
+        let value = value.trim();
+        if value.is_empty()
+            || value.len() > Self::MAX_BYTES
+            || !value.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b':' | b'-')
+            })
+        {
+            return Err(InvalidBackendId);
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for BackendId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl AsRef<str> for BackendId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl FromStr for BackendId {
+    type Err = InvalidBackendId;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for BackendId {
+    type Error = InvalidBackendId;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<BackendId> for String {
+    fn from(value: BackendId) -> Self {
+        value.into_inner()
+    }
+}
+
+impl<'de> Deserialize<'de> for BackendId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("backend id must be 1..=128 bytes of ASCII letters, digits, '/', '.', '_', ':', or '-'")]
+pub struct InvalidBackendId;
+
+/// Product family implemented by a backend adapter.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    Tailscale,
+    Headscale,
+    CloudflareTunnel,
+    CloudflareOneClient,
+    CloudflareMesh,
+    ZeroTier,
+    NetBird,
+    Nebula,
+    WireGuard,
+    Netmaker,
+    Innernet,
+    Other(String),
+}
+
+/// Who owns the backend process and its lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendOwnership {
+    /// Attach to an independently managed daemon or OS service.
+    AttachExternal,
+    /// Spawn and supervise a child process owned by WutherCore.
+    ManagedChild,
+    /// Run the backend in-process or through an embedded library.
+    Embedded,
+}
+
+/// Fine-grained feature advertised by an observed backend instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeshCapability {
+    L3Interface,
+    EmbeddedDialer,
+    LocalEndpoint,
+    PrivateIngress,
+    PublicIngress,
+    SubnetRoutes,
+    ExitNode,
+    PeerInventory,
+    IdentityLookup,
+    DnsNamespace,
+    ManagementApi,
+    EventStream,
+    HighAvailability,
+    PacketForwarding,
+    ServiceExposure,
+}
+
+/// Lifecycle and health phase common to all backend adapters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendPhase {
+    Disabled,
+    Probing,
+    Starting,
+    NeedsAuth,
+    Connecting,
+    Ready,
+    Degraded,
+    Stopping,
+    Stopped,
+    Conflict,
+    Failed,
+    Unsupported,
+}
+
+/// Dynamic data-plane object exposed by a running backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum Attachment {
+    Interface(InterfaceAttachment),
+    Route(RouteAttachment),
+    Endpoint(EndpointAttachment),
+    Ingress(IngressAttachment),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InterfaceAttachment {
+    pub name: String,
+    #[serde(default)]
+    pub addresses: Vec<IpNet>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtu: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteAttachment {
+    pub prefix: IpNet,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interface: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EndpointPurpose {
+    Control,
+    LocalDial,
+    Metrics,
+    Health,
+    Management,
+    Other(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum EndpointAddress {
+    Socket(SocketAddr),
+    UnixSocket(PathBuf),
+    NamedPipe(String),
+    Url(String),
+    Opaque(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointAttachment {
+    pub purpose: EndpointPurpose,
+    pub address: EndpointAddress,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngressProtocol {
+    Http,
+    Https,
+    Tcp,
+    Udp,
+    Ssh,
+    Rdp,
+    Other(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngressAttachment {
+    pub name: String,
+    pub protocol: IngressProtocol,
+    /// Provider-side hostname, service name, or network selector.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub target: EndpointAddress,
+}
+
+/// Transport namespace used when claiming a local listening socket.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SocketTransport {
+    Tcp,
+    Udp,
+    Other(String),
+}
+
+/// Inclusive host firewall mark range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct FwmarkRange {
+    start: u32,
+    end: u32,
+}
+
+impl FwmarkRange {
+    pub fn new(start: u32, end: u32) -> Result<Self, InvalidFwmarkRange> {
+        if start > end {
+            return Err(InvalidFwmarkRange { start, end });
+        }
+        Ok(Self { start, end })
+    }
+
+    pub fn start(self) -> u32 {
+        self.start
+    }
+
+    pub fn end(self) -> u32 {
+        self.end
+    }
+
+    pub fn contains(self, value: u32) -> bool {
+        self.start <= value && value <= self.end
+    }
+
+    pub fn overlaps(self, other: Self) -> bool {
+        self.start <= other.end && other.start <= self.end
+    }
+}
+
+impl<'de> Deserialize<'de> for FwmarkRange {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireRange {
+            start: u32,
+            end: u32,
+        }
+
+        let value = WireRange::deserialize(deserializer)?;
+        Self::new(value.start, value.end).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("fwmark range start {start:#x} exceeds end {end:#x}")]
+pub struct InvalidFwmarkRange {
+    pub start: u32,
+    pub end: u32,
+}
+
+/// Host resource that can be claimed by one or more coordinated backends.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum SystemResource {
+    RouteManager,
+    DefaultRouteV4,
+    DefaultRouteV6,
+    DnsManager,
+    FirewallManager,
+    HostsDatabase,
+    /// Exclusive ownership of an operating-system-assigned interface name.
+    ///
+    /// This is intentionally broader than [`Self::Interface`]: platforms such
+    /// as macOS utun and Android VpnService choose the final interface name
+    /// only while activating the device.
+    InterfaceManager,
+    Interface {
+        name: String,
+    },
+    ListenSocket {
+        transport: SocketTransport,
+        address: SocketAddr,
+    },
+    AddressPrefix {
+        prefix: IpNet,
+    },
+    RoutePrefix {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        table: Option<u32>,
+        prefix: IpNet,
+    },
+    RouteTable {
+        table: u32,
+    },
+    FwmarkRange {
+        range: FwmarkRange,
+    },
+}
+
+/// Sharing mode of a host resource claim.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ClaimMode {
+    Exclusive,
+    CoordinatedShared { coordination_key: String },
+}
+
+impl fmt::Debug for ClaimMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Exclusive => formatter.write_str("Exclusive"),
+            Self::CoordinatedShared { .. } => formatter
+                .debug_struct("CoordinatedShared")
+                .field("coordination_key", &"[redacted]")
+                .finish(),
+        }
+    }
+}
+
+impl ClaimMode {
+    /// Construct a coordinated claim while enforcing a non-empty key.
+    ///
+    /// Conflict detection remains defensive and rejects empty keys that may
+    /// arrive from older or manually constructed configurations.
+    pub fn coordinated_shared(
+        coordination_key: impl Into<String>,
+    ) -> Result<Self, InvalidCoordinationKey> {
+        let coordination_key = coordination_key.into();
+        let coordination_key = coordination_key.trim();
+        if coordination_key.is_empty() {
+            return Err(InvalidCoordinationKey);
+        }
+        Ok(Self::CoordinatedShared {
+            coordination_key: coordination_key.to_owned(),
+        })
+    }
+
+    pub fn coordination_key(&self) -> Option<&str> {
+        match self {
+            Self::Exclusive => None,
+            Self::CoordinatedShared { coordination_key } => Some(coordination_key),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("coordination key must not be empty or whitespace")]
+pub struct InvalidCoordinationKey;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ResourceClaim {
+    pub resource: SystemResource,
+    pub mode: ClaimMode,
+}
+
+impl ResourceClaim {
+    pub fn exclusive(resource: SystemResource) -> Self {
+        Self {
+            resource,
+            mode: ClaimMode::Exclusive,
+        }
+    }
+
+    pub fn coordinated(
+        resource: SystemResource,
+        coordination_key: impl Into<String>,
+    ) -> Result<Self, InvalidCoordinationKey> {
+        Ok(Self {
+            resource,
+            mode: ClaimMode::coordinated_shared(coordination_key)?,
+        })
+    }
+}
+
+/// Stable identity of a host subsystem that owns a reservation outside the
+/// mesh backend registry.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct HostSubsystemId(BackendId);
+
+impl HostSubsystemId {
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidBackendId> {
+        BackendId::new(value).map(Self)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for HostSubsystemId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// A reservation owned by a host subsystem outside the backend registry.
+///
+/// This dedicated input type prevents a backend owner from being supplied as
+/// a host reservation. Conversion to the shared wire model happens only after
+/// the supervisor has crossed this typed boundary.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct HostResourceClaim {
+    pub owner: HostSubsystemId,
+    pub claim: ResourceClaim,
+}
+
+impl HostResourceClaim {
+    pub fn new(owner: HostSubsystemId, claim: ResourceClaim) -> Self {
+        Self { owner, claim }
+    }
+
+    pub fn into_owned(self) -> OwnedResourceClaim {
+        OwnedResourceClaim::host(self.owner, self.claim)
+    }
+}
+
+/// Collision-proof namespace for resource owners.
+///
+/// A backend and a host subsystem with the same textual name are intentionally
+/// distinct owners, so conflict detection never suppresses a real collision.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(tag = "namespace", content = "id", rename_all = "snake_case")]
+pub enum ResourceOwner {
+    Backend(BackendId),
+    HostSubsystem(HostSubsystemId),
+}
+
+impl ResourceOwner {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Backend(id) => id.as_str(),
+            Self::HostSubsystem(id) => id.as_str(),
+        }
+    }
+
+    pub fn backend_id(&self) -> Option<&BackendId> {
+        match self {
+            Self::Backend(id) => Some(id),
+            Self::HostSubsystem(_) => None,
+        }
+    }
+}
+
+impl fmt::Display for ResourceOwner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Backend(id) => write!(formatter, "backend:{id}"),
+            Self::HostSubsystem(id) => write!(formatter, "host:{id}"),
+        }
+    }
+}
+
+/// A resource claim associated with its collision-proof owner.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct OwnedResourceClaim {
+    pub owner: ResourceOwner,
+    pub claim: ResourceClaim,
+}
+
+impl OwnedResourceClaim {
+    pub fn backend(owner: BackendId, claim: ResourceClaim) -> Self {
+        Self {
+            owner: ResourceOwner::Backend(owner),
+            claim,
+        }
+    }
+
+    pub fn host(owner: HostSubsystemId, claim: ResourceClaim) -> Self {
+        Self {
+            owner: ResourceOwner::HostSubsystem(owner),
+            claim,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub level: DiagnosticLevel,
+    pub code: String,
+    pub message: String,
+}
+
+impl Diagnostic {
+    pub fn new(
+        level: DiagnosticLevel,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            level,
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Complete, serializable observation of one backend.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackendStatus {
+    pub id: BackendId,
+    pub kind: BackendKind,
+    pub ownership: BackendOwnership,
+    pub phase: BackendPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub capabilities: BTreeSet<MeshCapability>,
+    #[serde(default)]
+    pub attachments: Vec<Attachment>,
+    #[serde(default)]
+    pub resource_claims: Vec<ResourceClaim>,
+    #[serde(default)]
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl BackendStatus {
+    pub fn new(id: BackendId, kind: BackendKind, ownership: BackendOwnership) -> Self {
+        Self {
+            id,
+            kind,
+            ownership,
+            phase: BackendPhase::Stopped,
+            version: None,
+            capabilities: BTreeSet::new(),
+            attachments: Vec::new(),
+            resource_claims: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn owned_resource_claims(&self) -> Vec<OwnedResourceClaim> {
+        self.resource_claims
+            .iter()
+            .cloned()
+            .map(|claim| OwnedResourceClaim::backend(self.id.clone(), claim))
+            .collect()
+    }
+}
+
+/// Alias used by probe/reconcile APIs that return an observed snapshot.
+pub type BackendObservation = BackendStatus;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MeshSupervisorPhase {
+    Idle,
+    Starting,
+    Running,
+    Degraded,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+/// Complete internal supervisor snapshot.
+///
+/// This model intentionally preserves provider observations for lifecycle and
+/// conflict decisions. It must not be serialized directly to an untrusted
+/// client; use [`Self::public_view`] for `/v1/mesh/status`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MeshSnapshot {
+    pub generation: u64,
+    pub supervisor_phase: MeshSupervisorPhase,
+    pub running: bool,
+    /// Host-level reservations (for example packet capture or a pre-existing
+    /// listener) that participate in conflict checks even when no backend is
+    /// currently running.
+    #[serde(default, with = "sorted_owned_claims")]
+    pub reservations: Vec<OwnedResourceClaim>,
+    /// A `BTreeMap` makes backend iteration and serialization deterministic.
+    #[serde(default)]
+    pub statuses: BTreeMap<BackendId, BackendStatus>,
+    #[serde(default)]
+    pub conflicts: Vec<crate::conflict::ResourceConflict>,
+    #[serde(default)]
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl MeshSnapshot {
+    pub fn new(generation: u64, supervisor_phase: MeshSupervisorPhase, running: bool) -> Self {
+        Self {
+            generation,
+            supervisor_phase,
+            running,
+            reservations: Vec::new(),
+            statuses: BTreeMap::new(),
+            conflicts: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    pub fn insert_status(&mut self, status: BackendStatus) -> Option<BackendStatus> {
+        self.statuses.insert(status.id.clone(), status)
+    }
+
+    /// Replace host reservations and normalize them to deterministic order.
+    pub fn set_reservations(&mut self, reservations: impl IntoIterator<Item = OwnedResourceClaim>) {
+        self.reservations = reservations.into_iter().collect();
+        self.reservations.sort();
+        self.reservations.dedup();
+    }
+
+    /// Build a separately typed, bounded and redacted API projection.
+    #[must_use]
+    pub fn public_view(&self) -> PublicMeshSnapshot {
+        PublicMeshSnapshot::from(self)
+    }
+}
+
+const PUBLIC_VERSION_MAX_BYTES: usize = 128;
+const PUBLIC_CUSTOM_MAX_BYTES: usize = 256;
+const PUBLIC_URL_MAX_BYTES: usize = 2 * 1024;
+const PUBLIC_DIAGNOSTIC_CODE_MAX_BYTES: usize = 64;
+const PUBLIC_DIAGNOSTIC_MESSAGE: &str = "diagnostic details are available in local process logs";
+const PUBLIC_REDACTED_VALUE: &str = "[redacted]";
+
+/// Product family in a public mesh snapshot.
+///
+/// Provider-defined names are bounded and stripped of control characters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicBackendKind {
+    Tailscale,
+    Headscale,
+    CloudflareTunnel,
+    CloudflareOneClient,
+    CloudflareMesh,
+    ZeroTier,
+    NetBird,
+    Nebula,
+    WireGuard,
+    Netmaker,
+    Innernet,
+    Other(String),
+}
+
+impl From<&BackendKind> for PublicBackendKind {
+    fn from(value: &BackendKind) -> Self {
+        match value {
+            BackendKind::Tailscale => Self::Tailscale,
+            BackendKind::Headscale => Self::Headscale,
+            BackendKind::CloudflareTunnel => Self::CloudflareTunnel,
+            BackendKind::CloudflareOneClient => Self::CloudflareOneClient,
+            BackendKind::CloudflareMesh => Self::CloudflareMesh,
+            BackendKind::ZeroTier => Self::ZeroTier,
+            BackendKind::NetBird => Self::NetBird,
+            BackendKind::Nebula => Self::Nebula,
+            BackendKind::WireGuard => Self::WireGuard,
+            BackendKind::Netmaker => Self::Netmaker,
+            BackendKind::Innernet => Self::Innernet,
+            BackendKind::Other(name) => Self::Other(public_custom_string(name)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum PublicAttachment {
+    Interface(PublicInterfaceAttachment),
+    Route(PublicRouteAttachment),
+    Endpoint(PublicEndpointAttachment),
+    Ingress(PublicIngressAttachment),
+}
+
+impl From<&Attachment> for PublicAttachment {
+    fn from(value: &Attachment) -> Self {
+        match value {
+            Attachment::Interface(interface) => Self::Interface(interface.into()),
+            Attachment::Route(route) => Self::Route(route.into()),
+            Attachment::Endpoint(endpoint) => Self::Endpoint(endpoint.into()),
+            Attachment::Ingress(ingress) => Self::Ingress(ingress.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicInterfaceAttachment {
+    pub name: String,
+    pub addresses: Vec<IpNet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mtu: Option<u32>,
+}
+
+impl From<&InterfaceAttachment> for PublicInterfaceAttachment {
+    fn from(value: &InterfaceAttachment) -> Self {
+        Self {
+            name: public_custom_string(&value.name),
+            addresses: value.addresses.clone(),
+            index: value.index,
+            mtu: value.mtu,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicRouteAttachment {
+    pub prefix: IpNet,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metric: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interface: Option<String>,
+}
+
+impl From<&RouteAttachment> for PublicRouteAttachment {
+    fn from(value: &RouteAttachment) -> Self {
+        Self {
+            prefix: value.prefix,
+            table: value.table,
+            metric: value.metric,
+            interface: value
+                .interface
+                .as_deref()
+                .and_then(|interface| sanitize_optional_text(interface, PUBLIC_CUSTOM_MAX_BYTES)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicEndpointPurpose {
+    Control,
+    LocalDial,
+    Metrics,
+    Health,
+    Management,
+    Other(String),
+}
+
+impl From<&EndpointPurpose> for PublicEndpointPurpose {
+    fn from(value: &EndpointPurpose) -> Self {
+        match value {
+            EndpointPurpose::Control => Self::Control,
+            EndpointPurpose::LocalDial => Self::LocalDial,
+            EndpointPurpose::Metrics => Self::Metrics,
+            EndpointPurpose::Health => Self::Health,
+            EndpointPurpose::Management => Self::Management,
+            EndpointPurpose::Other(name) => Self::Other(public_custom_string(name)),
+        }
+    }
+}
+
+/// Endpoint address safe for an unauthenticated serialization boundary.
+///
+/// URL values retain only scheme, host and port. Filesystem paths, named pipes,
+/// opaque values, and malformed URLs are represented by `hidden`, which
+/// deliberately has no value field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum PublicEndpointAddress {
+    Socket(SocketAddr),
+    Url(String),
+    Hidden,
+}
+
+impl From<&EndpointAddress> for PublicEndpointAddress {
+    fn from(value: &EndpointAddress) -> Self {
+        match value {
+            EndpointAddress::Socket(address) => Self::Socket(*address),
+            EndpointAddress::UnixSocket(_) | EndpointAddress::NamedPipe(_) => Self::Hidden,
+            EndpointAddress::Url(url) => public_url(url).map(Self::Url).unwrap_or(Self::Hidden),
+            EndpointAddress::Opaque(_) => Self::Hidden,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicEndpointAttachment {
+    pub purpose: PublicEndpointPurpose,
+    pub address: PublicEndpointAddress,
+}
+
+impl From<&EndpointAttachment> for PublicEndpointAttachment {
+    fn from(value: &EndpointAttachment) -> Self {
+        Self {
+            purpose: (&value.purpose).into(),
+            address: (&value.address).into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicIngressProtocol {
+    Http,
+    Https,
+    Tcp,
+    Udp,
+    Ssh,
+    Rdp,
+    Other(String),
+}
+
+impl From<&IngressProtocol> for PublicIngressProtocol {
+    fn from(value: &IngressProtocol) -> Self {
+        match value {
+            IngressProtocol::Http => Self::Http,
+            IngressProtocol::Https => Self::Https,
+            IngressProtocol::Tcp => Self::Tcp,
+            IngressProtocol::Udp => Self::Udp,
+            IngressProtocol::Ssh => Self::Ssh,
+            IngressProtocol::Rdp => Self::Rdp,
+            IngressProtocol::Other(name) => Self::Other(public_custom_string(name)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicIngressAttachment {
+    pub name: String,
+    pub protocol: PublicIngressProtocol,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub target: PublicEndpointAddress,
+}
+
+impl From<&IngressAttachment> for PublicIngressAttachment {
+    fn from(value: &IngressAttachment) -> Self {
+        Self {
+            name: public_custom_string(&value.name),
+            protocol: (&value.protocol).into(),
+            source: value
+                .source
+                .as_deref()
+                .and_then(|source| sanitize_optional_text(source, PUBLIC_CUSTOM_MAX_BYTES)),
+            target: (&value.target).into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PublicSocketTransport {
+    Tcp,
+    Udp,
+    Other(String),
+}
+
+impl From<&SocketTransport> for PublicSocketTransport {
+    fn from(value: &SocketTransport) -> Self {
+        match value {
+            SocketTransport::Tcp => Self::Tcp,
+            SocketTransport::Udp => Self::Udp,
+            SocketTransport::Other(name) => Self::Other(public_custom_string(name)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", content = "details", rename_all = "snake_case")]
+pub enum PublicSystemResource {
+    RouteManager,
+    DefaultRouteV4,
+    DefaultRouteV6,
+    DnsManager,
+    FirewallManager,
+    HostsDatabase,
+    InterfaceManager,
+    Interface {
+        name: String,
+    },
+    ListenSocket {
+        transport: PublicSocketTransport,
+        address: SocketAddr,
+    },
+    AddressPrefix {
+        prefix: IpNet,
+    },
+    RoutePrefix {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        table: Option<u32>,
+        prefix: IpNet,
+    },
+    RouteTable {
+        table: u32,
+    },
+    FwmarkRange {
+        range: FwmarkRange,
+    },
+}
+
+impl From<&SystemResource> for PublicSystemResource {
+    fn from(value: &SystemResource) -> Self {
+        match value {
+            SystemResource::RouteManager => Self::RouteManager,
+            SystemResource::DefaultRouteV4 => Self::DefaultRouteV4,
+            SystemResource::DefaultRouteV6 => Self::DefaultRouteV6,
+            SystemResource::DnsManager => Self::DnsManager,
+            SystemResource::FirewallManager => Self::FirewallManager,
+            SystemResource::HostsDatabase => Self::HostsDatabase,
+            SystemResource::InterfaceManager => Self::InterfaceManager,
+            SystemResource::Interface { name } => Self::Interface {
+                name: public_custom_string(name),
+            },
+            SystemResource::ListenSocket { transport, address } => Self::ListenSocket {
+                transport: transport.into(),
+                address: *address,
+            },
+            SystemResource::AddressPrefix { prefix } => Self::AddressPrefix { prefix: *prefix },
+            SystemResource::RoutePrefix { table, prefix } => Self::RoutePrefix {
+                table: *table,
+                prefix: *prefix,
+            },
+            SystemResource::RouteTable { table } => Self::RouteTable { table: *table },
+            SystemResource::FwmarkRange { range } => Self::FwmarkRange { range: *range },
+        }
+    }
+}
+
+/// Public sharing mode. The coordination key is intentionally absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum PublicClaimMode {
+    Exclusive,
+    CoordinatedShared,
+}
+
+impl From<&ClaimMode> for PublicClaimMode {
+    fn from(value: &ClaimMode) -> Self {
+        match value {
+            ClaimMode::Exclusive => Self::Exclusive,
+            ClaimMode::CoordinatedShared { .. } => Self::CoordinatedShared,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicResourceClaim {
+    pub resource: PublicSystemResource,
+    pub mode: PublicClaimMode,
+}
+
+impl From<&ResourceClaim> for PublicResourceClaim {
+    fn from(value: &ResourceClaim) -> Self {
+        Self {
+            resource: (&value.resource).into(),
+            mode: (&value.mode).into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "namespace", content = "id", rename_all = "snake_case")]
+pub enum PublicResourceOwner {
+    Backend(BackendId),
+    HostSubsystem(HostSubsystemId),
+}
+
+impl From<&ResourceOwner> for PublicResourceOwner {
+    fn from(value: &ResourceOwner) -> Self {
+        match value {
+            ResourceOwner::Backend(id) => Self::Backend(id.clone()),
+            ResourceOwner::HostSubsystem(id) => Self::HostSubsystem(id.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicOwnedResourceClaim {
+    pub owner: PublicResourceOwner,
+    pub claim: PublicResourceClaim,
+}
+
+impl From<&OwnedResourceClaim> for PublicOwnedResourceClaim {
+    fn from(value: &OwnedResourceClaim) -> Self {
+        Self {
+            owner: (&value.owner).into(),
+            claim: (&value.claim).into(),
+        }
+    }
+}
+
+/// Diagnostic safe for the public API.
+///
+/// Arbitrary provider messages are never copied. The code is retained only
+/// when it is a bounded structured identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicDiagnostic {
+    pub level: DiagnosticLevel,
+    pub code: String,
+    pub message: &'static str,
+}
+
+impl From<&Diagnostic> for PublicDiagnostic {
+    fn from(value: &Diagnostic) -> Self {
+        Self {
+            level: value.level,
+            code: public_diagnostic_code(&value.code),
+            message: PUBLIC_DIAGNOSTIC_MESSAGE,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicBackendStatus {
+    pub id: BackendId,
+    pub kind: PublicBackendKind,
+    pub ownership: BackendOwnership,
+    pub phase: BackendPhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub capabilities: BTreeSet<MeshCapability>,
+    pub attachments: Vec<PublicAttachment>,
+    pub resource_claims: Vec<PublicResourceClaim>,
+    pub diagnostics: Vec<PublicDiagnostic>,
+}
+
+impl From<&BackendStatus> for PublicBackendStatus {
+    fn from(value: &BackendStatus) -> Self {
+        Self {
+            id: value.id.clone(),
+            kind: (&value.kind).into(),
+            ownership: value.ownership,
+            phase: value.phase,
+            version: value
+                .version
+                .as_deref()
+                .and_then(|version| sanitize_optional_text(version, PUBLIC_VERSION_MAX_BYTES)),
+            capabilities: value.capabilities.clone(),
+            attachments: value
+                .attachments
+                .iter()
+                .map(PublicAttachment::from)
+                .collect(),
+            resource_claims: value
+                .resource_claims
+                .iter()
+                .map(PublicResourceClaim::from)
+                .collect(),
+            diagnostics: value
+                .diagnostics
+                .iter()
+                .map(PublicDiagnostic::from)
+                .collect(),
+        }
+    }
+}
+
+/// Bounded and redacted projection returned by `/v1/mesh/status`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicMeshSnapshot {
+    pub generation: u64,
+    pub supervisor_phase: MeshSupervisorPhase,
+    pub running: bool,
+    pub reservations: Vec<PublicOwnedResourceClaim>,
+    pub statuses: BTreeMap<BackendId, PublicBackendStatus>,
+    pub conflicts: Vec<crate::conflict::PublicResourceConflict>,
+    pub diagnostics: Vec<PublicDiagnostic>,
+}
+
+impl From<&MeshSnapshot> for PublicMeshSnapshot {
+    fn from(value: &MeshSnapshot) -> Self {
+        Self {
+            generation: value.generation,
+            supervisor_phase: value.supervisor_phase,
+            running: value.running,
+            reservations: value
+                .reservations
+                .iter()
+                .map(PublicOwnedResourceClaim::from)
+                .collect(),
+            statuses: value
+                .statuses
+                .iter()
+                .map(|(id, status)| (id.clone(), status.into()))
+                .collect(),
+            conflicts: value
+                .conflicts
+                .iter()
+                .map(crate::conflict::PublicResourceConflict::from)
+                .collect(),
+            diagnostics: value
+                .diagnostics
+                .iter()
+                .map(PublicDiagnostic::from)
+                .collect(),
+        }
+    }
+}
+
+pub(crate) fn public_custom_string(value: &str) -> String {
+    sanitize_required_text(value, PUBLIC_CUSTOM_MAX_BYTES)
+}
+
+fn sanitize_required_text(value: &str, max_bytes: usize) -> String {
+    sanitize_optional_text(value, max_bytes).unwrap_or_else(|| PUBLIC_REDACTED_VALUE.to_owned())
+}
+
+fn sanitize_optional_text(value: &str, max_bytes: usize) -> Option<String> {
+    let mut output = String::with_capacity(value.len().min(max_bytes));
+    for character in value.chars() {
+        let character = if character.is_control() {
+            ' '
+        } else {
+            character
+        };
+        if output.len().saturating_add(character.len_utf8()) > max_bytes {
+            break;
+        }
+        output.push(character);
+    }
+    let output = output.trim();
+    (!output.is_empty()).then(|| output.to_owned())
+}
+
+fn public_diagnostic_code(code: &str) -> String {
+    let code = code.trim();
+    if code.is_empty()
+        || code.len() > PUBLIC_DIAGNOSTIC_CODE_MAX_BYTES
+        || !code
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+    {
+        "mesh.backend_diagnostic".to_owned()
+    } else {
+        code.to_owned()
+    }
+}
+
+fn public_url(value: &str) -> Option<String> {
+    let mut url = Url::parse(value).ok()?;
+    // Public mesh endpoints are network locations. This also rejects opaque
+    // schemes such as `javascript:` and `data:`.
+    url.host_str()?;
+    url.set_password(None).ok()?;
+    url.set_username("").ok()?;
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+
+    let value = url.to_string();
+    if value.len() > PUBLIC_URL_MAX_BYTES || value.chars().any(char::is_control) {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+mod sorted_owned_claims {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::OwnedResourceClaim;
+
+    pub fn serialize<S>(
+        reservations: &[OwnedResourceClaim],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut reservations = reservations.to_vec();
+        reservations.sort();
+        reservations.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<OwnedResourceClaim>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut reservations = Vec::<OwnedResourceClaim>::deserialize(deserializer)?;
+        reservations.sort();
+        reservations.dedup();
+        Ok(reservations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_id_rejects_empty_and_normalizes_outer_whitespace() {
+        assert_eq!(BackendId::new("").unwrap_err(), InvalidBackendId);
+        assert_eq!(BackendId::new(" \t ").unwrap_err(), InvalidBackendId);
+        assert_eq!(
+            BackendId::new("  office-mesh  ").unwrap().as_str(),
+            "office-mesh"
+        );
+    }
+
+    #[test]
+    fn backend_id_rejects_oversize_and_log_injection_characters() {
+        assert!(BackendId::new("a".repeat(BackendId::MAX_BYTES)).is_ok());
+        assert!(BackendId::new("a".repeat(BackendId::MAX_BYTES + 1)).is_err());
+        for value in [
+            "line\nforge",
+            "carriage\rforge",
+            "tab\tforge",
+            "has space",
+            "非ascii",
+        ] {
+            assert!(BackendId::new(value).is_err(), "{value:?} must be rejected");
+        }
+        assert!(BackendId::new("tailscale/system:prod_1.2").is_ok());
+    }
+
+    #[test]
+    fn backend_id_deserialization_cannot_inject_serialized_or_logged_lines() {
+        let result = serde_json::from_str::<BackendId>(r#""safe\nforged""#);
+        assert!(result.is_err());
+
+        let id = BackendId::new("safe/backend:1.2").unwrap();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, r#""safe/backend:1.2""#);
+        assert!(
+            !id.to_string()
+                .chars()
+                .any(|character| matches!(character, '\r' | '\n' | '\t'))
+        );
+    }
+
+    #[test]
+    fn coordination_key_must_be_non_empty() {
+        assert_eq!(
+            ClaimMode::coordinated_shared("  ").unwrap_err(),
+            InvalidCoordinationKey
+        );
+        assert_eq!(
+            ClaimMode::coordinated_shared(" shared-route ").unwrap(),
+            ClaimMode::CoordinatedShared {
+                coordination_key: "shared-route".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn coordination_key_debug_is_redacted() {
+        let mode = ClaimMode::coordinated_shared("coordination-key-secret").unwrap();
+        let debug = format!("{mode:?}");
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains("coordination-key-secret"));
+    }
+
+    #[test]
+    fn fwmark_range_validates_and_detects_boundary_overlap() {
+        let left = FwmarkRange::new(0x100, 0x1ff).unwrap();
+        let right = FwmarkRange::new(0x1ff, 0x2ff).unwrap();
+        assert!(left.overlaps(right));
+        assert!(left.contains(0x100));
+        assert!(left.contains(0x1ff));
+        assert!(FwmarkRange::new(2, 1).is_err());
+    }
+
+    #[test]
+    fn snapshot_statuses_are_ordered_by_backend_id() {
+        let mut snapshot = MeshSnapshot::new(7, MeshSupervisorPhase::Running, true);
+        for id in ["z-backend", "a-backend", "m-backend"] {
+            snapshot.insert_status(BackendStatus::new(
+                BackendId::new(id).unwrap(),
+                BackendKind::Other("test".to_owned()),
+                BackendOwnership::AttachExternal,
+            ));
+        }
+
+        let ids: Vec<_> = snapshot.statuses.keys().map(BackendId::as_str).collect();
+        assert_eq!(ids, ["a-backend", "m-backend", "z-backend"]);
+    }
+
+    #[test]
+    fn snapshot_reservations_are_normalized() {
+        let mut snapshot = MeshSnapshot::new(8, MeshSupervisorPhase::Idle, false);
+        let claim = |owner: &str| {
+            OwnedResourceClaim::host(
+                HostSubsystemId::new(owner).unwrap(),
+                ResourceClaim::exclusive(SystemResource::DnsManager),
+            )
+        };
+
+        snapshot.set_reservations([claim("z-host"), claim("a-host"), claim("z-host")]);
+
+        let owners: Vec<_> = snapshot
+            .reservations
+            .iter()
+            .map(|claim| claim.owner.as_str())
+            .collect();
+        assert_eq!(owners, ["a-host", "z-host"]);
+    }
+
+    #[test]
+    fn public_view_redacts_provider_controlled_values() {
+        let id = BackendId::new("public-test").unwrap();
+        let mut status = BackendStatus::new(
+            id.clone(),
+            BackendKind::Other(format!("vendor\n{}", "界".repeat(200))),
+            BackendOwnership::AttachExternal,
+        );
+        status.phase = BackendPhase::Ready;
+        status.version = Some(format!("v1\r\n{}", "版".repeat(100)));
+        status.attachments = vec![
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Health,
+                address: EndpointAddress::Url("https://example.com:8443/health/check".to_owned()),
+            }),
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Control,
+                address: EndpointAddress::Url(
+                    "https://alice:password-secret@example.com:9443/private/path\
+                     ?token=query-secret#fragment-secret"
+                        .replace(' ', ""),
+                ),
+            }),
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Other("broken\nurl".to_owned()),
+                address: EndpointAddress::Url("not a url invalid-url-secret".to_owned()),
+            }),
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Management,
+                address: EndpointAddress::Opaque("opaque-secret".to_owned()),
+            }),
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Control,
+                address: EndpointAddress::UnixSocket(PathBuf::from("/tmp/socket-path-secret")),
+            }),
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Control,
+                address: EndpointAddress::NamedPipe("named-pipe-secret".to_owned()),
+            }),
+        ];
+        status.resource_claims.push(
+            ResourceClaim::coordinated(
+                SystemResource::Interface {
+                    name: "mesh\ninterface".to_owned(),
+                },
+                "coordination-secret",
+            )
+            .unwrap(),
+        );
+        status.diagnostics = vec![
+            Diagnostic::new(DiagnosticLevel::Error, "unsafe\ncode", "diagnostic-secret"),
+            Diagnostic::new(
+                DiagnosticLevel::Warning,
+                "mesh.safe_code",
+                "another-diagnostic-secret",
+            ),
+        ];
+
+        let mut snapshot = MeshSnapshot::new(9, MeshSupervisorPhase::Running, true);
+        snapshot.insert_status(status);
+        let public = snapshot.public_view();
+        let public_status = &public.statuses[&id];
+
+        let PublicBackendKind::Other(kind) = &public_status.kind else {
+            panic!("custom kind must remain custom");
+        };
+        assert!(kind.len() <= PUBLIC_CUSTOM_MAX_BYTES);
+        assert!(!kind.chars().any(char::is_control));
+
+        let version = public_status.version.as_deref().unwrap();
+        assert!(version.len() <= PUBLIC_VERSION_MAX_BYTES);
+        assert!(!version.chars().any(char::is_control));
+
+        let addresses: Vec<_> = public_status
+            .attachments
+            .iter()
+            .map(|attachment| match attachment {
+                PublicAttachment::Endpoint(endpoint) => &endpoint.address,
+                other => panic!("expected endpoint, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            addresses[0],
+            &PublicEndpointAddress::Url("https://example.com:8443/".to_owned())
+        );
+        assert_eq!(
+            addresses[1],
+            &PublicEndpointAddress::Url("https://example.com:9443/".to_owned())
+        );
+        assert!(
+            addresses[2..]
+                .iter()
+                .all(|address| matches!(address, &&PublicEndpointAddress::Hidden))
+        );
+
+        assert_eq!(public_status.diagnostics[0].code, "mesh.backend_diagnostic");
+        assert_eq!(public_status.diagnostics[1].code, "mesh.safe_code");
+        assert!(
+            public_status
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.message == PUBLIC_DIAGNOSTIC_MESSAGE)
+        );
+
+        let serialized = serde_json::to_string(&public).unwrap();
+        for secret in [
+            "alice",
+            "password-secret",
+            "query-secret",
+            "fragment-secret",
+            "health/check",
+            "private/path",
+            "invalid-url-secret",
+            "opaque-secret",
+            "socket-path-secret",
+            "named-pipe-secret",
+            "coordination-secret",
+            "diagnostic-secret",
+            "another-diagnostic-secret",
+            "coordination_key",
+        ] {
+            assert!(
+                !serialized.contains(secret),
+                "public projection leaked {secret}: {serialized}"
+            );
+        }
+    }
+}

--- a/crates/core-mesh/src/process.rs
+++ b/crates/core-mesh/src/process.rs
@@ -1,0 +1,2657 @@
+//! Managed subprocess primitives for mesh backends owned by WutherCore.
+//!
+//! This module is deliberately **not** an adapter for an already-running
+//! external daemon. A [`ManagedChild`] can only be created by spawning a
+//! [`ManagedProcessSpec`], so dropping it cannot accidentally terminate a
+//! system-owned `tailscaled` or another process discovered by PID.
+//!
+//! `command-group` supplies the platform boundary: a POSIX process group on
+//! Unix and a Job Object on Windows. All forced termination therefore applies
+//! to the complete tree created by the managed daemon.
+
+use std::{
+    collections::VecDeque,
+    ffi::{OsStr, OsString},
+    fmt,
+    future::Future,
+    io::{self, Write},
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::{Path, PathBuf},
+    pin::Pin,
+    process::{ExitStatus, Stdio},
+    sync::{Arc, Mutex, RwLock},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use command_group::{AsyncCommandGroup, AsyncGroupChild};
+use tempfile::{Builder as TempFileBuilder, NamedTempFile};
+use thiserror::Error;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    process::ChildStdin,
+    sync::{broadcast, mpsc, oneshot, watch},
+    task::JoinHandle,
+    time::{Instant, MissedTickBehavior},
+};
+use tokio_util::sync::CancellationToken;
+use zeroize::Zeroizing;
+
+const REDACTION_MARKER: &[u8] = b"[REDACTED]";
+const MIN_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// A clonable registry of values which must never be exposed by managed
+/// process diagnostics.
+///
+/// The process launcher automatically registers the program argv and every
+/// explicitly configured environment value. Callers additionally register
+/// credentials, tokens, or secret-file contents. Empty values are ignored.
+/// Registered bytes are zeroized when the final [`Redactor`] clone is dropped.
+#[derive(Clone, Default)]
+pub struct Redactor {
+    values: Arc<RwLock<Vec<Zeroizing<Vec<u8>>>>>,
+}
+
+impl Redactor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an exact byte sequence as sensitive.
+    pub fn register(&self, value: impl AsRef<[u8]>) {
+        let value = value.as_ref();
+        if value.is_empty() {
+            return;
+        }
+        let mut values = self.values.write().unwrap_or_else(|e| e.into_inner());
+        if values.iter().any(|known| known.as_slice() == value) {
+            return;
+        }
+        values.push(Zeroizing::new(value.to_vec()));
+        // Prefer the longest match when one secret is a prefix of another.
+        values.sort_by_key(|value| std::cmp::Reverse(value.len()));
+    }
+
+    fn register_os(&self, value: &OsStr) {
+        self.register(value.to_string_lossy().as_bytes());
+    }
+
+    /// Return a redacted representation suitable for an error or log line.
+    pub fn redact(&self, value: impl AsRef<[u8]>) -> String {
+        String::from_utf8_lossy(&self.redact_bytes(value.as_ref())).into_owned()
+    }
+
+    fn redact_bytes(&self, value: &[u8]) -> Vec<u8> {
+        let mut stream = StreamingRedactor::new(self.clone());
+        stream.push(value, true)
+    }
+
+    fn match_at_start(&self, pending: &[u8]) -> RedactionMatch {
+        let values = self.values.read().unwrap_or_else(|e| e.into_inner());
+        let mut potential_prefix = false;
+        for value in values.iter() {
+            let value = value.as_slice();
+            if pending.starts_with(value) {
+                return RedactionMatch::Complete(value.len());
+            }
+            if value.starts_with(pending) {
+                potential_prefix = true;
+            }
+        }
+        if potential_prefix {
+            RedactionMatch::PotentialPrefix
+        } else {
+            RedactionMatch::None
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.values.read().unwrap_or_else(|e| e.into_inner()).len()
+    }
+}
+
+impl fmt::Debug for Redactor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Redactor")
+            .field("registered_values", &self.len())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RedactionMatch {
+    Complete(usize),
+    PotentialPrefix,
+    None,
+}
+
+/// Streaming exact-match redaction. Bytes which might be the prefix of a
+/// secret are retained until the next chunk, preventing a credential split
+/// across two pipe reads from escaping.
+struct StreamingRedactor {
+    redactor: Redactor,
+    pending: Vec<u8>,
+}
+
+impl StreamingRedactor {
+    fn new(redactor: Redactor) -> Self {
+        Self {
+            redactor,
+            pending: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8], eof: bool) -> Vec<u8> {
+        self.pending.extend_from_slice(bytes);
+        let mut output = Vec::with_capacity(bytes.len());
+        let mut consumed = 0;
+        while consumed < self.pending.len() {
+            match self.redactor.match_at_start(&self.pending[consumed..]) {
+                RedactionMatch::Complete(len) => {
+                    consumed += len;
+                    output.extend_from_slice(REDACTION_MARKER);
+                }
+                RedactionMatch::PotentialPrefix if !eof => break,
+                RedactionMatch::PotentialPrefix => {
+                    // A process may terminate after writing only a prefix of a
+                    // credential. Treat that fragment as sensitive as well.
+                    consumed = self.pending.len();
+                    output.extend_from_slice(REDACTION_MARKER);
+                }
+                RedactionMatch::None => {
+                    output.push(self.pending[consumed]);
+                    consumed += 1;
+                }
+            }
+        }
+        if consumed != 0 {
+            self.pending.drain(..consumed);
+        }
+        output
+    }
+}
+
+/// Bounded capture settings for each output stream.
+#[derive(Debug, Clone, Copy)]
+pub struct OutputPolicy {
+    /// Retain at most this many already-redacted bytes per stream.
+    pub max_bytes_per_stream: usize,
+    /// Size of each asynchronous pipe read.
+    pub read_chunk_bytes: usize,
+    /// Maximum time spent draining pipes after the process group has exited.
+    pub drain_timeout: Duration,
+}
+
+impl Default for OutputPolicy {
+    fn default() -> Self {
+        Self {
+            max_bytes_per_stream: 64 * 1024,
+            read_chunk_bytes: 4096,
+            drain_timeout: Duration::from_millis(250),
+        }
+    }
+}
+
+/// A bounded, redacted stream snapshot.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CapturedLog {
+    pub text: String,
+    pub truncated: bool,
+    pub dropped_bytes: usize,
+}
+
+/// Current stdout and stderr snapshots.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProcessLogs {
+    pub stdout: CapturedLog,
+    pub stderr: CapturedLog,
+}
+
+#[derive(Debug)]
+struct BoundedLog {
+    bytes: VecDeque<u8>,
+    max_bytes: usize,
+    dropped_bytes: usize,
+}
+
+impl BoundedLog {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            bytes: VecDeque::with_capacity(max_bytes.min(4096)),
+            max_bytes,
+            dropped_bytes: 0,
+        }
+    }
+
+    fn append(&mut self, bytes: &[u8]) {
+        if self.max_bytes == 0 {
+            self.dropped_bytes = self.dropped_bytes.saturating_add(bytes.len());
+            return;
+        }
+        self.bytes.extend(bytes.iter().copied());
+        while self.bytes.len() > self.max_bytes {
+            self.bytes.pop_front();
+            self.dropped_bytes = self.dropped_bytes.saturating_add(1);
+        }
+    }
+
+    fn snapshot(&self) -> CapturedLog {
+        let bytes = self.bytes.iter().copied().collect::<Vec<_>>();
+        CapturedLog {
+            text: String::from_utf8_lossy(&bytes).into_owned(),
+            truncated: self.dropped_bytes != 0,
+            dropped_bytes: self.dropped_bytes,
+        }
+    }
+}
+
+type SharedLog = Arc<Mutex<BoundedLog>>;
+
+async fn capture_output<R>(mut reader: R, redactor: Redactor, sink: SharedLog, chunk_size: usize)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = vec![0_u8; chunk_size.max(1)];
+    let mut streaming = StreamingRedactor::new(redactor);
+    loop {
+        match reader.read(&mut buffer).await {
+            Ok(0) => {
+                let tail = streaming.push(&[], true);
+                sink.lock().unwrap_or_else(|e| e.into_inner()).append(&tail);
+                break;
+            }
+            Ok(read) => {
+                let redacted = streaming.push(&buffer[..read], false);
+                sink.lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .append(&redacted);
+            }
+            Err(_) => {
+                let tail = streaming.push(&[], true);
+                sink.lock().unwrap_or_else(|e| e.into_inner()).append(&tail);
+                break;
+            }
+        }
+    }
+}
+
+/// A securely-created temporary file containing a secret.
+///
+/// The file name is random and creation is exclusive. On Unix the mode is
+/// explicitly forced to `0600` before contents are written. Windows uses
+/// `tempfile`'s exclusive file creation in the current user's temporary
+/// directory; its confidentiality boundary is the ACL inherited from that
+/// directory. Installations requiring a stricter Windows DACL must supply a
+/// pre-hardened temporary directory through [`SecretFile::create_in`].
+///
+/// The contents are registered with the supplied [`Redactor`], are never
+/// returned by this API, and therefore do not need to appear in argv. Dropping
+/// the value removes the temporary file through [`NamedTempFile`].
+pub struct SecretFile {
+    file: NamedTempFile,
+}
+
+impl SecretFile {
+    pub fn create(contents: impl AsRef<[u8]>, redactor: &Redactor) -> io::Result<Self> {
+        Self::create_in(std::env::temp_dir(), contents, redactor)
+    }
+
+    pub fn create_in(
+        directory: impl AsRef<Path>,
+        contents: impl AsRef<[u8]>,
+        redactor: &Redactor,
+    ) -> io::Result<Self> {
+        let contents = contents.as_ref();
+        redactor.register(contents);
+        let mut file = TempFileBuilder::new()
+            .prefix("wuther-mesh-secret-")
+            .tempfile_in(directory)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.as_file()
+                .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        file.as_file_mut().write_all(contents)?;
+        file.as_file_mut().flush()?;
+        Ok(Self { file })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.file.path()
+    }
+
+    /// Explicitly close and delete the file, reporting deletion failures.
+    pub fn close(self) -> io::Result<()> {
+        self.file.close()
+    }
+}
+
+impl fmt::Debug for SecretFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretFile")
+            .field("path", &"[temporary secret path]")
+            .finish()
+    }
+}
+
+/// Error returned by a readiness or graceful-shutdown hook.
+#[derive(Debug, Clone, Error)]
+#[error("{message}")]
+pub struct ProcessHookError {
+    message: String,
+}
+
+impl ProcessHookError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Poll a process hook across an unwind boundary without retaining or
+/// formatting its panic payload.
+///
+/// The constructor is also guarded by [`catch_hook_future`], covering custom
+/// trait implementations which panic before returning their future.
+struct CatchHookUnwind<F> {
+    inner: Pin<Box<F>>,
+}
+
+impl<F> CatchHookUnwind<F> {
+    fn new(future: F) -> Self {
+        Self {
+            inner: Box::pin(future),
+        }
+    }
+}
+
+impl<F: Future> Future for CatchHookUnwind<F> {
+    type Output = Result<F::Output, ()>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match catch_unwind(AssertUnwindSafe(|| this.inner.as_mut().poll(context))) {
+            Ok(Poll::Ready(output)) => Poll::Ready(Ok(output)),
+            Ok(Poll::Pending) => Poll::Pending,
+            Err(_) => Poll::Ready(Err(())),
+        }
+    }
+}
+
+fn catch_hook_future<F>(create: impl FnOnce() -> F) -> Result<CatchHookUnwind<F>, ()>
+where
+    F: Future,
+{
+    catch_unwind(AssertUnwindSafe(create))
+        .map(CatchHookUnwind::new)
+        .map_err(|_| ())
+}
+
+/// Information available to a readiness probe.
+#[derive(Debug, Clone)]
+pub struct ReadinessContext {
+    pid: u32,
+    started_at: Instant,
+    cancellation: CancellationToken,
+}
+
+impl ReadinessContext {
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn started_at(&self) -> Instant {
+        self.started_at
+    }
+
+    pub fn cancellation(&self) -> &CancellationToken {
+        &self.cancellation
+    }
+}
+
+/// Asynchronous readiness contract for a newly spawned daemon.
+///
+/// Implementations may retry internally, but should observe the cancellation
+/// token in [`ReadinessContext`]. The manager concurrently checks for early
+/// process exit and enforces the configured readiness timeout.
+#[async_trait]
+pub trait ReadinessProbe: Send + Sync {
+    async fn wait_until_ready(&self, context: ReadinessContext) -> Result<(), ProcessHookError>;
+}
+
+#[derive(Debug, Default)]
+pub struct ImmediateReadiness;
+
+#[async_trait]
+impl ReadinessProbe for ImmediateReadiness {
+    async fn wait_until_ready(&self, _context: ReadinessContext) -> Result<(), ProcessHookError> {
+        Ok(())
+    }
+}
+
+/// A handle exposed to a graceful-shutdown hook.
+#[derive(Clone)]
+pub struct ShutdownContext {
+    pid: u32,
+    stdin: Arc<tokio::sync::Mutex<Option<ChildStdin>>>,
+    cancellation: CancellationToken,
+}
+
+impl ShutdownContext {
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn cancellation(&self) -> &CancellationToken {
+        &self.cancellation
+    }
+
+    /// Write a protocol-specific shutdown command to the managed daemon.
+    pub async fn write_stdin(&self, bytes: &[u8]) -> io::Result<()> {
+        let mut stdin = self.stdin.lock().await;
+        let Some(stdin) = stdin.as_mut() else {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "managed process stdin is closed",
+            ));
+        };
+        stdin.write_all(bytes).await?;
+        stdin.flush().await
+    }
+
+    /// Close stdin after a shutdown command has been written.
+    pub async fn close_stdin(&self) {
+        self.stdin.lock().await.take();
+    }
+}
+
+impl fmt::Debug for ShutdownContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShutdownContext")
+            .field("pid", &self.pid)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Protocol-specific graceful shutdown. Returning does not imply the process
+/// has exited; the manager still waits up to `shutdown_timeout`, then kills and
+/// reaps the complete process group.
+#[async_trait]
+pub trait GracefulShutdown: Send + Sync {
+    async fn shutdown(&self, context: ShutdownContext) -> Result<(), ProcessHookError>;
+}
+
+#[derive(Debug, Default)]
+pub struct NoopGracefulShutdown;
+
+#[async_trait]
+impl GracefulShutdown for NoopGracefulShutdown {
+    async fn shutdown(&self, _context: ShutdownContext) -> Result<(), ProcessHookError> {
+        Ok(())
+    }
+}
+
+/// A graceful shutdown hook which writes a fixed command to child stdin.
+pub struct StdinGracefulShutdown {
+    bytes: Zeroizing<Vec<u8>>,
+    close_after_write: bool,
+}
+
+impl StdinGracefulShutdown {
+    pub fn new(bytes: impl AsRef<[u8]>) -> Self {
+        Self {
+            bytes: Zeroizing::new(bytes.as_ref().to_vec()),
+            close_after_write: true,
+        }
+    }
+
+    pub fn keep_stdin_open(mut self) -> Self {
+        self.close_after_write = false;
+        self
+    }
+}
+
+impl fmt::Debug for StdinGracefulShutdown {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StdinGracefulShutdown")
+            .field("bytes", &"[redacted]")
+            .field("close_after_write", &self.close_after_write)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl GracefulShutdown for StdinGracefulShutdown {
+    async fn shutdown(&self, context: ShutdownContext) -> Result<(), ProcessHookError> {
+        context
+            .write_stdin(&self.bytes)
+            .await
+            .map_err(|e| ProcessHookError::new(e.to_string()))?;
+        if self.close_after_write {
+            context.close_stdin().await;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestartCondition {
+    Never,
+    OnFailure,
+    Always,
+}
+
+/// Backoff parameters used by [`ManagedDaemon::ensure_running`].
+#[derive(Debug, Clone, Copy)]
+pub struct RestartPolicy {
+    pub condition: RestartCondition,
+    /// Number of restarts after the initial attempt.
+    pub max_restarts: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+impl RestartPolicy {
+    pub const NEVER: Self = Self {
+        condition: RestartCondition::Never,
+        max_restarts: 0,
+        initial_backoff: Duration::ZERO,
+        max_backoff: Duration::ZERO,
+    };
+
+    fn permits(self, status: Option<ExitStatus>, attempts: u32) -> bool {
+        if attempts >= self.max_restarts {
+            return false;
+        }
+        match self.condition {
+            RestartCondition::Never => false,
+            RestartCondition::Always => true,
+            RestartCondition::OnFailure => status.map(|s| !s.success()).unwrap_or(true),
+        }
+    }
+
+    fn backoff(self, attempt: u32) -> Duration {
+        if attempt == 0 {
+            return Duration::ZERO;
+        }
+        let shift = (attempt - 1).min(31);
+        let multiplier = 1_u32 << shift;
+        self.initial_backoff
+            .checked_mul(multiplier)
+            .unwrap_or(self.max_backoff)
+            .min(self.max_backoff)
+    }
+}
+
+impl Default for RestartPolicy {
+    fn default() -> Self {
+        Self::NEVER
+    }
+}
+
+/// Internal launch contract for a daemon owned by WutherCore.
+///
+/// This is intentionally not serializable user configuration. In particular,
+/// hooks are executable Rust policy and secret files are live resources.
+/// Authentication material must use [`Self::add_secret_file`] rather than
+/// `args` or `env`: argv is observable by other local processes and `OsString`
+/// environment storage cannot be reliably zeroized. The environment is
+/// cleared by default; concrete adapters must explicitly allowlist every
+/// variable their official daemon needs.
+pub struct ManagedProcessSpec {
+    pub program: PathBuf,
+    pub args: Vec<OsString>,
+    pub env: Vec<(OsString, OsString)>,
+    pub clear_env: bool,
+    pub cwd: Option<PathBuf>,
+    /// Readiness must be selected explicitly. Use
+    /// [`ManagedProcessSpec::with_immediate_readiness`] only for programs whose
+    /// successful spawn is itself a complete readiness contract.
+    pub readiness: Option<Arc<dyn ReadinessProbe>>,
+    pub readiness_timeout: Duration,
+    pub startup_poll_interval: Duration,
+    pub monitor_poll_interval: Duration,
+    pub stop: Arc<dyn GracefulShutdown>,
+    pub shutdown_timeout: Duration,
+    /// Maximum time an explicit lifecycle operation waits for the process
+    /// group reaper. The reaper remains independently owned if this deadline
+    /// expires, so cancelling a caller never creates a second concurrent wait.
+    pub reap_timeout: Duration,
+    pub output: OutputPolicy,
+    pub restart: RestartPolicy,
+    redactor: Redactor,
+    secret_files: Vec<SecretFile>,
+}
+
+impl ManagedProcessSpec {
+    pub fn new(program: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            clear_env: true,
+            cwd: None,
+            readiness: None,
+            readiness_timeout: Duration::from_secs(30),
+            startup_poll_interval: Duration::from_millis(10),
+            monitor_poll_interval: Duration::from_millis(10),
+            stop: Arc::new(NoopGracefulShutdown),
+            shutdown_timeout: Duration::from_secs(10),
+            reap_timeout: Duration::from_secs(5),
+            output: OutputPolicy::default(),
+            restart: RestartPolicy::NEVER,
+            redactor: Redactor::new(),
+            secret_files: Vec::new(),
+        }
+    }
+
+    pub fn arg(&mut self, arg: impl Into<OsString>) -> &mut Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn env(&mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> &mut Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn with_readiness(&mut self, readiness: Arc<dyn ReadinessProbe>) -> &mut Self {
+        self.readiness = Some(readiness);
+        self
+    }
+
+    pub fn with_immediate_readiness(&mut self) -> &mut Self {
+        self.readiness = Some(Arc::new(ImmediateReadiness));
+        self
+    }
+
+    pub fn register_secret(&self, value: impl AsRef<[u8]>) {
+        self.redactor.register(value);
+    }
+
+    pub fn redactor(&self) -> Redactor {
+        self.redactor.clone()
+    }
+
+    /// Create and retain a secret file for the full daemon lifecycle.
+    ///
+    /// Only the random path is returned. The contents are registered with the
+    /// redactor and cannot be recovered through this API.
+    pub fn add_secret_file(&mut self, contents: impl AsRef<[u8]>) -> io::Result<PathBuf> {
+        let file = SecretFile::create(contents, &self.redactor)?;
+        let path = file.path().to_path_buf();
+        self.secret_files.push(file);
+        Ok(path)
+    }
+
+    pub fn add_secret_file_in(
+        &mut self,
+        directory: impl AsRef<Path>,
+        contents: impl AsRef<[u8]>,
+    ) -> io::Result<PathBuf> {
+        let file = SecretFile::create_in(directory, contents, &self.redactor)?;
+        let path = file.path().to_path_buf();
+        self.secret_files.push(file);
+        Ok(path)
+    }
+
+    fn register_launch_values(&self) {
+        self.redactor.register_os(self.program.as_os_str());
+        for arg in &self.args {
+            self.redactor.register_os(arg);
+        }
+        for (_, value) in &self.env {
+            self.redactor.register_os(value);
+        }
+    }
+}
+
+impl fmt::Debug for ManagedProcessSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ManagedProcessSpec")
+            .field("program", &"[redacted argv]")
+            .field(
+                "args",
+                &format_args!("[{} redacted values]", self.args.len()),
+            )
+            .field("env", &format_args!("[{} redacted values]", self.env.len()))
+            .field("clear_env", &self.clear_env)
+            .field("cwd", &self.cwd)
+            .field("readiness_configured", &self.readiness.is_some())
+            .field("readiness_timeout", &self.readiness_timeout)
+            .field("startup_poll_interval", &self.startup_poll_interval)
+            .field("monitor_poll_interval", &self.monitor_poll_interval)
+            .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("reap_timeout", &self.reap_timeout)
+            .field("output", &self.output)
+            .field("restart", &self.restart)
+            .field("secret_files", &self.secret_files.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedChildState {
+    Starting,
+    Ready,
+    Stopping,
+    Exited,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminationKind {
+    Exited,
+    Graceful,
+    Forced,
+}
+
+#[derive(Debug, Clone)]
+pub struct TerminationReport {
+    pub kind: TerminationKind,
+    pub status: ExitStatus,
+    pub logs: ProcessLogs,
+}
+
+#[derive(Debug, Error)]
+pub enum ManagedProcessError {
+    #[error("managed process readiness must be configured explicitly")]
+    ReadinessNotConfigured,
+    #[error("failed to spawn managed program `{program}`: {source}")]
+    Spawn {
+        program: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("managed process {pid} exited before readiness: {status}")]
+    ExitedBeforeReady {
+        pid: u32,
+        status: ExitStatus,
+        logs: ProcessLogs,
+    },
+    #[error("managed process {pid} readiness timed out after {timeout:?}")]
+    ReadinessTimeout {
+        pid: u32,
+        timeout: Duration,
+        termination: TerminationReport,
+    },
+    #[error("managed process {pid} readiness probe failed: {message}")]
+    ReadinessFailed {
+        pid: u32,
+        message: String,
+        termination: TerminationReport,
+    },
+    #[error("managed process {pid} readiness probe panicked")]
+    ReadinessProbePanicked {
+        pid: u32,
+        termination: TerminationReport,
+    },
+    #[error("managed process {pid} startup was cancelled")]
+    StartupCancelled {
+        pid: u32,
+        termination: TerminationReport,
+    },
+    #[error("managed process {pid} graceful shutdown hook failed: {message}")]
+    ShutdownHookFailed {
+        pid: u32,
+        message: String,
+        termination: TerminationReport,
+    },
+    #[error("managed process {pid} graceful shutdown hook panicked")]
+    ShutdownHookPanicked {
+        pid: u32,
+        termination: TerminationReport,
+    },
+    #[error("managed process group operation `{operation}` failed: {source}")]
+    GroupIo {
+        operation: &'static str,
+        #[source]
+        source: io::Error,
+    },
+    #[error("managed process reaper task failed: {0}")]
+    Reaper(String),
+    #[error("managed process {pid} group reap timed out after {timeout:?}")]
+    ReapTimeout { pid: u32, timeout: Duration },
+    #[error("managed daemon has been stopped")]
+    DaemonStopped,
+    #[error("managed daemon supervisor failed: {0}")]
+    DaemonFailed(String),
+}
+
+/// Handle for a process tree created by this module.
+///
+/// There is intentionally no `from_pid`, `from_child`, or attach API.
+pub struct ManagedChild {
+    pid: u32,
+    state: ManagedChildState,
+    child: Option<AsyncGroupChild>,
+    stdin: Arc<tokio::sync::Mutex<Option<ChildStdin>>>,
+    cancellation: CancellationToken,
+    stdout: SharedLog,
+    stderr: SharedLog,
+    output_tasks: Vec<JoinHandle<()>>,
+    output_drain_timeout: Duration,
+    reap_timeout: Duration,
+    spec_guard: Option<Arc<ManagedProcessSpec>>,
+    runtime: tokio::runtime::Handle,
+}
+
+impl fmt::Debug for ManagedChild {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ManagedChild")
+            .field("pid", &self.pid)
+            .field("state", &self.state)
+            .field("logs", &self.logs())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ManagedChild {
+    async fn spawn(
+        spec: Arc<ManagedProcessSpec>,
+        parent_cancellation: &CancellationToken,
+    ) -> Result<Self, ManagedProcessError> {
+        let readiness = spec
+            .readiness
+            .clone()
+            .ok_or(ManagedProcessError::ReadinessNotConfigured)?;
+        let runtime = tokio::runtime::Handle::current();
+        spec.register_launch_values();
+
+        let mut command = tokio::process::Command::new(&spec.program);
+        command
+            .args(&spec.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        if spec.clear_env {
+            command.env_clear();
+        }
+        command.envs(spec.env.iter().map(|(key, value)| (key, value)));
+        if let Some(cwd) = &spec.cwd {
+            command.current_dir(cwd);
+        }
+
+        let mut child = command
+            .group()
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|source| ManagedProcessError::Spawn {
+                program: spec
+                    .redactor
+                    .redact(spec.program.to_string_lossy().as_bytes()),
+                source,
+            })?;
+        let pid = child.id().ok_or_else(|| ManagedProcessError::GroupIo {
+            operation: "read spawned process id",
+            source: io::Error::other("child exited while spawning"),
+        })?;
+        let stdin = Arc::new(tokio::sync::Mutex::new(child.inner().stdin.take()));
+        let stdout_reader = child.inner().stdout.take();
+        let stderr_reader = child.inner().stderr.take();
+        let stdout = Arc::new(Mutex::new(BoundedLog::new(
+            spec.output.max_bytes_per_stream,
+        )));
+        let stderr = Arc::new(Mutex::new(BoundedLog::new(
+            spec.output.max_bytes_per_stream,
+        )));
+        let mut output_tasks = Vec::with_capacity(2);
+        if let Some(reader) = stdout_reader {
+            output_tasks.push(tokio::spawn(capture_output(
+                reader,
+                spec.redactor.clone(),
+                stdout.clone(),
+                spec.output.read_chunk_bytes,
+            )));
+        }
+        if let Some(reader) = stderr_reader {
+            output_tasks.push(tokio::spawn(capture_output(
+                reader,
+                spec.redactor.clone(),
+                stderr.clone(),
+                spec.output.read_chunk_bytes,
+            )));
+        }
+
+        let cancellation = parent_cancellation.child_token();
+        let mut managed = Self {
+            pid,
+            state: ManagedChildState::Starting,
+            child: Some(child),
+            stdin,
+            cancellation: cancellation.clone(),
+            stdout,
+            stderr,
+            output_tasks,
+            output_drain_timeout: spec.output.drain_timeout,
+            reap_timeout: spec.reap_timeout,
+            spec_guard: Some(spec.clone()),
+            runtime,
+        };
+
+        let readiness_timeout = spec.readiness_timeout;
+        let poll_interval = spec.startup_poll_interval.max(MIN_POLL_INTERVAL);
+        let readiness_context = ReadinessContext {
+            pid,
+            started_at: Instant::now(),
+            cancellation: cancellation.clone(),
+        };
+        let readiness_future =
+            match catch_hook_future(|| readiness.wait_until_ready(readiness_context)) {
+                Ok(future) => future,
+                Err(()) => {
+                    let termination = managed.force_terminate().await?;
+                    return Err(ManagedProcessError::ReadinessProbePanicked { pid, termination });
+                }
+            };
+        tokio::pin!(readiness_future);
+        let deadline = tokio::time::sleep(readiness_timeout);
+        tokio::pin!(deadline);
+        let mut poll = tokio::time::interval(poll_interval);
+        poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => {
+                    let termination = managed.force_terminate().await?;
+                    return Err(ManagedProcessError::StartupCancelled { pid, termination });
+                }
+                result = &mut readiness_future => {
+                    if let Some(status) = managed.try_wait()? {
+                        let report = managed.finish_natural(status, TerminationKind::Exited).await?;
+                        return Err(ManagedProcessError::ExitedBeforeReady {
+                            pid,
+                            status: report.status,
+                            logs: report.logs,
+                        });
+                    }
+                    match result {
+                        Ok(Ok(())) => {
+                            managed.state = ManagedChildState::Ready;
+                            return Ok(managed);
+                        }
+                        Ok(Err(error)) => {
+                            let message = spec.redactor.redact(error.to_string());
+                            let termination = managed.force_terminate().await?;
+                            return Err(ManagedProcessError::ReadinessFailed {
+                                pid,
+                                message,
+                                termination,
+                            });
+                        }
+                        Err(()) => {
+                            let termination = managed.force_terminate().await?;
+                            return Err(ManagedProcessError::ReadinessProbePanicked {
+                                pid,
+                                termination,
+                            });
+                        }
+                    }
+                }
+                _ = poll.tick() => {
+                    if let Some(status) = managed.try_wait()? {
+                        let report = managed.finish_natural(status, TerminationKind::Exited).await?;
+                        return Err(ManagedProcessError::ExitedBeforeReady {
+                            pid,
+                            status: report.status,
+                            logs: report.logs,
+                        });
+                    }
+                }
+                _ = &mut deadline => {
+                    let termination = managed.force_terminate().await?;
+                    return Err(ManagedProcessError::ReadinessTimeout {
+                        pid,
+                        timeout: readiness_timeout,
+                        termination,
+                    });
+                }
+            }
+        }
+    }
+
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn state(&self) -> ManagedChildState {
+        self.state
+    }
+
+    pub fn logs(&self) -> ProcessLogs {
+        ProcessLogs {
+            stdout: self
+                .stdout
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .snapshot(),
+            stderr: self
+                .stderr
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .snapshot(),
+        }
+    }
+
+    fn try_wait(&mut self) -> Result<Option<ExitStatus>, ManagedProcessError> {
+        self.child
+            .as_mut()
+            .expect("managed child handle missing before exit")
+            .inner()
+            .try_wait()
+            .map_err(|source| ManagedProcessError::GroupIo {
+                operation: "try_wait for process leader",
+                source,
+            })
+    }
+
+    async fn finish_output(&mut self) {
+        let mut tasks = std::mem::take(&mut self.output_tasks);
+        if tasks.is_empty() {
+            return;
+        }
+        let drain = async {
+            for task in &mut tasks {
+                let _ = task.await;
+            }
+        };
+        if tokio::time::timeout(self.output_drain_timeout, drain)
+            .await
+            .is_err()
+        {
+            for task in tasks {
+                task.abort();
+            }
+        }
+    }
+
+    async fn reap_group(&mut self, force: bool) -> Result<ExitStatus, ManagedProcessError> {
+        self.cancellation.cancel();
+        self.stdin.lock().await.take();
+        let mut child = self
+            .child
+            .take()
+            .expect("managed child reaped more than once");
+        if force {
+            match child.start_kill() {
+                Ok(()) => {}
+                Err(error) if process_group_is_already_absent(&error) => {}
+                Err(source) => {
+                    self.child = Some(child);
+                    return Err(ManagedProcessError::GroupIo {
+                        operation: "kill process group",
+                        source,
+                    });
+                }
+            }
+        }
+        let guard = self.spec_guard.take();
+        // command-group documents that cancelling its Unix wait future can
+        // race with a second wait. The dedicated task owns the only wait, and
+        // keeps secret files alive until the process group is fully reaped.
+        let mut reaper = tokio::spawn(async move {
+            let _guard = guard;
+            child.wait().await
+        });
+        let status = tokio::time::timeout(self.reap_timeout, &mut reaper)
+            .await
+            .map_err(|_| ManagedProcessError::ReapTimeout {
+                pid: self.pid,
+                timeout: self.reap_timeout,
+            })?
+            .map_err(|error| ManagedProcessError::Reaper(error.to_string()))?
+            .map_err(|source| ManagedProcessError::GroupIo {
+                operation: "wait for process group",
+                source,
+            })?;
+        self.state = ManagedChildState::Exited;
+        self.finish_output().await;
+        Ok(status)
+    }
+
+    async fn finish_natural(
+        &mut self,
+        _observed_status: ExitStatus,
+        kind: TerminationKind,
+    ) -> Result<TerminationReport, ManagedProcessError> {
+        // A daemon leader may exit while helpers remain alive. The inner
+        // leader-only `try_wait` above deliberately leaves command-group's
+        // group status uncached, allowing this kill + wait to cover the whole
+        // POSIX process group or Windows Job Object.
+        let status = self.reap_group(true).await?;
+        Ok(TerminationReport {
+            kind,
+            status,
+            logs: self.logs(),
+        })
+    }
+
+    async fn force_terminate(&mut self) -> Result<TerminationReport, ManagedProcessError> {
+        self.state = ManagedChildState::Stopping;
+        let status = self.reap_group(true).await?;
+        Ok(TerminationReport {
+            kind: TerminationKind::Forced,
+            status,
+            logs: self.logs(),
+        })
+    }
+
+    /// Poll once for an unexpected exit.
+    pub async fn poll_exit(&mut self) -> Result<Option<TerminationReport>, ManagedProcessError> {
+        let Some(status) = self.try_wait()? else {
+            return Ok(None);
+        };
+        self.finish_natural(status, TerminationKind::Exited)
+            .await
+            .map(Some)
+    }
+
+    /// Wait for natural exit. Cancelling this future synchronously requests a
+    /// group kill and schedules a best-effort wait on the captured runtime.
+    /// Let this future complete (or use [`ManagedDaemon::close`]) when a
+    /// completed reap is required.
+    pub async fn wait(mut self) -> Result<TerminationReport, ManagedProcessError> {
+        let mut poll = tokio::time::interval(MIN_POLL_INTERVAL);
+        poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.cancellation.cancelled() => return self.force_terminate().await,
+                _ = poll.tick() => {
+                    if let Some(status) = self.try_wait()? {
+                        return self.finish_natural(status, TerminationKind::Exited).await;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Request graceful shutdown, wait for the configured deadline, then kill
+    /// and reap the complete process group if it is still alive.
+    pub async fn shutdown(
+        mut self,
+        hook: Arc<dyn GracefulShutdown>,
+        timeout: Duration,
+        redactor: Redactor,
+    ) -> Result<TerminationReport, ManagedProcessError> {
+        if let Some(status) = self.try_wait()? {
+            return self.finish_natural(status, TerminationKind::Exited).await;
+        }
+        self.state = ManagedChildState::Stopping;
+        let deadline_at = Instant::now() + timeout;
+        let context = ShutdownContext {
+            pid: self.pid,
+            stdin: self.stdin.clone(),
+            cancellation: self.cancellation.clone(),
+        };
+        let hook_future = match catch_hook_future(|| hook.shutdown(context)) {
+            Ok(future) => future,
+            Err(()) => {
+                let termination = self.force_terminate().await?;
+                return Err(ManagedProcessError::ShutdownHookPanicked {
+                    pid: self.pid,
+                    termination,
+                });
+            }
+        };
+        tokio::pin!(hook_future);
+        let deadline = tokio::time::sleep_until(deadline_at);
+        tokio::pin!(deadline);
+        tokio::select! {
+            biased;
+            _ = self.cancellation.cancelled() => return self.force_terminate().await,
+            _ = &mut deadline => return self.force_terminate().await,
+            result = &mut hook_future => {
+                match result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => {
+                        let message = redactor.redact(error.to_string());
+                        let termination = self.force_terminate().await?;
+                        return Err(ManagedProcessError::ShutdownHookFailed {
+                            pid: self.pid,
+                            message,
+                            termination,
+                        });
+                    }
+                    Err(()) => {
+                        let termination = self.force_terminate().await?;
+                        return Err(ManagedProcessError::ShutdownHookPanicked {
+                            pid: self.pid,
+                            termination,
+                        });
+                    }
+                }
+            }
+        }
+
+        let mut poll = tokio::time::interval(MIN_POLL_INTERVAL);
+        poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.cancellation.cancelled() => return self.force_terminate().await,
+                _ = &mut deadline => return self.force_terminate().await,
+                _ = poll.tick() => {
+                    if let Some(status) = self.try_wait()? {
+                        return self.finish_natural(status, TerminationKind::Graceful).await;
+                    }
+                }
+            }
+        }
+    }
+
+    fn kill_and_reap_on_drop(&mut self) {
+        self.cancellation.cancel();
+        for task in self.output_tasks.drain(..) {
+            task.abort();
+        }
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let _ = child.start_kill();
+        let guard = self.spec_guard.take();
+        let reaper = async move {
+            let _guard = guard;
+            let _ = child.wait().await;
+        };
+        // Tokio currently returns a cancelled JoinHandle after runtime
+        // shutdown. Keep Drop panic-free even if that implementation detail
+        // changes; group termination was already requested synchronously.
+        let _ =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.runtime.spawn(reaper)));
+        // Drop is intentionally best-effort: it requests group termination
+        // synchronously, but a runtime which is already shutting down cannot
+        // promise completion of the scheduled wait. Explicit async lifecycle
+        // methods provide the bounded wait contract.
+    }
+}
+
+fn process_group_is_already_absent(error: &io::Error) -> bool {
+    if matches!(
+        error.kind(),
+        io::ErrorKind::InvalidInput | io::ErrorKind::NotFound
+    ) {
+        return true;
+    }
+
+    #[cfg(unix)]
+    {
+        // command-group uses killpg(2) on Unix. ESRCH means that the leader
+        // and every helper in the owned group have already exited, which is
+        // the desired idempotent termination result.
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return true;
+        }
+    }
+
+    false
+}
+
+impl Drop for ManagedChild {
+    fn drop(&mut self) {
+        self.kill_and_reap_on_drop();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ManagedDaemonState {
+    Stopped,
+    Starting,
+    Running { pid: u32, restart_attempt: u32 },
+    Backoff { attempt: u32, until: Instant },
+    Exited { status: ExitStatus },
+    Failed { message: String },
+}
+
+#[derive(Debug, Clone)]
+pub enum EnsureRunningOutcome {
+    Started { pid: u32 },
+    Restarted { pid: u32, attempt: u32 },
+    AlreadyRunning { pid: u32 },
+    Exited(TerminationReport),
+}
+
+/// Lifecycle notifications published by a managed daemon.
+#[derive(Debug, Clone)]
+pub enum ManagedDaemonEvent {
+    Ready { pid: u32, restart_attempt: u32 },
+    UnexpectedExit(TerminationReport),
+    RestartScheduled { attempt: u32, delay: Duration },
+    Restarted { pid: u32, attempt: u32 },
+    SpawnFailed { attempt: u32, message: String },
+    Cancelled(Option<TerminationReport>),
+    Stopped(Option<TerminationReport>),
+    Failed { message: String },
+}
+
+#[derive(Clone)]
+struct LiveLogHandles {
+    stdout: SharedLog,
+    stderr: SharedLog,
+}
+
+impl LiveLogHandles {
+    fn snapshot(&self) -> ProcessLogs {
+        ProcessLogs {
+            stdout: self
+                .stdout
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .snapshot(),
+            stderr: self
+                .stderr
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .snapshot(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct DaemonShared {
+    live_logs: Mutex<Option<LiveLogHandles>>,
+    last_logs: Mutex<ProcessLogs>,
+    last_exit: Mutex<Option<TerminationReport>>,
+    last_error: Mutex<Option<String>>,
+}
+
+impl DaemonShared {
+    fn set_live_logs(&self, logs: LiveLogHandles) {
+        *self.live_logs.lock().unwrap_or_else(|e| e.into_inner()) = Some(logs);
+    }
+
+    fn clear_live_logs(&self) {
+        self.live_logs
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+    }
+
+    fn record_report(&self, report: &TerminationReport) {
+        self.clear_live_logs();
+        *self.last_logs.lock().unwrap_or_else(|e| e.into_inner()) = report.logs.clone();
+        *self.last_exit.lock().unwrap_or_else(|e| e.into_inner()) = Some(report.clone());
+    }
+
+    fn record_error(&self, message: String) {
+        *self.last_error.lock().unwrap_or_else(|e| e.into_inner()) = Some(message);
+    }
+
+    fn clear_error(&self) {
+        self.last_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+    }
+
+    fn logs(&self) -> ProcessLogs {
+        if let Some(logs) = self
+            .live_logs
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+        {
+            return logs.snapshot();
+        }
+        self.last_logs
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    fn last_exit(&self) -> Option<TerminationReport> {
+        self.last_exit
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    fn last_error(&self) -> Option<String> {
+        self.last_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+}
+
+#[derive(Debug)]
+enum DaemonCommand {
+    Stop,
+}
+
+#[derive(Debug)]
+enum MonitorOutcome {
+    Unexpected(TerminationReport),
+    Cancelled(TerminationReport),
+    Stopped(TerminationReport),
+}
+
+/// Background supervisor for one owned daemon.
+///
+/// Once [`ensure_running`](Self::ensure_running) reports readiness, a dedicated
+/// task owns the child, observes unexpected exit, publishes it, and applies
+/// the restart policy without requiring another reconcile call.
+///
+/// [`close`](Self::close) is the explicit lifecycle boundary: it waits for the
+/// supervisor's bounded process-group reap. `Drop` only requests cancellation
+/// and detaches that task; if the Tokio runtime is already shutting down, Drop
+/// cannot promise that asynchronous reaping completed.
+pub struct ManagedDaemon {
+    spec: Arc<ManagedProcessSpec>,
+    state_tx: Option<watch::Sender<ManagedDaemonState>>,
+    state_rx: watch::Receiver<ManagedDaemonState>,
+    event_tx: broadcast::Sender<ManagedDaemonEvent>,
+    command_tx: mpsc::UnboundedSender<DaemonCommand>,
+    command_rx: Option<mpsc::UnboundedReceiver<DaemonCommand>>,
+    cancellation: CancellationToken,
+    supervisor: Option<JoinHandle<Result<Option<TerminationReport>, ManagedProcessError>>>,
+    shared: Arc<DaemonShared>,
+    stop_requested: bool,
+    closed: bool,
+}
+
+impl fmt::Debug for ManagedDaemon {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ManagedDaemon")
+            .field("state", &self.state())
+            .field("logs", &self.logs())
+            .field("last_error", &self.last_error())
+            .field("closed", &self.closed)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ManagedDaemon {
+    pub fn new(spec: ManagedProcessSpec) -> Self {
+        let (state_tx, state_rx) = watch::channel(ManagedDaemonState::Stopped);
+        let (event_tx, _) = broadcast::channel(64);
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        Self {
+            spec: Arc::new(spec),
+            state_tx: Some(state_tx),
+            state_rx,
+            event_tx,
+            command_tx,
+            command_rx: Some(command_rx),
+            cancellation: CancellationToken::new(),
+            supervisor: None,
+            shared: Arc::new(DaemonShared::default()),
+            stop_requested: false,
+            closed: false,
+        }
+    }
+
+    pub fn state(&self) -> ManagedDaemonState {
+        self.state_rx.borrow().clone()
+    }
+
+    pub fn subscribe_state(&self) -> watch::Receiver<ManagedDaemonState> {
+        self.state_rx.clone()
+    }
+
+    pub fn subscribe_events(&self) -> broadcast::Receiver<ManagedDaemonEvent> {
+        self.event_tx.subscribe()
+    }
+
+    pub fn logs(&self) -> ProcessLogs {
+        self.shared.logs()
+    }
+
+    /// Most recently completed process lifetime, retained across restarts.
+    pub fn last_exit(&self) -> Option<TerminationReport> {
+        self.shared.last_exit()
+    }
+
+    /// Latest unresolved supervisor error. A successful ready transition
+    /// clears it.
+    pub fn last_error(&self) -> Option<String> {
+        self.shared.last_error()
+    }
+
+    /// Request immediate cancellation. A running child is force-terminated;
+    /// startup and restart backoff are interrupted without another reconcile.
+    pub fn cancel(&self) {
+        self.cancellation.cancel();
+    }
+
+    /// Start the background supervisor and wait for its first ready child.
+    pub async fn ensure_running(&mut self) -> Result<EnsureRunningOutcome, ManagedProcessError> {
+        if self.closed || self.cancellation.is_cancelled() {
+            return Err(ManagedProcessError::DaemonStopped);
+        }
+
+        if self.supervisor.is_none() {
+            let state_tx = self
+                .state_tx
+                .take()
+                .expect("daemon state sender missing before supervisor start");
+            let command_rx = self
+                .command_rx
+                .take()
+                .expect("daemon command receiver missing before supervisor start");
+            let (initial_tx, initial_rx) = oneshot::channel();
+            let supervisor = tokio::spawn(run_daemon_supervisor(
+                self.spec.clone(),
+                state_tx,
+                self.event_tx.clone(),
+                command_rx,
+                self.cancellation.clone(),
+                self.shared.clone(),
+                initial_tx,
+            ));
+            self.supervisor = Some(supervisor);
+            return initial_rx.await.map_err(|_| {
+                ManagedProcessError::DaemonFailed(
+                    "supervisor ended before publishing initial readiness".into(),
+                )
+            })?;
+        }
+
+        self.current_or_waiting_outcome().await
+    }
+
+    /// Compatibility alias. Background monitoring no longer needs polling.
+    pub async fn reconcile(&mut self) -> Result<EnsureRunningOutcome, ManagedProcessError> {
+        self.ensure_running().await
+    }
+
+    async fn current_or_waiting_outcome(
+        &mut self,
+    ) -> Result<EnsureRunningOutcome, ManagedProcessError> {
+        loop {
+            match self.state() {
+                ManagedDaemonState::Running {
+                    pid,
+                    restart_attempt: _,
+                } => return Ok(EnsureRunningOutcome::AlreadyRunning { pid }),
+                ManagedDaemonState::Exited { .. } => {
+                    let report = self.shared.last_exit().ok_or_else(|| {
+                        ManagedProcessError::DaemonFailed(
+                            "exit state published without a termination report".into(),
+                        )
+                    })?;
+                    return Ok(EnsureRunningOutcome::Exited(report));
+                }
+                ManagedDaemonState::Failed { message } => {
+                    return Err(ManagedProcessError::DaemonFailed(message));
+                }
+                ManagedDaemonState::Stopped if self.supervisor.is_some() => {
+                    return Err(ManagedProcessError::DaemonStopped);
+                }
+                ManagedDaemonState::Stopped
+                | ManagedDaemonState::Starting
+                | ManagedDaemonState::Backoff { .. } => {}
+            }
+            self.state_rx.changed().await.map_err(|_| {
+                ManagedProcessError::DaemonFailed("supervisor state channel closed".into())
+            })?;
+            if let ManagedDaemonState::Running {
+                pid,
+                restart_attempt,
+            } = self.state()
+            {
+                return if restart_attempt == 0 {
+                    Ok(EnsureRunningOutcome::Started { pid })
+                } else {
+                    Ok(EnsureRunningOutcome::Restarted {
+                        pid,
+                        attempt: restart_attempt,
+                    })
+                };
+            }
+        }
+    }
+
+    /// Wait for the next observed process termination. Restart policy remains
+    /// active in the background.
+    pub async fn wait_for_exit(
+        &mut self,
+    ) -> Result<Option<TerminationReport>, ManagedProcessError> {
+        // Subscribe before sampling state so a transition between those two
+        // operations is queued rather than missed.
+        let mut events = self.subscribe_events();
+        match self.state() {
+            ManagedDaemonState::Exited { .. } | ManagedDaemonState::Stopped => {
+                return Ok(self.shared.last_exit());
+            }
+            ManagedDaemonState::Failed { message } => {
+                return self
+                    .shared
+                    .last_exit()
+                    .map(Some)
+                    .ok_or(ManagedProcessError::DaemonFailed(message));
+            }
+            ManagedDaemonState::Starting
+            | ManagedDaemonState::Running { .. }
+            | ManagedDaemonState::Backoff { .. } => {}
+        }
+        loop {
+            match events.recv().await {
+                Ok(ManagedDaemonEvent::UnexpectedExit(report))
+                | Ok(ManagedDaemonEvent::Cancelled(Some(report)))
+                | Ok(ManagedDaemonEvent::Stopped(Some(report))) => return Ok(Some(report)),
+                Ok(ManagedDaemonEvent::Failed { message }) => {
+                    return Err(ManagedProcessError::DaemonFailed(message));
+                }
+                Ok(_) => {}
+                Err(broadcast::error::RecvError::Lagged(_)) => match self.state() {
+                    ManagedDaemonState::Exited { .. } | ManagedDaemonState::Stopped => {
+                        return Ok(self.shared.last_exit());
+                    }
+                    ManagedDaemonState::Failed { message } => {
+                        return self
+                            .shared
+                            .last_exit()
+                            .map(Some)
+                            .ok_or(ManagedProcessError::DaemonFailed(message));
+                    }
+                    ManagedDaemonState::Starting
+                    | ManagedDaemonState::Running { .. }
+                    | ManagedDaemonState::Backoff { .. } => {}
+                },
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Ok(self.shared.last_exit());
+                }
+            }
+        }
+    }
+
+    /// Stop desired state and wait for the background owner to finish its
+    /// bounded group reap. Unlike Drop, completion of this future is the
+    /// explicit cleanup contract.
+    pub async fn close(&mut self) -> Result<Option<TerminationReport>, ManagedProcessError> {
+        if self.closed {
+            return Ok(self.shared.last_exit());
+        }
+        let startup_or_backoff = matches!(
+            self.state(),
+            ManagedDaemonState::Starting | ManagedDaemonState::Backoff { .. }
+        );
+        let Some(supervisor) = self.supervisor.as_mut() else {
+            self.cancellation.cancel();
+            if let Some(state_tx) = self.state_tx.as_ref() {
+                state_tx.send_replace(ManagedDaemonState::Stopped);
+            }
+            self.closed = true;
+            return Ok(None);
+        };
+
+        if !self.stop_requested && !self.cancellation.is_cancelled() {
+            self.stop_requested = true;
+            if startup_or_backoff {
+                self.cancellation.cancel();
+            } else {
+                let _ = self.command_tx.send(DaemonCommand::Stop);
+            }
+        }
+
+        let result = supervisor
+            .await
+            .map_err(|error| ManagedProcessError::Reaper(error.to_string()))?;
+        self.supervisor.take();
+        self.closed = true;
+        result
+    }
+
+    pub async fn stop(&mut self) -> Result<Option<TerminationReport>, ManagedProcessError> {
+        self.close().await
+    }
+}
+
+impl Drop for ManagedDaemon {
+    fn drop(&mut self) {
+        if !self.closed {
+            self.cancellation.cancel();
+        }
+        // Dropping JoinHandle detaches the supervisor. It continues to own the
+        // process while the runtime is alive; ManagedChild's own Drop still
+        // synchronously requests a group kill during runtime shutdown.
+    }
+}
+
+impl ManagedChild {
+    fn live_log_handles(&self) -> LiveLogHandles {
+        LiveLogHandles {
+            stdout: self.stdout.clone(),
+            stderr: self.stderr.clone(),
+        }
+    }
+}
+
+fn publish_state(state_tx: &watch::Sender<ManagedDaemonState>, state: ManagedDaemonState) {
+    state_tx.send_replace(state);
+}
+
+fn publish_event(event_tx: &broadcast::Sender<ManagedDaemonEvent>, event: ManagedDaemonEvent) {
+    let _ = event_tx.send(event);
+}
+
+fn report_from_error(error: &ManagedProcessError) -> Option<TerminationReport> {
+    match error {
+        ManagedProcessError::ReadinessTimeout { termination, .. }
+        | ManagedProcessError::ReadinessFailed { termination, .. }
+        | ManagedProcessError::ReadinessProbePanicked { termination, .. }
+        | ManagedProcessError::StartupCancelled { termination, .. }
+        | ManagedProcessError::ShutdownHookFailed { termination, .. }
+        | ManagedProcessError::ShutdownHookPanicked { termination, .. } => {
+            Some(termination.clone())
+        }
+        ManagedProcessError::ExitedBeforeReady { status, logs, .. } => Some(TerminationReport {
+            kind: TerminationKind::Exited,
+            status: *status,
+            logs: logs.clone(),
+        }),
+        _ => None,
+    }
+}
+
+async fn wait_for_restart(
+    until: Instant,
+    commands: &mut mpsc::UnboundedReceiver<DaemonCommand>,
+    cancellation: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => false,
+        command = commands.recv() => {
+            match command {
+                Some(DaemonCommand::Stop) | None => false,
+            }
+        }
+        _ = tokio::time::sleep_until(until) => true,
+    }
+}
+
+async fn run_daemon_supervisor(
+    spec: Arc<ManagedProcessSpec>,
+    state_tx: watch::Sender<ManagedDaemonState>,
+    event_tx: broadcast::Sender<ManagedDaemonEvent>,
+    mut commands: mpsc::UnboundedReceiver<DaemonCommand>,
+    cancellation: CancellationToken,
+    shared: Arc<DaemonShared>,
+    initial_tx: oneshot::Sender<Result<EnsureRunningOutcome, ManagedProcessError>>,
+) -> Result<Option<TerminationReport>, ManagedProcessError> {
+    let mut initial_tx = Some(initial_tx);
+    let mut restart_attempts = 0_u32;
+    let mut last_report = None;
+
+    loop {
+        publish_state(&state_tx, ManagedDaemonState::Starting);
+        let spawn_result = ManagedChild::spawn(spec.clone(), &cancellation).await;
+        let mut child = match spawn_result {
+            Ok(child) => child,
+            Err(error) => {
+                let report = report_from_error(&error);
+                if let Some(report) = report.as_ref() {
+                    shared.record_report(report);
+                    last_report = Some(report.clone());
+                } else {
+                    shared.clear_live_logs();
+                }
+                let message = spec.redactor.redact(error.to_string());
+                shared.record_error(message.clone());
+
+                if let Some(initial_tx) = initial_tx.take() {
+                    let _ = initial_tx.send(Err(error));
+                } else {
+                    publish_event(
+                        &event_tx,
+                        ManagedDaemonEvent::SpawnFailed {
+                            attempt: restart_attempts,
+                            message: message.clone(),
+                        },
+                    );
+                }
+
+                if cancellation.is_cancelled() {
+                    publish_state(&state_tx, ManagedDaemonState::Stopped);
+                    publish_event(
+                        &event_tx,
+                        ManagedDaemonEvent::Cancelled(last_report.clone()),
+                    );
+                    return Ok(last_report);
+                }
+
+                if !spec.restart.permits(None, restart_attempts) {
+                    publish_state(
+                        &state_tx,
+                        ManagedDaemonState::Failed {
+                            message: message.clone(),
+                        },
+                    );
+                    publish_event(&event_tx, ManagedDaemonEvent::Failed { message });
+                    return Ok(last_report);
+                }
+
+                restart_attempts = restart_attempts.saturating_add(1);
+                let delay = spec.restart.backoff(restart_attempts);
+                let until = Instant::now() + delay;
+                publish_state(
+                    &state_tx,
+                    ManagedDaemonState::Backoff {
+                        attempt: restart_attempts,
+                        until,
+                    },
+                );
+                publish_event(
+                    &event_tx,
+                    ManagedDaemonEvent::RestartScheduled {
+                        attempt: restart_attempts,
+                        delay,
+                    },
+                );
+                if !wait_for_restart(until, &mut commands, &cancellation).await {
+                    publish_state(&state_tx, ManagedDaemonState::Stopped);
+                    let event = if cancellation.is_cancelled() {
+                        ManagedDaemonEvent::Cancelled(last_report.clone())
+                    } else {
+                        ManagedDaemonEvent::Stopped(last_report.clone())
+                    };
+                    publish_event(&event_tx, event);
+                    return Ok(last_report);
+                }
+                continue;
+            }
+        };
+
+        let pid = child.pid();
+        shared.set_live_logs(child.live_log_handles());
+        shared.clear_error();
+        publish_state(
+            &state_tx,
+            ManagedDaemonState::Running {
+                pid,
+                restart_attempt: restart_attempts,
+            },
+        );
+        publish_event(
+            &event_tx,
+            ManagedDaemonEvent::Ready {
+                pid,
+                restart_attempt: restart_attempts,
+            },
+        );
+        if restart_attempts != 0 {
+            publish_event(
+                &event_tx,
+                ManagedDaemonEvent::Restarted {
+                    pid,
+                    attempt: restart_attempts,
+                },
+            );
+        }
+        if let Some(initial_tx) = initial_tx.take() {
+            let outcome = if restart_attempts == 0 {
+                EnsureRunningOutcome::Started { pid }
+            } else {
+                EnsureRunningOutcome::Restarted {
+                    pid,
+                    attempt: restart_attempts,
+                }
+            };
+            let _ = initial_tx.send(Ok(outcome));
+        }
+
+        let mut poll = tokio::time::interval(spec.monitor_poll_interval.max(MIN_POLL_INTERVAL));
+        poll.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let monitor = loop {
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => {
+                    break child.force_terminate().await.map(MonitorOutcome::Cancelled);
+                }
+                command = commands.recv() => {
+                    match command {
+                        Some(DaemonCommand::Stop) | None => {
+                            break child
+                                .shutdown(
+                                    spec.stop.clone(),
+                                    spec.shutdown_timeout,
+                                    spec.redactor.clone(),
+                                )
+                                .await
+                                .map(MonitorOutcome::Stopped);
+                        }
+                    }
+                }
+                _ = poll.tick() => {
+                    match child.poll_exit().await {
+                        Ok(Some(report)) => break Ok(MonitorOutcome::Unexpected(report)),
+                        Ok(None) => {}
+                        Err(error) => break Err(error),
+                    }
+                }
+            }
+        };
+
+        let outcome = match monitor {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                shared.clear_live_logs();
+                let message = spec.redactor.redact(error.to_string());
+                shared.record_error(message.clone());
+                publish_state(
+                    &state_tx,
+                    ManagedDaemonState::Failed {
+                        message: message.clone(),
+                    },
+                );
+                publish_event(
+                    &event_tx,
+                    ManagedDaemonEvent::Failed {
+                        message: message.clone(),
+                    },
+                );
+                return Err(error);
+            }
+        };
+
+        match outcome {
+            MonitorOutcome::Cancelled(report) => {
+                shared.record_report(&report);
+                publish_state(&state_tx, ManagedDaemonState::Stopped);
+                publish_event(
+                    &event_tx,
+                    ManagedDaemonEvent::Cancelled(Some(report.clone())),
+                );
+                return Ok(Some(report));
+            }
+            MonitorOutcome::Stopped(report) => {
+                shared.record_report(&report);
+                publish_state(&state_tx, ManagedDaemonState::Stopped);
+                publish_event(&event_tx, ManagedDaemonEvent::Stopped(Some(report.clone())));
+                return Ok(Some(report));
+            }
+            MonitorOutcome::Unexpected(report) => {
+                let status = report.status;
+                shared.record_report(&report);
+                last_report = Some(report.clone());
+                publish_state(&state_tx, ManagedDaemonState::Exited { status });
+                publish_event(&event_tx, ManagedDaemonEvent::UnexpectedExit(report));
+
+                if !spec.restart.permits(Some(status), restart_attempts) {
+                    return Ok(last_report);
+                }
+                restart_attempts = restart_attempts.saturating_add(1);
+                let delay = spec.restart.backoff(restart_attempts);
+                let until = Instant::now() + delay;
+                publish_state(
+                    &state_tx,
+                    ManagedDaemonState::Backoff {
+                        attempt: restart_attempts,
+                        until,
+                    },
+                );
+                publish_event(
+                    &event_tx,
+                    ManagedDaemonEvent::RestartScheduled {
+                        attempt: restart_attempts,
+                        delay,
+                    },
+                );
+                if !wait_for_restart(until, &mut commands, &cancellation).await {
+                    publish_state(&state_tx, ManagedDaemonState::Stopped);
+                    let event = if cancellation.is_cancelled() {
+                        ManagedDaemonEvent::Cancelled(last_report.clone())
+                    } else {
+                        ManagedDaemonEvent::Stopped(last_report.clone())
+                    };
+                    publish_event(&event_tx, event);
+                    return Ok(last_report);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        env, fs,
+        io::{BufRead, Write},
+        net::{SocketAddr, TcpStream},
+        process::Command,
+        sync::mpsc as std_mpsc,
+        thread,
+        time::{Duration as StdDuration, Instant as StdInstant},
+    };
+    use tokio::net::TcpListener;
+
+    const HELPER_MODE: &str = "WUTHER_PROCESS_HELPER_MODE";
+    const READY_ADDR: &str = "WUTHER_PROCESS_HELPER_READY_ADDR";
+    const TRIGGER_FILE: &str = "WUTHER_PROCESS_HELPER_TRIGGER_FILE";
+    const RELEASE_FILE: &str = "WUTHER_PROCESS_HELPER_RELEASE_FILE";
+    const ENV_SECRET: &str = "WUTHER_PROCESS_HELPER_ENV_SECRET";
+    const DESC_READY_FILE: &str = "WUTHER_PROCESS_HELPER_DESC_READY_FILE";
+    const DESC_TRIGGER_FILE: &str = "WUTHER_PROCESS_HELPER_DESC_TRIGGER_FILE";
+    const LEAK_FILE: &str = "WUTHER_PROCESS_HELPER_LEAK_FILE";
+    const HOOK_PANIC_PAYLOAD: &str = "unregistered-hook-panic-payload-must-stay-private";
+
+    fn helper_args() -> [&'static str; 4] {
+        [
+            "--exact",
+            "process::tests::managed_process_test_helper",
+            "--nocapture",
+            "--test-threads=1",
+        ]
+    }
+
+    fn env_path(key: &str) -> PathBuf {
+        PathBuf::from(env::var_os(key).unwrap_or_else(|| panic!("{key} is required")))
+    }
+
+    fn wait_for_path(path: &Path) {
+        while !path.exists() {
+            thread::sleep(StdDuration::from_millis(1));
+        }
+    }
+
+    fn send_ready() {
+        let address = env::var(READY_ADDR)
+            .expect("ready address")
+            .parse::<SocketAddr>()
+            .expect("valid ready address");
+        let deadline = StdInstant::now() + StdDuration::from_secs(5);
+        loop {
+            match TcpStream::connect_timeout(&address, StdDuration::from_millis(100)) {
+                Ok(mut stream) => {
+                    stream.write_all(b"READY\n").expect("write ready handshake");
+                    return;
+                }
+                Err(error) if StdInstant::now() < deadline => {
+                    let _ = error;
+                    thread::sleep(StdDuration::from_millis(1));
+                }
+                Err(error) => panic!("ready handshake failed: {error}"),
+            }
+        }
+    }
+
+    fn run_control_helper() {
+        send_ready();
+        let mut line = String::new();
+        std::io::stdin()
+            .lock()
+            .read_line(&mut line)
+            .expect("read shutdown command");
+        assert_eq!(line, "stop\n");
+    }
+
+    fn run_control_or_trigger_helper() {
+        send_ready();
+        let trigger = env_path(TRIGGER_FILE);
+        let (line_tx, line_rx) = std_mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let mut line = String::new();
+            let _ = std::io::stdin().lock().read_line(&mut line);
+            let _ = line_tx.send(line);
+        });
+        loop {
+            if trigger.exists() {
+                let _ = fs::remove_file(&trigger);
+                std::process::exit(9);
+            }
+            match line_rx.try_recv() {
+                Ok(line) => {
+                    assert_eq!(line, "stop\n");
+                    return;
+                }
+                Err(std_mpsc::TryRecvError::Empty) => {
+                    thread::sleep(StdDuration::from_millis(1));
+                }
+                Err(std_mpsc::TryRecvError::Disconnected) => {
+                    panic!("stdin reader disconnected")
+                }
+            }
+        }
+    }
+
+    fn run_output_helper() {
+        send_ready();
+        let argv_value = env::args()
+            .find(|arg| arg == "--nocapture")
+            .expect("test harness argv");
+        let env_secret = env::var(ENV_SECRET).expect("environment secret");
+        print!("{argv_value}|{env_secret}|registered-secret|");
+        print!("{}", "x".repeat(512));
+        print!("|registered-secret");
+        eprint!("{env_secret}");
+        std::io::stdout().flush().expect("flush stdout");
+        std::io::stderr().flush().expect("flush stderr");
+        wait_for_path(&env_path(RELEASE_FILE));
+    }
+
+    fn run_leader_with_descendant_helper() {
+        let executable = env::current_exe().expect("current test executable");
+        let descendant_ready = env_path(DESC_READY_FILE);
+        let descendant_trigger = env_path(DESC_TRIGGER_FILE);
+        let leak = env_path(LEAK_FILE);
+        let mut command = Command::new(executable);
+        command
+            .args(helper_args())
+            .env(HELPER_MODE, "descendant")
+            .env(DESC_READY_FILE, &descendant_ready)
+            .env(DESC_TRIGGER_FILE, &descendant_trigger)
+            .env(LEAK_FILE, &leak)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let _descendant = command.spawn().expect("spawn descendant helper");
+        wait_for_path(&descendant_ready);
+        send_ready();
+        wait_for_path(&env_path(TRIGGER_FILE));
+        std::process::exit(9);
+    }
+
+    fn run_descendant_helper() {
+        fs::write(env_path(DESC_READY_FILE), b"ready").expect("publish descendant readiness");
+        wait_for_path(&env_path(DESC_TRIGGER_FILE));
+        fs::write(env_path(LEAK_FILE), b"leaked").expect("write leak marker");
+    }
+
+    /// The same Rust test executable is the child fixture. This avoids shell
+    /// startup timing and exercises readiness through a real TCP handshake.
+    #[test]
+    fn managed_process_test_helper() {
+        let Ok(mode) = env::var(HELPER_MODE) else {
+            return;
+        };
+        match mode.as_str() {
+            "control" => run_control_helper(),
+            "control_or_trigger" => run_control_or_trigger_helper(),
+            "early_exit" => std::process::exit(7),
+            "no_ready" => loop {
+                thread::park_timeout(StdDuration::from_secs(1));
+            },
+            "output" => run_output_helper(),
+            "leader_with_descendant" => run_leader_with_descendant_helper(),
+            "descendant" => run_descendant_helper(),
+            other => panic!("unknown helper mode: {other}"),
+        }
+    }
+
+    #[derive(Debug)]
+    struct TcpHandshakeProbe {
+        listener: Arc<TcpListener>,
+    }
+
+    #[async_trait]
+    impl ReadinessProbe for TcpHandshakeProbe {
+        async fn wait_until_ready(
+            &self,
+            context: ReadinessContext,
+        ) -> Result<(), ProcessHookError> {
+            let (mut stream, _) = tokio::select! {
+                _ = context.cancellation().cancelled() => {
+                    return Err(ProcessHookError::new("readiness cancelled"));
+                }
+                accepted = self.listener.accept() => {
+                    accepted.map_err(|error| ProcessHookError::new(error.to_string()))?
+                }
+            };
+            let mut handshake = [0_u8; 6];
+            tokio::select! {
+                _ = context.cancellation().cancelled() => {
+                    return Err(ProcessHookError::new("readiness cancelled"));
+                }
+                result = stream.read_exact(&mut handshake) => {
+                    result.map_err(|error| ProcessHookError::new(error.to_string()))?;
+                }
+            }
+            if &handshake != b"READY\n" {
+                return Err(ProcessHookError::new("invalid readiness handshake"));
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct PanickingReadinessProbe;
+
+    #[async_trait]
+    impl ReadinessProbe for PanickingReadinessProbe {
+        async fn wait_until_ready(
+            &self,
+            _context: ReadinessContext,
+        ) -> Result<(), ProcessHookError> {
+            panic!("{HOOK_PANIC_PAYLOAD}");
+        }
+    }
+
+    #[derive(Debug)]
+    struct PanickingShutdownHook;
+
+    #[async_trait]
+    impl GracefulShutdown for PanickingShutdownHook {
+        async fn shutdown(&self, _context: ShutdownContext) -> Result<(), ProcessHookError> {
+            panic!("{HOOK_PANIC_PAYLOAD}");
+        }
+    }
+
+    async fn helper_spec(mode: &str) -> ManagedProcessSpec {
+        let listener = Arc::new(
+            TcpListener::bind(("127.0.0.1", 0))
+                .await
+                .expect("bind readiness listener"),
+        );
+        let address = listener.local_addr().expect("readiness address");
+        let mut spec =
+            ManagedProcessSpec::new(env::current_exe().expect("current test executable"));
+        spec.args(helper_args());
+        spec.env(HELPER_MODE, mode);
+        spec.env(READY_ADDR, address.to_string());
+        #[cfg(windows)]
+        for key in ["SystemRoot", "WINDIR"] {
+            if let Some(value) = env::var_os(key) {
+                spec.env(key, value);
+            }
+        }
+        spec.with_readiness(Arc::new(TcpHandshakeProbe { listener }));
+        spec.readiness_timeout = Duration::from_secs(2);
+        spec.startup_poll_interval = Duration::from_millis(2);
+        spec.monitor_poll_interval = Duration::from_millis(2);
+        spec.shutdown_timeout = Duration::from_millis(300);
+        spec.reap_timeout = Duration::from_secs(2);
+        spec.output.drain_timeout = Duration::from_millis(300);
+        spec
+    }
+
+    async fn receive_matching(
+        events: &mut broadcast::Receiver<ManagedDaemonEvent>,
+        predicate: impl Fn(&ManagedDaemonEvent) -> bool,
+    ) -> ManagedDaemonEvent {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match events.recv().await {
+                    Ok(event) if predicate(&event) => return event,
+                    Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(broadcast::error::RecvError::Closed) => {
+                        panic!("daemon event channel closed")
+                    }
+                }
+            }
+        })
+        .await
+        .expect("matching daemon event")
+    }
+
+    #[tokio::test]
+    async fn readiness_requires_explicit_opt_in() {
+        let mut spec =
+            ManagedProcessSpec::new(env::current_exe().expect("current test executable"));
+        spec.args(helper_args());
+        spec.env(HELPER_MODE, "early_exit");
+        let mut daemon = ManagedDaemon::new(spec);
+
+        let error = daemon.ensure_running().await.unwrap_err();
+        assert!(matches!(error, ManagedProcessError::ReadinessNotConfigured));
+        daemon.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn starts_after_real_handshake_and_closes_gracefully() {
+        let mut spec = helper_spec("control").await;
+        spec.stop = Arc::new(StdinGracefulShutdown::new(b"stop\n"));
+        let mut daemon = ManagedDaemon::new(spec);
+
+        assert!(matches!(
+            daemon.ensure_running().await.unwrap(),
+            EnsureRunningOutcome::Started { .. }
+        ));
+        assert!(matches!(
+            daemon.state(),
+            ManagedDaemonState::Running {
+                restart_attempt: 0,
+                ..
+            }
+        ));
+        let report = daemon.close().await.unwrap().unwrap();
+        assert_eq!(report.kind, TerminationKind::Graceful);
+        assert!(report.status.success());
+    }
+
+    #[tokio::test]
+    async fn detects_exit_before_readiness() {
+        let spec = helper_spec("early_exit").await;
+        let mut daemon = ManagedDaemon::new(spec);
+
+        let error = daemon.ensure_running().await.unwrap_err();
+        match error {
+            ManagedProcessError::ExitedBeforeReady { status, .. } => {
+                assert_eq!(status.code(), Some(7));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        daemon.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn readiness_timeout_force_kills_and_reaps_group() {
+        let mut spec = helper_spec("no_ready").await;
+        spec.readiness_timeout = Duration::from_millis(50);
+        let mut daemon = ManagedDaemon::new(spec);
+
+        let error = daemon.ensure_running().await.unwrap_err();
+        match error {
+            ManagedProcessError::ReadinessTimeout { termination, .. } => {
+                assert_eq!(termination.kind, TerminationKind::Forced);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        daemon.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn readiness_panic_is_fixed_public_error_and_reaps_group() {
+        let mut spec = helper_spec("no_ready").await;
+        spec.with_readiness(Arc::new(PanickingReadinessProbe));
+        let mut daemon = ManagedDaemon::new(spec);
+
+        let error = daemon.ensure_running().await.unwrap_err();
+        let rendered = format!("{error}\n{error:?}");
+        let termination = match &error {
+            ManagedProcessError::ReadinessProbePanicked { termination, .. } => termination,
+            other => panic!("unexpected error: {other:?}"),
+        };
+        assert_eq!(termination.kind, TerminationKind::Forced);
+        assert!(rendered.contains("readiness probe panicked"));
+        assert!(!rendered.contains(HOOK_PANIC_PAYLOAD));
+        assert!(
+            !format!("{:?}", termination.logs).contains(HOOK_PANIC_PAYLOAD),
+            "panic payload escaped into managed child logs"
+        );
+        assert!(
+            !daemon
+                .last_error()
+                .expect("readiness error is retained")
+                .contains(HOOK_PANIC_PAYLOAD)
+        );
+
+        let report = daemon
+            .close()
+            .await
+            .unwrap()
+            .expect("forced termination report");
+        assert_eq!(report.kind, TerminationKind::Forced);
+        assert!(!format!("{:?}", daemon.state()).contains(HOOK_PANIC_PAYLOAD));
+    }
+
+    #[tokio::test]
+    async fn shutdown_timeout_force_kills_and_reaps_group() {
+        let mut spec = helper_spec("control").await;
+        spec.stop = Arc::new(NoopGracefulShutdown);
+        spec.shutdown_timeout = Duration::from_millis(50);
+        let mut daemon = ManagedDaemon::new(spec);
+        daemon.ensure_running().await.unwrap();
+
+        let report = daemon.close().await.unwrap().unwrap();
+        assert_eq!(report.kind, TerminationKind::Forced);
+        assert!(!report.status.success());
+    }
+
+    #[tokio::test]
+    async fn shutdown_hook_panic_is_fixed_public_error_and_reaps_group() {
+        let mut spec = helper_spec("control").await;
+        spec.stop = Arc::new(PanickingShutdownHook);
+        let mut daemon = ManagedDaemon::new(spec);
+        daemon.ensure_running().await.unwrap();
+
+        let error = daemon.close().await.unwrap_err();
+        let rendered = format!("{error}\n{error:?}");
+        let termination = match &error {
+            ManagedProcessError::ShutdownHookPanicked { termination, .. } => termination,
+            other => panic!("unexpected error: {other:?}"),
+        };
+        assert_eq!(termination.kind, TerminationKind::Forced);
+        assert!(rendered.contains("graceful shutdown hook panicked"));
+        assert!(!rendered.contains(HOOK_PANIC_PAYLOAD));
+        assert!(
+            !format!("{:?}", termination.logs).contains(HOOK_PANIC_PAYLOAD),
+            "panic payload escaped into managed child logs"
+        );
+        assert!(
+            !daemon
+                .last_error()
+                .expect("shutdown error is retained")
+                .contains(HOOK_PANIC_PAYLOAD)
+        );
+        assert!(!format!("{:?}", daemon.state()).contains(HOOK_PANIC_PAYLOAD));
+    }
+
+    #[tokio::test]
+    async fn output_is_bounded_and_sensitive_sources_are_redacted() {
+        let directory = tempfile::tempdir().unwrap();
+        let release = directory.path().join("release");
+        let mut spec = helper_spec("output").await;
+        spec.env(ENV_SECRET, "env-secret");
+        spec.env(RELEASE_FILE, release.as_os_str());
+        spec.register_secret("registered-secret");
+        spec.output = OutputPolicy {
+            max_bytes_per_stream: 96,
+            read_chunk_bytes: 3,
+            drain_timeout: Duration::from_millis(300),
+        };
+        let mut daemon = ManagedDaemon::new(spec);
+        daemon.ensure_running().await.unwrap();
+
+        fs::write(&release, b"go").unwrap();
+        let report = daemon.wait_for_exit().await.unwrap().unwrap();
+        let combined = format!("{}{}", report.logs.stdout.text, report.logs.stderr.text);
+        assert!(!combined.contains("--nocapture"));
+        assert!(!combined.contains("env-secret"));
+        assert!(!combined.contains("registered-secret"));
+        assert!(combined.contains("[REDACTED]"));
+        assert!(report.logs.stdout.truncated);
+        assert!(report.logs.stdout.text.len() <= 96);
+        assert!(report.logs.stderr.text.len() <= 96);
+        daemon.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unexpected_exit_is_published_and_restarted_without_reconcile() {
+        let directory = tempfile::tempdir().unwrap();
+        let trigger = directory.path().join("exit");
+        let mut spec = helper_spec("control_or_trigger").await;
+        spec.env(TRIGGER_FILE, trigger.as_os_str());
+        spec.stop = Arc::new(StdinGracefulShutdown::new(b"stop\n"));
+        spec.restart = RestartPolicy {
+            condition: RestartCondition::OnFailure,
+            max_restarts: 1,
+            initial_backoff: Duration::from_millis(5),
+            max_backoff: Duration::from_millis(5),
+        };
+        let mut daemon = ManagedDaemon::new(spec);
+        let mut events = daemon.subscribe_events();
+        daemon.ensure_running().await.unwrap();
+
+        fs::write(&trigger, b"exit").unwrap();
+        let exit = receive_matching(&mut events, |event| {
+            matches!(event, ManagedDaemonEvent::UnexpectedExit(_))
+        })
+        .await;
+        let ManagedDaemonEvent::UnexpectedExit(report) = exit else {
+            unreachable!()
+        };
+        assert_eq!(report.status.code(), Some(9));
+        let restarted = receive_matching(&mut events, |event| {
+            matches!(event, ManagedDaemonEvent::Restarted { attempt: 1, .. })
+        })
+        .await;
+        assert!(matches!(
+            restarted,
+            ManagedDaemonEvent::Restarted { attempt: 1, .. }
+        ));
+        assert!(matches!(
+            daemon.state(),
+            ManagedDaemonState::Running {
+                restart_attempt: 1,
+                ..
+            }
+        ));
+        assert_eq!(
+            daemon
+                .last_exit()
+                .expect("restart retains operational exit history")
+                .status
+                .code(),
+            Some(9)
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), daemon.wait_for_exit())
+                .await
+                .is_err(),
+            "a restarted child must not replay the previous exit as its next exit"
+        );
+
+        let report = daemon.close().await.unwrap().unwrap();
+        assert_eq!(report.kind, TerminationKind::Graceful);
+    }
+
+    #[tokio::test]
+    async fn cancellation_force_terminates_running_child() {
+        let spec = helper_spec("control").await;
+        let mut daemon = ManagedDaemon::new(spec);
+        daemon.ensure_running().await.unwrap();
+
+        daemon.cancel();
+        let report = tokio::time::timeout(Duration::from_secs(1), daemon.close())
+            .await
+            .expect("cancelled daemon closes")
+            .unwrap()
+            .unwrap();
+        assert_eq!(report.kind, TerminationKind::Forced);
+        assert!(matches!(daemon.state(), ManagedDaemonState::Stopped));
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_restart_backoff() {
+        let directory = tempfile::tempdir().unwrap();
+        let trigger = directory.path().join("exit");
+        let mut spec = helper_spec("control_or_trigger").await;
+        spec.env(TRIGGER_FILE, trigger.as_os_str());
+        spec.restart = RestartPolicy {
+            condition: RestartCondition::OnFailure,
+            max_restarts: 1,
+            initial_backoff: Duration::from_secs(5),
+            max_backoff: Duration::from_secs(5),
+        };
+        let mut daemon = ManagedDaemon::new(spec);
+        let mut events = daemon.subscribe_events();
+        daemon.ensure_running().await.unwrap();
+
+        fs::write(&trigger, b"exit").unwrap();
+        receive_matching(&mut events, |event| {
+            matches!(
+                event,
+                ManagedDaemonEvent::RestartScheduled { attempt: 1, .. }
+            )
+        })
+        .await;
+        daemon.cancel();
+        tokio::time::timeout(Duration::from_millis(500), daemon.close())
+            .await
+            .expect("backoff cancellation is immediate")
+            .unwrap();
+        assert!(matches!(daemon.state(), ManagedDaemonState::Stopped));
+    }
+
+    #[tokio::test]
+    async fn leader_exit_terminates_and_reaps_remaining_group() {
+        let directory = tempfile::tempdir().unwrap();
+        let leader_trigger = directory.path().join("leader-exit");
+        let descendant_ready = directory.path().join("descendant-ready");
+        let descendant_trigger = directory.path().join("descendant-trigger");
+        let leak = directory.path().join("descendant-leaked");
+        let mut spec = helper_spec("leader_with_descendant").await;
+        spec.env(TRIGGER_FILE, leader_trigger.as_os_str());
+        spec.env(DESC_READY_FILE, descendant_ready.as_os_str());
+        spec.env(DESC_TRIGGER_FILE, descendant_trigger.as_os_str());
+        spec.env(LEAK_FILE, leak.as_os_str());
+        let mut daemon = ManagedDaemon::new(spec);
+        let mut events = daemon.subscribe_events();
+        daemon.ensure_running().await.unwrap();
+
+        fs::write(&leader_trigger, b"exit").unwrap();
+        receive_matching(&mut events, |event| {
+            matches!(event, ManagedDaemonEvent::UnexpectedExit(_))
+        })
+        .await;
+        fs::write(&descendant_trigger, b"leak").unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !leak.exists(),
+            "leader exit left a process-group descendant alive"
+        );
+        daemon.close().await.unwrap();
+    }
+
+    #[test]
+    fn streaming_redactor_covers_chunk_boundaries() {
+        let redactor = Redactor::new();
+        redactor.register("split-secret");
+        let mut stream = StreamingRedactor::new(redactor);
+        assert_eq!(stream.push(b"before split-", false), b"before ");
+        assert_eq!(stream.push(b"secret after", true), b"[REDACTED] after");
+    }
+
+    #[test]
+    fn captured_runtime_spawn_is_non_panicking_after_shutdown() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let handle = runtime.handle().clone();
+        drop(runtime);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            drop(handle.spawn(async {}));
+        }));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn secret_file_drop_removes_path() {
+        let redactor = Redactor::new();
+        let path = {
+            let file = SecretFile::create(b"top-secret", &redactor).unwrap();
+            let path = file.path().to_path_buf();
+            assert!(path.exists());
+            assert_eq!(redactor.redact("top-secret"), "[REDACTED]");
+            path
+        };
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secret_file_is_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let redactor = Redactor::new();
+        let file = SecretFile::create(b"top-secret", &redactor).unwrap();
+        let mode = fs::metadata(file.path()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_absent_unix_process_group_is_an_idempotent_kill_result() {
+        let error = io::Error::from_raw_os_error(libc::ESRCH);
+        assert!(process_group_is_already_absent(&error));
+    }
+}

--- a/crates/core-mesh/src/registry.rs
+++ b/crates/core-mesh/src/registry.rs
@@ -1,0 +1,350 @@
+//! Deterministic backend registration with frozen descriptors.
+
+#![forbid(unsafe_code)]
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use crate::{
+    backend::{BackendDescriptor, BackendResult, ExternalNetworkBackend, OwnedNetworkBackend},
+    model::{BackendId, BackendObservation, BackendOwnership, BackendStatus},
+};
+
+#[derive(Clone)]
+enum BackendRef {
+    External(Arc<dyn ExternalNetworkBackend>),
+    Owned(Arc<dyn OwnedNetworkBackend>),
+}
+
+impl BackendRef {
+    async fn probe(&self) -> BackendResult<BackendObservation> {
+        match self {
+            Self::External(backend) => backend.probe().await,
+            Self::Owned(backend) => backend.probe().await,
+        }
+    }
+
+    async fn reconcile(&self, observation: &BackendObservation) -> BackendResult<BackendStatus> {
+        match self {
+            Self::External(backend) => backend.reconcile(observation).await,
+            Self::Owned(backend) => backend.reconcile(observation).await,
+        }
+    }
+
+    async fn status(&self) -> BackendResult<BackendStatus> {
+        match self {
+            Self::External(backend) => backend.status().await,
+            Self::Owned(backend) => backend.status().await,
+        }
+    }
+
+    async fn release(&self) -> BackendResult<()> {
+        match self {
+            Self::External(backend) => backend.detach().await,
+            Self::Owned(backend) => backend.terminate().await,
+        }
+    }
+}
+
+/// Frozen registry entry.
+///
+/// The descriptor is captured once during registration. The backend may return
+/// different dynamic metadata later, but lookups, conflict ownership, and
+/// release always use this immutable value.
+pub struct RegisteredBackend {
+    descriptor: BackendDescriptor,
+    backend: BackendRef,
+    call_gate: Mutex<()>,
+}
+
+impl RegisteredBackend {
+    pub fn descriptor(&self) -> &BackendDescriptor {
+        &self.descriptor
+    }
+
+    pub fn id(&self) -> &BackendId {
+        self.descriptor.id()
+    }
+
+    pub(crate) fn call_gate(&self) -> &Mutex<()> {
+        &self.call_gate
+    }
+
+    pub(crate) async fn probe(&self) -> BackendResult<BackendObservation> {
+        self.backend.probe().await
+    }
+
+    pub(crate) async fn reconcile(
+        &self,
+        observation: &BackendObservation,
+    ) -> BackendResult<BackendStatus> {
+        self.backend.reconcile(observation).await
+    }
+
+    pub(crate) async fn status(&self) -> BackendResult<BackendStatus> {
+        self.backend.status().await
+    }
+
+    pub(crate) async fn release(&self) -> BackendResult<()> {
+        self.backend.release().await
+    }
+}
+
+pub type RegisteredBackendRef = Arc<RegisteredBackend>;
+
+/// Registration errors are reported before a supervisor can start.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RegistryError {
+    #[error("mesh backend id `{0}` is already registered")]
+    DuplicateBackendId(BackendId),
+
+    #[error(
+        "backend `{id}` descriptor ownership {actual:?} does not match registration class {expected:?}"
+    )]
+    OwnershipMismatch {
+        id: BackendId,
+        expected: BackendOwnership,
+        actual: BackendOwnership,
+    },
+}
+
+/// Ordered registry of configured mesh backends.
+///
+/// A `Vec` preserves registration order for deterministic reconcile and reverse
+/// release. The map is only an index and never controls lifecycle order.
+#[derive(Default)]
+pub struct BackendRegistry {
+    ordered: Vec<RegisteredBackendRef>,
+    positions: BTreeMap<BackendId, usize>,
+}
+
+impl BackendRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_external(
+        &mut self,
+        backend: Arc<dyn ExternalNetworkBackend>,
+    ) -> Result<(), RegistryError> {
+        self.insert(
+            BackendRef::External(backend),
+            BackendOwnership::AttachExternal,
+        )
+    }
+
+    pub fn register_managed(
+        &mut self,
+        backend: Arc<dyn OwnedNetworkBackend>,
+    ) -> Result<(), RegistryError> {
+        self.insert(BackendRef::Owned(backend), BackendOwnership::ManagedChild)
+    }
+
+    pub fn register_embedded(
+        &mut self,
+        backend: Arc<dyn OwnedNetworkBackend>,
+    ) -> Result<(), RegistryError> {
+        self.insert(BackendRef::Owned(backend), BackendOwnership::Embedded)
+    }
+
+    fn insert(
+        &mut self,
+        backend: BackendRef,
+        expected: BackendOwnership,
+    ) -> Result<(), RegistryError> {
+        let descriptor = match &backend {
+            BackendRef::External(backend) => backend.descriptor(),
+            BackendRef::Owned(backend) => backend.descriptor(),
+        };
+        let id = descriptor.id().clone();
+        if descriptor.ownership() != expected {
+            return Err(RegistryError::OwnershipMismatch {
+                id,
+                expected,
+                actual: descriptor.ownership(),
+            });
+        }
+        if self.positions.contains_key(&id) {
+            return Err(RegistryError::DuplicateBackendId(id));
+        }
+
+        let position = self.ordered.len();
+        self.positions.insert(id, position);
+        self.ordered.push(Arc::new(RegisteredBackend {
+            descriptor,
+            backend,
+            call_gate: Mutex::new(()),
+        }));
+        Ok(())
+    }
+
+    pub fn get(&self, id: &BackendId) -> Option<&RegisteredBackendRef> {
+        self.positions
+            .get(id)
+            .and_then(|position| self.ordered.get(*position))
+    }
+
+    pub fn ordered(&self) -> &[RegisteredBackendRef] {
+        &self.ordered
+    }
+
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &RegisteredBackendRef> + ExactSizeIterator {
+        self.ordered.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.ordered.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ordered.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex as StdMutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::{backend::NetworkBackend, model::BackendKind};
+
+    struct StubBackend {
+        descriptor: StdMutex<BackendDescriptor>,
+    }
+
+    impl StubBackend {
+        fn new(id: &str) -> Self {
+            Self {
+                descriptor: StdMutex::new(BackendDescriptor::new(
+                    BackendId::new(id).expect("valid test backend id"),
+                    BackendKind::Other("test".to_owned()),
+                    BackendOwnership::AttachExternal,
+                )),
+            }
+        }
+
+        fn mutate_id(&self, id: &str) {
+            let mut descriptor = self.descriptor.lock().expect("descriptor lock");
+            *descriptor = BackendDescriptor::new(
+                BackendId::new(id).expect("valid mutated id"),
+                descriptor.kind().clone(),
+                descriptor.ownership(),
+            );
+        }
+
+        fn status_value(&self) -> BackendStatus {
+            let descriptor = self.descriptor();
+            BackendStatus::new(
+                descriptor.id().clone(),
+                descriptor.kind().clone(),
+                descriptor.ownership(),
+            )
+        }
+    }
+
+    #[async_trait]
+    impl NetworkBackend for StubBackend {
+        fn descriptor(&self) -> BackendDescriptor {
+            self.descriptor.lock().expect("descriptor lock").clone()
+        }
+
+        async fn probe(&self) -> BackendResult<BackendObservation> {
+            Ok(self.status_value())
+        }
+
+        async fn reconcile(
+            &self,
+            _observation: &BackendObservation,
+        ) -> BackendResult<BackendStatus> {
+            Ok(self.status_value())
+        }
+
+        async fn status(&self) -> BackendResult<BackendStatus> {
+            Ok(self.status_value())
+        }
+    }
+
+    #[async_trait]
+    impl ExternalNetworkBackend for StubBackend {
+        async fn detach(&self) -> BackendResult<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl OwnedNetworkBackend for StubBackend {
+        async fn terminate(&self) -> BackendResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn duplicate_backend_id_is_rejected() {
+        let mut registry = BackendRegistry::new();
+        registry
+            .register_external(Arc::new(StubBackend::new("same")))
+            .expect("first registration succeeds");
+
+        assert_eq!(
+            registry
+                .register_external(Arc::new(StubBackend::new("same")))
+                .expect_err("duplicate id must fail"),
+            RegistryError::DuplicateBackendId(
+                BackendId::new("same").expect("valid test backend id")
+            )
+        );
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn registration_order_is_stable_and_not_sorted_by_id() {
+        let mut registry = BackendRegistry::new();
+        for id in ["z", "a", "m"] {
+            registry
+                .register_external(Arc::new(StubBackend::new(id)))
+                .expect("unique backend");
+        }
+
+        let ids: Vec<_> = registry.iter().map(|entry| entry.id().clone()).collect();
+        assert_eq!(
+            ids,
+            ["z", "a", "m"]
+                .into_iter()
+                .map(|id| BackendId::new(id).expect("valid test backend id"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn descriptor_is_frozen_when_backend_dynamic_id_changes() {
+        let backend = Arc::new(StubBackend::new("original"));
+        let mut registry = BackendRegistry::new();
+        registry
+            .register_external(backend.clone())
+            .expect("registration succeeds");
+
+        backend.mutate_id("mutated");
+
+        let original = BackendId::new("original").unwrap();
+        let mutated = BackendId::new("mutated").unwrap();
+        assert_eq!(registry.ordered()[0].id(), &original);
+        assert!(registry.get(&original).is_some());
+        assert!(registry.get(&mutated).is_none());
+    }
+
+    #[test]
+    fn registration_class_must_match_frozen_descriptor() {
+        let backend = Arc::new(StubBackend::new("external"));
+        let mut registry = BackendRegistry::new();
+        assert!(matches!(
+            registry.register_managed(backend),
+            Err(RegistryError::OwnershipMismatch { .. })
+        ));
+    }
+}

--- a/crates/core-mesh/src/supervisor.rs
+++ b/crates/core-mesh/src/supervisor.rs
@@ -1,0 +1,3550 @@
+//! Transactional mesh backend supervision.
+//!
+//! Backend futures are untrusted external boundaries. Every invocation is
+//! cancellation-aware and deadline-bounded, while the global lifecycle mutex
+//! is held only for short state transitions.
+
+#![forbid(unsafe_code)]
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    future::Future,
+    panic::{AssertUnwindSafe, catch_unwind},
+    pin::Pin,
+    sync::{Arc, Weak},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use thiserror::Error;
+use tokio::{
+    sync::{Mutex, MutexGuard, watch},
+    task::JoinHandle,
+    time::{self, MissedTickBehavior},
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    backend::{BackendError, BackendResult},
+    conflict::{ResourceConflict, detect_conflicts},
+    model::{
+        Attachment, BackendId, BackendKind, BackendOwnership, BackendPhase, BackendStatus,
+        ClaimMode, Diagnostic, DiagnosticLevel, EndpointAddress, EndpointPurpose,
+        HostResourceClaim, IngressProtocol, MeshSnapshot, MeshSupervisorPhase, OwnedResourceClaim,
+        ResourceClaim, ResourceOwner, SocketTransport, SystemResource,
+    },
+    registry::{BackendRegistry, RegisteredBackend, RegisteredBackendRef},
+};
+
+type OperationResult = Result<MeshSnapshot, MeshError>;
+
+const MAX_DIAGNOSTICS_PER_SCOPE: usize = 64;
+const MAX_DIAGNOSTIC_CODE_BYTES: usize = 128;
+const MAX_DIAGNOSTIC_MESSAGE_BYTES: usize = 1024;
+
+// Observations cross an untrusted provider boundary before conflict detection.
+// These private limits keep that boundary cheap enough for an in-process
+// supervisor while still allowing a large real-world mesh inventory. They are
+// intentionally private until concrete adapters establish a compatibility
+// reason to make them part of the public API.
+const MAX_ATTACHMENTS_PER_OBSERVATION: usize = 128;
+const MAX_RESOURCE_CLAIMS_PER_OBSERVATION: usize = 128;
+const MAX_CAPABILITIES_PER_OBSERVATION: usize = 64;
+const MAX_COLLECTION_ITEMS_PER_OBSERVATION: usize = 1024;
+const MAX_PROVIDER_STRING_BYTES: usize = 4096;
+const MAX_PROVIDER_STRING_BYTES_PER_OBSERVATION: usize = 64 * 1024;
+const INVALID_OBSERVATION_MESSAGE: &str = "backend observation exceeded safety limits";
+
+#[derive(Default)]
+struct ObservationBudget {
+    collection_items: usize,
+    string_bytes: usize,
+}
+
+impl ObservationBudget {
+    fn add_collection(&mut self, items: usize) -> Result<(), &'static str> {
+        self.collection_items = self
+            .collection_items
+            .checked_add(items)
+            .ok_or(INVALID_OBSERVATION_MESSAGE)?;
+        if self.collection_items > MAX_COLLECTION_ITEMS_PER_OBSERVATION {
+            return Err(INVALID_OBSERVATION_MESSAGE);
+        }
+        Ok(())
+    }
+
+    fn add_string(&mut self, value: &str) -> Result<(), &'static str> {
+        self.add_string_with_limit(value, MAX_PROVIDER_STRING_BYTES)
+    }
+
+    fn add_string_with_limit(
+        &mut self,
+        value: &str,
+        individual_limit: usize,
+    ) -> Result<(), &'static str> {
+        if value.len() > individual_limit {
+            return Err(INVALID_OBSERVATION_MESSAGE);
+        }
+        self.string_bytes = self
+            .string_bytes
+            .checked_add(value.len())
+            .ok_or(INVALID_OBSERVATION_MESSAGE)?;
+        if self.string_bytes > MAX_PROVIDER_STRING_BYTES_PER_OBSERVATION {
+            return Err(INVALID_OBSERVATION_MESSAGE);
+        }
+        Ok(())
+    }
+}
+
+/// One safe, API-visible backend failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendFailure {
+    pub backend: BackendId,
+    pub operation: &'static str,
+    pub code: String,
+    pub message: String,
+}
+
+impl BackendFailure {
+    fn from_backend(backend: BackendId, operation: &'static str, error: &BackendError) -> Self {
+        Self {
+            backend,
+            operation,
+            code: error.code().to_owned(),
+            message: error.public_message().to_owned(),
+        }
+    }
+
+    fn safe(
+        backend: BackendId,
+        operation: &'static str,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        let error = BackendError::new(code, message);
+        Self::from_backend(backend, operation, &error)
+    }
+
+    fn diagnostic(&self) -> Diagnostic {
+        Diagnostic::new(
+            DiagnosticLevel::Error,
+            format!(
+                "mesh.backend.{}.{}",
+                self.operation,
+                self.code.replace(':', ".")
+            ),
+            format!(
+                "backend `{}` {} failed: {}",
+                self.backend, self.operation, self.message
+            ),
+        )
+    }
+}
+
+/// Transactional supervisor error.
+///
+/// `Display` and `Debug` are safe renderings. Structured conflict claims are
+/// internal data and must be projected through `PublicResourceConflict`
+/// before crossing an API boundary.
+#[derive(Clone, Error)]
+pub enum MeshError {
+    #[error("mesh backend probe failed: {failures:?}")]
+    Probe { failures: Vec<BackendFailure> },
+
+    #[error("mesh backend status refresh failed: {failures:?}")]
+    Status { failures: Vec<BackendFailure> },
+
+    #[error("mesh resource conflicts prevent reconciliation")]
+    Conflicts { conflicts: Vec<ResourceConflict> },
+
+    #[error(
+        "mesh backend reconciliation failed: {failure:?}; rollback failures: {rollback_failures:?}"
+    )]
+    Reconcile {
+        failure: BackendFailure,
+        rollback_failures: Vec<BackendFailure>,
+    },
+
+    #[error("mesh shutdown failed: {failures:?}")]
+    Stop { failures: Vec<BackendFailure> },
+
+    #[error("mesh still has resources requiring shutdown: {backends:?}")]
+    ResidualResources { backends: Vec<BackendId> },
+
+    #[error("mesh lifecycle worker ended before publishing a result")]
+    OperationLost,
+
+    #[error(
+        "mesh lifecycle worker failed internally: {failure:?}; cleanup failures: {cleanup_failures:?}"
+    )]
+    Internal {
+        failure: BackendFailure,
+        cleanup_failures: Vec<BackendFailure>,
+    },
+}
+
+impl fmt::Debug for MeshError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Probe { failures } => formatter
+                .debug_struct("MeshError::Probe")
+                .field("failures", failures)
+                .finish(),
+            Self::Status { failures } => formatter
+                .debug_struct("MeshError::Status")
+                .field("failures", failures)
+                .finish(),
+            Self::Conflicts { conflicts } => formatter
+                .debug_struct("MeshError::Conflicts")
+                .field("count", &conflicts.len())
+                .finish(),
+            Self::Reconcile {
+                failure,
+                rollback_failures,
+            } => formatter
+                .debug_struct("MeshError::Reconcile")
+                .field("failure", failure)
+                .field("rollback_failures", rollback_failures)
+                .finish(),
+            Self::Stop { failures } => formatter
+                .debug_struct("MeshError::Stop")
+                .field("failures", failures)
+                .finish(),
+            Self::ResidualResources { backends } => formatter
+                .debug_struct("MeshError::ResidualResources")
+                .field("backends", backends)
+                .finish(),
+            Self::OperationLost => formatter.write_str("MeshError::OperationLost"),
+            Self::Internal {
+                failure,
+                cleanup_failures,
+            } => formatter
+                .debug_struct("MeshError::Internal")
+                .field("failure", failure)
+                .field("cleanup_failures", cleanup_failures)
+                .finish(),
+        }
+    }
+}
+
+/// Operation-specific deadlines for untrusted backend adapters.
+///
+/// Reconciliation commonly includes daemon startup and readiness polling, so
+/// it intentionally receives a much larger budget than status observation.
+#[derive(Debug, Clone)]
+pub struct BackendCallTimeouts {
+    pub gate: Duration,
+    pub probe: Duration,
+    pub reconcile: Duration,
+    pub status: Duration,
+    pub release: Duration,
+}
+
+impl Default for BackendCallTimeouts {
+    fn default() -> Self {
+        Self {
+            gate: Duration::from_secs(2),
+            probe: Duration::from_secs(10),
+            reconcile: Duration::from_secs(120),
+            status: Duration::from_secs(5),
+            release: Duration::from_secs(30),
+        }
+    }
+}
+
+impl BackendCallTimeouts {
+    fn normalized(mut self) -> Self {
+        for timeout in [
+            &mut self.gate,
+            &mut self.probe,
+            &mut self.reconcile,
+            &mut self.status,
+            &mut self.release,
+        ] {
+            if timeout.is_zero() {
+                *timeout = Duration::from_millis(1);
+            }
+        }
+        self
+    }
+}
+
+/// Time bounds for untrusted backend calls and dynamic claim monitoring.
+#[derive(Debug, Clone)]
+pub struct SupervisorOptions {
+    pub backend_timeouts: BackendCallTimeouts,
+    /// Zero disables background status monitoring.
+    pub monitor_interval: Duration,
+}
+
+impl Default for SupervisorOptions {
+    fn default() -> Self {
+        Self {
+            backend_timeouts: BackendCallTimeouts::default(),
+            monitor_interval: Duration::from_secs(5),
+        }
+    }
+}
+
+impl SupervisorOptions {
+    fn normalized(mut self) -> Self {
+        self.backend_timeouts = self.backend_timeouts.normalized();
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OperationKind {
+    Start,
+    Stop,
+}
+
+struct ActiveOperation {
+    id: u64,
+    kind: OperationKind,
+    cancel: CancellationToken,
+    completion: watch::Sender<Option<OperationResult>>,
+}
+
+struct MonitorTask {
+    cancel: CancellationToken,
+    join: JoinHandle<()>,
+}
+
+#[derive(Default)]
+struct LifecycleState {
+    running: bool,
+    /// Successfully reconciled or not-yet-released backends in registration
+    /// order.
+    started: Vec<BackendId>,
+    /// Reconcile may already have acquired resources before returning.
+    in_flight: Option<BackendId>,
+    active: Option<ActiveOperation>,
+    next_operation_id: u64,
+    monitor: Option<MonitorTask>,
+    /// Backends automatically isolated by fail-closed monitoring. This state
+    /// remains latched until callers acknowledge it with a complete stop,
+    /// followed by a fresh start.
+    isolated: BTreeSet<BackendId>,
+    /// Isolated backends whose detach/terminate operation has not yet
+    /// completed successfully. The monitor retries these before trusting any
+    /// later healthy status observation.
+    pending_release: BTreeSet<BackendId>,
+    isolation_conflicts: Vec<ResourceConflict>,
+}
+
+struct SupervisorInner {
+    registry: BackendRegistry,
+    reservations: Vec<OwnedResourceClaim>,
+    options: SupervisorOptions,
+    lifecycle: Mutex<LifecycleState>,
+    maintenance: Mutex<()>,
+    snapshots: watch::Sender<MeshSnapshot>,
+    shutdown: CancellationToken,
+}
+
+/// Coordinates conflict-free startup, monitoring, isolation, and shutdown.
+pub struct MeshSupervisor {
+    inner: Arc<SupervisorInner>,
+}
+
+impl Drop for MeshSupervisor {
+    fn drop(&mut self) {
+        self.inner.shutdown.cancel();
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let inner = Arc::clone(&self.inner);
+        // A runtime may begin shutting down between `try_current` and
+        // `spawn`. Destructors must never propagate a runtime-state panic.
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            runtime.spawn(async move {
+                inner.emergency_shutdown().await;
+            })
+        }));
+    }
+}
+
+impl MeshSupervisor {
+    pub fn new(registry: BackendRegistry, reservations: Vec<HostResourceClaim>) -> Self {
+        Self::with_options(registry, reservations, SupervisorOptions::default())
+    }
+
+    pub fn with_options(
+        registry: BackendRegistry,
+        reservations: Vec<HostResourceClaim>,
+        options: SupervisorOptions,
+    ) -> Self {
+        let mut reservations: Vec<_> = reservations
+            .into_iter()
+            .map(HostResourceClaim::into_owned)
+            .collect();
+        reservations.sort();
+        reservations.dedup();
+
+        let mut snapshot = MeshSnapshot::new(0, MeshSupervisorPhase::Idle, false);
+        snapshot.set_reservations(reservations.clone());
+        for entry in registry.iter() {
+            snapshot.insert_status(Self::empty_status(entry));
+        }
+        let (snapshots, _) = watch::channel(snapshot);
+
+        Self {
+            inner: Arc::new(SupervisorInner {
+                registry,
+                reservations,
+                options: options.normalized(),
+                lifecycle: Mutex::new(LifecycleState::default()),
+                maintenance: Mutex::new(()),
+                snapshots,
+                shutdown: CancellationToken::new(),
+            }),
+        }
+    }
+
+    /// Return the latest immutable snapshot without awaiting a lock.
+    pub fn snapshot(&self) -> MeshSnapshot {
+        self.inner.snapshot()
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<MeshSnapshot> {
+        self.inner.snapshots.subscribe()
+    }
+
+    /// Start in a detached transaction.
+    ///
+    /// Aborting the caller does not abort the transaction. A timed out or
+    /// cancelled reconcile is followed by bounded reverse release, including
+    /// the in-flight backend.
+    pub async fn start(&self) -> OperationResult {
+        loop {
+            let mut launch = None;
+            let (receiver, retry_after_wait) = {
+                let mut lifecycle = self.inner.lifecycle.lock().await;
+                if lifecycle.running {
+                    return Ok(self.snapshot());
+                }
+                if let Some(active) = &lifecycle.active {
+                    (
+                        active.completion.subscribe(),
+                        active.kind != OperationKind::Start,
+                    )
+                } else {
+                    if !lifecycle.started.is_empty()
+                        || !lifecycle.isolated.is_empty()
+                        || !lifecycle.pending_release.is_empty()
+                    {
+                        let mut backends = lifecycle.started.clone();
+                        backends.extend(lifecycle.isolated.iter().cloned());
+                        backends.extend(lifecycle.pending_release.iter().cloned());
+                        backends.sort();
+                        backends.dedup();
+                        return Err(MeshError::ResidualResources { backends });
+                    }
+                    let (id, cancel, completion, receiver) = self
+                        .inner
+                        .new_operation(&mut lifecycle, OperationKind::Start);
+                    launch = Some((id, cancel, completion));
+                    (receiver, false)
+                }
+            };
+
+            if let Some((id, cancel, completion)) = launch {
+                self.inner.spawn_start(id, cancel, completion);
+            }
+            let result = wait_for_operation(receiver).await;
+            if retry_after_wait {
+                continue;
+            }
+            return result;
+        }
+    }
+
+    /// Stop in a detached transaction.
+    ///
+    /// If startup is active, stop cancels it without waiting for a global lock;
+    /// the startup worker performs rollback, after which stop retries any
+    /// release that failed.
+    pub async fn stop(&self) -> OperationResult {
+        loop {
+            let mut launch = None;
+            let (receiver, retry_after_wait) = {
+                let mut lifecycle = self.inner.lifecycle.lock().await;
+                if let Some(active) = &lifecycle.active {
+                    if active.kind == OperationKind::Start {
+                        active.cancel.cancel();
+                    }
+                    (
+                        active.completion.subscribe(),
+                        active.kind == OperationKind::Start,
+                    )
+                } else if !lifecycle.running
+                    && lifecycle.started.is_empty()
+                    && lifecycle.isolated.is_empty()
+                    && lifecycle.pending_release.is_empty()
+                {
+                    return Ok(self.snapshot());
+                } else {
+                    let monitor = lifecycle.monitor.take();
+                    if let Some(monitor) = &monitor {
+                        monitor.cancel.cancel();
+                    }
+                    let (id, cancel, completion, receiver) = self
+                        .inner
+                        .new_operation(&mut lifecycle, OperationKind::Stop);
+                    launch = Some((id, cancel, completion, monitor));
+                    (receiver, false)
+                }
+            };
+
+            if let Some((id, cancel, completion, monitor)) = launch {
+                self.inner.spawn_stop(id, cancel, completion, monitor);
+            }
+            let result = wait_for_operation(receiver).await;
+            if retry_after_wait {
+                continue;
+            }
+            return result;
+        }
+    }
+
+    /// Explicit observation-only refresh for internal callers.
+    ///
+    /// It is deadline-bounded and observation-only. Dynamic isolation is owned
+    /// by the supervisor's background monitor, so an HTTP GET never terminates
+    /// or detaches a backend.
+    pub async fn refresh(&self) -> OperationResult {
+        self.inner
+            .refresh_once(false, self.inner.shutdown.child_token())
+            .await
+    }
+
+    fn empty_status(entry: &RegisteredBackendRef) -> BackendStatus {
+        let descriptor = entry.descriptor();
+        BackendStatus::new(
+            descriptor.id().clone(),
+            descriptor.kind().clone(),
+            descriptor.ownership(),
+        )
+    }
+}
+
+impl SupervisorInner {
+    fn snapshot(&self) -> MeshSnapshot {
+        self.snapshots.borrow().clone()
+    }
+
+    fn new_operation(
+        &self,
+        lifecycle: &mut LifecycleState,
+        kind: OperationKind,
+    ) -> (
+        u64,
+        CancellationToken,
+        watch::Sender<Option<OperationResult>>,
+        watch::Receiver<Option<OperationResult>>,
+    ) {
+        lifecycle.next_operation_id = lifecycle.next_operation_id.saturating_add(1);
+        let id = lifecycle.next_operation_id;
+        let cancel = self.shutdown.child_token();
+        let (completion, receiver) = watch::channel(None);
+        lifecycle.active = Some(ActiveOperation {
+            id,
+            kind,
+            cancel: cancel.clone(),
+            completion: completion.clone(),
+        });
+        (id, cancel, completion, receiver)
+    }
+
+    fn spawn_start(
+        self: &Arc<Self>,
+        id: u64,
+        cancel: CancellationToken,
+        completion: watch::Sender<Option<OperationResult>>,
+    ) {
+        let worker_inner = Arc::clone(self);
+        let worker = tokio::spawn(async move { worker_inner.run_start(cancel).await });
+        let coordinator = Arc::clone(self);
+        tokio::spawn(async move {
+            let result = match worker.await {
+                Ok(result) => result,
+                Err(_) => coordinator.recover_worker_panic(OperationKind::Start).await,
+            };
+            coordinator.finish_operation(id).await;
+            completion.send_replace(Some(result));
+        });
+    }
+
+    fn spawn_stop(
+        self: &Arc<Self>,
+        id: u64,
+        cancel: CancellationToken,
+        completion: watch::Sender<Option<OperationResult>>,
+        monitor: Option<MonitorTask>,
+    ) {
+        let worker_inner = Arc::clone(self);
+        let worker = tokio::spawn(async move { worker_inner.run_stop(cancel, monitor).await });
+        let coordinator = Arc::clone(self);
+        tokio::spawn(async move {
+            let result = match worker.await {
+                Ok(result) => result,
+                Err(_) => coordinator.recover_worker_panic(OperationKind::Stop).await,
+            };
+            coordinator.finish_operation(id).await;
+            completion.send_replace(Some(result));
+        });
+    }
+
+    async fn finish_operation(&self, id: u64) {
+        let mut lifecycle = self.lifecycle.lock().await;
+        if lifecycle
+            .active
+            .as_ref()
+            .is_some_and(|active| active.id == id)
+        {
+            lifecycle.active = None;
+        }
+    }
+
+    /// Last-owner best-effort cleanup.
+    ///
+    /// Dropping the public supervisor first cancels an active transaction,
+    /// waits for its own bounded rollback, and only then retries residual
+    /// resources. This avoids racing a normal `stop` with a duplicate release.
+    async fn emergency_shutdown(self: Arc<Self>) {
+        self.shutdown.cancel();
+        let (receiver, monitor) = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            let monitor = lifecycle.monitor.take();
+            if let Some(monitor) = &monitor {
+                monitor.cancel.cancel();
+            }
+            (
+                lifecycle.active.as_ref().map(|active| {
+                    active.cancel.cancel();
+                    active.completion.subscribe()
+                }),
+                monitor,
+            )
+        };
+        Self::drain_monitor(monitor).await;
+        if let Some(receiver) = receiver {
+            let _ =
+                time::timeout(self.emergency_drain_timeout(), wait_for_operation(receiver)).await;
+        }
+
+        // A cancelled monitor may already be inside a fail-closed release.
+        // Waiting on the same maintenance boundary prevents duplicate
+        // detach/terminate calls and stale lifecycle commits.
+        let _maintenance = self.maintenance.lock().await;
+        let targets = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            let mut targets = lifecycle.started.clone();
+            if let Some(in_flight) = lifecycle.in_flight.take()
+                && !targets.contains(&in_flight)
+            {
+                targets.push(in_flight);
+            }
+            targets
+        };
+        if targets.is_empty() {
+            return;
+        }
+
+        let mut working = self.snapshot();
+        working.running = false;
+        working.supervisor_phase = MeshSupervisorPhase::Stopping;
+        for id in &targets {
+            if let Some(status) = working.statuses.get_mut(id) {
+                status.phase = BackendPhase::Stopping;
+            }
+        }
+        self.publish(working.clone());
+
+        let cleanup = CancellationToken::new();
+        let outcome = self
+            .release_targets(&targets, &cleanup, &mut working.statuses)
+            .await;
+        {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.started = retain_failed_order(&targets, &outcome.failed_ids);
+            lifecycle.running = false;
+            lifecycle.in_flight = None;
+            lifecycle
+                .pending_release
+                .retain(|id| outcome.failed_ids.contains(id));
+            if outcome.failures.is_empty() {
+                lifecycle.isolated.clear();
+                lifecycle.pending_release.clear();
+                lifecycle.isolation_conflicts.clear();
+            }
+        }
+        working.running = false;
+        if outcome.failures.is_empty() {
+            working.supervisor_phase = MeshSupervisorPhase::Stopped;
+            working.conflicts.clear();
+            working.diagnostics.clear();
+            for status in working.statuses.values_mut() {
+                status.phase = BackendPhase::Stopped;
+                status.diagnostics.clear();
+            }
+        } else {
+            working.supervisor_phase = MeshSupervisorPhase::Failed;
+            working
+                .diagnostics
+                .extend(outcome.failures.iter().map(BackendFailure::diagnostic));
+        }
+        self.publish(working);
+    }
+
+    fn emergency_drain_timeout(&self) -> Duration {
+        let backend_count =
+            u32::try_from(self.registry.len().saturating_add(1)).unwrap_or(u32::MAX);
+        self.options
+            .backend_timeouts
+            .gate
+            .saturating_add(self.options.backend_timeouts.release)
+            .saturating_mul(backend_count)
+            .saturating_add(Duration::from_secs(1))
+    }
+
+    async fn recover_worker_panic(&self, kind: OperationKind) -> OperationResult {
+        let operation = match kind {
+            OperationKind::Start => "start",
+            OperationKind::Stop => "stop",
+        };
+        let monitor = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            let monitor = lifecycle.monitor.take();
+            if let Some(monitor) = &monitor {
+                monitor.cancel.cancel();
+            }
+            monitor
+        };
+        Self::drain_monitor(monitor).await;
+        let _maintenance = self.maintenance.lock().await;
+        let targets = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            let mut targets = lifecycle.started.clone();
+            if let Some(in_flight) = lifecycle.in_flight.take()
+                && !targets.contains(&in_flight)
+            {
+                targets.push(in_flight);
+            }
+            lifecycle.running = false;
+            targets
+        };
+        let failure = BackendFailure::safe(
+            BackendId::new("mesh.supervisor").expect("static id"),
+            operation,
+            "internal_panic",
+            "mesh lifecycle worker panicked",
+        );
+        let mut working = self.snapshot();
+        let cleanup = CancellationToken::new();
+        let outcome = self
+            .release_targets(&targets, &cleanup, &mut working.statuses)
+            .await;
+        {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.started = retain_failed_order(&targets, &outcome.failed_ids);
+            lifecycle.in_flight = None;
+            lifecycle.running = false;
+            lifecycle
+                .pending_release
+                .retain(|id| outcome.failed_ids.contains(id));
+        }
+        working.running = false;
+        working.supervisor_phase = MeshSupervisorPhase::Failed;
+        working.diagnostics.push(failure.diagnostic());
+        working
+            .diagnostics
+            .extend(outcome.failures.iter().map(BackendFailure::diagnostic));
+        self.publish(working);
+        Err(MeshError::Internal {
+            failure,
+            cleanup_failures: outcome.failures,
+        })
+    }
+
+    async fn run_start(self: &Arc<Self>, cancel: CancellationToken) -> OperationResult {
+        {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.isolated.clear();
+            lifecycle.pending_release.clear();
+            lifecycle.isolation_conflicts.clear();
+        }
+        let mut working = self.snapshot();
+        working.supervisor_phase = MeshSupervisorPhase::Starting;
+        working.running = false;
+        working.conflicts.clear();
+        working.diagnostics.clear();
+        working.set_reservations(self.reservations.clone());
+        for entry in self.registry.iter() {
+            let status = working
+                .statuses
+                .entry(entry.id().clone())
+                .or_insert_with(|| MeshSupervisor::empty_status(entry));
+            status.phase = BackendPhase::Probing;
+        }
+        self.publish(working.clone());
+
+        let mut observations = Vec::with_capacity(self.registry.len());
+        let mut probe_failures = Vec::new();
+        for entry in self.registry.iter() {
+            match self.call_probe(entry, &cancel).await {
+                Ok(observation) => {
+                    if let Err(message) = Self::validate_observation(entry, &observation) {
+                        let failure = BackendFailure::safe(
+                            entry.id().clone(),
+                            "probe",
+                            "invalid_status",
+                            message,
+                        );
+                        let mut failed = MeshSupervisor::empty_status(entry);
+                        failed.phase = BackendPhase::Failed;
+                        failed.diagnostics.push(failure.diagnostic());
+                        working.insert_status(failed);
+                        probe_failures.push(failure);
+                    } else {
+                        working.insert_status(observation.clone());
+                        observations.push((entry.clone(), observation));
+                    }
+                }
+                Err(error) => {
+                    let failure = BackendFailure::from_backend(entry.id().clone(), "probe", &error);
+                    let mut failed = MeshSupervisor::empty_status(entry);
+                    failed.phase = BackendPhase::Failed;
+                    failed.diagnostics.push(failure.diagnostic());
+                    working.insert_status(failed);
+                    probe_failures.push(failure);
+                    if cancel.is_cancelled() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if !probe_failures.is_empty() {
+            {
+                let mut lifecycle = self.lifecycle.lock().await;
+                lifecycle.running = false;
+                lifecycle.in_flight = None;
+            }
+            working.supervisor_phase = MeshSupervisorPhase::Failed;
+            working
+                .diagnostics
+                .extend(probe_failures.iter().map(BackendFailure::diagnostic));
+            self.publish(working);
+            return Err(MeshError::Probe {
+                failures: probe_failures,
+            });
+        }
+
+        let conflicts = self.detect_observation_conflicts(&observations);
+        if !conflicts.is_empty() {
+            Self::mark_conflicts(&mut working, &conflicts, false);
+            {
+                let mut lifecycle = self.lifecycle.lock().await;
+                lifecycle.running = false;
+                lifecycle.in_flight = None;
+            }
+            self.publish(working);
+            return Err(MeshError::Conflicts { conflicts });
+        }
+
+        for (entry, observation) in observations {
+            {
+                let mut lifecycle = self.lifecycle.lock().await;
+                lifecycle.in_flight = Some(entry.id().clone());
+            }
+            let result = self
+                .call_reconcile(&entry, &observation, &cancel)
+                .await
+                .and_then(|status| {
+                    Self::validate_reconciled_status(&entry, &observation, &status)
+                        .map_err(|message| BackendError::new("invalid_status", message))?;
+                    Ok(status)
+                });
+
+            match result {
+                Ok(status) => {
+                    let mut lifecycle = self.lifecycle.lock().await;
+                    lifecycle.in_flight = None;
+                    lifecycle.started.push(entry.id().clone());
+                    drop(lifecycle);
+                    working.insert_status(status);
+                }
+                Err(error) => {
+                    let failure =
+                        BackendFailure::from_backend(entry.id().clone(), "reconcile", &error);
+                    let mut failed = observation;
+                    failed.phase = BackendPhase::Failed;
+                    failed.diagnostics.push(failure.diagnostic());
+                    working.insert_status(failed);
+
+                    let rollback_targets = {
+                        let mut lifecycle = self.lifecycle.lock().await;
+                        let mut targets = lifecycle.started.clone();
+                        if !targets.contains(entry.id()) {
+                            targets.push(entry.id().clone());
+                        }
+                        lifecycle.in_flight = None;
+                        targets
+                    };
+                    let cleanup = CancellationToken::new();
+                    let outcome = self
+                        .release_targets(&rollback_targets, &cleanup, &mut working.statuses)
+                        .await;
+                    {
+                        let mut lifecycle = self.lifecycle.lock().await;
+                        lifecycle.started =
+                            retain_failed_order(&rollback_targets, &outcome.failed_ids);
+                        lifecycle.running = false;
+                    }
+                    if let Some(status) = working.statuses.get_mut(entry.id()) {
+                        status.phase = BackendPhase::Failed;
+                    }
+                    working.running = false;
+                    working.supervisor_phase = MeshSupervisorPhase::Failed;
+                    working.diagnostics.push(failure.diagnostic());
+                    working
+                        .diagnostics
+                        .extend(outcome.failures.iter().map(BackendFailure::diagnostic));
+                    self.publish(working);
+                    return Err(MeshError::Reconcile {
+                        failure,
+                        rollback_failures: outcome.failures,
+                    });
+                }
+            }
+        }
+
+        if cancel.is_cancelled() {
+            let targets = {
+                let lifecycle = self.lifecycle.lock().await;
+                lifecycle.started.clone()
+            };
+            let failure = BackendFailure::safe(
+                BackendId::new("mesh.supervisor").expect("static id"),
+                "reconcile",
+                "operation_cancelled",
+                "startup was cancelled before commit",
+            );
+            let cleanup = CancellationToken::new();
+            let outcome = self
+                .release_targets(&targets, &cleanup, &mut working.statuses)
+                .await;
+            {
+                let mut lifecycle = self.lifecycle.lock().await;
+                lifecycle.started = retain_failed_order(&targets, &outcome.failed_ids);
+                lifecycle.running = false;
+            }
+            working.running = false;
+            working.supervisor_phase = MeshSupervisorPhase::Failed;
+            working.diagnostics.push(failure.diagnostic());
+            self.publish(working);
+            return Err(MeshError::Reconcile {
+                failure,
+                rollback_failures: outcome.failures,
+            });
+        }
+
+        let started = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.running = true;
+            lifecycle.in_flight = None;
+            lifecycle.started.clone()
+        };
+        working.running = true;
+        working.supervisor_phase = self.aggregate_phase(&started, &working.statuses);
+        self.publish(working);
+        self.install_monitor().await;
+        Ok(self.snapshot())
+    }
+
+    async fn run_stop(
+        &self,
+        cancel: CancellationToken,
+        monitor: Option<MonitorTask>,
+    ) -> OperationResult {
+        Self::drain_monitor(monitor).await;
+        // `refresh_once` holds this boundary across observation, isolation,
+        // and lifecycle commit. Stop must join that same serial order before
+        // re-reading `started`, otherwise it can release a backend twice.
+        let _maintenance = self.maintenance.lock().await;
+        let targets = {
+            let lifecycle = self.lifecycle.lock().await;
+            lifecycle.started.clone()
+        };
+        let mut working = self.snapshot();
+        working.supervisor_phase = MeshSupervisorPhase::Stopping;
+        working.running = false;
+        working.diagnostics.clear();
+        for id in &targets {
+            if let Some(status) = working.statuses.get_mut(id) {
+                status.phase = BackendPhase::Stopping;
+            }
+        }
+        self.publish(working.clone());
+
+        let outcome = self
+            .release_targets(&targets, &cancel, &mut working.statuses)
+            .await;
+        {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.started = retain_failed_order(&targets, &outcome.failed_ids);
+            lifecycle.running = false;
+            lifecycle.in_flight = None;
+            lifecycle
+                .pending_release
+                .retain(|id| outcome.failed_ids.contains(id));
+            if outcome.failures.is_empty() {
+                lifecycle.isolated.clear();
+                lifecycle.pending_release.clear();
+                lifecycle.isolation_conflicts.clear();
+            }
+        }
+        working.running = false;
+        if outcome.failures.is_empty() {
+            working.conflicts.clear();
+            working.diagnostics.clear();
+            for status in working.statuses.values_mut() {
+                status.phase = BackendPhase::Stopped;
+                status.diagnostics.clear();
+            }
+            working.supervisor_phase = MeshSupervisorPhase::Stopped;
+            self.publish(working);
+            Ok(self.snapshot())
+        } else {
+            working.supervisor_phase = MeshSupervisorPhase::Failed;
+            working
+                .diagnostics
+                .extend(outcome.failures.iter().map(BackendFailure::diagnostic));
+            self.publish(working);
+            Err(MeshError::Stop {
+                failures: outcome.failures,
+            })
+        }
+    }
+
+    async fn install_monitor(self: &Arc<Self>) {
+        if self.options.monitor_interval.is_zero() {
+            return;
+        }
+        let cancel = self.shutdown.child_token();
+        let task_cancel = cancel.clone();
+        let weak: Weak<Self> = Arc::downgrade(self);
+        let interval_duration = self.options.monitor_interval;
+        let join = tokio::spawn(async move {
+            let mut interval = time::interval(interval_duration);
+            interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            // `interval` ticks immediately; dynamic state cannot have changed
+            // before the configured first interval.
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = task_cancel.cancelled() => break,
+                    _ = interval.tick() => {
+                        let Some(inner) = weak.upgrade() else {
+                            break;
+                        };
+                        let _ = inner.refresh_once(true, task_cancel.clone()).await;
+                    }
+                }
+            }
+        });
+        let previous = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.monitor.replace(MonitorTask { cancel, join })
+        };
+        if let Some(previous) = previous {
+            previous.cancel.cancel();
+            Self::drain_monitor(Some(previous)).await;
+        }
+    }
+
+    async fn drain_monitor(monitor: Option<MonitorTask>) {
+        let Some(monitor) = monitor else {
+            return;
+        };
+        // Do not render JoinError: a panic payload may contain adapter data.
+        // The maintenance mutex is acquired after this call and remains the
+        // authoritative proof that no monitor side effect is still running.
+        let _ = monitor.join.await;
+    }
+
+    async fn refresh_once(
+        &self,
+        isolate_conflicts: bool,
+        cancel: CancellationToken,
+    ) -> OperationResult {
+        let _maintenance = match self.acquire_maintenance(&cancel).await {
+            Ok(guard) => guard,
+            Err(error) => {
+                return Err(MeshError::Status {
+                    failures: vec![BackendFailure::from_backend(
+                        BackendId::new("mesh.supervisor").expect("static id"),
+                        "status",
+                        &error,
+                    )],
+                });
+            }
+        };
+
+        let (
+            mut started,
+            was_running,
+            operation_active,
+            isolated,
+            pending_release,
+            isolation_conflicts,
+        ) = {
+            let lifecycle = self.lifecycle.lock().await;
+            (
+                lifecycle.started.clone(),
+                lifecycle.running,
+                lifecycle.active.is_some(),
+                lifecycle.isolated.clone(),
+                lifecycle.pending_release.clone(),
+                lifecycle.isolation_conflicts.clone(),
+            )
+        };
+        if operation_active {
+            return Ok(self.snapshot());
+        }
+
+        let mut working = self.snapshot();
+        if isolated.is_empty() {
+            working.conflicts.clear();
+            working.diagnostics.clear();
+        } else {
+            working.conflicts = isolation_conflicts.clone();
+        }
+
+        // A failed fail-closed release remains a release obligation even if a
+        // later status call looks healthy. Retry it before trusting or
+        // publishing any new observation. Once release begins it uses a fresh
+        // bounded cleanup token: cancelling the monitor asks it to stop after
+        // the commit, rather than dropping an externally visible operation
+        // half-way through and racing explicit `stop`.
+        if isolate_conflicts && !pending_release.is_empty() {
+            if cancel.is_cancelled() {
+                return Ok(self.snapshot());
+            }
+            let targets: Vec<_> = started
+                .iter()
+                .filter(|id| pending_release.contains(*id))
+                .cloned()
+                .collect();
+            let cleanup = CancellationToken::new();
+            let outcome = self
+                .release_targets(&targets, &cleanup, &mut working.statuses)
+                .await;
+            let released: BTreeSet<_> = targets
+                .iter()
+                .filter(|id| !outcome.failed_ids.contains(*id))
+                .cloned()
+                .collect();
+            {
+                let mut lifecycle = self.lifecycle.lock().await;
+                lifecycle.started.retain(|id| !released.contains(id));
+                lifecycle
+                    .pending_release
+                    .retain(|id| outcome.failed_ids.contains(id));
+                lifecycle.running = false;
+                started = lifecycle.started.clone();
+            }
+            for id in &targets {
+                if let Some(status) = working.statuses.get_mut(id) {
+                    status.phase = if outcome.failed_ids.contains(id) {
+                        BackendPhase::Failed
+                    } else {
+                        BackendPhase::Stopped
+                    };
+                    push_diagnostic_unique(
+                        &mut status.diagnostics,
+                        Diagnostic::new(
+                            if outcome.failed_ids.contains(id) {
+                                DiagnosticLevel::Error
+                            } else {
+                                DiagnosticLevel::Warning
+                            },
+                            if outcome.failed_ids.contains(id) {
+                                "mesh.fail_closed_release_retry_failed"
+                            } else {
+                                "mesh.fail_closed_release_retry_succeeded"
+                            },
+                            if outcome.failed_ids.contains(id) {
+                                "fail-closed backend release retry failed"
+                            } else {
+                                "fail-closed backend release retry succeeded"
+                            },
+                        ),
+                    );
+                }
+            }
+            working.running = false;
+            working.supervisor_phase = MeshSupervisorPhase::Degraded;
+            working.conflicts = isolation_conflicts.clone();
+            for failure in &outcome.failures {
+                push_diagnostic_unique(&mut working.diagnostics, failure.diagnostic());
+            }
+            self.publish(working.clone());
+            if !outcome.failures.is_empty() {
+                return Err(MeshError::Status {
+                    failures: outcome.failures,
+                });
+            }
+            if started.is_empty() || cancel.is_cancelled() {
+                return Ok(self.snapshot());
+            }
+        }
+
+        if started.is_empty() {
+            return Ok(self.snapshot());
+        }
+
+        let mut failures = Vec::new();
+        for id in &started {
+            let Some(entry) = self.registry.get(id) else {
+                failures.push(BackendFailure::safe(
+                    id.clone(),
+                    "status",
+                    "registry_entry_missing",
+                    "registered backend disappeared",
+                ));
+                continue;
+            };
+            match self.call_status(entry, &cancel).await {
+                Ok(status) => {
+                    let expected = working.statuses.get(id);
+                    if let Err(message) =
+                        Self::validate_running_observation(entry, expected, &status)
+                    {
+                        failures.push(BackendFailure::safe(
+                            id.clone(),
+                            "status",
+                            "invalid_status",
+                            message,
+                        ));
+                    } else {
+                        working.insert_status(status);
+                    }
+                }
+                Err(error) => {
+                    failures.push(BackendFailure::from_backend(id.clone(), "status", &error));
+                }
+            }
+            if cancel.is_cancelled() {
+                return Ok(self.snapshot());
+            }
+        }
+
+        if !failures.is_empty() {
+            for failure in &failures {
+                if let Some(status) = working.statuses.get_mut(&failure.backend) {
+                    status.phase = BackendPhase::Degraded;
+                    status.diagnostics.push(failure.diagnostic());
+                }
+            }
+            if self.lifecycle.lock().await.active.is_some() {
+                return Ok(self.snapshot());
+            }
+
+            // A monitor must fail closed when status identity or resource
+            // claims cannot be verified. Public refresh remains observation
+            // only and therefore never reaches this release path.
+            let mut release_failures = Vec::new();
+            if isolate_conflicts {
+                let failed_ids: BTreeSet<_> = failures
+                    .iter()
+                    .map(|failure| failure.backend.clone())
+                    .collect();
+                let targets: Vec<_> = started
+                    .iter()
+                    .filter(|id| failed_ids.contains(*id))
+                    .cloned()
+                    .collect();
+                if cancel.is_cancelled() {
+                    return Ok(self.snapshot());
+                }
+                let cleanup = CancellationToken::new();
+                let outcome = self
+                    .release_targets(&targets, &cleanup, &mut working.statuses)
+                    .await;
+                let released: BTreeSet<_> = targets
+                    .iter()
+                    .filter(|id| !outcome.failed_ids.contains(*id))
+                    .cloned()
+                    .collect();
+                {
+                    let mut lifecycle = self.lifecycle.lock().await;
+                    lifecycle.started.retain(|id| !released.contains(id));
+                    lifecycle.isolated.extend(targets.iter().cloned());
+                    lifecycle
+                        .pending_release
+                        .extend(outcome.failed_ids.iter().cloned());
+                    lifecycle.running = false;
+                }
+                for id in &targets {
+                    if let Some(status) = working.statuses.get_mut(id) {
+                        status.phase = BackendPhase::Failed;
+                        status.diagnostics.push(Diagnostic::new(
+                            if outcome.failed_ids.contains(id) {
+                                DiagnosticLevel::Error
+                            } else {
+                                DiagnosticLevel::Warning
+                            },
+                            if outcome.failed_ids.contains(id) {
+                                "mesh.status_fail_closed_isolation_failed"
+                            } else {
+                                "mesh.status_fail_closed_isolated"
+                            },
+                            if outcome.failed_ids.contains(id) {
+                                "backend status could not be verified; fail-closed isolation failed"
+                            } else {
+                                "backend status could not be verified; backend was isolated"
+                            },
+                        ));
+                    }
+                }
+                release_failures = outcome.failures;
+                working.running = false;
+            } else {
+                working.running = was_running;
+            }
+            working.supervisor_phase = MeshSupervisorPhase::Degraded;
+            working
+                .diagnostics
+                .extend(failures.iter().map(BackendFailure::diagnostic));
+            working
+                .diagnostics
+                .extend(release_failures.iter().map(BackendFailure::diagnostic));
+            self.publish(working);
+            failures.extend(release_failures);
+            return Err(MeshError::Status { failures });
+        }
+
+        let mut claims = self.reservations.clone();
+        for id in &started {
+            if let Some(status) = working.statuses.get(id) {
+                claims.extend(status.owned_resource_claims());
+            }
+        }
+        let conflicts = detect_conflicts(&claims);
+        if conflicts.is_empty() {
+            if self.lifecycle.lock().await.active.is_some() {
+                return Ok(self.snapshot());
+            }
+            working.running =
+                was_running && isolated.is_empty() && started.len() == self.registry.len();
+            working.supervisor_phase = if isolated.is_empty() {
+                self.aggregate_phase(&started, &working.statuses)
+            } else {
+                MeshSupervisorPhase::Degraded
+            };
+            working.conflicts = isolation_conflicts;
+            self.publish(working);
+            return Ok(self.snapshot());
+        }
+
+        Self::mark_conflicts(&mut working, &conflicts, true);
+        working.conflicts = merge_conflicts(isolation_conflicts.clone(), conflicts.clone());
+        if !isolate_conflicts {
+            if self.lifecycle.lock().await.active.is_some() {
+                return Ok(self.snapshot());
+            }
+            working.running = was_running;
+            self.publish(working);
+            return Err(MeshError::Conflicts { conflicts });
+        }
+
+        // Only backend owners can be isolated. Host reservations remain
+        // authoritative and never receive lifecycle calls.
+        let affected: BTreeSet<BackendId> = conflicts
+            .iter()
+            .flat_map(|conflict| [&conflict.left.owner, &conflict.right.owner])
+            .filter_map(|owner| match owner {
+                ResourceOwner::Backend(id) => Some(id.clone()),
+                ResourceOwner::HostSubsystem(_) => None,
+            })
+            .collect();
+        let targets: Vec<_> = started
+            .iter()
+            .filter(|id| affected.contains(*id))
+            .cloned()
+            .collect();
+        if cancel.is_cancelled() {
+            return Ok(self.snapshot());
+        }
+        let cleanup = CancellationToken::new();
+        let outcome = self
+            .release_targets(&targets, &cleanup, &mut working.statuses)
+            .await;
+
+        let released: BTreeSet<_> = targets
+            .iter()
+            .filter(|id| !outcome.failed_ids.contains(*id))
+            .cloned()
+            .collect();
+        let latched_conflicts = {
+            let mut lifecycle = self.lifecycle.lock().await;
+            lifecycle.started.retain(|id| !released.contains(id));
+            lifecycle.isolated.extend(targets.iter().cloned());
+            lifecycle
+                .pending_release
+                .extend(outcome.failed_ids.iter().cloned());
+            lifecycle.isolation_conflicts =
+                merge_conflicts(lifecycle.isolation_conflicts.clone(), conflicts.clone());
+            lifecycle.running = false;
+            lifecycle.isolation_conflicts.clone()
+        };
+        for id in &targets {
+            if let Some(status) = working.statuses.get_mut(id) {
+                status.phase = BackendPhase::Conflict;
+                status.diagnostics.push(Diagnostic::new(
+                    if outcome.failed_ids.contains(id) {
+                        DiagnosticLevel::Error
+                    } else {
+                        DiagnosticLevel::Warning
+                    },
+                    if outcome.failed_ids.contains(id) {
+                        "mesh.dynamic_conflict_isolation_failed"
+                    } else {
+                        "mesh.dynamic_conflict_isolated"
+                    },
+                    if outcome.failed_ids.contains(id) {
+                        "dynamic resource conflict detected; automatic isolation failed"
+                    } else {
+                        "dynamic resource conflict detected; backend was isolated"
+                    },
+                ));
+            }
+        }
+        working.running = false;
+        working.supervisor_phase = MeshSupervisorPhase::Degraded;
+        working.conflicts = latched_conflicts;
+        working
+            .diagnostics
+            .extend(outcome.failures.iter().map(BackendFailure::diagnostic));
+        self.publish(working);
+        Err(MeshError::Conflicts { conflicts })
+    }
+
+    fn detect_observation_conflicts(
+        &self,
+        observations: &[(RegisteredBackendRef, BackendStatus)],
+    ) -> Vec<ResourceConflict> {
+        let mut claims = self.reservations.clone();
+        for (_, observation) in observations {
+            claims.extend(observation.owned_resource_claims());
+        }
+        detect_conflicts(&claims)
+    }
+
+    fn mark_conflicts(working: &mut MeshSnapshot, conflicts: &[ResourceConflict], dynamic: bool) {
+        let affected: BTreeSet<_> = conflicts
+            .iter()
+            .flat_map(|conflict| [&conflict.left.owner, &conflict.right.owner])
+            .filter_map(ResourceOwner::backend_id)
+            .cloned()
+            .collect();
+        for id in affected {
+            if let Some(status) = working.statuses.get_mut(&id) {
+                status.phase = BackendPhase::Conflict;
+                status.diagnostics.push(Diagnostic::new(
+                    DiagnosticLevel::Error,
+                    "mesh.resource_conflict",
+                    if dynamic {
+                        format!("backend `{id}` now claims a host resource incompatibly")
+                    } else {
+                        format!("backend `{id}` claims a host resource incompatibly")
+                    },
+                ));
+            }
+        }
+        working.running = false;
+        working.supervisor_phase = MeshSupervisorPhase::Degraded;
+        working.conflicts = conflicts.to_vec();
+        working.diagnostics.push(Diagnostic::new(
+            DiagnosticLevel::Error,
+            if dynamic {
+                "mesh.dynamic_resource_conflicts"
+            } else {
+                "mesh.resource_conflicts"
+            },
+            format!(
+                "{} {}host resource conflict(s) detected",
+                conflicts.len(),
+                if dynamic { "dynamic " } else { "" }
+            ),
+        ));
+    }
+
+    async fn release_targets(
+        &self,
+        targets: &[BackendId],
+        cancel: &CancellationToken,
+        statuses: &mut BTreeMap<BackendId, BackendStatus>,
+    ) -> ReleaseOutcome {
+        let mut outcome = ReleaseOutcome::default();
+        for id in targets.iter().rev() {
+            let Some(entry) = self.registry.get(id) else {
+                let failure = BackendFailure::safe(
+                    id.clone(),
+                    "release",
+                    "registry_entry_missing",
+                    "registered backend disappeared",
+                );
+                mark_release_failed(statuses, &failure);
+                outcome.failed_ids.insert(id.clone());
+                outcome.failures.push(failure);
+                continue;
+            };
+            let operation = match entry.descriptor().ownership() {
+                crate::model::BackendOwnership::AttachExternal => "detach",
+                crate::model::BackendOwnership::ManagedChild
+                | crate::model::BackendOwnership::Embedded => "terminate",
+            };
+            match self.call_release(entry, operation, cancel).await {
+                Ok(()) => {
+                    if let Some(status) = statuses.get_mut(id) {
+                        status.phase = BackendPhase::Stopped;
+                    }
+                }
+                Err(error) => {
+                    let failure = BackendFailure::from_backend(id.clone(), operation, &error);
+                    mark_release_failed(statuses, &failure);
+                    outcome.failed_ids.insert(id.clone());
+                    outcome.failures.push(failure);
+                }
+            }
+        }
+        outcome
+    }
+
+    async fn call_probe(
+        &self,
+        entry: &RegisteredBackendRef,
+        cancel: &CancellationToken,
+    ) -> BackendResult<BackendStatus> {
+        let _guard = self.acquire_backend(entry, "probe", cancel).await?;
+        self.await_backend(
+            "probe",
+            self.options.backend_timeouts.probe,
+            cancel,
+            entry.probe(),
+        )
+        .await
+    }
+
+    async fn call_reconcile(
+        &self,
+        entry: &RegisteredBackendRef,
+        observation: &BackendStatus,
+        cancel: &CancellationToken,
+    ) -> BackendResult<BackendStatus> {
+        let _guard = self.acquire_backend(entry, "reconcile", cancel).await?;
+        self.await_backend(
+            "reconcile",
+            self.options.backend_timeouts.reconcile,
+            cancel,
+            entry.reconcile(observation),
+        )
+        .await
+    }
+
+    async fn call_status(
+        &self,
+        entry: &RegisteredBackendRef,
+        cancel: &CancellationToken,
+    ) -> BackendResult<BackendStatus> {
+        let _guard = self.acquire_backend(entry, "status", cancel).await?;
+        self.await_backend(
+            "status",
+            self.options.backend_timeouts.status,
+            cancel,
+            entry.status(),
+        )
+        .await
+    }
+
+    async fn call_release(
+        &self,
+        entry: &RegisteredBackendRef,
+        operation: &'static str,
+        cancel: &CancellationToken,
+    ) -> BackendResult<()> {
+        let _guard = self.acquire_backend(entry, operation, cancel).await?;
+        self.await_backend(
+            operation,
+            self.options.backend_timeouts.release,
+            cancel,
+            entry.release(),
+        )
+        .await
+    }
+
+    async fn acquire_backend<'a>(
+        &self,
+        entry: &'a RegisteredBackend,
+        operation: &'static str,
+        cancel: &CancellationToken,
+    ) -> BackendResult<MutexGuard<'a, ()>> {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => Err(BackendError::cancelled(operation)),
+            result = time::timeout(
+                self.options.backend_timeouts.gate,
+                entry.call_gate().lock(),
+            ) => result.map_err(|_| BackendError::timed_out(operation)),
+        }
+    }
+
+    async fn acquire_maintenance<'a>(
+        &'a self,
+        cancel: &CancellationToken,
+    ) -> BackendResult<MutexGuard<'a, ()>> {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => Err(BackendError::cancelled("status")),
+            result = time::timeout(
+                self.options.backend_timeouts.gate,
+                self.maintenance.lock(),
+            ) => result.map_err(|_| BackendError::timed_out("status")),
+        }
+    }
+
+    async fn await_backend<T>(
+        &self,
+        operation: &'static str,
+        deadline: Duration,
+        cancel: &CancellationToken,
+        future: impl Future<Output = BackendResult<T>>,
+    ) -> BackendResult<T> {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => Err(BackendError::cancelled(operation)),
+            result = time::timeout(
+                deadline,
+                CatchUnwindFuture::new(future),
+            ) => {
+                match result {
+                    Err(_) => Err(BackendError::timed_out(operation)),
+                    Ok(Err(())) => Err(BackendError::new(
+                        "backend_panic",
+                        format!("{operation} panicked inside the backend adapter"),
+                    )),
+                    Ok(Ok(result)) => result,
+                }
+            }
+        }
+    }
+
+    fn validate_identity(
+        entry: &RegisteredBackendRef,
+        status: &BackendStatus,
+    ) -> Result<(), String> {
+        let descriptor = entry.descriptor();
+        if &status.id != descriptor.id() {
+            return Err(format!(
+                "returned id `{}` does not match frozen id `{}`",
+                status.id,
+                descriptor.id()
+            ));
+        }
+        if &status.kind != descriptor.kind() {
+            return Err("returned backend kind does not match the frozen descriptor".to_owned());
+        }
+        if status.ownership != descriptor.ownership() {
+            return Err(
+                "returned backend ownership does not match the frozen descriptor".to_owned(),
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_observation(
+        entry: &RegisteredBackendRef,
+        status: &BackendStatus,
+    ) -> Result<(), String> {
+        Self::validate_observation_bounds(status).map_err(str::to_owned)?;
+        Self::validate_identity(entry, status)
+    }
+
+    fn validate_running_observation(
+        entry: &RegisteredBackendRef,
+        expected: Option<&BackendStatus>,
+        status: &BackendStatus,
+    ) -> Result<(), String> {
+        Self::validate_observation(entry, status)?;
+        if entry.descriptor().ownership() == BackendOwnership::AttachExternal {
+            let Some(expected) = expected else {
+                return Err("external backend has no frozen resource claim envelope".to_owned());
+            };
+            if normalized_resource_claims(&expected.resource_claims)
+                != normalized_resource_claims(&status.resource_claims)
+            {
+                return Err(
+                    "external backend changed its conservative resource claim envelope".to_owned(),
+                );
+            }
+        }
+        if !is_running_backend_phase(status.phase) {
+            return Err("status returned a non-running phase".to_owned());
+        }
+        Ok(())
+    }
+
+    fn validate_observation_bounds(status: &BackendStatus) -> Result<(), &'static str> {
+        if status.attachments.len() > MAX_ATTACHMENTS_PER_OBSERVATION
+            || status.resource_claims.len() > MAX_RESOURCE_CLAIMS_PER_OBSERVATION
+            || status.diagnostics.len() > MAX_DIAGNOSTICS_PER_SCOPE
+            || status.capabilities.len() > MAX_CAPABILITIES_PER_OBSERVATION
+        {
+            return Err(INVALID_OBSERVATION_MESSAGE);
+        }
+
+        let mut budget = ObservationBudget::default();
+        budget.add_collection(status.capabilities.len())?;
+        budget.add_collection(status.attachments.len())?;
+        budget.add_collection(status.resource_claims.len())?;
+        budget.add_collection(status.diagnostics.len())?;
+
+        if let BackendKind::Other(name) = &status.kind {
+            budget.add_string(name)?;
+        }
+        if let Some(version) = &status.version {
+            budget.add_string(version)?;
+        }
+        for attachment in &status.attachments {
+            validate_attachment_bounds(attachment, &mut budget)?;
+        }
+        for claim in &status.resource_claims {
+            validate_resource_claim_bounds(claim, &mut budget)?;
+        }
+        for diagnostic in &status.diagnostics {
+            budget.add_string_with_limit(&diagnostic.code, MAX_DIAGNOSTIC_CODE_BYTES)?;
+            budget.add_string_with_limit(&diagnostic.message, MAX_DIAGNOSTIC_MESSAGE_BYTES)?;
+        }
+        Ok(())
+    }
+
+    fn validate_reconciled_status(
+        entry: &RegisteredBackendRef,
+        observation: &BackendStatus,
+        status: &BackendStatus,
+    ) -> Result<(), String> {
+        Self::validate_observation(entry, status)?;
+
+        if normalized_resource_claims(&observation.resource_claims)
+            != normalized_resource_claims(&status.resource_claims)
+        {
+            return Err(
+                "reconcile returned resource claims that were not covered by preflight".to_owned(),
+            );
+        }
+        if !is_running_backend_phase(status.phase) {
+            return Err("reconcile returned a non-running phase".to_owned());
+        }
+        Ok(())
+    }
+
+    fn aggregate_phase(
+        &self,
+        started: &[BackendId],
+        statuses: &BTreeMap<BackendId, BackendStatus>,
+    ) -> MeshSupervisorPhase {
+        if started.len() == self.registry.len()
+            && started.iter().all(|id| {
+                statuses
+                    .get(id)
+                    .is_some_and(|status| status.phase == BackendPhase::Ready)
+            })
+        {
+            MeshSupervisorPhase::Running
+        } else {
+            MeshSupervisorPhase::Degraded
+        }
+    }
+
+    fn publish(&self, mut snapshot: MeshSnapshot) {
+        let previous = self.snapshots.borrow().generation;
+        snapshot.generation = previous.saturating_add(1);
+        snapshot.set_reservations(self.reservations.clone());
+        normalize_diagnostics(&mut snapshot.diagnostics);
+        for status in snapshot.statuses.values_mut() {
+            normalize_diagnostics(&mut status.diagnostics);
+        }
+        self.snapshots.send_replace(snapshot);
+    }
+}
+
+fn is_running_backend_phase(phase: BackendPhase) -> bool {
+    matches!(
+        phase,
+        BackendPhase::Ready
+            | BackendPhase::Degraded
+            | BackendPhase::NeedsAuth
+            | BackendPhase::Connecting
+    )
+}
+
+fn normalized_resource_claims(claims: &[ResourceClaim]) -> Vec<ResourceClaim> {
+    let mut claims = claims.to_vec();
+    claims.sort();
+    claims.dedup();
+    claims
+}
+
+fn validate_attachment_bounds(
+    attachment: &Attachment,
+    budget: &mut ObservationBudget,
+) -> Result<(), &'static str> {
+    match attachment {
+        Attachment::Interface(interface) => {
+            budget.add_string(&interface.name)?;
+            budget.add_collection(interface.addresses.len())?;
+        }
+        Attachment::Route(route) => {
+            if let Some(interface) = &route.interface {
+                budget.add_string(interface)?;
+            }
+        }
+        Attachment::Endpoint(endpoint) => {
+            if let EndpointPurpose::Other(purpose) = &endpoint.purpose {
+                budget.add_string(purpose)?;
+            }
+            validate_endpoint_address_bounds(&endpoint.address, budget)?;
+        }
+        Attachment::Ingress(ingress) => {
+            budget.add_string(&ingress.name)?;
+            if let IngressProtocol::Other(protocol) = &ingress.protocol {
+                budget.add_string(protocol)?;
+            }
+            if let Some(source) = &ingress.source {
+                budget.add_string(source)?;
+            }
+            validate_endpoint_address_bounds(&ingress.target, budget)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_endpoint_address_bounds(
+    address: &EndpointAddress,
+    budget: &mut ObservationBudget,
+) -> Result<(), &'static str> {
+    match address {
+        EndpointAddress::Socket(_) => Ok(()),
+        EndpointAddress::UnixSocket(path) => budget.add_string(&path.to_string_lossy()),
+        EndpointAddress::NamedPipe(value)
+        | EndpointAddress::Url(value)
+        | EndpointAddress::Opaque(value) => budget.add_string(value),
+    }
+}
+
+fn validate_resource_claim_bounds(
+    claim: &ResourceClaim,
+    budget: &mut ObservationBudget,
+) -> Result<(), &'static str> {
+    if let ClaimMode::CoordinatedShared { coordination_key } = &claim.mode {
+        budget.add_string(coordination_key)?;
+    }
+    match &claim.resource {
+        SystemResource::Interface { name } => budget.add_string(name)?,
+        SystemResource::ListenSocket { transport, .. } => {
+            if let SocketTransport::Other(transport) = transport {
+                budget.add_string(transport)?;
+            }
+        }
+        SystemResource::RouteManager
+        | SystemResource::InterfaceManager
+        | SystemResource::DefaultRouteV4
+        | SystemResource::DefaultRouteV6
+        | SystemResource::DnsManager
+        | SystemResource::FirewallManager
+        | SystemResource::HostsDatabase
+        | SystemResource::AddressPrefix { .. }
+        | SystemResource::RoutePrefix { .. }
+        | SystemResource::RouteTable { .. }
+        | SystemResource::FwmarkRange { .. } => {}
+    }
+    Ok(())
+}
+
+/// Convert a panic raised while polling an untrusted backend future into a
+/// normal, redacted backend failure. The panic payload is deliberately ignored.
+struct CatchUnwindFuture<F> {
+    inner: Pin<Box<F>>,
+}
+
+impl<F> CatchUnwindFuture<F> {
+    fn new(future: F) -> Self {
+        Self {
+            inner: Box::pin(future),
+        }
+    }
+}
+
+impl<F: Future> Future for CatchUnwindFuture<F> {
+    type Output = Result<F::Output, ()>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match catch_unwind(AssertUnwindSafe(|| this.inner.as_mut().poll(context))) {
+            Ok(Poll::Ready(output)) => Poll::Ready(Ok(output)),
+            Ok(Poll::Pending) => Poll::Pending,
+            Err(_) => Poll::Ready(Err(())),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ReleaseOutcome {
+    failures: Vec<BackendFailure>,
+    failed_ids: BTreeSet<BackendId>,
+}
+
+fn mark_release_failed(
+    statuses: &mut BTreeMap<BackendId, BackendStatus>,
+    failure: &BackendFailure,
+) {
+    if let Some(status) = statuses.get_mut(&failure.backend) {
+        status.phase = BackendPhase::Failed;
+        push_diagnostic_unique(&mut status.diagnostics, failure.diagnostic());
+    }
+}
+
+fn push_diagnostic_unique(diagnostics: &mut Vec<Diagnostic>, mut diagnostic: Diagnostic) {
+    normalize_diagnostic_fields(&mut diagnostic);
+    if let Some(index) = diagnostics
+        .iter()
+        .position(|existing| existing.level == diagnostic.level && existing.code == diagnostic.code)
+    {
+        diagnostics.remove(index);
+    }
+    diagnostics.push(diagnostic);
+    normalize_diagnostics(diagnostics);
+}
+
+fn normalize_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    // Adapter-supplied messages may contain a retry counter or timestamp. Keep
+    // only the newest value for each stable (level, code) identity, and retain
+    // only the newest bounded set of identities. This keeps long-running
+    // monitor snapshots bounded without trusting adapter message stability.
+    let mut identities = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(diagnostics.len().min(MAX_DIAGNOSTICS_PER_SCOPE));
+    for mut diagnostic in diagnostics.drain(..).rev() {
+        normalize_diagnostic_fields(&mut diagnostic);
+        let identity = (diagnostic.level, diagnostic.code.clone());
+        if identities.insert(identity) {
+            normalized.push(diagnostic);
+            if normalized.len() == MAX_DIAGNOSTICS_PER_SCOPE {
+                break;
+            }
+        }
+    }
+    normalized.reverse();
+    *diagnostics = normalized;
+}
+
+fn normalize_diagnostic_fields(diagnostic: &mut Diagnostic) {
+    truncate_utf8_bytes(&mut diagnostic.code, MAX_DIAGNOSTIC_CODE_BYTES);
+    truncate_utf8_bytes(&mut diagnostic.message, MAX_DIAGNOSTIC_MESSAGE_BYTES);
+}
+
+fn truncate_utf8_bytes(value: &mut String, max_bytes: usize) {
+    if value.len() <= max_bytes {
+        return;
+    }
+    let mut boundary = max_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary = boundary.saturating_sub(1);
+    }
+    value.truncate(boundary);
+}
+
+fn retain_failed_order(original: &[BackendId], failed: &BTreeSet<BackendId>) -> Vec<BackendId> {
+    original
+        .iter()
+        .filter(|id| failed.contains(*id))
+        .cloned()
+        .collect()
+}
+
+fn merge_conflicts(
+    mut existing: Vec<ResourceConflict>,
+    additional: Vec<ResourceConflict>,
+) -> Vec<ResourceConflict> {
+    existing.extend(additional);
+    existing.sort();
+    existing.dedup();
+    existing
+}
+
+async fn wait_for_operation(
+    mut receiver: watch::Receiver<Option<OperationResult>>,
+) -> OperationResult {
+    loop {
+        if let Some(result) = receiver.borrow().clone() {
+            return result;
+        }
+        if receiver.changed().await.is_err() {
+            return Err(MeshError::OperationLost);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::pending,
+        io,
+        sync::{
+            Arc, Mutex as StdMutex,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Instant,
+    };
+
+    use async_trait::async_trait;
+    use tokio::{
+        sync::Notify,
+        time::{sleep, timeout},
+    };
+
+    use super::*;
+    use crate::{
+        backend::{BackendDescriptor, ExternalNetworkBackend, NetworkBackend, OwnedNetworkBackend},
+        model::{
+            BackendKind, BackendObservation, BackendOwnership, EndpointAttachment, HostSubsystemId,
+            InterfaceAttachment, ResourceClaim, SystemResource,
+        },
+    };
+
+    const TEST_TIMEOUT: Duration = Duration::from_millis(40);
+    const TEST_DEADLINE: Duration = Duration::from_secs(2);
+
+    #[test]
+    fn diagnostics_keep_latest_message_per_stable_identity() {
+        let mut diagnostics = vec![
+            Diagnostic::new(DiagnosticLevel::Error, "mesh.retry", "attempt 1"),
+            Diagnostic::new(DiagnosticLevel::Warning, "mesh.retry", "warning"),
+            Diagnostic::new(DiagnosticLevel::Error, "mesh.retry", "attempt 2"),
+        ];
+
+        normalize_diagnostics(&mut diagnostics);
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].level, DiagnosticLevel::Warning);
+        assert_eq!(diagnostics[0].message, "warning");
+        assert_eq!(diagnostics[1].level, DiagnosticLevel::Error);
+        assert_eq!(diagnostics[1].message, "attempt 2");
+    }
+
+    #[test]
+    fn diagnostics_are_bounded_to_the_newest_stable_identities() {
+        let mut diagnostics = (0..(MAX_DIAGNOSTICS_PER_SCOPE + 6))
+            .map(|index| {
+                Diagnostic::new(
+                    DiagnosticLevel::Error,
+                    format!("mesh.test.{index}"),
+                    format!("diagnostic {index}"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        normalize_diagnostics(&mut diagnostics);
+
+        assert_eq!(diagnostics.len(), MAX_DIAGNOSTICS_PER_SCOPE);
+        assert_eq!(diagnostics[0].code, "mesh.test.6");
+        assert_eq!(
+            diagnostics
+                .last()
+                .map(|diagnostic| diagnostic.code.as_str()),
+            Some("mesh.test.69")
+        );
+    }
+
+    #[test]
+    fn updating_a_full_diagnostic_scope_moves_identity_to_the_newest_position() {
+        let mut diagnostics = (0..MAX_DIAGNOSTICS_PER_SCOPE)
+            .map(|index| {
+                Diagnostic::new(
+                    DiagnosticLevel::Error,
+                    format!("mesh.test.{index}"),
+                    format!("diagnostic {index}"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        push_diagnostic_unique(
+            &mut diagnostics,
+            Diagnostic::new(DiagnosticLevel::Error, "mesh.test.0", "newest update"),
+        );
+        assert_eq!(diagnostics.len(), MAX_DIAGNOSTICS_PER_SCOPE);
+        assert_eq!(diagnostics.last().unwrap().code, "mesh.test.0");
+        assert_eq!(diagnostics.last().unwrap().message, "newest update");
+
+        push_diagnostic_unique(
+            &mut diagnostics,
+            Diagnostic::new(DiagnosticLevel::Error, "mesh.test.new", "new identity"),
+        );
+        assert_eq!(diagnostics.len(), MAX_DIAGNOSTICS_PER_SCOPE);
+        assert!(!diagnostics.iter().any(|item| item.code == "mesh.test.1"));
+        assert!(diagnostics.iter().any(|item| item.code == "mesh.test.0"));
+        assert_eq!(diagnostics.last().unwrap().code, "mesh.test.new");
+    }
+
+    #[test]
+    fn diagnostic_fields_are_utf8_safely_bounded() {
+        let mut diagnostics = Vec::new();
+        push_diagnostic_unique(
+            &mut diagnostics,
+            Diagnostic::new(
+                DiagnosticLevel::Error,
+                "界".repeat(MAX_DIAGNOSTIC_CODE_BYTES),
+                "🙂".repeat(MAX_DIAGNOSTIC_MESSAGE_BYTES),
+            ),
+        );
+
+        let diagnostic = diagnostics.first().expect("normalized diagnostic");
+        assert!(diagnostic.code.len() <= MAX_DIAGNOSTIC_CODE_BYTES);
+        assert!(diagnostic.message.len() <= MAX_DIAGNOSTIC_MESSAGE_BYTES);
+        assert!(diagnostic.code.is_char_boundary(diagnostic.code.len()));
+        assert!(
+            diagnostic
+                .message
+                .is_char_boundary(diagnostic.message.len())
+        );
+        assert!(diagnostic.code.chars().all(|character| character == '界'));
+        assert!(
+            diagnostic
+                .message
+                .chars()
+                .all(|character| character == '🙂')
+        );
+    }
+
+    #[test]
+    fn observation_bounds_cover_top_level_nested_and_total_budgets() {
+        let base = BackendStatus::new(
+            backend_id("bounded"),
+            BackendKind::Other("test".to_owned()),
+            BackendOwnership::ManagedChild,
+        );
+
+        let mut too_many_attachments = base.clone();
+        too_many_attachments.attachments = vec![
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Control,
+                address: EndpointAddress::Opaque("endpoint".to_owned()),
+            });
+            MAX_ATTACHMENTS_PER_OBSERVATION + 1
+        ];
+
+        let mut too_many_claims = base.clone();
+        too_many_claims.resource_claims =
+            vec![exclusive(SystemResource::DnsManager); MAX_RESOURCE_CLAIMS_PER_OBSERVATION + 1];
+
+        let mut too_many_diagnostics = base.clone();
+        too_many_diagnostics.diagnostics =
+            vec![
+                Diagnostic::new(DiagnosticLevel::Info, "mesh.test", "bounded");
+                MAX_DIAGNOSTICS_PER_SCOPE + 1
+            ];
+
+        let mut too_many_nested_items = base.clone();
+        too_many_nested_items.attachments = vec![Attachment::Interface(InterfaceAttachment {
+            name: "mesh0".to_owned(),
+            addresses: vec![
+                "192.0.2.1/32".parse().expect("valid prefix");
+                MAX_COLLECTION_ITEMS_PER_OBSERVATION + 1
+            ],
+            index: None,
+            mtu: None,
+        })];
+
+        let mut oversized_string = base.clone();
+        oversized_string.version = Some("x".repeat(MAX_PROVIDER_STRING_BYTES + 1));
+
+        let mut excessive_total_string_bytes = base;
+        excessive_total_string_bytes.attachments = (0..=(MAX_PROVIDER_STRING_BYTES_PER_OBSERVATION
+            / MAX_PROVIDER_STRING_BYTES))
+            .map(|_| {
+                Attachment::Endpoint(EndpointAttachment {
+                    purpose: EndpointPurpose::Control,
+                    address: EndpointAddress::Opaque("x".repeat(MAX_PROVIDER_STRING_BYTES)),
+                })
+            })
+            .collect();
+
+        for observation in [
+            too_many_attachments,
+            too_many_claims,
+            too_many_diagnostics,
+            too_many_nested_items,
+            oversized_string,
+            excessive_total_string_bytes,
+        ] {
+            assert_eq!(
+                SupervisorInner::validate_observation_bounds(&observation),
+                Err(INVALID_OBSERVATION_MESSAGE)
+            );
+        }
+    }
+
+    #[test]
+    fn conflict_error_display_and_debug_do_not_expose_coordination_keys() {
+        let secret = "secret-coordination-key";
+        let claims = vec![
+            OwnedResourceClaim::backend(
+                backend_id("left"),
+                ResourceClaim::coordinated(SystemResource::DnsManager, secret)
+                    .expect("valid coordination key"),
+            ),
+            OwnedResourceClaim::backend(
+                backend_id("right"),
+                ResourceClaim::coordinated(SystemResource::DnsManager, "different-key")
+                    .expect("valid coordination key"),
+            ),
+        ];
+        let conflicts = detect_conflicts(&claims);
+        assert!(!conflicts.is_empty());
+        assert!(
+            conflicts.iter().any(|conflict| {
+                [
+                    conflict.left.claim.mode.coordination_key(),
+                    conflict.right.claim.mode.coordination_key(),
+                ]
+                .into_iter()
+                .flatten()
+                .any(|coordination_key| coordination_key == secret)
+            }),
+            "test must exercise a conflict that actually contains the secret"
+        );
+
+        let error = MeshError::Conflicts { conflicts };
+        let rendered = format!("{error} {error:?}");
+        assert!(!rendered.contains(secret));
+        assert!(!rendered.contains("different-key"));
+        assert!(rendered.contains("mesh resource conflicts prevent reconciliation"));
+        assert!(rendered.contains("count"));
+    }
+
+    struct FakeBackend {
+        label: String,
+        descriptor: StdMutex<BackendDescriptor>,
+        probe_claims: Vec<ResourceClaim>,
+        probe_override: StdMutex<Option<BackendStatus>>,
+        status_claims: StdMutex<Option<Vec<ResourceClaim>>>,
+        status_override: StdMutex<Option<BackendStatus>>,
+        reconcile_claims: StdMutex<Option<Vec<ResourceClaim>>>,
+        reconcile_delay: StdMutex<Option<Duration>>,
+        status_delay: StdMutex<Option<Duration>>,
+        probe_secret: StdMutex<Option<String>>,
+        events: Arc<StdMutex<Vec<String>>>,
+        reconcile_count: AtomicUsize,
+        detach_count: AtomicUsize,
+        terminate_count: AtomicUsize,
+        attached: AtomicBool,
+        process_alive: AtomicBool,
+        fail_reconcile: AtomicBool,
+        panic_reconcile: AtomicBool,
+        fail_detach: AtomicBool,
+        fail_terminate: AtomicBool,
+        hang_probe: AtomicBool,
+        hang_reconcile: AtomicBool,
+        hang_status: AtomicBool,
+        hang_detach: AtomicBool,
+        hang_terminate: AtomicBool,
+        block_terminate: AtomicBool,
+        reconcile_entered: Notify,
+        terminate_entered: Notify,
+        continue_terminate: Notify,
+    }
+
+    impl FakeBackend {
+        fn new(
+            id: &str,
+            ownership: BackendOwnership,
+            probe_claims: Vec<ResourceClaim>,
+            events: Arc<StdMutex<Vec<String>>>,
+        ) -> Self {
+            Self {
+                label: id.to_owned(),
+                descriptor: StdMutex::new(BackendDescriptor::new(
+                    backend_id(id),
+                    BackendKind::Other("test".to_owned()),
+                    ownership,
+                )),
+                probe_claims,
+                probe_override: StdMutex::new(None),
+                status_claims: StdMutex::new(None),
+                status_override: StdMutex::new(None),
+                reconcile_claims: StdMutex::new(None),
+                reconcile_delay: StdMutex::new(None),
+                status_delay: StdMutex::new(None),
+                probe_secret: StdMutex::new(None),
+                events,
+                reconcile_count: AtomicUsize::new(0),
+                detach_count: AtomicUsize::new(0),
+                terminate_count: AtomicUsize::new(0),
+                attached: AtomicBool::new(false),
+                process_alive: AtomicBool::new(ownership == BackendOwnership::AttachExternal),
+                fail_reconcile: AtomicBool::new(false),
+                panic_reconcile: AtomicBool::new(false),
+                fail_detach: AtomicBool::new(false),
+                fail_terminate: AtomicBool::new(false),
+                hang_probe: AtomicBool::new(false),
+                hang_reconcile: AtomicBool::new(false),
+                hang_status: AtomicBool::new(false),
+                hang_detach: AtomicBool::new(false),
+                hang_terminate: AtomicBool::new(false),
+                block_terminate: AtomicBool::new(false),
+                reconcile_entered: Notify::new(),
+                terminate_entered: Notify::new(),
+                continue_terminate: Notify::new(),
+            }
+        }
+
+        fn status_with(&self, phase: BackendPhase, claims: Vec<ResourceClaim>) -> BackendStatus {
+            let descriptor = self.descriptor();
+            let mut status = BackendStatus::new(
+                descriptor.id().clone(),
+                descriptor.kind().clone(),
+                descriptor.ownership(),
+            );
+            status.phase = phase;
+            status.resource_claims = claims;
+            status
+        }
+
+        fn record(&self, operation: &str) {
+            self.events
+                .lock()
+                .expect("event lock")
+                .push(format!("{operation}:{}", self.label));
+        }
+
+        fn set_dynamic_claims(&self, claims: Vec<ResourceClaim>) {
+            *self.status_claims.lock().expect("status claims lock") = Some(claims);
+        }
+
+        fn mutate_descriptor_id(&self, id: &str) {
+            let mut descriptor = self.descriptor.lock().expect("descriptor lock");
+            *descriptor = BackendDescriptor::new(
+                backend_id(id),
+                descriptor.kind().clone(),
+                descriptor.ownership(),
+            );
+        }
+    }
+
+    #[async_trait]
+    impl NetworkBackend for FakeBackend {
+        fn descriptor(&self) -> BackendDescriptor {
+            self.descriptor.lock().expect("descriptor lock").clone()
+        }
+
+        async fn probe(&self) -> BackendResult<BackendObservation> {
+            self.record("probe");
+            if self.hang_probe.load(Ordering::SeqCst) {
+                pending::<()>().await;
+            }
+            if let Some(status) = self
+                .probe_override
+                .lock()
+                .expect("probe override lock")
+                .clone()
+            {
+                return Ok(status);
+            }
+            if let Some(secret) = self.probe_secret.lock().expect("probe secret lock").clone() {
+                return Err(BackendError::new("auth_failed", "authentication failed")
+                    .with_sensitive_source(io::Error::other(secret)));
+            }
+            Ok(self.status_with(BackendPhase::Stopped, self.probe_claims.clone()))
+        }
+
+        async fn reconcile(
+            &self,
+            observation: &BackendObservation,
+        ) -> BackendResult<BackendStatus> {
+            self.record("reconcile");
+            self.reconcile_count.fetch_add(1, Ordering::SeqCst);
+            self.attached.store(true, Ordering::SeqCst);
+            self.process_alive.store(true, Ordering::SeqCst);
+            self.reconcile_entered.notify_one();
+            let reconcile_delay = *self.reconcile_delay.lock().expect("reconcile delay lock");
+            if let Some(delay) = reconcile_delay {
+                sleep(delay).await;
+            }
+            if self.hang_reconcile.load(Ordering::SeqCst) {
+                pending::<()>().await;
+            }
+            if self.panic_reconcile.load(Ordering::SeqCst) {
+                panic!("raw backend panic payload must stay private");
+            }
+            if self.fail_reconcile.load(Ordering::SeqCst) {
+                return Err(BackendError::new(
+                    "reconcile_failed",
+                    "synthetic reconcile failure",
+                ));
+            }
+            let claims = self
+                .reconcile_claims
+                .lock()
+                .expect("reconcile claims lock")
+                .clone()
+                .unwrap_or_else(|| observation.resource_claims.clone());
+            Ok(self.status_with(BackendPhase::Ready, claims))
+        }
+
+        async fn status(&self) -> BackendResult<BackendStatus> {
+            self.record("status");
+            let status_delay = *self.status_delay.lock().expect("status delay lock");
+            if let Some(delay) = status_delay {
+                sleep(delay).await;
+            }
+            if self.hang_status.load(Ordering::SeqCst) {
+                pending::<()>().await;
+            }
+            if let Some(status) = self
+                .status_override
+                .lock()
+                .expect("status override lock")
+                .clone()
+            {
+                return Ok(status);
+            }
+            let claims = self
+                .status_claims
+                .lock()
+                .expect("status claims lock")
+                .clone()
+                .unwrap_or_else(|| self.probe_claims.clone());
+            let phase = if self.attached.load(Ordering::SeqCst) {
+                BackendPhase::Ready
+            } else {
+                BackendPhase::Stopped
+            };
+            Ok(self.status_with(phase, claims))
+        }
+    }
+
+    #[async_trait]
+    impl ExternalNetworkBackend for FakeBackend {
+        async fn detach(&self) -> BackendResult<()> {
+            self.record("detach");
+            self.detach_count.fetch_add(1, Ordering::SeqCst);
+            if self.hang_detach.load(Ordering::SeqCst) {
+                pending::<()>().await;
+            }
+            if self.fail_detach.load(Ordering::SeqCst) {
+                return Err(BackendError::new(
+                    "detach_failed",
+                    "synthetic detach failure",
+                ));
+            }
+            self.attached.store(false, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl OwnedNetworkBackend for FakeBackend {
+        async fn terminate(&self) -> BackendResult<()> {
+            self.record("terminate");
+            self.terminate_count.fetch_add(1, Ordering::SeqCst);
+            if self.block_terminate.load(Ordering::SeqCst) {
+                self.terminate_entered.notify_one();
+                self.continue_terminate.notified().await;
+            }
+            if self.hang_terminate.load(Ordering::SeqCst) {
+                pending::<()>().await;
+            }
+            if self.fail_terminate.load(Ordering::SeqCst) {
+                return Err(BackendError::new(
+                    "terminate_failed",
+                    "synthetic terminate failure",
+                ));
+            }
+            self.attached.store(false, Ordering::SeqCst);
+            self.process_alive.store(false, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn backend_id(value: &str) -> BackendId {
+        BackendId::new(value).expect("valid backend id")
+    }
+
+    fn exclusive(resource: SystemResource) -> ResourceClaim {
+        ResourceClaim::exclusive(resource)
+    }
+
+    fn registry(backends: &[Arc<FakeBackend>]) -> BackendRegistry {
+        let mut registry = BackendRegistry::new();
+        for backend in backends {
+            match backend.descriptor().ownership() {
+                BackendOwnership::AttachExternal => registry
+                    .register_external(backend.clone())
+                    .expect("external registration"),
+                BackendOwnership::ManagedChild => registry
+                    .register_managed(backend.clone())
+                    .expect("managed registration"),
+                BackendOwnership::Embedded => registry
+                    .register_embedded(backend.clone())
+                    .expect("embedded registration"),
+            }
+        }
+        registry
+    }
+
+    fn supervisor(
+        backends: &[Arc<FakeBackend>],
+        reservations: Vec<HostResourceClaim>,
+        monitor_interval: Duration,
+    ) -> MeshSupervisor {
+        supervisor_with_timeouts(
+            backends,
+            reservations,
+            monitor_interval,
+            BackendCallTimeouts {
+                gate: TEST_TIMEOUT,
+                probe: TEST_TIMEOUT,
+                reconcile: TEST_TIMEOUT,
+                status: TEST_TIMEOUT,
+                release: TEST_TIMEOUT,
+            },
+        )
+    }
+
+    fn supervisor_with_timeouts(
+        backends: &[Arc<FakeBackend>],
+        reservations: Vec<HostResourceClaim>,
+        monitor_interval: Duration,
+        backend_timeouts: BackendCallTimeouts,
+    ) -> MeshSupervisor {
+        MeshSupervisor::with_options(
+            registry(backends),
+            reservations,
+            SupervisorOptions {
+                backend_timeouts,
+                monitor_interval,
+            },
+        )
+    }
+
+    fn event_log(events: &Arc<StdMutex<Vec<String>>>) -> Vec<String> {
+        events.lock().expect("event lock").clone()
+    }
+
+    async fn wait_until(mut predicate: impl FnMut() -> bool) {
+        timeout(TEST_DEADLINE, async {
+            loop {
+                if predicate() {
+                    return;
+                }
+                sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("condition should become true before deadline");
+    }
+
+    #[tokio::test]
+    async fn host_reservation_and_backend_with_same_name_still_conflict() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let claim = exclusive(SystemResource::DnsManager);
+        let backend = Arc::new(FakeBackend::new(
+            "capture",
+            BackendOwnership::ManagedChild,
+            vec![claim.clone()],
+            events,
+        ));
+        let reservation = HostResourceClaim::new(
+            HostSubsystemId::new("capture").expect("valid host subsystem id"),
+            claim,
+        );
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            vec![reservation],
+            Duration::ZERO,
+        );
+
+        let error = supervisor
+            .start()
+            .await
+            .expect_err("separate namespaces must conflict");
+        assert!(matches!(error, MeshError::Conflicts { .. }));
+        assert_eq!(backend.reconcile_count.load(Ordering::SeqCst), 0);
+        let conflict = &supervisor.snapshot().conflicts[0];
+        assert_ne!(conflict.left.owner, conflict.right.owner);
+        assert!(
+            [&conflict.left.owner, &conflict.right.owner]
+                .iter()
+                .any(|owner| matches!(owner, ResourceOwner::Backend(_)))
+        );
+        assert!(
+            [&conflict.left.owner, &conflict.right.owner]
+                .iter()
+                .any(|owner| matches!(owner, ResourceOwner::HostSubsystem(_)))
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_probe_is_rejected_before_reconcile_with_a_fixed_error() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "oversized-probe",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let secret = "provider-diagnostic-must-not-be-published";
+        let mut observation = backend.status_with(BackendPhase::Stopped, Vec::new());
+        observation.diagnostics =
+            vec![
+                Diagnostic::new(DiagnosticLevel::Error, "provider.error", secret);
+                MAX_DIAGNOSTICS_PER_SCOPE + 1
+            ];
+        *backend.probe_override.lock().expect("probe override lock") = Some(observation);
+        let supervisor = supervisor(std::slice::from_ref(&backend), Vec::new(), Duration::ZERO);
+
+        let error = supervisor
+            .start()
+            .await
+            .expect_err("oversized probe must fail closed");
+        let MeshError::Probe { failures } = &error else {
+            panic!("expected probe failure");
+        };
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].code, "invalid_status");
+        assert_eq!(failures[0].message, INVALID_OBSERVATION_MESSAGE);
+        assert_eq!(backend.reconcile_count.load(Ordering::SeqCst), 0);
+        assert!(!format!("{error:?}").contains(secret));
+        assert!(
+            !serde_json::to_string(&supervisor.snapshot())
+                .unwrap()
+                .contains(secret)
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_and_shutdown_are_deterministic_and_reverse_ordered() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let first = Arc::new(FakeBackend::new(
+            "first",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let second = Arc::new(FakeBackend::new(
+            "second",
+            BackendOwnership::Embedded,
+            Vec::new(),
+            events.clone(),
+        ));
+        let supervisor = supervisor(&[first.clone(), second.clone()], Vec::new(), Duration::ZERO);
+
+        let started = supervisor.start().await.expect("start succeeds");
+        assert!(started.running);
+        assert_eq!(started.supervisor_phase, MeshSupervisorPhase::Running);
+        supervisor.stop().await.expect("stop succeeds");
+
+        let lifecycle_events: Vec<_> = event_log(&events)
+            .into_iter()
+            .filter(|event| event.starts_with("reconcile") || event.starts_with("terminate"))
+            .collect();
+        assert_eq!(
+            lifecycle_events,
+            [
+                "reconcile:first",
+                "reconcile:second",
+                "terminate:second",
+                "terminate:first",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_failure_releases_in_flight_and_started_backends_in_reverse() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let first = Arc::new(FakeBackend::new(
+            "first",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let second = Arc::new(FakeBackend::new(
+            "second",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        second.fail_reconcile.store(true, Ordering::SeqCst);
+        let supervisor = supervisor(&[first.clone(), second.clone()], Vec::new(), Duration::ZERO);
+
+        assert!(matches!(
+            supervisor.start().await,
+            Err(MeshError::Reconcile { .. })
+        ));
+        let release_events: Vec<_> = event_log(&events)
+            .into_iter()
+            .filter(|event| event.starts_with("terminate"))
+            .collect();
+        assert_eq!(release_events, ["terminate:second", "terminate:first"]);
+        assert!(!first.process_alive.load(Ordering::SeqCst));
+        assert!(!second.process_alive.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn stop_aggregates_failures_and_retries_only_residual_backends() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let first = Arc::new(FakeBackend::new(
+            "first",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let second = Arc::new(FakeBackend::new(
+            "second",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let supervisor = supervisor(&[first.clone(), second.clone()], Vec::new(), Duration::ZERO);
+        supervisor.start().await.expect("start succeeds");
+        second.fail_terminate.store(true, Ordering::SeqCst);
+
+        let error = supervisor
+            .stop()
+            .await
+            .expect_err("one termination should fail");
+        let MeshError::Stop { failures } = error else {
+            panic!("expected stop error");
+        };
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].backend, backend_id("second"));
+        assert!(!first.process_alive.load(Ordering::SeqCst));
+        assert!(second.process_alive.load(Ordering::SeqCst));
+
+        second.fail_terminate.store(false, Ordering::SeqCst);
+        supervisor.stop().await.expect("residual retry succeeds");
+        assert_eq!(first.terminate_count.load(Ordering::SeqCst), 1);
+        assert_eq!(second.terminate_count.load(Ordering::SeqCst), 2);
+        let release_events: Vec<_> = event_log(&events)
+            .into_iter()
+            .filter(|event| event.starts_with("terminate"))
+            .collect();
+        assert_eq!(
+            release_events,
+            ["terminate:second", "terminate:first", "terminate:second"]
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_start_and_stop_calls_share_one_transaction() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "shared",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = Arc::new(supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::ZERO,
+        ));
+
+        let left = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.start().await }
+        });
+        let right = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.start().await }
+        });
+        left.await.unwrap().expect("first start");
+        right.await.unwrap().expect("second start");
+        assert_eq!(backend.reconcile_count.load(Ordering::SeqCst), 1);
+
+        let left = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.stop().await }
+        });
+        let right = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.stop().await }
+        });
+        left.await.unwrap().expect("first stop");
+        right.await.unwrap().expect("second stop");
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn snapshots_have_monotonic_generations() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "generation",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(&[backend], Vec::new(), Duration::ZERO);
+
+        let initial = supervisor.snapshot().generation;
+        let started = supervisor.start().await.unwrap().generation;
+        let refreshed = supervisor.refresh().await.unwrap().generation;
+        let stopped = supervisor.stop().await.unwrap().generation;
+        assert!(initial < started);
+        assert!(started < refreshed);
+        assert!(refreshed < stopped);
+    }
+
+    #[tokio::test]
+    async fn external_backend_is_detached_without_terminating_its_daemon() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "external",
+            BackendOwnership::AttachExternal,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(std::slice::from_ref(&backend), Vec::new(), Duration::ZERO);
+
+        supervisor.start().await.unwrap();
+        supervisor.stop().await.unwrap();
+        assert_eq!(backend.detach_count.load(Ordering::SeqCst), 1);
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 0);
+        assert!(!backend.attached.load(Ordering::SeqCst));
+        assert!(backend.process_alive.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn external_backend_cannot_expand_its_frozen_resource_envelope() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "external-envelope",
+            BackendOwnership::AttachExternal,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+
+        supervisor.start().await.unwrap();
+        backend.set_dynamic_claims(vec![exclusive(SystemResource::DnsManager)]);
+
+        wait_until(|| backend.detach_count.load(Ordering::SeqCst) == 1).await;
+        let snapshot = supervisor.snapshot();
+        assert!(!snapshot.running);
+        assert_eq!(snapshot.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert_eq!(
+            snapshot.statuses[&backend_id("external-envelope")].phase,
+            BackendPhase::Failed
+        );
+        assert!(
+            snapshot.statuses[&backend_id("external-envelope")]
+                .resource_claims
+                .is_empty(),
+            "the unreserved claim must never enter the trusted snapshot"
+        );
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 0);
+        assert!(
+            backend.process_alive.load(Ordering::SeqCst),
+            "detaching an external adapter must not terminate its daemon"
+        );
+        assert!(
+            snapshot.statuses[&backend_id("external-envelope")]
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "mesh.status_fail_closed_isolated")
+        );
+        supervisor.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn every_hanging_backend_operation_is_deadline_bounded() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let probe = Arc::new(FakeBackend::new(
+            "hanging-probe",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        probe.hang_probe.store(true, Ordering::SeqCst);
+        let probe_supervisor = supervisor(&[probe], Vec::new(), Duration::ZERO);
+        let started_at = Instant::now();
+        assert!(matches!(
+            probe_supervisor.start().await,
+            Err(MeshError::Probe { .. })
+        ));
+        assert!(started_at.elapsed() < TEST_DEADLINE);
+
+        let backend = Arc::new(FakeBackend::new(
+            "hanging-status-release",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(std::slice::from_ref(&backend), Vec::new(), Duration::ZERO);
+        supervisor.start().await.unwrap();
+        backend.hang_status.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            timeout(TEST_DEADLINE, supervisor.refresh()).await.unwrap(),
+            Err(MeshError::Status { .. })
+        ));
+        backend.hang_status.store(false, Ordering::SeqCst);
+        backend.hang_terminate.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            timeout(TEST_DEADLINE, supervisor.stop()).await.unwrap(),
+            Err(MeshError::Stop { .. })
+        ));
+        backend.hang_terminate.store(false, Ordering::SeqCst);
+        supervisor.stop().await.expect("release retry succeeds");
+    }
+
+    #[tokio::test]
+    async fn reconcile_has_a_larger_deadline_than_status_observation() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "operation-deadlines",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        *backend
+            .reconcile_delay
+            .lock()
+            .expect("reconcile delay lock") = Some(Duration::from_millis(70));
+        *backend.status_delay.lock().expect("status delay lock") = Some(Duration::from_millis(45));
+        let supervisor = supervisor_with_timeouts(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::ZERO,
+            BackendCallTimeouts {
+                gate: Duration::from_millis(20),
+                probe: Duration::from_millis(30),
+                reconcile: Duration::from_millis(100),
+                status: Duration::from_millis(20),
+                release: Duration::from_millis(40),
+            },
+        );
+
+        supervisor
+            .start()
+            .await
+            .expect("longer reconcile budget should allow readiness");
+        let error = supervisor
+            .refresh()
+            .await
+            .expect_err("short status budget should fail promptly");
+        let MeshError::Status { failures } = error else {
+            panic!("expected status timeout");
+        };
+        assert_eq!(failures[0].code, "operation_timeout");
+        *backend.status_delay.lock().expect("status delay lock") = None;
+        supervisor.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropping_last_supervisor_owner_releases_started_backends_once() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "drop-cleanup",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let dropped_supervisor =
+            supervisor(std::slice::from_ref(&backend), Vec::new(), Duration::ZERO);
+        dropped_supervisor.start().await.unwrap();
+
+        drop(dropped_supervisor);
+        wait_until(|| backend.terminate_count.load(Ordering::SeqCst) == 1).await;
+        assert!(!backend.process_alive.load(Ordering::SeqCst));
+
+        let second_events = Arc::new(StdMutex::new(Vec::new()));
+        let explicitly_stopped = Arc::new(FakeBackend::new(
+            "drop-after-stop",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            second_events,
+        ));
+        let supervisor = supervisor(
+            std::slice::from_ref(&explicitly_stopped),
+            Vec::new(),
+            Duration::ZERO,
+        );
+        supervisor.start().await.unwrap();
+        supervisor.stop().await.unwrap();
+        drop(supervisor);
+        sleep(Duration::from_millis(30)).await;
+        assert_eq!(explicitly_stopped.terminate_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn drop_is_non_panicking_when_entered_runtime_is_already_shut_down() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        let handle = runtime.handle().clone();
+        drop(runtime);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = handle.enter();
+            let supervisor = MeshSupervisor::new(BackendRegistry::new(), Vec::new());
+            drop(supervisor);
+        }));
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn aborted_start_caller_does_not_leak_partially_acquired_resources() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "abort-safe",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        backend.hang_reconcile.store(true, Ordering::SeqCst);
+        let supervisor = Arc::new(supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::ZERO,
+        ));
+
+        let caller = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.start().await }
+        });
+        timeout(TEST_DEADLINE, backend.reconcile_entered.notified())
+            .await
+            .expect("reconcile entered");
+        caller.abort();
+        assert!(
+            caller
+                .await
+                .expect_err("caller should be aborted")
+                .is_cancelled()
+        );
+
+        wait_until(|| backend.terminate_count.load(Ordering::SeqCst) == 1).await;
+        assert!(!backend.process_alive.load(Ordering::SeqCst));
+        wait_until(|| supervisor.snapshot().supervisor_phase == MeshSupervisorPhase::Failed).await;
+        supervisor
+            .stop()
+            .await
+            .expect("no residual resources remain");
+    }
+
+    #[tokio::test]
+    async fn panicking_backend_completes_waiters_and_rolls_back_safely() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "panic-safe",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        backend.panic_reconcile.store(true, Ordering::SeqCst);
+        let supervisor = Arc::new(supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::ZERO,
+        ));
+
+        let first = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.start().await }
+        });
+        let second = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.start().await }
+        });
+        for waiter in [first, second] {
+            let error = timeout(TEST_DEADLINE, waiter)
+                .await
+                .expect("waiter must complete")
+                .expect("waiter task must not panic")
+                .expect_err("panicking backend must fail startup");
+            let MeshError::Reconcile { failure, .. } = error else {
+                panic!("expected redacted reconcile failure");
+            };
+            assert_eq!(failure.code, "backend_panic");
+            assert!(!failure.message.contains("raw backend panic payload"));
+        }
+        assert_eq!(backend.reconcile_count.load(Ordering::SeqCst), 1);
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+        assert!(!backend.process_alive.load(Ordering::SeqCst));
+        let json = serde_json::to_string(&supervisor.snapshot()).unwrap();
+        assert!(!json.contains("raw backend panic payload"));
+    }
+
+    #[tokio::test]
+    async fn stop_cancels_hanging_start_without_waiting_for_backend_deadline() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "cancel-safe",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        backend.hang_reconcile.store(true, Ordering::SeqCst);
+        let supervisor = Arc::new(supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::ZERO,
+        ));
+        let caller = tokio::spawn({
+            let supervisor = supervisor.clone();
+            async move { supervisor.start().await }
+        });
+        timeout(TEST_DEADLINE, backend.reconcile_entered.notified())
+            .await
+            .expect("reconcile entered");
+
+        timeout(TEST_DEADLINE, supervisor.stop())
+            .await
+            .expect("stop must not deadlock")
+            .expect("rollback succeeds");
+        assert!(matches!(
+            caller.await.unwrap(),
+            Err(MeshError::Reconcile { .. })
+        ));
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+        assert!(!backend.process_alive.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn background_monitor_isolates_dynamic_conflicts_in_reverse_order() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let first = Arc::new(FakeBackend::new(
+            "first",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let second = Arc::new(FakeBackend::new(
+            "second",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let third = Arc::new(FakeBackend::new(
+            "third",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let supervisor = supervisor(
+            &[first.clone(), second.clone(), third.clone()],
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+        supervisor.start().await.unwrap();
+        let claim = exclusive(SystemResource::DnsManager);
+        first.set_dynamic_claims(vec![claim.clone()]);
+        second.set_dynamic_claims(vec![claim]);
+
+        wait_until(|| {
+            first.terminate_count.load(Ordering::SeqCst) == 1
+                && second.terminate_count.load(Ordering::SeqCst) == 1
+        })
+        .await;
+        let snapshot = supervisor.snapshot();
+        assert!(!snapshot.running);
+        assert_eq!(snapshot.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert_eq!(
+            snapshot.statuses[&backend_id("first")].phase,
+            BackendPhase::Conflict
+        );
+        assert_eq!(
+            snapshot.statuses[&backend_id("second")].phase,
+            BackendPhase::Conflict
+        );
+        assert_eq!(
+            snapshot.statuses[&backend_id("third")].phase,
+            BackendPhase::Ready
+        );
+        assert_eq!(third.terminate_count.load(Ordering::SeqCst), 0);
+        let latched_conflicts = snapshot.conflicts.clone();
+
+        // A later healthy observation of the unaffected backend must not erase
+        // the fact that two configured backends were isolated.
+        let refreshed = supervisor.refresh().await.unwrap();
+        assert!(!refreshed.running);
+        assert_eq!(refreshed.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert_eq!(refreshed.conflicts, latched_conflicts);
+        assert!(matches!(
+            supervisor.start().await,
+            Err(MeshError::ResidualResources { .. })
+        ));
+        let releases: Vec<_> = event_log(&events)
+            .into_iter()
+            .filter(|event| event.starts_with("terminate"))
+            .collect();
+        assert_eq!(releases, ["terminate:second", "terminate:first"]);
+
+        supervisor
+            .stop()
+            .await
+            .expect("explicit stop acknowledges isolation");
+        assert_eq!(third.terminate_count.load(Ordering::SeqCst), 1);
+        let stopped = supervisor.snapshot();
+        assert_eq!(stopped.supervisor_phase, MeshSupervisorPhase::Stopped);
+        assert!(stopped.conflicts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn public_refresh_observes_conflicts_without_lifecycle_side_effects() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let first = Arc::new(FakeBackend::new(
+            "first",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events.clone(),
+        ));
+        let second = Arc::new(FakeBackend::new(
+            "second",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(&[first.clone(), second.clone()], Vec::new(), Duration::ZERO);
+        supervisor.start().await.unwrap();
+        let claim = exclusive(SystemResource::DnsManager);
+        first.set_dynamic_claims(vec![claim.clone()]);
+        second.set_dynamic_claims(vec![claim]);
+
+        assert!(matches!(
+            supervisor.refresh().await,
+            Err(MeshError::Conflicts { .. })
+        ));
+        assert_eq!(first.terminate_count.load(Ordering::SeqCst), 0);
+        assert_eq!(second.terminate_count.load(Ordering::SeqCst), 0);
+        assert!(supervisor.snapshot().running);
+        supervisor.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn monitor_fails_closed_when_dynamic_identity_cannot_be_verified() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "frozen-id",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+        supervisor.start().await.unwrap();
+        backend.mutate_descriptor_id("untrusted-id");
+
+        wait_until(|| backend.terminate_count.load(Ordering::SeqCst) == 1).await;
+        let snapshot = supervisor.snapshot();
+        assert!(!snapshot.running);
+        assert_eq!(snapshot.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert_eq!(
+            snapshot.statuses[&backend_id("frozen-id")].phase,
+            BackendPhase::Failed
+        );
+        assert!(!snapshot.statuses.contains_key(&backend_id("untrusted-id")));
+        assert!(
+            snapshot.statuses[&backend_id("frozen-id")]
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "mesh.status_fail_closed_isolated")
+        );
+        assert!(matches!(
+            supervisor.start().await,
+            Err(MeshError::ResidualResources { .. })
+        ));
+        supervisor.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn monitor_fails_closed_when_dynamic_status_exceeds_bounds() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "oversized-status",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+        supervisor.start().await.unwrap();
+
+        let secret = "oversized-status-secret";
+        let mut status = backend.status_with(BackendPhase::Ready, Vec::new());
+        status.attachments = vec![
+            Attachment::Endpoint(EndpointAttachment {
+                purpose: EndpointPurpose::Control,
+                address: EndpointAddress::Opaque(secret.to_owned()),
+            });
+            MAX_ATTACHMENTS_PER_OBSERVATION + 1
+        ];
+        *backend
+            .status_override
+            .lock()
+            .expect("status override lock") = Some(status);
+
+        wait_until(|| backend.terminate_count.load(Ordering::SeqCst) == 1).await;
+        let snapshot = supervisor.snapshot();
+        assert!(!snapshot.running);
+        assert_eq!(snapshot.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert_eq!(
+            snapshot.statuses[&backend_id("oversized-status")].phase,
+            BackendPhase::Failed
+        );
+        assert!(
+            snapshot.statuses[&backend_id("oversized-status")]
+                .attachments
+                .is_empty()
+        );
+        assert!(
+            snapshot.statuses[&backend_id("oversized-status")]
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "mesh.status_fail_closed_isolated")
+        );
+        assert!(!serde_json::to_string(&snapshot).unwrap().contains(secret));
+        supervisor.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn monitor_fails_closed_when_dynamic_phase_is_not_running() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "invalid-dynamic-phase",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+        supervisor.start().await.unwrap();
+
+        let status = backend.status_with(BackendPhase::Stopped, Vec::new());
+        *backend
+            .status_override
+            .lock()
+            .expect("status override lock") = Some(status);
+
+        wait_until(|| backend.terminate_count.load(Ordering::SeqCst) == 1).await;
+        let snapshot = supervisor.snapshot();
+        assert!(!snapshot.running);
+        assert_eq!(snapshot.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert_eq!(
+            snapshot.statuses[&backend_id("invalid-dynamic-phase")].phase,
+            BackendPhase::Failed
+        );
+        assert!(
+            snapshot.statuses[&backend_id("invalid-dynamic-phase")]
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "mesh.status_fail_closed_isolated")
+        );
+        supervisor.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stop_drains_in_flight_monitor_release_without_duplicate_termination() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "monitor-stop-race",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        backend.block_terminate.store(true, Ordering::SeqCst);
+        let supervisor = Arc::new(supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(10),
+        ));
+        supervisor.start().await.unwrap();
+        backend.mutate_descriptor_id("untrusted-monitor-stop-race");
+
+        timeout(TEST_DEADLINE, backend.terminate_entered.notified())
+            .await
+            .expect("monitor entered fail-closed termination");
+        let stop = tokio::spawn({
+            let supervisor = Arc::clone(&supervisor);
+            async move { supervisor.stop().await }
+        });
+
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+        backend.block_terminate.store(false, Ordering::SeqCst);
+        backend.continue_terminate.notify_one();
+
+        let stopped = timeout(TEST_DEADLINE, stop)
+            .await
+            .expect("stop must drain monitor")
+            .expect("stop task")
+            .expect("stop succeeds");
+        assert_eq!(stopped.supervisor_phase, MeshSupervisorPhase::Stopped);
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+        assert!(!backend.process_alive.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn monitor_retries_failed_fail_closed_release_before_trusting_status() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "release-retry",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        backend.fail_terminate.store(true, Ordering::SeqCst);
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(40),
+        );
+        supervisor.start().await.unwrap();
+        backend.mutate_descriptor_id("untrusted-release-retry");
+
+        wait_until(|| backend.terminate_count.load(Ordering::SeqCst) == 1).await;
+        assert!(backend.process_alive.load(Ordering::SeqCst));
+        assert!(
+            supervisor.snapshot().statuses[&backend_id("release-retry")]
+                .diagnostics
+                .iter()
+                .any(|diagnostic| {
+                    diagnostic.code == "mesh.status_fail_closed_isolation_failed"
+                })
+        );
+
+        backend.mutate_descriptor_id("release-retry");
+        backend.fail_terminate.store(false, Ordering::SeqCst);
+        wait_until(|| {
+            backend.terminate_count.load(Ordering::SeqCst) == 2
+                && !backend.process_alive.load(Ordering::SeqCst)
+        })
+        .await;
+        let retried = supervisor.snapshot();
+        assert_eq!(retried.supervisor_phase, MeshSupervisorPhase::Degraded);
+        assert!(
+            retried.statuses[&backend_id("release-retry")]
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "mesh.fail_closed_release_retry_succeeded")
+        );
+
+        supervisor
+            .stop()
+            .await
+            .expect("stop only clears the isolation latch");
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn emergency_drop_drains_in_flight_monitor_release_once() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "monitor-drop-race",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        backend.block_terminate.store(true, Ordering::SeqCst);
+        let supervisor = supervisor(
+            std::slice::from_ref(&backend),
+            Vec::new(),
+            Duration::from_millis(10),
+        );
+        supervisor.start().await.unwrap();
+        backend.mutate_descriptor_id("untrusted-monitor-drop-race");
+
+        timeout(TEST_DEADLINE, backend.terminate_entered.notified())
+            .await
+            .expect("monitor entered fail-closed termination");
+        drop(supervisor);
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+        backend.block_terminate.store(false, Ordering::SeqCst);
+        backend.continue_terminate.notify_one();
+
+        wait_until(|| !backend.process_alive.load(Ordering::SeqCst)).await;
+        sleep(Duration::from_millis(20)).await;
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_cannot_acquire_claims_missing_from_preflight() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "claim-mutation",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        *backend
+            .reconcile_claims
+            .lock()
+            .expect("reconcile claims lock") = Some(vec![exclusive(SystemResource::DnsManager)]);
+        let supervisor = supervisor(std::slice::from_ref(&backend), Vec::new(), Duration::ZERO);
+
+        let error = supervisor.start().await.expect_err("claim drift rejected");
+        let MeshError::Reconcile { failure, .. } = error else {
+            panic!("expected reconcile error");
+        };
+        assert_eq!(failure.code, "invalid_status");
+        assert_eq!(backend.terminate_count.load(Ordering::SeqCst), 1);
+        assert!(!backend.process_alive.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn sensitive_backend_source_never_reaches_errors_or_snapshot_json() {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let backend = Arc::new(FakeBackend::new(
+            "secret",
+            BackendOwnership::ManagedChild,
+            Vec::new(),
+            events,
+        ));
+        let secret = "sk-private-raw-stderr";
+        *backend.probe_secret.lock().expect("probe secret lock") =
+            Some(format!("raw CLI stderr contains {secret}"));
+        let supervisor = supervisor(&[backend], Vec::new(), Duration::ZERO);
+
+        let error = supervisor.start().await.expect_err("probe must fail");
+        let rendered_error = format!("{error:?}");
+        let json = serde_json::to_string(&supervisor.snapshot()).unwrap();
+        assert!(!rendered_error.contains(secret));
+        assert!(!json.contains(secret));
+        assert!(json.contains("auth_failed"));
+        assert!(json.contains("authentication failed"));
+    }
+}

--- a/crates/core-runtime/src/dns_listener.rs
+++ b/crates/core-runtime/src/dns_listener.rs
@@ -34,6 +34,21 @@ pub enum DnsListenerError {
     TcpBind(SocketAddr, std::io::Error),
 }
 
+/// Parse the configured DNS listen address without binding a socket.
+///
+/// This is the single source of truth shared by startup and host-resource
+/// arbitration. Empty input and port `0` are disabled, matching mihomo.
+pub fn parse_dns_listen_addr(listen: &str) -> Result<Option<SocketAddr>, DnsListenerError> {
+    let trimmed = listen.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let addr: SocketAddr = trimmed.parse().map_err(|e: std::net::AddrParseError| {
+        DnsListenerError::InvalidAddr(trimmed.to_string(), e.to_string())
+    })?;
+    Ok((addr.port() != 0).then_some(addr))
+}
+
 /// 同时持有 UDP + TCP listener 句柄，drop 时取消两个后台 task。
 ///
 /// `Disabled` 变体表示"配置上不启动"——按 mihomo 默认行为，空地址或 port=0
@@ -126,23 +141,20 @@ pub async fn spawn_dns_listener(
     listen: &str,
     service: Arc<DnsService>,
 ) -> Result<DnsListener, DnsListenerError> {
-    let trimmed = listen.trim();
-    if trimmed.is_empty() {
-        debug!(target: "dns::listener", "listen empty; DNS server disabled (mihomo-aligned)");
+    let Some(addr) = parse_dns_listen_addr(listen)? else {
+        let trimmed = listen.trim();
+        if trimmed.is_empty() {
+            debug!(target: "dns::listener", "listen empty; DNS server disabled (mihomo-aligned)");
+        } else {
+            // mihomo `dns/server.go:73-77`: port == "0" → return early, no listener.
+            info!(
+                target: "dns::listener",
+                listen = %trimmed,
+                "port=0 视为 disabled（mihomo 行为）；如需 OS 选端口请显式指定 :PORT"
+            );
+        }
         return Ok(DnsListener::disabled());
-    }
-    let addr: SocketAddr = trimmed.parse().map_err(|e: std::net::AddrParseError| {
-        DnsListenerError::InvalidAddr(trimmed.to_string(), e.to_string())
-    })?;
-    if addr.port() == 0 {
-        // mihomo `dns/server.go:73-77`: port == "0" → return early, no listener.
-        info!(
-            target: "dns::listener",
-            listen = %trimmed,
-            "port=0 视为 disabled（mihomo 行为）；如需 OS 选端口请显式指定 :PORT"
-        );
-        return Ok(DnsListener::disabled());
-    }
+    };
 
     // ---- UDP ----
     let udp = UdpSocket::bind(addr)
@@ -335,6 +347,20 @@ mod tests {
         let p = l.local_addr().unwrap().port();
         drop(l);
         p
+    }
+
+    #[test]
+    fn parser_matches_disabled_and_active_listener_semantics() {
+        assert_eq!(parse_dns_listen_addr("   ").unwrap(), None);
+        assert_eq!(parse_dns_listen_addr("127.0.0.1:0").unwrap(), None);
+        assert_eq!(
+            parse_dns_listen_addr(" 127.0.0.1:5353 ").unwrap(),
+            Some("127.0.0.1:5353".parse().unwrap())
+        );
+        assert!(matches!(
+            parse_dns_listen_addr("localhost:5353"),
+            Err(DnsListenerError::InvalidAddr(_, _))
+        ));
     }
 
     #[tokio::test]

--- a/crates/core-runtime/src/lib.rs
+++ b/crates/core-runtime/src/lib.rs
@@ -12,7 +12,7 @@ pub mod health;
 pub mod int_ranges;
 pub mod listener_handler;
 
-pub use dns_listener::{DnsListener, DnsListenerError, spawn_dns_listener};
+pub use dns_listener::{DnsListener, DnsListenerError, parse_dns_listen_addr, spawn_dns_listener};
 pub use engine::{DialResult, RoutePick, Runtime, RuntimeError, UdpDialResult};
 pub use group_selector::{FlowMeta, GroupOptions, GroupSelector, LbStrategy};
 pub use health::{

--- a/crates/wuther-core/src/host_resources.rs
+++ b/crates/wuther-core/src/host_resources.rs
@@ -1,0 +1,419 @@
+use std::{collections::BTreeSet, net::SocketAddr};
+
+use anyhow::{Result, ensure};
+use core_config::runtime_plan::RuntimePlan;
+use core_mesh::{
+    ClaimMode, HostResourceClaim, HostSubsystemId, ResourceClaim, SocketTransport, SystemResource,
+};
+
+/// Declare every fixed process-level listener before mesh backends can mutate
+/// host networking.
+///
+/// DNS port `0` is disabled by definition. Mixed and API listeners have an
+/// explicit `Option` for disabling, so port `0` is rejected: an OS-assigned
+/// port cannot be represented by an exact preflight reservation.
+pub(crate) fn listener_resource_claims(plan: &RuntimePlan) -> Result<Vec<HostResourceClaim>> {
+    let mut claims = BTreeSet::new();
+
+    if let Some(listen) = plan.resolver.listen.as_deref() {
+        let address = core_runtime::parse_dns_listen_addr(listen)
+            .map_err(|error| anyhow::anyhow!("DNS listener declaration failed: {error}"))?;
+        if let Some(address) = address {
+            let owner = host_owner("wuther.dns");
+            claims.insert(socket_claim(owner.clone(), SocketTransport::Udp, address));
+            claims.insert(socket_claim(owner, SocketTransport::Tcp, address));
+        }
+    }
+
+    if let Some(mixed) = &plan.listen.mixed {
+        let address = mixed
+            .socket_addr()
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        ensure!(
+            address.port() != 0,
+            "mixed listener port 0 cannot be reserved; omit listen.local to disable it"
+        );
+        // SOCKS5 UDP ASSOCIATE uses a separate OS-assigned relay socket, not
+        // the configured mixed TCP port.
+        claims.insert(socket_claim(
+            host_owner("wuther.mixed"),
+            SocketTransport::Tcp,
+            address,
+        ));
+    }
+
+    if plan.ui.on {
+        if let Some(panel) = &plan.listen.panel {
+            let address = panel
+                .socket_addr()
+                .map_err(|error| anyhow::anyhow!("{error}"))?;
+            ensure!(
+                address.port() != 0,
+                "API listener port 0 cannot be reserved; disable ui or omit listen.panel"
+            );
+            claims.insert(socket_claim(
+                host_owner("wuther.api"),
+                SocketTransport::Tcp,
+                address,
+            ));
+        }
+    }
+
+    debug_assert!(
+        claims
+            .iter()
+            .all(|claim| matches!(claim.claim.mode, ClaimMode::Exclusive))
+    );
+    Ok(claims.into_iter().collect())
+}
+
+fn host_owner(id: &'static str) -> HostSubsystemId {
+    HostSubsystemId::new(id).expect("static host subsystem id is valid")
+}
+
+fn socket_claim(
+    owner: HostSubsystemId,
+    transport: SocketTransport,
+    address: SocketAddr,
+) -> HostResourceClaim {
+    HostResourceClaim::new(
+        owner,
+        ResourceClaim::exclusive(SystemResource::ListenSocket { transport, address }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    fn plan(yaml: &str) -> RuntimePlan {
+        core_config::loader::load_from_str(yaml).expect("valid runtime plan")
+    }
+
+    fn sockets(claims: &[HostResourceClaim]) -> BTreeSet<(String, SocketTransport, SocketAddr)> {
+        claims
+            .iter()
+            .map(|claim| {
+                let SystemResource::ListenSocket { transport, address } = &claim.claim.resource
+                else {
+                    panic!("listener declaration returned a non-socket claim");
+                };
+                assert!(matches!(claim.claim.mode, ClaimMode::Exclusive));
+                (claim.owner.as_str().to_owned(), transport.clone(), *address)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn declares_dns_mixed_and_enabled_api_sockets_with_distinct_owners() {
+        let plan = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  local:
+    host: 127.0.0.1
+    port: 7890
+    udp: true
+  panel: 9090
+resolver:
+  listen: "127.0.0.1:1053"
+route:
+  preset: direct
+ui:
+  on: true
+  secret: test-only
+"#,
+        );
+
+        let claims = listener_resource_claims(&plan).unwrap();
+        assert_eq!(
+            claims.len(),
+            sockets(&claims).len(),
+            "claims must be unique"
+        );
+        assert_eq!(
+            sockets(&claims),
+            BTreeSet::from([
+                (
+                    "wuther.api".to_owned(),
+                    SocketTransport::Tcp,
+                    "127.0.0.1:9090".parse().unwrap(),
+                ),
+                (
+                    "wuther.dns".to_owned(),
+                    SocketTransport::Tcp,
+                    "127.0.0.1:1053".parse().unwrap(),
+                ),
+                (
+                    "wuther.dns".to_owned(),
+                    SocketTransport::Udp,
+                    "127.0.0.1:1053".parse().unwrap(),
+                ),
+                (
+                    "wuther.mixed".to_owned(),
+                    SocketTransport::Tcp,
+                    "127.0.0.1:7890".parse().unwrap(),
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn declares_ipv6_dns_mixed_and_api_sockets() {
+        let plan = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  local:
+    host: "[::1]"
+    port: 7890
+    udp: false
+  panel: "[::1]:9090"
+resolver:
+  listen: "[::1]:1053"
+route:
+  preset: direct
+ui:
+  on: true
+  secret: test-only
+"#,
+        );
+
+        assert_eq!(
+            sockets(&listener_resource_claims(&plan).unwrap()),
+            BTreeSet::from([
+                (
+                    "wuther.api".to_owned(),
+                    SocketTransport::Tcp,
+                    "[::1]:9090".parse().unwrap(),
+                ),
+                (
+                    "wuther.dns".to_owned(),
+                    SocketTransport::Tcp,
+                    "[::1]:1053".parse().unwrap(),
+                ),
+                (
+                    "wuther.dns".to_owned(),
+                    SocketTransport::Udp,
+                    "[::1]:1053".parse().unwrap(),
+                ),
+                (
+                    "wuther.mixed".to_owned(),
+                    SocketTransport::Tcp,
+                    "[::1]:7890".parse().unwrap(),
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn disabled_dns_and_ui_do_not_declare_sockets() {
+        let plan = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 9090
+resolver:
+  listen: "127.0.0.1:0"
+route:
+  preset: direct
+ui:
+  on: false
+"#,
+        );
+
+        let claims = listener_resource_claims(&plan).unwrap();
+        assert!(
+            claims
+                .iter()
+                .all(|claim| claim.owner.as_str() != "wuther.dns")
+        );
+        assert!(
+            claims
+                .iter()
+                .all(|claim| claim.owner.as_str() != "wuther.api")
+        );
+    }
+
+    #[test]
+    fn absent_listeners_and_blank_dns_declare_nothing() {
+        let plan = plan(
+            r#"
+version: 1
+profile: server
+listen:
+  panel: false
+resolver:
+  listen: "   "
+route:
+  preset: direct
+ui:
+  on: false
+"#,
+        );
+
+        assert!(listener_resource_claims(&plan).unwrap().is_empty());
+    }
+
+    #[test]
+    fn dynamic_mixed_and_api_ports_are_rejected_before_arbitration() {
+        let mut mixed = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  local: 7890
+route:
+  preset: direct
+"#,
+        );
+        mixed.listen.mixed.as_mut().unwrap().port = 0;
+        assert!(
+            listener_resource_claims(&mixed)
+                .unwrap_err()
+                .to_string()
+                .contains("mixed listener port 0")
+        );
+
+        let mut api = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 9090
+route:
+  preset: direct
+ui:
+  on: true
+  secret: test-only
+"#,
+        );
+        api.listen.panel.as_mut().unwrap().port = 0;
+        assert!(
+            listener_resource_claims(&api)
+                .unwrap_err()
+                .to_string()
+                .contains("API listener port 0")
+        );
+    }
+
+    #[test]
+    fn colliding_process_listeners_are_visible_to_mesh_preflight() {
+        let plan = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  local: 7890
+resolver:
+  listen: "127.0.0.1:7890"
+route:
+  preset: direct
+"#,
+        );
+        let owned = listener_resource_claims(&plan)
+            .unwrap()
+            .into_iter()
+            .map(HostResourceClaim::into_owned)
+            .collect::<Vec<_>>();
+
+        let conflicts = core_mesh::detect_conflicts(&owned);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_ne!(conflicts[0].left.owner, conflicts[0].right.owner);
+        assert!(matches!(
+            &conflicts[0].left.claim.resource,
+            SystemResource::ListenSocket {
+                transport: SocketTransport::Tcp,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &conflicts[0].right.claim.resource,
+            SystemResource::ListenSocket {
+                transport: SocketTransport::Tcp,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn ipv6_wildcard_and_exact_tcp_listeners_conflict() {
+        let plan = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  local:
+    host: "[::1]"
+    port: 7890
+resolver:
+  listen: "[::]:7890"
+route:
+  preset: direct
+"#,
+        );
+        let owned = listener_resource_claims(&plan)
+            .unwrap()
+            .into_iter()
+            .map(HostResourceClaim::into_owned)
+            .collect::<Vec<_>>();
+
+        let conflicts = core_mesh::detect_conflicts(&owned);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_ne!(conflicts[0].left.owner, conflicts[0].right.owner);
+    }
+
+    #[test]
+    fn invalid_listener_addresses_fail_before_mesh_start() {
+        let base = plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  local: 7890
+  panel: 9090
+resolver:
+  listen: "127.0.0.1:1053"
+route:
+  preset: direct
+ui:
+  on: true
+  secret: test-only
+"#,
+        );
+
+        let mut invalid_dns = base.clone();
+        invalid_dns.resolver.listen = Some("not-a-socket".to_owned());
+        assert!(
+            listener_resource_claims(&invalid_dns)
+                .unwrap_err()
+                .to_string()
+                .contains("DNS listener declaration failed")
+        );
+
+        let mut invalid_mixed = base.clone();
+        invalid_mixed.listen.mixed.as_mut().unwrap().host = "not-an-ip".to_owned();
+        assert!(
+            listener_resource_claims(&invalid_mixed)
+                .unwrap_err()
+                .to_string()
+                .contains("非法监听地址")
+        );
+
+        let mut invalid_api = base;
+        invalid_api.listen.panel.as_mut().unwrap().host = "not-an-ip".to_owned();
+        assert!(
+            listener_resource_claims(&invalid_api)
+                .unwrap_err()
+                .to_string()
+                .contains("非法面板地址")
+        );
+    }
+}

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -6,6 +6,8 @@
 //! * `explain <yaml>`：输出编译后的 RuntimePlan（JSON，便于排错）。
 //! * `migrate mihomo <old.yaml> -o <friendly.yaml>`：旧配置迁移。
 
+mod host_resources;
+
 use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Context;
@@ -19,6 +21,8 @@ use core_ruleset::{RulesetManager, RulesetSpec, RulesetType};
 use core_runtime::{Runtime, UrlTestConfig, UrlTester};
 use core_store::Store;
 use tracing::{info, warn};
+
+use crate::host_resources::listener_resource_claims;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -463,10 +467,101 @@ mod tests {
         assert!(tracing.stdout);
         assert!(tracing.file.is_some());
     }
+
+    #[test]
+    fn capture_claims_only_attach_the_static_host_owner() {
+        let config = core_config::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+capture:
+  on: true
+  method: virtual_nic
+  tun:
+    interface_name: mesh-arbitration-test
+    address: [198.19.0.0/30, "fd00:1234::/126"]
+    auto_route: true
+groups:
+  main:
+    choose: manual
+nodes: []
+"#,
+        )
+        .expect("valid capture config");
+        let capture =
+            core_capture::CapturePlan::from_config(&config.capture).expect("capture plan compiles");
+
+        let unowned = core_capture::host_resource_claims(&capture);
+        let owned = capture_resource_claims(&capture);
+
+        assert!(!unowned.is_empty());
+        assert_eq!(
+            owned
+                .iter()
+                .map(|owned| owned.claim.clone())
+                .collect::<Vec<_>>(),
+            unowned
+        );
+        assert!(
+            owned
+                .iter()
+                .all(|claim| claim.owner.as_str() == "wuther.capture")
+        );
+    }
+
+    #[test]
+    fn disabled_capture_reserves_no_mesh_resources() {
+        let config = core_config::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+capture:
+  on: false
+groups:
+  main:
+    choose: manual
+nodes: []
+"#,
+        )
+        .expect("valid capture config");
+        let capture =
+            core_capture::CapturePlan::from_config(&config.capture).expect("capture plan compiles");
+
+        assert!(capture_resource_claims(&capture).is_empty());
+    }
+
+    #[tokio::test]
+    async fn mesh_fail_stop_observes_an_already_failed_snapshot() {
+        let (sender, mut updates) = tokio::sync::watch::channel(core_mesh::MeshSnapshot::new(
+            7,
+            core_mesh::MeshSupervisorPhase::Failed,
+            false,
+        ));
+
+        let snapshot = wait_for_mesh_fail_stop(&mut updates)
+            .await
+            .expect("failed snapshot");
+        assert_eq!(snapshot.generation, 7);
+        assert!(!snapshot.running);
+        drop(sender);
+    }
+
+    #[tokio::test]
+    async fn mesh_fail_stop_treats_a_closed_status_channel_as_fatal() {
+        let (sender, mut updates) = tokio::sync::watch::channel(core_mesh::MeshSnapshot::new(
+            1,
+            core_mesh::MeshSupervisorPhase::Running,
+            true,
+        ));
+        drop(sender);
+
+        assert!(wait_for_mesh_fail_stop(&mut updates).await.is_none());
+    }
 }
 
 fn cmd_check(config: PathBuf) -> anyhow::Result<()> {
     let plan = load_from_path(&config).map_err(|e| anyhow::anyhow!("{e}"))?;
+    listener_resource_claims(&plan).context("listener resource validation failed")?;
     println!(
         "OK: {} 节点 / {} 分组 / {} 条规则",
         plan.nodes.len(),
@@ -512,6 +607,17 @@ fn tracing_config_from_user_log(log: &core_config::model::Log) -> core_observe::
         file,
         format,
     }
+}
+
+/// Attach the process-level host owner to capture's platform-specific claims.
+fn capture_resource_claims(plan: &core_capture::CapturePlan) -> Vec<core_mesh::HostResourceClaim> {
+    use core_mesh::{HostResourceClaim, HostSubsystemId};
+    let owner =
+        HostSubsystemId::new("wuther.capture").expect("static capture subsystem id is valid");
+    core_capture::host_resource_claims(plan)
+        .into_iter()
+        .map(|claim| HostResourceClaim::new(owner.clone(), claim))
+        .collect()
 }
 
 async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
@@ -574,6 +680,32 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         Err(e) => warn!(target: "capture", error = %e, "diagnose failed"),
     }
     info!(target: "mesh", "{}", core_mesh::diagnose(&plan.mesh));
+
+    // 组网监督器必须在 runtime/capture/监听器之前启动。当前公共层注册 capture
+    // 对宿主路由、接口和防火墙的保留，以及 DNS、Mixed、API 的固定监听端口；
+    // 后续具体产品后端按独立 PR 加入 registry。即使 registry 为空，保留资源也会
+    // 出现在 /v1/mesh/status，且同一条事务路径已经覆盖未来后端的
+    // probe -> preflight -> reconcile。
+    let mut capture_plan = core_capture::CapturePlan::from_config(&plan.capture)
+        .map_err(|error| anyhow::anyhow!("capture resource declaration failed: {error}"))?;
+    capture_plan.ipv6_enabled = plan.resolver.ipv6;
+    let mut host_claims = capture_resource_claims(&capture_plan);
+    host_claims.extend(listener_resource_claims(&plan)?);
+    let mesh_supervisor = Arc::new(core_mesh::MeshSupervisor::new(
+        core_mesh::BackendRegistry::new(),
+        host_claims,
+    ));
+    let mesh_snapshot = mesh_supervisor
+        .start()
+        .await
+        .map_err(|error| anyhow::anyhow!("mesh preflight failed: {error}"))?;
+    info!(
+        target: "mesh",
+        generation = mesh_snapshot.generation,
+        reservations = mesh_snapshot.reservations.len(),
+        backends = mesh_snapshot.statuses.len(),
+        "mesh supervisor ready"
+    );
 
     // 打开持久化 store（默认 data/state/wuthercore.redb）。
     let store = match Store::open("data/state/wuthercore.redb") {
@@ -757,6 +889,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
                 clash_compat: plan.ui.api.clash_compat,
                 urltest: urltest.clone(),
                 capture: capture_handle.clone(),
+                mesh: Some(mesh_supervisor.clone()),
                 feeds: Some(feed_mgr_handle.clone()),
                 cors_origins: plan.ui.cors.clone(),
             };
@@ -770,19 +903,59 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
 
     info!("WutherCore started, press Ctrl-C to stop.");
-    tokio::signal::ctrl_c().await?;
-    info!("shutdown signal, bye.");
+    let mut mesh_updates = mesh_supervisor.subscribe();
+    let shutdown_signal = tokio::select! {
+        signal = tokio::signal::ctrl_c() => {
+            info!("shutdown signal, bye.");
+            signal
+        }
+        snapshot = wait_for_mesh_fail_stop(&mut mesh_updates) => {
+            if let Some(snapshot) = snapshot {
+                warn!(
+                    target: "mesh",
+                    generation = snapshot.generation,
+                    phase = ?snapshot.supervisor_phase,
+                    conflicts = snapshot.conflicts.len(),
+                    "mesh supervision was lost; stopping host capture and runtime fail-closed"
+                );
+            } else {
+                warn!(
+                    target: "mesh",
+                    "mesh status channel closed; stopping host capture and runtime fail-closed"
+                );
+            }
+            Ok(())
+        }
+    };
     if let Some(sup) = capture_handle {
         if let Err(e) = sup.stop().await {
             warn!(target: "capture", error = %e, "capture stop failed");
         }
+    }
+    if let Err(error) = mesh_supervisor.stop().await {
+        warn!(target: "mesh", error = %error, "mesh supervisor stop failed");
     }
     feed_mgr_handle.stop();
     runtime.shutdown().await;
     for h in handles {
         h.abort();
     }
+    shutdown_signal?;
     Ok(())
+}
+
+async fn wait_for_mesh_fail_stop(
+    updates: &mut tokio::sync::watch::Receiver<core_mesh::MeshSnapshot>,
+) -> Option<core_mesh::MeshSnapshot> {
+    loop {
+        let snapshot = updates.borrow_and_update().clone();
+        if !snapshot.running {
+            return Some(snapshot);
+        }
+        if updates.changed().await.is_err() {
+            return None;
+        }
+    }
 }
 
 /// 把 [`core_ruleset::RulesetIndex`] 适配为 [`core_capture::IpSetProvider`]。

--- a/docs/API.md
+++ b/docs/API.md
@@ -63,6 +63,7 @@ WebSocket/SSE 因浏览器协议限制，可使用 `?token=<secret>`。普通 GE
 | `GET` | `/v1/resolver/query` | 调试 DNS 查询 |
 | `GET` | `/v1/route/check` | 调试路由结果 |
 | `GET` | `/v1/capture/state` | 流量接管状态 |
+| `GET` | `/v1/mesh/status` | 组网监督器、后端、动态附件、资源声明与冲突快照 |
 | `GET` | `/v1/smart/why` | 查看 Smart 选择理由 |
 | `POST` | `/v1/smart/pin` | 固定节点 |
 | `POST` | `/v1/smart/avoid` | 临时回避节点 |
@@ -71,6 +72,12 @@ WebSocket/SSE 因浏览器协议限制，可使用 `?token=<secret>`。普通 GE
 | `GET` | `/v1/smart/nodes/:group` | 查看组内 Smart 节点 |
 
 请求参数和响应结构在 1.0 前仍可能变化。集成时应保留未知字段，并对非 2xx 响应记录状态码和脱敏后的消息。
+
+`/v1/mesh/status` 只返回监督器当前内存快照的安全公开投影：handler 调用 `MeshSupervisor::snapshot().public_view()`，不会执行 `probe`、`status` 或 `refresh`，不会访问外部 daemon、触发后端启停/隔离，也不会推进快照 generation。启动、停止和默认 5 秒一次的后台监控负责发布新的内部快照。
+
+公开投影会解析 URL endpoint，只保留 scheme、host 和 port，删除 userinfo、path、query、fragment；非法 URL、Unix socket、named pipe 与 `Opaque` endpoint 只返回无 value 的 `hidden`。version 和所有自定义字符串有长度上限并清理控制字符；diagnostic 只公开 level、安全 code 和固定 message；资源声明与冲突均不公开 `coordination_key`。响应模型也没有命令环境或秘密文件字段。
+
+主程序未注入组网监督器时，该端点明确返回 `503 mesh_supervisor_unavailable`，不会把“未初始化”误报成“所有后端正常”。当前基础设施阶段没有注册具体产品后端，因此 `statuses` 可以为空；capture 以及 DNS/Mixed/API 固定监听的 reservations 仍会正常出现在快照中。
 
 ## 示例
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 | 文档 | 内容 |
 | --- | --- |
 | [架构说明](ARCHITECTURE.md) | workspace 边界、连接数据流与主要扩展点 |
+| [组网后端基础设施](mesh-backend-foundation.md) | 后端能力、系统资源仲裁、进程所有权与事务生命周期 |
 | [内核设计文档](../RP内核设计文档.md) | 完整设计背景和实现细节 |
 | [构建性能](BUILD-PERF.md) | Cargo profile、缓存与编译性能 |
 | [构建脚本](../scripts/README.md) | 多平台构建方式和产物 |

--- a/docs/mesh-backend-foundation.md
+++ b/docs/mesh-backend-foundation.md
@@ -1,0 +1,123 @@
+# 组网后端基础设施
+
+`core-mesh` 为 Tailscale、Cloudflare、ZeroTier、NetBird、WireGuard、Nebula 等组网产品提供统一的能力、资源和生命周期边界。具体后端不得直接在主程序启动过程中修改系统；它必须先报告观测结果和资源声明，再由 `MeshSupervisor` 完成统一预检。
+
+本阶段只交付通用基础设施，没有把“进程能够启动”冒充成任何具体产品的完整支持。当前 `wuther-core` 注册的是空 `BackendRegistry`，只把 capture 的宿主保留资源注入监督器；具体产品的配置、认证、进程接入和数据面适配仍需在后续独立变更中接入官方控制面/数据面依赖、实现能力探测，并完成对应平台的集成测试。
+
+## 生命周期
+
+每次启动遵循同一事务：
+
+1. 冻结注册时的后端 ID、产品类型和所有权，后续不信任适配器动态改变身份。
+2. 对全部后端执行只读 `probe`。
+3. 合并后端声明与 WutherCore capture 等强类型宿主保留资源。
+4. 在任何副作用发生前完成冲突检测。
+5. 按注册顺序执行 `reconcile`。
+6. 任一步失败时，对已经成功启动的后端逆序释放。
+7. 正常退出时同样逆序关闭，并尝试收集全部关闭错误。
+
+默认后端调用时限分别为：调用 gate 2 秒、`probe` 10 秒、`reconcile` 120 秒、`status` 5 秒、`detach`/`terminate` 30 秒。零值调用时限会归一化为 1 毫秒；只有零值 `monitor_interval` 表示禁用监控。每个后端的调用由独立 gate 串行化，适配器 future 的超时、取消和 panic 都会转换为脱敏失败。
+
+调用方取消或丢弃 `start`/`stop` future 不会中断已经开始的事务 worker。活动启动被停止时，worker 会对已启动后端和 in-flight 后端执行有界逆序回滚。`reconcile` 返回的资源声明必须与通过预检的 observation 完全相同，不能在预检后扩大资源集合。
+
+后台监控器默认每 5 秒执行一次只读状态观测，并重新验证冻结身份、运行相位、返回规模与动态资源冲突。状态调用失败、超时、panic、身份无法验证、返回非运行相位、越过有界观察预算或运行期出现新冲突时，监督器把 `running` 置为 false，并逆注册顺序释放对应后端由 WutherCore 拥有的生命周期对象。`managed_child`/`embedded` 的成功释放会消除它们拥有的系统资源；`attach_external` 的成功 `detach` 只隔离本进程的观察器和临时附件，绝不代表外部 daemon 的 DNS、路由或防火墙状态已经消失。
+
+因此外部适配器的 `probe` 资源声明不是瞬时状态，而是连接期间所有可能 daemon 状态的保守固定 envelope；`reconcile` 和每次 `status` 必须返回同一声明集合（排序和重复项不影响比较）。监督器会拒绝运行中扩大或缩小 envelope。当前 `wuther-core` 还持续订阅监督器快照：一旦已经启动的监督器变为非运行或状态通道关闭，会主动停止 capture、其他后端、runtime 和监听器，形成应用级 fail-stop。直接复用 `core-mesh` 的其他宿主同样必须消费这个非运行信号并停止自己的宿主资源，不能把 external `detach` 描述为已经消除了 daemon 资源。
+
+隔离失败会保留错误并进入 pending-release，后续监控 tick 必须先重试释放，不能因为 daemon 又报告健康就重新信任它。隔离状态和动态冲突会锁存；只有完成一次完整且成功的 `stop`，随后重新 `start`，才会重新获取资源，避免未知状态下自动恢复造成争用。显式 stop 和析构清理都会先取消并 drain 在途监控任务，再在同一个 maintenance 边界重读 started 集合，避免 monitor/stop 对同一外部资源并发释放。
+
+状态通过 `/v1/mesh/status` 返回。这个 GET 端点只读取完整的内部 `MeshSnapshot`，再生成独立的 `PublicMeshSnapshot`；它不调用外部 daemon、不推进快照 generation，也不产生系统副作用。启动、停止和后台监控器负责更新内部快照。公开快照中的后端映射按 ID 稳定序列化，宿主 reservations 排序并去重；适配器提供的附件和资源声明保留输入顺序，需要可重现输出的适配器必须自行稳定排序。诊断按 `(level, code)` 保留最新一条并设置数量与字符串硬上限，防止长期重试或恶意适配器让 watch 快照无界增长。
+
+公开投影不复用适配器原始字符串：URL 必须成功解析，并且只保留 scheme、host 和 port；userinfo、path、query 和 fragment 一律删除，非法 URL 不回显。Unix socket、named pipe 与 `Opaque` endpoint 默认变为没有 value 的 `hidden`。version 和产品/接口/协议等自定义字符串按 UTF-8 字节设上限并清理控制字符；diagnostic 只保留 level 与通过结构化校验的 code，message 使用固定公开文本；资源共享状态只公开 `exclusive`/`coordinated_shared`，不序列化 `coordination_key`，冲突原因也不包含密钥值。
+
+内部快照结构同样没有命令环境或秘密文件字段，但仍保留生命周期判断所需的 observation，不得直接作为不受信任的 API DTO。协调 claim 和 conflict 的错误 `Display`/`Debug` 同样必须脱敏。适配器依然不得把令牌、原始 CLI stderr 或其他秘密写入业务字段；`BackendError` 的 sensitive source 不进入 `Display`、`Debug` 或公开投影。
+
+## 所有权边界
+
+| 所有权 | 含义 | 关闭行为 |
+|---|---|---|
+| `attach_external` | 用户或操作系统管理的 daemon/service；资源声明必须是整个 attach 生命周期的固定保守 envelope | 通过 `ExternalNetworkBackend::detach` 只停止 WutherCore 自己的 watcher、连接和临时附件；禁止停止服务、注销节点或删除系统配置；异常时由宿主消费 `running=false` 并执行应用级 fail-stop |
+| `managed_child` | WutherCore 创建的独立子进程 | 通过 `OwnedNetworkBackend::terminate` 先尝试优雅关闭，超时后终止整个 Unix 进程组或 Windows Job，并等待回收 |
+| `embedded` | 进程内实例或受控 helper | 通过 `OwnedNetworkBackend::terminate` 仅释放该实例拥有的资源 |
+
+`detach`/`terminate` 是 at-least-once 操作，适配器必须实现幂等。调用超时只能说明监督器没有观察到完成，不能证明外部副作用未发生；后续 stop、故障恢复或 pending-release 重试可能再次调用释放。
+
+托管子进程必须使用参数数组而不是 shell 拼接，并显式配置就绪探针。监督器持续观察子进程退出；意外退出会被发布为状态，并按照有界退避策略重启，无需等待下一次 `reconcile`。认证材料写入随机秘密文件；Unix 权限固定为 `0600`，Windows 沿用当前用户的继承 ACL。秘密文件至少保留到进程组完成回收，并在最后一个 `ManagedProcessSpec`/`SecretFile` 持有者析构时删除；脱敏值在最后一个 `Redactor` clone 析构时 zeroize，调用方自己的原始秘密缓冲区不由本模块清理。日志使用有界缓冲区，跨读取分块执行秘密值脱敏。
+
+正常路径必须显式等待 `MeshSupervisor::stop` 和托管进程的 `ManagedDaemon::close` 并检查返回值；只有成功返回才表示对应的有界释放或进程组回收已经完成。Unix 上对已经自然消失的进程组返回 `ESRCH` 属于幂等成功，不会把“目标已不存在”误报成清理失败。对象析构只提供不 panic 的紧急 best-effort：监督器会取消活动事务，并在可用 Tokio runtime 上安排残留释放；托管进程会请求进程组终止并尽力安排回收。运行时已经关闭或不存在时，不能把 `Drop` 当作完成异步清理的证明。后端/readiness/shutdown hook 的 panic 会被转换为固定公开错误并触发进程组回收，但 Rust 全局 panic hook 可能先输出 panic payload；适配器不得把秘密放进 panic payload，嵌入应用也应按自身日志边界配置全局 hook。
+
+## 能力与附件
+
+能力描述后端实际能做什么，例如 L3 接口、内嵌拨号、子网路由、出口节点、私网/公网入口、身份查询、DNS namespace、事件流和高可用。能力不由产品名称推断，后端只能报告已经探测并验证的能力。
+
+附件描述运行时实际产生的数据面：
+
+- 接口名称、地址、索引与 MTU；
+- 路由前缀、路由表、metric 与所属接口；
+- 本地控制、拨号、健康和指标端点；
+- HTTP、HTTPS、TCP、UDP、SSH、RDP 等入口映射。
+
+后续路由、DNS 和 capture 同步必须消费这些动态附件，不能继续把某个产品的固定地址段当作完整网络视图。
+
+## 系统资源仲裁
+
+后端可声明以下资源：
+
+- 路由管理器、IPv4/IPv6 默认路由和路由表；
+- DNS、防火墙和 hosts 数据库；
+- 精确接口名、OS 动态分配接口的全局管理权、本地监听 socket；
+- 接口地址前缀、路由前缀；
+- 防火墙 mark 区间。
+
+冲突检测理解资源语义，而不只是比较枚举是否相等：
+
+- `0.0.0.0:PORT` 与同协议、同端口的任意 IPv4 监听冲突；
+- `[::]:PORT` 保守按可能的 dual-stack 监听处理；
+- IPv4/IPv6 CIDR 按包含关系检测重叠；
+- 地址前缀与其他后端的路由前缀也会检测重叠；
+- IPv4/IPv6 默认路由与对应地址族的 `/0` 路由前缀等价并冲突；
+- 路由表声明与显式使用相同（或未知）路由表的路由前缀冲突；
+- 两个路由前缀只有在显式路由表相同，或任一方路由表未知时，才按 CIDR 重叠冲突；两个明确且不同的路由表可以拥有相同前缀；
+- 全局路由/防火墙管理声明覆盖对应的细粒度路由、路由表和 mark 声明；
+- 接口管理权与任何具体接口名冲突，用于 macOS utun、Android VpnService 等只有 activation 时才知道最终名称的平台；
+- IPv4-mapped IPv6 listener 会归一化到对应 IPv4 地址空间，并与 IPv4 concrete/wildcard 及 dual-stack IPv6 wildcard 保守检测冲突；
+- 防火墙 mark 使用闭区间重叠判断。
+
+不同 owner 的重叠声明默认冲突。只有双方都使用相同且非空的 `coordination_key` 时才允许共享。这个 key 表示双方已经实现同一套原子更新与回滚协议，不是绕过检查的配置开关。
+
+## 后端实现约束
+
+一个后端适配器必须实现公共的 `NetworkBackend`，并根据所有权额外实现 `ExternalNetworkBackend` 或 `OwnedNetworkBackend`：
+
+- `descriptor`：提供只读取一次并冻结的 ID、产品类型和所有权；
+- `probe`：只读探测版本、状态、能力、附件和资源声明；
+- `reconcile`：只使用已经通过预检的观测结果建立本进程所需状态；
+- `status`：返回当前脱敏快照；
+- `detach`/`terminate`：严格遵守所有权边界并释放本适配器拥有的资源。
+
+`probe` 返回的 ID、产品类型和所有权必须与注册信息一致。监督器会在状态发布前验证这些字段，避免后端把资源错误归属给其他 owner。
+
+`attach_external` 不能依赖运行后才发现的 daemon 配置来扩充资源声明。适配器必须在只读 `probe` 阶段保守覆盖连接期间可能出现的 DNS、默认路由、子网路由、接口、监听和防火墙资源；如果无法给出安全 envelope，就必须在该宿主组合上返回 Unsupported/Conflict，而不是接入后再赌动态 `detach` 能停止外部 daemon。
+
+适配器错误只允许把稳定错误码和经过清理的内部消息写入完整快照。公开投影会再次校验错误码并用固定文本替换任意 message。原始 stderr、命令行、环境变量和认证响应只能作为内存中的敏感错误源保留，`Display`、`Debug` 和公开序列化均不得输出。所有 `probe`、`reconcile`、`status` 观察在进入冲突检测或 watch 快照前都必须通过统一的附件、资源、诊断、嵌套集合、单字符串和总字符串预算验证；越界结果按固定 `invalid_status` 处理，不能让后端调用 deadline 之外的本地 O(n²) 冲突计算失去上界。
+
+## 宿主保留资源
+
+主程序在启动组网后端前调用 `core_capture::host_resource_claims` 取得无 owner 的 `ResourceClaim`，再使用 `HostSubsystemId("wuther.capture")` 包装为专用的 `HostResourceClaim`。`MeshSupervisor` 构造函数只接受这个强类型宿主输入，并在边界内部转换为快照使用的 `OwnedResourceClaim`。宿主 owner 与后端 owner 使用不同命名空间；即使字符串恰好相同，也会被视为不同 owner 并执行冲突检测。宿主保留资源只参与仲裁，不会收到后端生命周期调用。
+
+同一预检还会用独立的 `wuther.dns`、`wuther.mixed`、`wuther.api` owner 声明进程实际启动的固定监听。DNS 按 mihomo 语义同时声明 TCP/UDP，空地址和端口 `0` 都表示禁用；Mixed 只声明其固定 TCP 端口，SOCKS5 UDP ASSOCIATE 的 relay 继续使用独立动态 socket；API 只在 `ui.on` 且 panel 已配置时声明 TCP。Mixed 与 API 的端口 `0` 无法形成精确预检，因此启动会在任何网络修改前失败。Mixed 绑定失败也不再回退到 `9001..=9099`，保证快照中的 reservation 与真实 socket 始终一致。不同进程子系统必须使用不同 owner，否则冲突器按“同一 owner 的重复声明”跳过后会掩盖进程内部端口碰撞。
+
+Capture 自己的 DNS hijack listener 仍属于 `wuther.capture`，不会与上面的可配置独立 DNS server 混为一谈。`hijack_dns=true` 时，Windows 声明 TCP/UDP `127.0.0.1:53` 与 `[::1]:53`，其他受支持平台声明 TCP/UDP `127.0.0.1:5454`；启动和预检共同读取同一份纯地址选择函数。
+
+| 平台/模式 | 当前实际声明 |
+| --- | --- |
+| Linux TUN | 接口与地址；`auto_route` 的 route manager、配置表、split-default、输出 mark，catch-all 时再声明逻辑默认路由；身份过滤声明 firewall；`strict_route` 声明双栈逻辑默认路由；`auto_redirect` 声明安装时 nft/TPROXY/NAT fallback 的保守并集 |
+| Linux TPROXY | route/firewall manager、表与代理 mark `0x2d0`、可配置 output mark（正常配置默认 `0x2024`）、IPv4 local default 及 TCP/UDP `0.0.0.0:7894`；启用 IPv6 时再声明 `::/0` local default、逻辑默认路由及 TCP/UDP `[::]:7894` |
+| Linux Redirect | 只声明 firewall manager |
+| Android TUN | root `/dev/net/tun` 的精确接口名与 VpnService 的 OS 动态接口管理权、地址及两条配置路径的保守并集；后者按 `VpnService.Builder` 实际静态路由声明 unknown-table route prefix，包含 `auto_route=false + route_address`，启用 DNS hijack 时声明 DNS manager |
+| Android TPROXY/Redirect | 不在预检中执行 `su`、`modprobe` 或 capability 探测；统一声明所有运行期 tier 的 fail-closed 并集：firewall、表 100、mark 1、双栈 local-default 与逻辑默认路由 |
+| Windows TUN | 接口与地址；`auto_route=false` 不声明路由，catch-all 声明实际双栈默认路由（IPv6 同时受 resolver 与 TUN IPv6 地址门控），纯 `route_address` 声明过滤、去重后的精确前缀，`route_address_set` 按实际行为回到 catch-all；启用 DNS hijack 时再声明 DNS manager |
+| macOS TUN | OS 动态 utun 接口管理权、地址、当前实际安装的 IPv4 默认路由；不把请求名冒充真实 utunN，也不虚构尚未实现的 PF/DNS |
+| iOS/其他 | iOS NetworkExtension 的接口与路由由宿主应用拥有，因此只在 DNS hijack 时声明 capture 私有 listener；其他未支持平台返回空声明 |
+
+这里故意反映“当前安装代码实际做什么”，而不是理想配置语义。Android TUN 在 native open 成功前无法知道最终使用 root TUN 还是宿主预配置的 VpnService fd，因此预检复用与 `VpnService.Builder` 相同的纯路由计算并声明两条路径的并集；Android framework 自行选择的接口名和路由表分别用 `InterfaceManager` 与 `table=None` 表示未知范围，以便与任意具体接口/重叠路由保守冲突。macOS 同样在打开设备后才得到真实 utunN，因此只声明动态接口管理权而不声明配置中的请求名。Android 透明模式的运行期 capability 探测可能在预检之后加载 TPROXY 模块，所以预检不能依据“模块当前未加载”缩小声明，而是始终覆盖所有可能成功的 tier。现有 Linux/Android 安装路径仍有部分 IPv6 操作没有完全遵守 resolver 的 `ipv6_enabled`；资源声明会保守覆盖这些真实操作，该历史行为需要在后续独立平台修复中统一，不能在本基础设施变更里静默改变。Linux `auto_redirect` 只有安装时才选择 fallback，所以预检采用保守并集，可能有意提前报告冲突。关闭 capture 或选择 `none` 时不声明资源，且声明路径不会触发任何 Android 能力探测。宿主 reservations 表示启动意图和仲裁边界，不是 capture 安装已经成功的证明；后续启动失败仍由 capture 自己回滚并报告。


### PR DESCRIPTION
## 背景

后续接入 Tailscale、Cloudflare、ZeroTier、NetBird 等组网产品前，核心必须先具备统一的能力描述、宿主资源仲裁、所有权边界和可靠的 daemon 生命周期。本 PR 仅交付这层公共基础设施；不包含具体产品适配器，也不修改任何代理协议实现。

本分支已在推送前重新抓取并对齐最新 `main`（`fc7a506`），保留并复用 #18 中 Windows TUN 的事务路由与回滚逻辑。

## 主要实现

- 新增提供商无关的组网后端能力、附件、资源、所有权和公开快照模型。
- 冻结后端身份与声明，区分 Wuther 托管进程和系统外部进程；外部 daemon 只能 detach，不会被误终止。
- 在产生副作用前，对接口、地址前缀、路由前缀、默认路由、路由表、fwmark、防火墙、DNS 和 TCP/UDP 监听地址做语义化冲突预检。
- 规范化 IPv4-mapped IPv6、通配监听、路由表作用域和协调键；协调键只参与内部比较，不进入日志、错误或 API。
- 新增事务化 `MeshSupervisor`：有界 probe/reconcile/status/release、逆序回滚、并发 start/stop 合并、调用取消、panic 隔离、运行期冲突监控、pending release 重试与 fail-stop。
- 新增托管进程基础设施：Unix process group、Windows Job Object、显式 readiness、优雅关闭/超时强杀、完整进程树回收、有界重启与日志、有界秘密文件、跨分块输出脱敏。
- 将 Linux/Android/Windows/macOS/iOS capture 的实际接口、地址、路由、mark、防火墙和 capture 私有 DNS 资源注入仲裁。
- Linux TPROXY 的 IPv4/IPv6 资源声明与真实启动配置一致；Windows 路由预检与真实启动复用同一算法。
- 将 DNS、Mixed 和 API 的真实监听资源以独立 owner 注入仲裁；Mixed 改为精确绑定，不再静默回退到未声明的 9001..9099。
- 配置编译阶段拒绝 Mixed/API 动态端口和非法面板地址，并复用 DNS 监听地址解析逻辑。
- 新增只读 `/v1/mesh/status`，仅输出稳定、严格脱敏的公开快照。
- 补充 API、README、CHANGELOG 和组网后端基础设施设计文档。

## 安全与一致性

- 后端错误、诊断、日志和公开状态均有长度预算及脱敏边界。
- URL 仅公开 origin；用户信息、路径、查询串、Unix socket、named pipe 和 opaque endpoint 不会越过 API 边界。
- 后端运行期状态不能扩大启动前冻结的资源包络。
- Wuther 的 capture、DNS、Mixed、API 与未来组网后端统一经过同一个宿主资源仲裁器。

## 验证

- Windows：`cargo test --workspace`
- Windows：`cargo check --workspace --all-targets`
- Windows：`cargo test -p core-capture --lib`（261/261）
- Windows：`cargo test -p core-config --lib`（35/35）
- Windows：`cargo test -p wuther-core --bin wuther-core`（10/10）
- Windows：`cargo clippy -p core-mesh --all-targets --no-deps -- -D warnings`
- Windows：`cargo clippy -p wuther-core --all-targets --no-deps -- -D warnings`
- Windows：`cargo rustdoc -p core-mesh --lib -- -D warnings`
- WSL/Linux：`cargo test -p core-mesh`（82/82）
- WSL/Linux：`cargo check -p core-mesh -p core-capture -p wuther-core`
- `cargo fmt --all -- --check`
- `git diff --check`

完整依赖图的 `clippy -D warnings` 仍会命中仓库既有的 `core-config/core-outbound` 警告；本 PR 触及的 `core-mesh` 与主程序目标已在 `--no-deps` 模式严格通过。

## 范围与后续

本 PR 不虚报具体 Tailscale/Cloudflare 等产品支持。具体后端、真实设备集成和相应平台测试将各自使用最新 `main` 的独立 worktree、单提交和独立中文 PR。

现有 Linux TUN auto-redirect/Android transparent 缺少透明监听器、Linux Redirect 规则不完整等 capture 缺陷也不在本基础设施 PR 中；它们会作为独立功能修复，连同真实监听和资源声明一起交付。