### PR TITLE
实现完整 REALITY 客户端与服务端支持

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/core-mesh",
     "crates/core-observe",
     "crates/core-process",
+    "crates/core-reality",
     "crates/wuther-core",
     "tests-e2e",
 ]
@@ -96,7 +97,7 @@ sha2              = "0.10"
 hmac              = "0.12"
 md-5              = "0.10"
 blake3            = "1"
-rustls            = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls            = { version = "=0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
 tokio-rustls      = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 rustls-pki-types  = "1"
 webpki-roots      = "0.26"
@@ -150,6 +151,15 @@ core-capture  = { path = "crates/core-capture" }
 core-mesh     = { path = "crates/core-mesh" }
 core-observe  = { path = "crates/core-observe" }
 core-process  = { path = "crates/core-process" }
+core-reality  = { path = "crates/core-reality" }
+xray-routing  = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584", package = "xray-routing" }
+xray-transport = { path = "third_party/xray-transport" }
+xray-utls     = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584", package = "xray-utls" }
+
+[patch.crates-io]
+# REALITY 必须在同一个真实 ClientHello 上完成 session-id 封装并继续握手；
+# 上游 rustls 没有 finalizer hook，固定使用经过该能力审阅的 shaped-rustls 提交。
+rustls = { git = "https://github.com/aimalygin/shaped-rustls", rev = "94f088e210fd2a56e413cce1c6d79c10852d500a" }
 
 # ============================================================================
 # 编译时间 / 二进制大小 / 运行性能的权衡

--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ python scripts/check-repository.py
 
 ## License
 
-WutherCore 使用 [MIT License](LICENSE) 开源。
+除 `third_party/xray-transport` 之外使用 [MIT License](LICENSE) 开源，`third_party/xray-transport` 使用 [MPL License](third_party/xray-transport/LICENSE-MPL-2.0)

--- a/crates/core-config/Cargo.toml
+++ b/crates/core-config/Cargo.toml
@@ -15,6 +15,9 @@ url = { workspace = true }
 ipnet = { workspace = true }
 percent-encoding = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
+uuid = { workspace = true }
+xray-utls = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -207,6 +207,269 @@ pub struct Listen {
     pub share: Option<Share>,
     #[serde(default)]
     pub auth: Vec<String>,
+    /// REALITY 是一层入站流安全协议；每个条目独立监听并在认证后交给
+    /// `protocol` 指定的内层代理协议。
+    #[serde(default, alias = "reality-inbounds", alias = "reality_inbounds")]
+    pub reality: Vec<RealityListen>,
+}
+
+/// Xray REALITY 服务端监听配置。
+///
+/// 字段名同时接受 Xray 的 camelCase 与本项目常用的 snake/kebab 写法；
+/// 未知字段一律拒绝，避免把密钥或限速字段拼错后静默降级。
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealityListen {
+    #[serde(default = "default_reality_listen_host")]
+    pub host: String,
+    pub port: u16,
+    #[serde(default = "default_reality_inner_protocol")]
+    pub protocol: String,
+    #[serde(default)]
+    pub users: Vec<String>,
+    #[serde(default)]
+    pub target: Option<RealityTarget>,
+    #[serde(default)]
+    pub dest: Option<RealityTarget>,
+    #[serde(default, rename = "type", alias = "target_type", alias = "target-type")]
+    pub target_type: Option<String>,
+    #[serde(default)]
+    pub show: bool,
+    #[serde(
+        default,
+        rename = "masterKeyLog",
+        alias = "master_key_log",
+        alias = "master-key-log"
+    )]
+    pub master_key_log: Option<String>,
+    #[serde(default)]
+    pub xver: u8,
+    #[serde(
+        default,
+        rename = "serverNames",
+        alias = "server_names",
+        alias = "server-names"
+    )]
+    pub server_names: Vec<String>,
+    #[serde(
+        default,
+        rename = "privateKey",
+        alias = "private_key",
+        alias = "private-key"
+    )]
+    pub private_key: String,
+    #[serde(
+        default,
+        rename = "minClientVer",
+        alias = "min_client_ver",
+        alias = "min-client-ver"
+    )]
+    pub min_client_ver: Option<String>,
+    #[serde(
+        default,
+        rename = "maxClientVer",
+        alias = "max_client_ver",
+        alias = "max-client-ver"
+    )]
+    pub max_client_ver: Option<String>,
+    /// 与 Xray 一致，单位为毫秒；0 表示不限制时钟差。
+    #[serde(
+        default,
+        rename = "maxTimeDiff",
+        alias = "max_time_diff",
+        alias = "max-time-diff"
+    )]
+    pub max_time_diff_ms: u64,
+    #[serde(default, rename = "shortIds", alias = "short_ids", alias = "short-ids")]
+    pub short_ids: Vec<String>,
+    #[serde(
+        default,
+        rename = "mldsa65Seed",
+        alias = "mldsa65_seed",
+        alias = "mldsa65-seed"
+    )]
+    pub mldsa65_seed: Option<String>,
+    #[serde(
+        default,
+        rename = "limitFallbackUpload",
+        alias = "limit_fallback_upload",
+        alias = "limit-fallback-upload"
+    )]
+    pub limit_fallback_upload: RealityFallbackLimit,
+    #[serde(
+        default,
+        rename = "limitFallbackDownload",
+        alias = "limit_fallback_download",
+        alias = "limit-fallback-download"
+    )]
+    pub limit_fallback_download: RealityFallbackLimit,
+    #[serde(default)]
+    pub limits: RealityResourceLimits,
+}
+
+impl std::fmt::Debug for RealityListen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RealityListen")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("protocol", &self.protocol)
+            .field("user_count", &self.users.len())
+            .field("target", &self.target)
+            .field("dest", &self.dest)
+            .field("target_type", &self.target_type)
+            .field("show", &self.show)
+            .field(
+                "master_key_log",
+                &self.master_key_log.as_ref().map(|_| "<redacted>"),
+            )
+            .field("xver", &self.xver)
+            .field("server_names", &self.server_names)
+            .field("private_key", &"<redacted>")
+            .field("min_client_ver", &self.min_client_ver)
+            .field("max_client_ver", &self.max_client_ver)
+            .field("max_time_diff_ms", &self.max_time_diff_ms)
+            .field("short_id_count", &self.short_ids.len())
+            .field("has_mldsa65_seed", &self.mldsa65_seed.is_some())
+            .field("limit_fallback_upload", &self.limit_fallback_upload)
+            .field("limit_fallback_download", &self.limit_fallback_download)
+            .field("limits", &self.limits)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum RealityTarget {
+    Port(u16),
+    Address(String),
+}
+
+impl RealityTarget {
+    pub fn normalized(&self) -> String {
+        match self {
+            Self::Port(port) => format!("localhost:{port}"),
+            Self::Address(address) => address.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RealityFallbackLimit {
+    #[serde(
+        default,
+        rename = "afterBytes",
+        alias = "after_bytes",
+        alias = "after-bytes"
+    )]
+    pub after_bytes: u64,
+    #[serde(
+        default,
+        rename = "bytesPerSec",
+        alias = "bytes_per_sec",
+        alias = "bytes-per-sec"
+    )]
+    pub bytes_per_sec: u64,
+    #[serde(
+        default,
+        rename = "burstBytesPerSec",
+        alias = "burst_bytes_per_sec",
+        alias = "burst-bytes-per-sec"
+    )]
+    pub burst_bytes_per_sec: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RealityResourceLimits {
+    #[serde(
+        default = "default_reality_handshake_timeout",
+        with = "humantime_serde",
+        alias = "handshake-timeout",
+        alias = "handshakeTimeout"
+    )]
+    pub handshake_timeout: Duration,
+    #[serde(
+        default = "default_reality_target_handshake_timeout",
+        with = "humantime_serde",
+        alias = "target-handshake-timeout",
+        alias = "targetHandshakeTimeout"
+    )]
+    pub target_handshake_timeout: Duration,
+    #[serde(
+        default = "default_reality_idle_timeout",
+        with = "humantime_serde",
+        alias = "idle-timeout",
+        alias = "idleTimeout"
+    )]
+    pub idle_timeout: Duration,
+    #[serde(
+        default = "default_reality_max_client_hello_records",
+        alias = "max-client-hello-records",
+        alias = "maxClientHelloRecords"
+    )]
+    pub max_client_hello_records: usize,
+    #[serde(
+        default = "default_reality_max_client_hello_record_payload",
+        alias = "max-client-hello-record-payload",
+        alias = "maxClientHelloRecordPayload"
+    )]
+    pub max_client_hello_record_payload: usize,
+    #[serde(
+        default = "default_reality_max_client_hello_bytes",
+        alias = "max-client-hello-bytes",
+        alias = "maxClientHelloBytes"
+    )]
+    pub max_client_hello_bytes: usize,
+    #[serde(
+        default = "default_reality_max_client_hello_wire_bytes",
+        alias = "max-client-hello-wire-bytes",
+        alias = "maxClientHelloWireBytes"
+    )]
+    pub max_client_hello_wire_bytes: usize,
+    #[serde(
+        default = "default_reality_max_target_records",
+        alias = "max-target-records",
+        alias = "maxTargetRecords"
+    )]
+    pub max_target_records: usize,
+    #[serde(
+        default = "default_reality_max_target_handshake_bytes",
+        alias = "max-target-handshake-bytes",
+        alias = "maxTargetHandshakeBytes"
+    )]
+    pub max_target_handshake_bytes: usize,
+    #[serde(
+        default = "default_reality_application_buffer_bytes",
+        alias = "application-buffer-bytes",
+        alias = "applicationBufferBytes"
+    )]
+    pub application_buffer_bytes: usize,
+    #[serde(
+        default = "default_reality_max_concurrent_handshakes",
+        alias = "max-concurrent-handshakes",
+        alias = "maxConcurrentHandshakes"
+    )]
+    pub max_concurrent_handshakes: usize,
+}
+
+impl Default for RealityResourceLimits {
+    fn default() -> Self {
+        Self {
+            handshake_timeout: default_reality_handshake_timeout(),
+            target_handshake_timeout: default_reality_target_handshake_timeout(),
+            idle_timeout: default_reality_idle_timeout(),
+            max_client_hello_records: default_reality_max_client_hello_records(),
+            max_client_hello_record_payload: default_reality_max_client_hello_record_payload(),
+            max_client_hello_bytes: default_reality_max_client_hello_bytes(),
+            max_client_hello_wire_bytes: default_reality_max_client_hello_wire_bytes(),
+            max_target_records: default_reality_max_target_records(),
+            max_target_handshake_bytes: default_reality_max_target_handshake_bytes(),
+            application_buffer_bytes: default_reality_application_buffer_bytes(),
+            max_concurrent_handshakes: default_reality_max_concurrent_handshakes(),
+        }
+    }
 }
 
 /// listen.local 支持端口写法 / 完整对象。
@@ -324,6 +587,7 @@ pub struct NodeDetail {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NodeLogin {
     #[serde(default)]
     pub user: Option<String>,
@@ -336,6 +600,7 @@ pub struct NodeLogin {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NodeSecure {
     #[serde(default)]
     pub tls: bool,
@@ -347,11 +612,117 @@ pub struct NodeSecure {
     pub utls: Option<String>,
     #[serde(default)]
     pub reality: Option<bool>,
+    #[serde(
+        default,
+        rename = "realitySettings",
+        alias = "reality_settings",
+        alias = "reality-settings"
+    )]
+    pub reality_settings: Option<RealityClientSettings>,
     #[serde(default)]
     pub ech: Option<bool>,
 }
 
+/// Xray REALITY 客户端字段。`password` 是 Xray 新名称，`publicKey` 为兼容旧名称；
+/// 编译阶段会做冲突检测与统一解码。
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealityClientSettings {
+    #[serde(default = "default_reality_fingerprint", alias = "fp")]
+    pub fingerprint: String,
+    #[serde(
+        default,
+        rename = "serverName",
+        alias = "server_name",
+        alias = "server-name",
+        alias = "sni"
+    )]
+    pub server_name: String,
+    #[serde(default, alias = "pbk")]
+    pub password: Option<String>,
+    #[serde(
+        default,
+        rename = "publicKey",
+        alias = "public_key",
+        alias = "public-key"
+    )]
+    pub public_key: Option<String>,
+    #[serde(
+        default,
+        rename = "shortId",
+        alias = "short_id",
+        alias = "short-id",
+        alias = "sid"
+    )]
+    pub short_id: String,
+    #[serde(
+        default,
+        rename = "mldsa65Verify",
+        alias = "mldsa65_verify",
+        alias = "mldsa65-verify",
+        alias = "pqv"
+    )]
+    pub mldsa65_verify: Option<String>,
+    #[serde(
+        default = "default_reality_spider_x",
+        rename = "spiderX",
+        alias = "spider_x",
+        alias = "spider-x",
+        alias = "spx"
+    )]
+    pub spider_x: String,
+    #[serde(default)]
+    pub show: bool,
+    #[serde(
+        default,
+        rename = "masterKeyLog",
+        alias = "master_key_log",
+        alias = "master-key-log"
+    )]
+    pub master_key_log: Option<String>,
+}
+
+impl Default for RealityClientSettings {
+    fn default() -> Self {
+        Self {
+            fingerprint: default_reality_fingerprint(),
+            server_name: String::new(),
+            password: None,
+            public_key: None,
+            short_id: String::new(),
+            mldsa65_verify: None,
+            spider_x: default_reality_spider_x(),
+            show: false,
+            master_key_log: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for RealityClientSettings {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RealityClientSettings")
+            .field("fingerprint", &self.fingerprint)
+            .field("server_name", &self.server_name)
+            .field("password", &self.password.as_ref().map(|_| "<redacted>"))
+            .field(
+                "public_key",
+                &self.public_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("short_id", &"<redacted>")
+            .field("has_mldsa65_verify", &self.mldsa65_verify.is_some())
+            .field("spider_x", &self.spider_x)
+            .field("show", &self.show)
+            .field(
+                "master_key_log",
+                &self.master_key_log.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NodeTransport {
     #[serde(default = "default_transport")]
     pub kind: String,
@@ -364,6 +735,7 @@ pub struct NodeTransport {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NodeNetwork {
     #[serde(default = "default_true")]
     pub udp: bool,
@@ -1292,6 +1664,51 @@ pub struct TailscaleUserspaceProxy {
 
 fn default_localhost() -> String {
     "127.0.0.1".into()
+}
+fn default_reality_listen_host() -> String {
+    "0.0.0.0".into()
+}
+fn default_reality_inner_protocol() -> String {
+    "vless".into()
+}
+fn default_reality_fingerprint() -> String {
+    "chrome".into()
+}
+fn default_reality_spider_x() -> String {
+    "/".into()
+}
+fn default_reality_handshake_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+fn default_reality_target_handshake_timeout() -> Duration {
+    Duration::from_secs(5)
+}
+fn default_reality_idle_timeout() -> Duration {
+    Duration::from_secs(5 * 60)
+}
+fn default_reality_max_client_hello_records() -> usize {
+    16
+}
+fn default_reality_max_client_hello_record_payload() -> usize {
+    16_640
+}
+fn default_reality_max_client_hello_bytes() -> usize {
+    u16::MAX as usize
+}
+fn default_reality_max_client_hello_wire_bytes() -> usize {
+    96 * 1024
+}
+fn default_reality_max_target_records() -> usize {
+    12
+}
+fn default_reality_max_target_handshake_bytes() -> usize {
+    96 * 1024
+}
+fn default_reality_application_buffer_bytes() -> usize {
+    256 * 1024
+}
+fn default_reality_max_concurrent_handshakes() -> usize {
+    1024
 }
 fn default_true() -> bool {
     true

--- a/crates/core-config/src/node_uri.rs
+++ b/crates/core-config/src/node_uri.rs
@@ -9,7 +9,10 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::error::{ConfigError, ConfigResult};
+use crate::{
+    error::{ConfigError, ConfigResult},
+    model::RealityClientSettings,
+};
 
 /// 出站类型枚举（与 `core-outbound::OutboundKind` 对齐）。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -107,6 +110,10 @@ pub struct ParsedNode {
     pub method: Option<String>,
     pub tls: bool,
     pub sni: Option<String>,
+    /// 完整 REALITY 客户端配置；不得降级为字符串 params，否则二进制密钥、
+    /// 默认值和冲突信息都会丢失。
+    #[serde(default)]
+    pub reality: Option<RealityClientSettings>,
     pub transport: String,
     pub udp: bool,
     /// 原始 URI，便于调试与 explain。
@@ -133,6 +140,7 @@ impl ParsedNode {
             method: None,
             tls: false,
             sni: None,
+            reality: None,
             transport: "tcp".into(),
             udp: true,
             raw: String::new(),
@@ -235,6 +243,12 @@ fn parse_url_like(uri: &str, proto: NodeProtocol) -> ConfigResult<ParsedNode> {
         .get("sni")
         .cloned()
         .or_else(|| params.get("peer").cloned());
+    if params
+        .get("security")
+        .is_some_and(|security| security.eq_ignore_ascii_case("reality"))
+    {
+        node.reality = Some(reality_settings_from_params(&params, &node.host)?);
+    }
     node.transport = params.get("type").cloned().unwrap_or_else(|| "tcp".into());
     let user = url.username();
     if !user.is_empty() {
@@ -263,6 +277,135 @@ fn parse_url_like(uri: &str, proto: NodeProtocol) -> ConfigResult<ParsedNode> {
     }
     node.params = params;
     Ok(node)
+}
+
+fn reality_settings_from_params(
+    params: &std::collections::BTreeMap<String, String>,
+    fallback_server_name: &str,
+) -> ConfigResult<RealityClientSettings> {
+    let get_unique = |names: &[&str]| -> ConfigResult<Option<String>> {
+        let mut found: Option<(&str, &String)> = None;
+        for name in names {
+            if let Some(value) = params.get(*name) {
+                if let Some((previous_name, previous)) = found {
+                    if previous != value {
+                        return Err(ConfigError::bad_node(format!(
+                            "REALITY 参数 `{previous_name}` 与 `{name}` 冲突"
+                        )));
+                    }
+                } else {
+                    found = Some((name, value));
+                }
+            }
+        }
+        Ok(found.map(|(_, value)| value.clone()))
+    };
+
+    let password = get_unique(&["password", "pbk"])?;
+    let public_key = get_unique(&["publicKey", "public_key"])?;
+    if password.is_some() && public_key.is_some() && password != public_key {
+        return Err(ConfigError::bad_node(
+            "REALITY password/pbk 与 publicKey 值冲突",
+        ));
+    }
+    let settings = RealityClientSettings {
+        fingerprint: get_unique(&["fingerprint", "fp"])?.unwrap_or_else(|| "chrome".into()),
+        server_name: get_unique(&["serverName", "server_name", "sni"])?
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| fallback_server_name.to_owned()),
+        password,
+        public_key,
+        short_id: get_unique(&["shortId", "short_id", "sid"])?.unwrap_or_default(),
+        mldsa65_verify: get_unique(&["mldsa65Verify", "mldsa65_verify", "pqv"])?,
+        spider_x: get_unique(&["spiderX", "spider_x", "spx"])?.unwrap_or_else(|| "/".into()),
+        show: params
+            .get("show")
+            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes")),
+        master_key_log: get_unique(&["masterKeyLog", "master_key_log"])?,
+    };
+    validate_reality_client_settings(&settings)?;
+    Ok(settings)
+}
+
+pub(crate) fn validate_reality_client_settings(
+    settings: &RealityClientSettings,
+) -> ConfigResult<()> {
+    use base64::Engine as _;
+
+    if settings.show {
+        return Err(ConfigError::bad_node(
+            "REALITY show 会输出握手密钥材料，WutherCore 出于密钥安全不提供该选项",
+        ));
+    }
+    if settings
+        .master_key_log
+        .as_deref()
+        .is_some_and(|value| !value.is_empty() && value != "none")
+    {
+        return Err(ConfigError::bad_node(
+            "REALITY masterKeyLog 会把会话密钥写入磁盘，WutherCore 出于密钥安全不提供该选项",
+        ));
+    }
+    if settings.server_name.trim().is_empty() {
+        return Err(ConfigError::bad_node("REALITY serverName 不能为空"));
+    }
+    let fingerprint = xray_utls::normalize_reality_supported_fingerprint(&settings.fingerprint)
+        .ok_or_else(|| {
+            ConfigError::bad_node(format!(
+                "未知或不具备 TLS 1.3 X25519 key-share 的 REALITY fingerprint：`{}`",
+                settings.fingerprint
+            ))
+        })?;
+    if fingerprint == "unsafe" || fingerprint == "hellogolang" {
+        return Err(ConfigError::bad_node(format!(
+            "REALITY 不接受 fingerprint `{fingerprint}`"
+        )));
+    }
+    let key = match (&settings.password, &settings.public_key) {
+        (Some(password), Some(public_key)) if password != public_key => {
+            return Err(ConfigError::bad_node(
+                "REALITY password 与 publicKey 同时配置但值不一致",
+            ));
+        }
+        (Some(password), _) => password,
+        (_, Some(public_key)) => public_key,
+        (None, None) => return Err(ConfigError::bad_node("REALITY password/publicKey 不能为空")),
+    };
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(key)
+        .map_err(|error| {
+            ConfigError::bad_node(format!("REALITY password 不是合法 base64url：{error}"))
+        })?;
+    if decoded.len() != 32 {
+        return Err(ConfigError::bad_node(
+            "REALITY password/publicKey 必须解码为 32 字节",
+        ));
+    }
+    if settings.short_id.len() > 16 || settings.short_id.len() % 2 != 0 {
+        return Err(ConfigError::bad_node(
+            "REALITY shortId 必须是 0 到 16 个偶数长度十六进制字符",
+        ));
+    }
+    hex::decode(&settings.short_id)
+        .map_err(|error| ConfigError::bad_node(format!("REALITY shortId 非法：{error}")))?;
+    if let Some(verify) = &settings.mldsa65_verify {
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(verify)
+            .map_err(|error| {
+                ConfigError::bad_node(format!("REALITY mldsa65Verify 不是合法 base64url：{error}"))
+            })?;
+        if decoded.len() != 1952 {
+            return Err(ConfigError::bad_node(
+                "REALITY mldsa65Verify 必须解码为 1952 字节",
+            ));
+        }
+    }
+    if !settings.spider_x.starts_with('/') {
+        return Err(ConfigError::bad_node("REALITY spiderX 必须以 `/` 开头"));
+    }
+    url::Url::parse(&format!("https://reality.invalid{}", settings.spider_x))
+        .map_err(|error| ConfigError::bad_node(format!("REALITY spiderX 非法：{error}")))?;
+    Ok(())
 }
 
 fn parse_http_socks(uri: &str, proto: NodeProtocol) -> ConfigResult<ParsedNode> {
@@ -444,6 +587,41 @@ mod tests {
         assert_eq!(n.port, 443);
         assert!(n.tls);
         assert_eq!(n.transport, "ws");
+    }
+
+    #[test]
+    fn parse_vless_reality_preserves_typed_security_fields() {
+        let node = parse_uri(
+            "vless://11111111-1111-1111-1111-111111111111@127.0.0.1:443?security=reality&sni=cover.example&fp=chrome&pbk=BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc&sid=0123456789abcdef&spx=%2Fnews%3Fp%3D10-20#REALITY",
+        )
+        .unwrap();
+        let reality = node.reality.expect("typed REALITY settings");
+        assert_eq!(reality.server_name, "cover.example");
+        assert_eq!(reality.fingerprint, "chrome");
+        assert_eq!(reality.short_id, "0123456789abcdef");
+        assert_eq!(reality.spider_x, "/news?p=10-20");
+        assert!(reality.password.is_some());
+        assert!(node.tls);
+    }
+
+    #[test]
+    fn parse_vless_reality_rejects_alias_conflicts() {
+        let error = parse_uri(
+            "vless://11111111-1111-1111-1111-111111111111@127.0.0.1:443?security=reality&sni=cover.example&fp=chrome&pbk=BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc&publicKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&sid=00",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("冲突"), "{error}");
+    }
+
+    #[test]
+    fn parse_vless_reality_rejects_key_share_incapable_fingerprint() {
+        let error = parse_uri(
+            "vless://11111111-1111-1111-1111-111111111111@127.0.0.1:443?security=reality&sni=cover.example&fp=android&pbk=BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc&sid=00",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("fingerprint"), "{error}");
     }
 
     #[test]

--- a/crates/core-config/src/profile.rs
+++ b/crates/core-config/src/profile.rs
@@ -14,6 +14,7 @@ pub fn apply_defaults(cfg: &mut UserConfig) {
         panel: None,
         share: None,
         auth: vec![],
+        reality: vec![],
     });
     if listen.local.is_none() {
         listen.local = match profile {

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     error::{ConfigError, ConfigResult},
     model::*,
-    node_uri::{NodeProtocol, ParsedNode, parse_uri},
+    node_uri::{NodeProtocol, ParsedNode, parse_uri, validate_reality_client_settings},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +39,8 @@ pub struct RuntimePlan {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListenPlan {
     pub mixed: Option<MixedListen>,
+    #[serde(default)]
+    pub reality: Vec<RealityListen>,
     pub panel: Option<PanelListen>,
     pub share: Share,
     pub auth: Vec<UserPass>,
@@ -202,6 +204,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         panel: None,
         share: None,
         auth: vec![],
+        reality: vec![],
     });
 
     let share = listen.share.unwrap_or(Share::False);
@@ -265,12 +268,260 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         })
         .collect();
 
+    let reality = compile_reality_listeners(&listen.reality)?;
+
     Ok(ListenPlan {
         mixed,
+        reality,
         panel,
         share,
         auth,
     })
+}
+
+fn compile_reality_listeners(listeners: &[RealityListen]) -> ConfigResult<Vec<RealityListen>> {
+    use base64::Engine as _;
+
+    let mut out = Vec::with_capacity(listeners.len());
+    let mut bound = std::collections::HashSet::new();
+    for (index, source) in listeners.iter().enumerate() {
+        let location = format!("listen.reality[{index}]");
+        if source.port == 0 {
+            return Err(ConfigError::invalid("REALITY 监听端口不能为 0").at(location));
+        }
+        if source.host.trim().is_empty() {
+            return Err(ConfigError::invalid("REALITY 监听地址不能为空").at(location));
+        }
+        if !bound.insert((source.host.clone(), source.port)) {
+            return Err(ConfigError::invalid("重复的 REALITY 监听地址").at(location));
+        }
+        if source.show {
+            return Err(ConfigError::invalid(
+                "REALITY show 会输出握手密钥材料，WutherCore 出于密钥安全不提供该选项",
+            )
+            .at(format!("{location}.show")));
+        }
+        if source
+            .master_key_log
+            .as_deref()
+            .is_some_and(|value| !value.is_empty() && value != "none")
+        {
+            return Err(ConfigError::invalid(
+                "REALITY masterKeyLog 会把会话密钥写入磁盘，WutherCore 出于密钥安全不提供该选项",
+            )
+            .at(format!("{location}.masterKeyLog")));
+        }
+        if source.xver > 2 {
+            return Err(ConfigError::invalid("REALITY xver 只能是 0、1 或 2")
+                .at(format!("{location}.xver")));
+        }
+        if !source.protocol.eq_ignore_ascii_case("vless") {
+            return Err(ConfigError::invalid(format!(
+                "当前 REALITY 入站只接受已完整实现的 VLESS 内层协议，收到 `{}`",
+                source.protocol
+            ))
+            .at(format!("{location}.protocol")));
+        }
+        if source.users.is_empty() {
+            return Err(
+                ConfigError::invalid("VLESS-over-REALITY 至少需要一个 users UUID")
+                    .at(format!("{location}.users")),
+            );
+        }
+        for (user_index, user) in source.users.iter().enumerate() {
+            uuid::Uuid::parse_str(user).map_err(|error| {
+                ConfigError::invalid(format!("非法 VLESS UUID：{error}"))
+                    .at(format!("{location}.users[{user_index}]"))
+            })?;
+        }
+        let target = match (&source.target, &source.dest) {
+            (Some(target), Some(dest)) if target != dest => {
+                return Err(
+                    ConfigError::invalid("REALITY target 与 dest 同时配置但值不一致").at(location),
+                );
+            }
+            (Some(target), _) | (_, Some(target)) => target.normalized(),
+            (None, None) => {
+                return Err(ConfigError::invalid("REALITY 缺少 target/dest")
+                    .at(format!("{location}.target")));
+            }
+        };
+        let target_type = source
+            .target_type
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_ascii_lowercase)
+            .unwrap_or_else(|| {
+                if target.starts_with('@') || target.starts_with('/') {
+                    "unix".to_owned()
+                } else {
+                    "tcp".to_owned()
+                }
+            });
+        if !matches!(target_type.as_str(), "tcp" | "unix") {
+            return Err(ConfigError::invalid(format!(
+                "REALITY type 只接受 tcp 或 unix，收到 `{target_type}`"
+            ))
+            .at(format!("{location}.type")));
+        }
+        if target_type == "tcp" && target.rsplit_once(':').is_none() {
+            return Err(ConfigError::invalid("REALITY TCP target 必须包含端口")
+                .at(format!("{location}.target")));
+        }
+        if target_type == "unix" && cfg!(windows) {
+            return Err(
+                ConfigError::invalid("当前 Windows 平台不支持 REALITY unix target")
+                    .at(format!("{location}.type")),
+            );
+        }
+        if source.server_names.is_empty()
+            || source
+                .server_names
+                .iter()
+                .any(|name| name.trim().is_empty())
+        {
+            return Err(ConfigError::invalid("REALITY serverNames 不能为空")
+                .at(format!("{location}.serverNames")));
+        }
+        let private_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&source.private_key)
+            .map_err(|error| {
+                ConfigError::invalid(format!("REALITY privateKey 不是合法 base64url：{error}"))
+                    .at(format!("{location}.privateKey"))
+            })?;
+        if private_key.len() != 32 {
+            return Err(
+                ConfigError::invalid("REALITY privateKey 必须解码为 32 字节")
+                    .at(format!("{location}.privateKey")),
+            );
+        }
+        if source.short_ids.is_empty() {
+            return Err(ConfigError::invalid("REALITY shortIds 不能为空")
+                .at(format!("{location}.shortIds")));
+        }
+        for (short_index, short_id) in source.short_ids.iter().enumerate() {
+            validate_reality_short_id(short_id).map_err(|message| {
+                ConfigError::invalid(message).at(format!("{location}.shortIds[{short_index}]"))
+            })?;
+        }
+        let min = parse_reality_version(
+            source.min_client_ver.as_deref().unwrap_or("26.3.27"),
+            &format!("{location}.minClientVer"),
+        )?;
+        let max = source
+            .max_client_ver
+            .as_deref()
+            .map(|version| parse_reality_version(version, &format!("{location}.maxClientVer")))
+            .transpose()?;
+        if max.is_some_and(|max| min > max) {
+            return Err(
+                ConfigError::invalid("REALITY minClientVer 不能大于 maxClientVer").at(location),
+            );
+        }
+        if let Some(seed) = &source.mldsa65_seed {
+            if seed == &source.private_key {
+                return Err(
+                    ConfigError::invalid("REALITY mldsa65Seed 不能与 privateKey 相同")
+                        .at(format!("{location}.mldsa65Seed")),
+                );
+            }
+            let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(seed)
+                .map_err(|error| {
+                    ConfigError::invalid(format!("REALITY mldsa65Seed 不是合法 base64url：{error}"))
+                        .at(format!("{location}.mldsa65Seed"))
+                })?;
+            if decoded.len() != 32 {
+                return Err(
+                    ConfigError::invalid("REALITY mldsa65Seed 必须解码为 32 字节")
+                        .at(format!("{location}.mldsa65Seed")),
+                );
+            }
+        }
+        validate_reality_fallback_limit(
+            source.limit_fallback_upload,
+            &format!("{location}.limitFallbackUpload"),
+        )?;
+        validate_reality_fallback_limit(
+            source.limit_fallback_download,
+            &format!("{location}.limitFallbackDownload"),
+        )?;
+        validate_reality_resource_limits(source.limits, &format!("{location}.limits"))?;
+
+        let mut normalized = source.clone();
+        normalized.target = Some(RealityTarget::Address(target));
+        normalized.dest = None;
+        normalized.target_type = Some(target_type);
+        normalized.min_client_ver = Some(format!("{}.{}.{}", min[0], min[1], min[2]));
+        normalized.max_client_ver =
+            max.map(|version| format!("{}.{}.{}", version[0], version[1], version[2]));
+        out.push(normalized);
+    }
+    Ok(out)
+}
+
+fn validate_reality_short_id(value: &str) -> Result<(), String> {
+    if value.len() > 16 || value.len() % 2 != 0 {
+        return Err("REALITY shortId 必须是 0 到 16 个偶数长度十六进制字符".into());
+    }
+    hex::decode(value)
+        .map(|_| ())
+        .map_err(|error| format!("REALITY shortId 不是合法十六进制：{error}"))
+}
+
+fn parse_reality_version(value: &str, location: &str) -> ConfigResult<[u8; 3]> {
+    let parts: Vec<_> = value.split('.').collect();
+    if parts.is_empty() || parts.len() > 3 || parts.iter().any(|part| part.is_empty()) {
+        return Err(ConfigError::invalid(format!(
+            "REALITY 客户端版本必须是 1 到 3 段十进制数字，收到 `{value}`"
+        ))
+        .at(location));
+    }
+    let mut version = [0u8; 3];
+    for (index, part) in parts.iter().enumerate() {
+        version[index] = part.parse().map_err(|_| {
+            ConfigError::invalid(format!("REALITY 客户端版本段必须小于 256：`{value}`"))
+                .at(location)
+        })?;
+    }
+    Ok(version)
+}
+
+fn validate_reality_fallback_limit(
+    limit: RealityFallbackLimit,
+    location: &str,
+) -> ConfigResult<()> {
+    if limit.bytes_per_sec == 0 && (limit.after_bytes != 0 || limit.burst_bytes_per_sec != 0) {
+        return Err(ConfigError::invalid(
+            "REALITY 回落 afterBytes/burstBytesPerSec 要求 bytesPerSec 非零",
+        )
+        .at(location));
+    }
+    Ok(())
+}
+
+fn validate_reality_resource_limits(
+    limits: RealityResourceLimits,
+    location: &str,
+) -> ConfigResult<()> {
+    if limits.handshake_timeout.is_zero()
+        || limits.target_handshake_timeout.is_zero()
+        || limits.idle_timeout.is_zero()
+        || limits.max_client_hello_records == 0
+        || limits.max_client_hello_record_payload == 0
+        || limits.max_client_hello_record_payload > 16_640
+        || limits.max_client_hello_bytes < 4
+        || limits.max_client_hello_bytes > u16::MAX as usize
+        || limits.max_client_hello_wire_bytes < 5
+        || limits.max_target_records < 3
+        || limits.max_target_handshake_bytes < 1024
+        || limits.application_buffer_bytes == 0
+        || limits.max_concurrent_handshakes == 0
+    {
+        return Err(ConfigError::invalid("非法 REALITY 资源上限").at(location));
+    }
+    Ok(())
 }
 
 fn compile_feeds(feeds: &BTreeMap<String, FeedSpec>) -> BTreeMap<String, FeedDetail> {
@@ -351,8 +602,62 @@ fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
         node.uuid = login.uuid.clone();
     }
     if let Some(secure) = &d.secure {
-        node.tls = secure.tls;
+        let reality_enabled = secure.reality.unwrap_or(false) || secure.reality_settings.is_some();
+        if secure.reality == Some(false) && secure.reality_settings.is_some() {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 同时禁用 reality 并提供 realitySettings",
+                d.name
+            )));
+        }
+        if secure.tls && reality_enabled {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 不能同时启用普通 TLS 与 REALITY",
+                d.name
+            )));
+        }
+        node.tls = secure.tls || reality_enabled;
         node.sni = secure.sni.clone();
+        if reality_enabled {
+            let mut reality = secure.reality_settings.clone().ok_or_else(|| {
+                ConfigError::bad_node(format!(
+                    "node {} 启用了 reality 但缺少 realitySettings",
+                    d.name
+                ))
+            })?;
+            if let Some(sni) = &secure.sni {
+                if !reality.server_name.is_empty() && &reality.server_name != sni {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {} 的 secure.sni 与 realitySettings.serverName 冲突",
+                        d.name
+                    )));
+                }
+                reality.server_name = sni.clone();
+            }
+            if let Some(fingerprint) = secure.fingerprint.as_ref().or(secure.utls.as_ref()) {
+                if !reality.fingerprint.is_empty()
+                    && !reality.fingerprint.eq_ignore_ascii_case(fingerprint)
+                    && !reality.fingerprint.eq_ignore_ascii_case("chrome")
+                {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {} 的 secure fingerprint/utls 与 realitySettings.fingerprint 冲突",
+                        d.name
+                    )));
+                }
+                reality.fingerprint = fingerprint.clone();
+            }
+            if let (Some(fingerprint), Some(utls)) = (&secure.fingerprint, &secure.utls)
+                && !fingerprint.eq_ignore_ascii_case(utls)
+            {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 的 secure.fingerprint 与 secure.utls 冲突",
+                    d.name
+                )));
+            }
+            validate_reality_client_settings(&reality)
+                .map_err(|error| error.at(format!("nodes.{}.secure.realitySettings", d.name)))?;
+            node.sni = Some(reality.server_name.clone());
+            node.reality = Some(reality);
+        }
     }
     if let Some(transport) = &d.transport {
         node.transport = transport.kind.clone();
@@ -981,10 +1286,260 @@ mod tests {
     use super::*;
     use crate::profile::apply_defaults;
 
+    fn base64url_bytes(byte: u8, len: usize) -> String {
+        use base64::Engine as _;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vec![byte; len])
+    }
+
+    fn valid_reality_listener() -> RealityListen {
+        serde_yaml::from_str(&format!(
+            r#"
+port: 2443
+protocol: vless
+users: [11111111-1111-1111-1111-111111111111]
+target: camouflage.example:443
+serverNames: [camouflage.example]
+privateKey: {}
+shortIds: [0123456789abcdef]
+"#,
+            base64url_bytes(7, 32)
+        ))
+        .unwrap()
+    }
+
     fn compile_cfg(yaml: &str) -> RuntimePlan {
         let mut cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
         apply_defaults(&mut cfg);
         compile(cfg).unwrap()
+    }
+
+    #[test]
+    fn reality_server_all_xray_fields_survive_normalization() {
+        let source: RealityListen = serde_yaml::from_str(&format!(
+            r#"
+host: 127.0.0.1
+port: 2443
+protocol: vless
+users: [11111111-1111-1111-1111-111111111111]
+dest: camouflage.example:443
+type: tcp
+show: false
+masterKeyLog: none
+xver: 2
+serverNames: [camouflage.example, www.example.com]
+privateKey: {}
+minClientVer: "26.3"
+maxClientVer: "26.9.1"
+maxTimeDiff: 45000
+shortIds: [0123456789abcdef, ""]
+mldsa65Seed: {}
+limitFallbackUpload:
+  afterBytes: 100
+  bytesPerSec: 1000
+  burstBytesPerSec: 2000
+limitFallbackDownload:
+  afterBytes: 200
+  bytesPerSec: 3000
+  burstBytesPerSec: 4000
+limits:
+  handshakeTimeout: 11s
+  targetHandshakeTimeout: 6s
+  idleTimeout: 7s
+  maxClientHelloRecords: 8
+  maxClientHelloRecordPayload: 16000
+  maxClientHelloBytes: 60000
+  maxClientHelloWireBytes: 70000
+  maxTargetRecords: 4
+  maxTargetHandshakeBytes: 8192
+  applicationBufferBytes: 65536
+  maxConcurrentHandshakes: 12
+"#,
+            base64url_bytes(7, 32),
+            base64url_bytes(8, 32),
+        ))
+        .unwrap();
+
+        let normalized = compile_reality_listeners(&[source]).unwrap().remove(0);
+        assert_eq!(normalized.host, "127.0.0.1");
+        assert_eq!(normalized.port, 2443);
+        assert_eq!(normalized.protocol, "vless");
+        assert_eq!(normalized.users.len(), 1);
+        assert_eq!(
+            normalized.target,
+            Some(RealityTarget::Address("camouflage.example:443".into()))
+        );
+        assert_eq!(normalized.dest, None);
+        assert_eq!(normalized.target_type.as_deref(), Some("tcp"));
+        assert!(!normalized.show);
+        assert_eq!(normalized.master_key_log.as_deref(), Some("none"));
+        assert_eq!(normalized.xver, 2);
+        assert_eq!(normalized.server_names.len(), 2);
+        assert_eq!(normalized.min_client_ver.as_deref(), Some("26.3.0"));
+        assert_eq!(normalized.max_client_ver.as_deref(), Some("26.9.1"));
+        assert_eq!(normalized.max_time_diff_ms, 45_000);
+        assert_eq!(normalized.short_ids, ["0123456789abcdef", ""]);
+        assert!(normalized.mldsa65_seed.is_some());
+        assert_eq!(normalized.limit_fallback_upload.after_bytes, 100);
+        assert_eq!(normalized.limit_fallback_upload.bytes_per_sec, 1_000);
+        assert_eq!(normalized.limit_fallback_upload.burst_bytes_per_sec, 2_000);
+        assert_eq!(normalized.limit_fallback_download.after_bytes, 200);
+        assert_eq!(normalized.limits.handshake_timeout, Duration::from_secs(11));
+        assert_eq!(
+            normalized.limits.target_handshake_timeout,
+            Duration::from_secs(6)
+        );
+        assert_eq!(normalized.limits.idle_timeout, Duration::from_secs(7));
+        assert_eq!(normalized.limits.max_client_hello_records, 8);
+        assert_eq!(normalized.limits.max_client_hello_record_payload, 16_000);
+        assert_eq!(normalized.limits.max_client_hello_bytes, 60_000);
+        assert_eq!(normalized.limits.max_client_hello_wire_bytes, 70_000);
+        assert_eq!(normalized.limits.max_target_records, 4);
+        assert_eq!(normalized.limits.max_target_handshake_bytes, 8_192);
+        assert_eq!(normalized.limits.application_buffer_bytes, 65_536);
+        assert_eq!(normalized.limits.max_concurrent_handshakes, 12);
+    }
+
+    #[test]
+    fn reality_server_snake_aliases_work_and_unknown_fields_fail() {
+        let source: RealityListen = serde_yaml::from_str(&format!(
+            r#"
+port: 2443
+users: [11111111-1111-1111-1111-111111111111]
+target: camouflage.example:443
+target_type: tcp
+server_names: [camouflage.example]
+private_key: {}
+min_client_ver: "26.3.27"
+max_time_diff: 1000
+short_ids: ["00"]
+limit_fallback_upload: {{bytes_per_sec: 1}}
+limits: {{max_client_hello_records: 4}}
+"#,
+            base64url_bytes(7, 32)
+        ))
+        .unwrap();
+        let normalized = compile_reality_listeners(&[source]).unwrap().remove(0);
+        assert_eq!(normalized.target_type.as_deref(), Some("tcp"));
+        assert_eq!(normalized.max_time_diff_ms, 1_000);
+        assert_eq!(normalized.limit_fallback_upload.bytes_per_sec, 1);
+        assert_eq!(normalized.limits.max_client_hello_records, 4);
+
+        let unknown = format!(
+            "port: 2443\nusers: []\ntarget: a:1\nserverNames: [a]\nprivateKey: {}\nshortIds: ['']\nserverNmaes: [typo]\n",
+            base64url_bytes(7, 32)
+        );
+        assert!(serde_yaml::from_str::<RealityListen>(&unknown).is_err());
+    }
+
+    #[test]
+    fn reality_server_rejects_conflicts_dangerous_options_and_bad_bounds() {
+        let valid = valid_reality_listener();
+
+        let mut conflict = valid.clone();
+        conflict.dest = Some(RealityTarget::Address("other.example:443".into()));
+        assert!(compile_reality_listeners(&[conflict]).is_err());
+
+        let mut show = valid.clone();
+        show.show = true;
+        assert!(compile_reality_listeners(&[show]).is_err());
+
+        let mut key_log = valid.clone();
+        key_log.master_key_log = Some("reality.keys".into());
+        assert!(compile_reality_listeners(&[key_log]).is_err());
+
+        let mut xver = valid.clone();
+        xver.xver = 3;
+        assert!(compile_reality_listeners(&[xver]).is_err());
+
+        let mut versions = valid.clone();
+        versions.min_client_ver = Some("27.0.0".into());
+        versions.max_client_ver = Some("26.9.9".into());
+        assert!(compile_reality_listeners(&[versions]).is_err());
+
+        let mut fallback = valid.clone();
+        fallback.limit_fallback_upload.after_bytes = 1;
+        assert!(compile_reality_listeners(&[fallback]).is_err());
+
+        let mut limits = valid.clone();
+        limits.limits.max_client_hello_bytes = u16::MAX as usize + 1;
+        assert!(compile_reality_listeners(&[limits]).is_err());
+
+        let mut equal_seed = valid;
+        equal_seed.mldsa65_seed = Some(equal_seed.private_key.clone());
+        assert!(compile_reality_listeners(&[equal_seed]).is_err());
+    }
+
+    #[test]
+    fn reality_client_rejects_key_alias_and_security_conflicts() {
+        let key = base64url_bytes(7, 32);
+        let mut settings = RealityClientSettings {
+            server_name: "camouflage.example".into(),
+            password: Some(key.clone()),
+            short_id: "0123456789abcdef".into(),
+            spider_x: "/news?p=8&c=2".into(),
+            ..RealityClientSettings::default()
+        };
+        validate_reality_client_settings(&settings).unwrap();
+
+        settings.public_key = Some(base64url_bytes(8, 32));
+        assert!(validate_reality_client_settings(&settings).is_err());
+        settings.public_key = None;
+        settings.show = true;
+        assert!(validate_reality_client_settings(&settings).is_err());
+        settings.show = false;
+        settings.master_key_log = Some("reality.keys".into());
+        assert!(validate_reality_client_settings(&settings).is_err());
+
+        let mut reality = settings;
+        reality.master_key_log = None;
+        let detail = NodeDetail {
+            name: "reality-client".into(),
+            protocol: Some("vless".into()),
+            address: Some("127.0.0.1:443".into()),
+            secure: Some(NodeSecure {
+                fingerprint: Some("chrome".into()),
+                utls: Some("firefox".into()),
+                reality: Some(true),
+                reality_settings: Some(reality),
+                ..NodeSecure::default()
+            }),
+            ..NodeDetail::default()
+        };
+        assert!(detail_to_parsed(&detail).is_err());
+    }
+
+    #[test]
+    fn reality_client_camel_and_snake_fields_deserialize_without_loss() {
+        let key = base64url_bytes(7, 32);
+        let verify = base64url_bytes(9, 1952);
+        let settings: RealityClientSettings = serde_yaml::from_str(&format!(
+            r#"
+fp: chrome
+server_name: camouflage.example
+pbk: {key}
+short-id: 0123456789abcdef
+mldsa65_verify: {verify}
+spiderX: /cover?p=4
+show: false
+master_key_log: none
+"#
+        ))
+        .unwrap();
+        validate_reality_client_settings(&settings).unwrap();
+        assert_eq!(settings.fingerprint, "chrome");
+        assert_eq!(settings.server_name, "camouflage.example");
+        assert_eq!(settings.password.as_deref(), Some(key.as_str()));
+        assert_eq!(settings.short_id, "0123456789abcdef");
+        assert_eq!(settings.mldsa65_verify.as_deref(), Some(verify.as_str()));
+        assert_eq!(settings.spider_x, "/cover?p=4");
+        assert_eq!(settings.master_key_log.as_deref(), Some("none"));
+
+        assert!(
+            serde_yaml::from_str::<RealityClientSettings>(&format!(
+                "serverName: a\npassword: {key}\nshortId: ''\nspiderX: /\npublicKye: typo\n"
+            ))
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/core-fetch/src/lib.rs
+++ b/crates/core-fetch/src/lib.rs
@@ -417,9 +417,12 @@ fn tls_config() -> Arc<ClientConfig> {
     static CONFIG: Lazy<Arc<ClientConfig>> = Lazy::new(|| {
         let mut roots = rustls::RootCertStore::empty();
         roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-        let cfg = ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth();
+        let cfg =
+            ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+                .with_safe_default_protocol_versions()
+                .expect("rustls ring default protocols")
+                .with_root_certificates(roots)
+                .with_no_client_auth();
         Arc::new(cfg)
     });
     CONFIG.clone()

--- a/crates/core-inbound/Cargo.toml
+++ b/crates/core-inbound/Cargo.toml
@@ -12,7 +12,9 @@ core-outbound = { workspace = true }
 core-smart    = { workspace = true }
 core-runtime  = { workspace = true }
 core-observe  = { workspace = true }
+core-reality  = { workspace = true }
 tokio         = { workspace = true }
+tokio-util    = { workspace = true }
 async-trait   = { workspace = true }
 bytes         = { workspace = true }
 anyhow        = { workspace = true }
@@ -21,6 +23,8 @@ tracing       = { workspace = true }
 parking_lot   = { workspace = true }
 base64        = { workspace = true }
 serde         = { workspace = true }
+uuid          = { workspace = true }
+subtle        = "2.6"
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd"))'.dependencies]
 nix = { version = "0.29", features = ["user", "fs"] }

--- a/crates/core-inbound/src/lib.rs
+++ b/crates/core-inbound/src/lib.rs
@@ -9,9 +9,13 @@
 pub mod listener;
 pub mod mixed;
 pub mod privilege;
+pub mod reality;
+pub mod vless;
 
 pub use listener::{bind_with_fallback, select_bind_addr};
 pub use mixed::{MixedListener, run_mixed};
 pub use privilege::{
     PrivilegeLevel, PrivilegeReport, ensure_best_effort_privilege, try_request_root_android,
 };
+pub use reality::{RealityListener, run_reality};
+pub use vless::{VlessConnectionContext, VlessInboundConfig, serve_vless_stream};

--- a/crates/core-inbound/src/reality.rs
+++ b/crates/core-inbound/src/reality.rs
@@ -1,0 +1,357 @@
+//! REALITY inbound listener with an authenticated VLESS inner protocol.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::io;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::Engine as _;
+use core_config::model::RealityListen as RealityListenConfig;
+use core_reality::{
+    ClientHelloLimits, FallbackLimit, ProxyProtocolVersion, RealityServer, RealityServerConfig,
+    RealityServerError, RealityServerLimits, decode_private_key, decode_short_id,
+};
+use core_runtime::Runtime;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::vless::{VlessConnectionContext, VlessInboundConfig, serve_vless_stream};
+
+#[derive(Clone)]
+pub struct RealityListener {
+    listen: SocketAddr,
+    server: RealityServer,
+    target: CamouflageTarget,
+    vless: Arc<VlessInboundConfig>,
+}
+
+impl fmt::Debug for RealityListener {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityListener")
+            .field("listen", &self.listen)
+            .field("server", &self.server.config())
+            .field("target", &self.target)
+            .field("vless", &self.vless)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+enum CamouflageTarget {
+    Tcp(String),
+    #[cfg(unix)]
+    Unix(String),
+}
+
+impl RealityListener {
+    pub fn from_config(config: &RealityListenConfig) -> io::Result<Self> {
+        let listen = format!("{}:{}", config.host, config.port)
+            .parse()
+            .map_err(|error| invalid_input(format!("invalid REALITY listen address: {error}")))?;
+        let target = config
+            .target
+            .as_ref()
+            .or(config.dest.as_ref())
+            .ok_or_else(|| invalid_input("REALITY target/dest is missing"))?
+            .normalized();
+        let target_type = config.target_type.as_deref().unwrap_or(
+            if target.starts_with('/') || target.starts_with('@') {
+                "unix"
+            } else {
+                "tcp"
+            },
+        );
+        let target = match target_type {
+            "tcp" => CamouflageTarget::Tcp(target.clone()),
+            #[cfg(unix)]
+            "unix" => CamouflageTarget::Unix(target.clone()),
+            #[cfg(not(unix))]
+            "unix" => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "REALITY unix target is not supported on this platform",
+                ));
+            }
+            other => {
+                return Err(invalid_input(format!(
+                    "unsupported REALITY target type `{other}`"
+                )));
+            }
+        };
+        let private_key = decode_private_key(&config.private_key)?;
+        let short_ids = config
+            .short_ids
+            .iter()
+            .map(|short_id| decode_short_id(short_id))
+            .collect::<io::Result<Vec<_>>>()?;
+        let min_client_version = config
+            .min_client_ver
+            .as_deref()
+            .map(parse_version)
+            .transpose()?
+            .or(Some([26, 3, 27]));
+        let max_client_version = config
+            .max_client_ver
+            .as_deref()
+            .map(parse_version)
+            .transpose()?;
+        let mldsa65_seed = config
+            .mldsa65_seed
+            .as_deref()
+            .map(decode_32_base64url)
+            .transpose()?;
+        let proxy_protocol = match config.xver {
+            0 => ProxyProtocolVersion::None,
+            1 => ProxyProtocolVersion::V1,
+            2 => ProxyProtocolVersion::V2,
+            value => {
+                return Err(invalid_input(format!(
+                    "REALITY xver must be 0, 1 or 2, got {value}"
+                )));
+            }
+        };
+        let limits = RealityServerLimits {
+            client_hello: ClientHelloLimits {
+                max_record_payload: config.limits.max_client_hello_record_payload,
+                max_handshake_bytes: config.limits.max_client_hello_bytes,
+                max_wire_bytes: config.limits.max_client_hello_wire_bytes,
+                max_records: config.limits.max_client_hello_records,
+            },
+            handshake_timeout: config.limits.handshake_timeout,
+            target_handshake_timeout: config.limits.target_handshake_timeout,
+            idle_timeout: config.limits.idle_timeout,
+            max_target_records: config.limits.max_target_records,
+            max_target_handshake_bytes: config.limits.max_target_handshake_bytes,
+            application_buffer_bytes: config.limits.application_buffer_bytes,
+            max_concurrent_handshakes: config.limits.max_concurrent_handshakes,
+        };
+        let server = RealityServer::new(RealityServerConfig {
+            camouflage_target: target_address(&target).to_owned(),
+            private_key,
+            server_names: config.server_names.iter().cloned().collect::<HashSet<_>>(),
+            short_ids,
+            min_client_version,
+            max_client_version,
+            max_time_difference: (config.max_time_diff_ms != 0)
+                .then(|| Duration::from_millis(config.max_time_diff_ms)),
+            mldsa65_seed,
+            cipher_suites: Vec::new(),
+            proxy_protocol,
+            fallback_upload: FallbackLimit {
+                after_bytes: config.limit_fallback_upload.after_bytes,
+                bytes_per_second: config.limit_fallback_upload.bytes_per_sec,
+                burst_bytes: config.limit_fallback_upload.burst_bytes_per_sec,
+            },
+            fallback_download: FallbackLimit {
+                after_bytes: config.limit_fallback_download.after_bytes,
+                bytes_per_second: config.limit_fallback_download.bytes_per_sec,
+                burst_bytes: config.limit_fallback_download.burst_bytes_per_sec,
+            },
+            limits,
+        })
+        .map_err(reality_error)?;
+        let vless = Arc::new(VlessInboundConfig::from_uuid_strings(
+            &config.users,
+            config.limits.handshake_timeout,
+            config
+                .limits
+                .max_concurrent_handshakes
+                .min(u16::MAX as usize),
+        )?);
+        Ok(Self {
+            listen,
+            server,
+            target,
+            vless,
+        })
+    }
+
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.listen
+    }
+}
+
+fn target_address(target: &CamouflageTarget) -> &str {
+    match target {
+        CamouflageTarget::Tcp(address) => address,
+        #[cfg(unix)]
+        CamouflageTarget::Unix(path) => path,
+    }
+}
+
+pub async fn run_reality(listener: RealityListener, runtime: Arc<Runtime>) -> io::Result<()> {
+    let socket = TcpListener::bind(listener.listen).await?;
+    let bound = socket.local_addr()?;
+    info!(addr = %bound, "REALITY inbound listening");
+    let cancellation = CancellationToken::new();
+    let _cancel_on_drop = cancellation.clone().drop_guard();
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            accepted = socket.accept() => {
+                let (stream, peer) = accepted?;
+                let local = stream.local_addr()?;
+                let _ = stream.set_nodelay(true);
+                let listener = listener.clone();
+                let runtime = runtime.clone();
+                let cancellation = cancellation.clone();
+                connections.spawn(async move {
+                    if let Err(error) = authenticate_and_serve(
+                        listener,
+                        stream,
+                        peer,
+                        local,
+                        runtime,
+                        cancellation,
+                    ).await {
+                        match error.downcast_ref::<RealityServerError>() {
+                            Some(RealityServerError::FallbackStarted { reason }) => {
+                                debug!(%peer, %reason, "REALITY camouflage fallback");
+                            }
+                            _ => debug!(%peer, error = %error, "REALITY connection failed"),
+                        }
+                    }
+                });
+            }
+            completed = connections.join_next(), if !connections.is_empty() => {
+                if let Some(Err(error)) = completed {
+                    warn!(error = %error, "REALITY connection task panicked");
+                }
+            }
+        }
+    }
+}
+
+async fn authenticate_and_serve(
+    listener: RealityListener,
+    stream: TcpStream,
+    peer: SocketAddr,
+    local: SocketAddr,
+    runtime: Arc<Runtime>,
+    cancellation: CancellationToken,
+) -> anyhow::Result<()> {
+    let inner_cancellation = cancellation.clone();
+    let accepted = match &listener.target {
+        CamouflageTarget::Tcp(address) => {
+            let target = tokio::time::timeout(
+                listener.server.config().limits.target_handshake_timeout,
+                TcpStream::connect(address),
+            )
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "camouflage target timeout"))??;
+            listener
+                .server
+                .accept_with_target(stream, target, peer, local, cancellation)
+                .await?
+        }
+        #[cfg(unix)]
+        CamouflageTarget::Unix(path) => {
+            let target = tokio::time::timeout(
+                listener.server.config().limits.target_handshake_timeout,
+                tokio::net::UnixStream::connect(path),
+            )
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "camouflage target timeout"))??;
+            listener
+                .server
+                .accept_with_target(stream, target, peer, local, cancellation)
+                .await?
+        }
+    };
+    serve_vless_stream(
+        accepted,
+        VlessConnectionContext {
+            source: peer,
+            local,
+        },
+        listener.vless,
+        runtime,
+        inner_cancellation,
+    )
+    .await?;
+    Ok(())
+}
+
+fn parse_version(value: &str) -> io::Result<[u8; 3]> {
+    let parts: Vec<_> = value.split('.').collect();
+    if parts.is_empty() || parts.len() > 3 || parts.iter().any(|part| part.is_empty()) {
+        return Err(invalid_input(format!(
+            "invalid REALITY client version `{value}`"
+        )));
+    }
+    let mut version = [0u8; 3];
+    for (index, part) in parts.iter().enumerate() {
+        version[index] = part
+            .parse()
+            .map_err(|_| invalid_input(format!("invalid REALITY client version `{value}`")))?;
+    }
+    Ok(version)
+}
+
+fn decode_32_base64url(value: &str) -> io::Result<[u8; 32]> {
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|error| invalid_input(format!("invalid base64url key: {error}")))?;
+    decoded
+        .try_into()
+        .map_err(|_| invalid_input("REALITY key must decode to 32 bytes"))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn reality_error(error: RealityServerError) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_config::model::{RealityFallbackLimit, RealityResourceLimits, RealityTarget};
+
+    fn valid_config() -> RealityListenConfig {
+        RealityListenConfig {
+            host: "127.0.0.1".into(),
+            port: 443,
+            protocol: "vless".into(),
+            users: vec!["11111111-1111-1111-1111-111111111111".into()],
+            target: Some(RealityTarget::Address("127.0.0.1:8443".into())),
+            dest: None,
+            target_type: Some("tcp".into()),
+            show: false,
+            master_key_log: None,
+            xver: 0,
+            server_names: vec!["example.com".into()],
+            private_key: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([7u8; 32]),
+            min_client_ver: Some("26.3.27".into()),
+            max_client_ver: None,
+            max_time_diff_ms: 60_000,
+            short_ids: vec!["0123456789abcdef".into()],
+            mldsa65_seed: None,
+            limit_fallback_upload: RealityFallbackLimit::default(),
+            limit_fallback_download: RealityFallbackLimit::default(),
+            limits: RealityResourceLimits::default(),
+        }
+    }
+
+    #[test]
+    fn listener_config_builds_and_redacts_secrets() {
+        let listener = RealityListener::from_config(&valid_config()).unwrap();
+        let debug = format!("{listener:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("BwcHBwcH"));
+    }
+
+    #[test]
+    fn listener_rejects_unknown_xver_defensively() {
+        let mut config = valid_config();
+        config.xver = 3;
+        assert!(RealityListener::from_config(&config).is_err());
+    }
+}

--- a/crates/core-inbound/src/vless.rs
+++ b/crates/core-inbound/src/vless.rs
@@ -1,0 +1,1143 @@
+//! Reusable authenticated VLESS inbound over any asynchronous byte stream.
+//!
+//! The transport (REALITY, gRPC, WebSocket, or another listener) is responsible
+//! for establishing a trusted stream and choosing the logical source address.
+//! This module owns VLESS authentication, commands 1/2/3, fixed-destination UDP,
+//! mux.cool, XUDP, resource bounds, half-close, routing and accounting.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use core_observe::ConnectionGuard;
+use core_outbound::adapter::UdpSocketLike;
+use core_runtime::{InboundMetadata, ListenerHandler, Runtime};
+use subtle::ConstantTimeEq as _;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{Mutex, mpsc};
+use tokio::task::{JoinHandle, JoinSet};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use uuid::Uuid;
+
+const VLESS_COMMAND_TCP: u8 = 1;
+const VLESS_COMMAND_UDP: u8 = 2;
+const VLESS_COMMAND_MUX: u8 = 3;
+const MUX_STATUS_NEW: u8 = 1;
+const MUX_STATUS_KEEP: u8 = 2;
+const MUX_STATUS_END: u8 = 3;
+const MUX_STATUS_KEEPALIVE: u8 = 4;
+const MUX_OPTION_DATA: u8 = 1;
+const MUX_OPTION_ERROR: u8 = 2;
+const MUX_NETWORK_TCP: u8 = 1;
+const MUX_NETWORK_UDP: u8 = 2;
+const MAX_MUX_METADATA_BYTES: usize = 512;
+const MAX_MUX_PAYLOAD_BYTES: usize = 8 * 1024;
+const MAX_VLESS_UDP_PAYLOAD_BYTES: usize = MAX_MUX_PAYLOAD_BYTES - 2;
+const MAX_XUDP_TARGETS_PER_SESSION: usize = 64;
+const MUX_INPUT_QUEUE_DEPTH: usize = 32;
+
+/// Validated VLESS authentication and resource policy, independent of the
+/// outer transport.
+#[derive(Clone)]
+pub struct VlessInboundConfig {
+    users: Arc<Vec<[u8; 16]>>,
+    handshake_timeout: Duration,
+    max_mux_sessions: usize,
+}
+
+impl VlessInboundConfig {
+    pub fn new(
+        users: Vec<[u8; 16]>,
+        handshake_timeout: Duration,
+        max_mux_sessions: usize,
+    ) -> io::Result<Self> {
+        let config = Self {
+            users: Arc::new(users),
+            handshake_timeout,
+            max_mux_sessions,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn from_uuid_strings<I, S>(
+        users: I,
+        handshake_timeout: Duration,
+        max_mux_sessions: usize,
+    ) -> io::Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let users = users
+            .into_iter()
+            .map(|user| {
+                Uuid::parse_str(user.as_ref())
+                    .map(|uuid| *uuid.as_bytes())
+                    .map_err(|error| invalid_input(format!("invalid VLESS user UUID: {error}")))
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+        Self::new(users, handshake_timeout, max_mux_sessions)
+    }
+
+    pub fn validate(&self) -> io::Result<()> {
+        if self.users.is_empty() {
+            return Err(invalid_input("VLESS requires at least one authorized UUID"));
+        }
+        if self.handshake_timeout.is_zero() {
+            return Err(invalid_input("VLESS handshake timeout must be non-zero"));
+        }
+        if self.max_mux_sessions == 0 {
+            return Err(invalid_input("VLESS max mux sessions must be non-zero"));
+        }
+        Ok(())
+    }
+
+    pub fn user_count(&self) -> usize {
+        self.users.len()
+    }
+
+    pub fn handshake_timeout(&self) -> Duration {
+        self.handshake_timeout
+    }
+
+    pub fn max_mux_sessions(&self) -> usize {
+        self.max_mux_sessions
+    }
+}
+
+impl fmt::Debug for VlessInboundConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VlessInboundConfig")
+            .field("user_count", &self.users.len())
+            .field("handshake_timeout", &self.handshake_timeout)
+            .field("max_mux_sessions", &self.max_mux_sessions)
+            .finish()
+    }
+}
+
+/// Transport-supplied connection identity. `source` may be a physical peer or
+/// a logical address derived from a trusted forwarded header; validation of
+/// that header belongs to the outer transport.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VlessConnectionContext {
+    pub source: SocketAddr,
+    pub local: SocketAddr,
+}
+
+/// Authenticate and serve a complete VLESS connection over an arbitrary
+/// bidirectional asynchronous byte stream.
+pub async fn serve_vless_stream<S>(
+    stream: S,
+    context: VlessConnectionContext,
+    config: Arc<VlessInboundConfig>,
+    runtime: Arc<Runtime>,
+    cancellation: CancellationToken,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    config.validate()?;
+    tokio::select! {
+        _ = cancellation.cancelled() => Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "VLESS connection cancelled",
+        )),
+        result = serve_vless(
+            stream,
+            context.source,
+            context.local,
+            config.users.clone(),
+            runtime,
+            config.handshake_timeout,
+            config.max_mux_sessions,
+        ) => result,
+    }
+}
+
+async fn serve_vless<S>(
+    mut stream: S,
+    peer: SocketAddr,
+    local: SocketAddr,
+    users: Arc<Vec<[u8; 16]>>,
+    runtime: Arc<Runtime>,
+    handshake_timeout: Duration,
+    max_mux_sessions: usize,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let request = tokio::time::timeout(
+        handshake_timeout,
+        read_vless_request(&mut stream, users.as_ref()),
+    )
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "VLESS handshake timed out"))??;
+    let handler = ListenerHandler::new(runtime);
+    match request.command {
+        VLESS_COMMAND_TCP => {
+            let target = request
+                .target
+                .ok_or_else(|| invalid_data("VLESS TCP request has no target"))?;
+            let metadata =
+                InboundMetadata::tcp("vless", "VLESS", peer, local, target.host, target.port);
+            let prepared = handler.prepare_tcp(metadata).await?;
+            stream.write_all(&[0, 0]).await?;
+            stream.flush().await?;
+            handler.relay_prepared_tcp(stream, prepared).await
+        }
+        VLESS_COMMAND_UDP => {
+            let target = request
+                .target
+                .ok_or_else(|| invalid_data("VLESS UDP request has no target"))?;
+            serve_vless_udp(stream, peer, local, target, handler).await
+        }
+        VLESS_COMMAND_MUX => {
+            stream.write_all(&[0, 0]).await?;
+            stream.flush().await?;
+            serve_vless_mux(stream, peer, local, handler, max_mux_sessions.max(1)).await
+        }
+        command => Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!("unsupported VLESS command {command}"),
+        )),
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct VlessTarget {
+    host: String,
+    port: u16,
+}
+
+#[derive(Debug)]
+struct VlessRequest {
+    command: u8,
+    target: Option<VlessTarget>,
+}
+
+async fn read_vless_request<S>(stream: &mut S, users: &[[u8; 16]]) -> io::Result<VlessRequest>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut fixed = [0u8; 18];
+    stream.read_exact(&mut fixed).await?;
+    if fixed[0] != 0 {
+        return Err(invalid_data(format!(
+            "unsupported VLESS version {}",
+            fixed[0]
+        )));
+    }
+    let authenticated = users.iter().fold(0u8, |matched, user| {
+        matched | user.ct_eq(&fixed[1..17]).unwrap_u8()
+    });
+    if authenticated == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "VLESS UUID is not authorized",
+        ));
+    }
+    let mut addons = vec![0u8; fixed[17] as usize];
+    stream.read_exact(&mut addons).await?;
+    if !addons.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "VLESS request addons (including XTLS Vision flow) are not enabled for this listener",
+        ));
+    }
+    let command = stream.read_u8().await?;
+    let target = match command {
+        VLESS_COMMAND_TCP | VLESS_COMMAND_UDP => Some(read_vless_target(stream).await?),
+        VLESS_COMMAND_MUX => None,
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported VLESS command {command}"),
+            ));
+        }
+    };
+    Ok(VlessRequest { command, target })
+}
+
+async fn read_vless_target<S>(stream: &mut S) -> io::Result<VlessTarget>
+where
+    S: AsyncRead + Unpin,
+{
+    let port = stream.read_u16().await?;
+    if port == 0 {
+        return Err(invalid_data("VLESS destination port is zero"));
+    }
+    let address_type = stream.read_u8().await?;
+    let host = match address_type {
+        1 => {
+            let mut address = [0u8; 4];
+            stream.read_exact(&mut address).await?;
+            IpAddr::from(address).to_string()
+        }
+        2 => {
+            let length = stream.read_u8().await? as usize;
+            if length == 0 {
+                return Err(invalid_data("VLESS destination domain is empty"));
+            }
+            let mut domain = vec![0u8; length];
+            stream.read_exact(&mut domain).await?;
+            let domain = std::str::from_utf8(&domain)
+                .map_err(|_| invalid_data("VLESS destination domain is not UTF-8"))?;
+            normalize_domain(domain)?
+        }
+        3 => {
+            let mut address = [0u8; 16];
+            stream.read_exact(&mut address).await?;
+            IpAddr::from(address).to_string()
+        }
+        kind => {
+            return Err(invalid_data(format!(
+                "unsupported VLESS address type {kind}"
+            )));
+        }
+    };
+    Ok(VlessTarget { host, port })
+}
+
+async fn serve_vless_udp<S>(
+    mut stream: S,
+    peer: SocketAddr,
+    local: SocketAddr,
+    target: VlessTarget,
+    handler: ListenerHandler,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let metadata = InboundMetadata::udp(
+        "vless",
+        "VLESS",
+        peer,
+        Some(local),
+        target.host,
+        target.port,
+    );
+    let prepared = handler.prepare_udp(metadata).await?;
+    stream.write_all(&[0, 0]).await?;
+    stream.flush().await?;
+    let socket: Arc<dyn UdpSocketLike> = Arc::from(prepared.socket);
+    let guard = prepared.guard;
+    let target_host = prepared.target_host;
+    let target_port = prepared.target_port;
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    let send_socket = socket.clone();
+    let send_handler = handler.clone();
+    let send = async {
+        loop {
+            let length = match reader.read_u16().await {
+                Ok(length) => usize::from(length),
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+                Err(error) => return Err(error),
+            };
+            if length == 0 || length > MAX_VLESS_UDP_PAYLOAD_BYTES {
+                return Err(invalid_data(format!(
+                    "VLESS UDP packet length {length} is outside 1..={MAX_VLESS_UDP_PAYLOAD_BYTES}"
+                )));
+            }
+            let mut payload = vec![0u8; length];
+            reader.read_exact(&mut payload).await?;
+            let sent = send_socket
+                .send_to(&payload, &target_host, target_port)
+                .await?;
+            if sent != payload.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "VLESS UDP outbound truncated a datagram",
+                ));
+            }
+            send_handler.record_upload(&guard, sent as u64);
+        }
+    };
+    let recv_socket = socket.clone();
+    let recv_handler = handler.clone();
+    let recv = async {
+        let mut payload = vec![0u8; MAX_VLESS_UDP_PAYLOAD_BYTES];
+        loop {
+            let length = recv_socket.recv_from(&mut payload).await?;
+            if length == 0 {
+                continue;
+            }
+            let length_u16 = u16::try_from(length)
+                .map_err(|_| invalid_data("VLESS UDP response exceeds u16 length"))?;
+            writer.write_all(&length_u16.to_be_bytes()).await?;
+            writer.write_all(&payload[..length]).await?;
+            writer.flush().await?;
+            recv_handler.record_download(&guard, length as u64);
+        }
+    };
+    let result = tokio::select! {
+        result = send => result,
+        result = recv => result,
+    };
+    let _ = socket.close().await;
+    result
+}
+
+#[derive(Debug)]
+struct MuxFrame {
+    session_id: u16,
+    status: u8,
+    network: Option<u8>,
+    target: Option<VlessTarget>,
+    payload: Option<Vec<u8>>,
+}
+
+#[derive(Debug)]
+struct MuxInput {
+    target: Option<VlessTarget>,
+    payload: Vec<u8>,
+}
+
+async fn serve_vless_mux<S>(
+    stream: S,
+    peer: SocketAddr,
+    local: SocketAddr,
+    handler: ListenerHandler,
+    max_sessions: usize,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut reader, writer) = tokio::io::split(stream);
+    let writer = Arc::new(Mutex::new(writer));
+    let mut sessions: HashMap<u16, mpsc::Sender<MuxInput>> = HashMap::new();
+    let mut tasks = JoinSet::new();
+
+    while let Some(frame) = read_mux_frame(&mut reader).await? {
+        sessions.retain(|_, sender| !sender.is_closed());
+        match frame.status {
+            MUX_STATUS_KEEPALIVE => {}
+            MUX_STATUS_END => {
+                sessions.remove(&frame.session_id);
+            }
+            MUX_STATUS_NEW => {
+                if sessions.contains_key(&frame.session_id) {
+                    return Err(invalid_data(format!(
+                        "duplicate VLESS mux session {}",
+                        frame.session_id
+                    )));
+                }
+                if sessions.len() >= max_sessions {
+                    write_mux_frame(
+                        &writer,
+                        frame.session_id,
+                        MUX_STATUS_END,
+                        MUX_OPTION_ERROR,
+                        None,
+                        None,
+                    )
+                    .await?;
+                    continue;
+                }
+                let network = frame
+                    .network
+                    .ok_or_else(|| invalid_data("new VLESS mux session has no network"))?;
+                let target = frame
+                    .target
+                    .clone()
+                    .ok_or_else(|| invalid_data("new VLESS mux session has no target"))?;
+                let (sender, receiver) = mpsc::channel(MUX_INPUT_QUEUE_DEPTH);
+                sessions.insert(frame.session_id, sender.clone());
+                let session_writer = writer.clone();
+                let session_handler = handler.clone();
+                let session_id = frame.session_id;
+                match network {
+                    MUX_NETWORK_TCP => tasks.spawn(async move {
+                        run_mux_tcp_session(
+                            session_id,
+                            target,
+                            peer,
+                            local,
+                            session_handler,
+                            session_writer,
+                            receiver,
+                        )
+                        .await
+                    }),
+                    MUX_NETWORK_UDP => tasks.spawn(async move {
+                        run_mux_udp_session(
+                            session_id,
+                            target,
+                            peer,
+                            local,
+                            session_handler,
+                            session_writer,
+                            receiver,
+                        )
+                        .await
+                    }),
+                    _ => unreachable!("validated mux network"),
+                };
+                if let Some(payload) = frame.payload {
+                    if sender
+                        .send(MuxInput {
+                            target: frame.target,
+                            payload,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        sessions.remove(&frame.session_id);
+                    }
+                }
+            }
+            MUX_STATUS_KEEP => {
+                if let Some(payload) = frame.payload {
+                    if let Some(sender) = sessions.get(&frame.session_id) {
+                        if sender
+                            .send(MuxInput {
+                                target: frame.target,
+                                payload,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            sessions.remove(&frame.session_id);
+                        }
+                    } else {
+                        write_mux_frame(
+                            &writer,
+                            frame.session_id,
+                            MUX_STATUS_END,
+                            MUX_OPTION_ERROR,
+                            None,
+                            None,
+                        )
+                        .await?;
+                    }
+                }
+            }
+            _ => unreachable!("validated mux status"),
+        }
+    }
+
+    drop(sessions);
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if error.kind() == io::ErrorKind::BrokenPipe => {}
+            Ok(Err(error)) => debug!(error = %error, "VLESS mux sub-session failed"),
+            Err(error) => debug!(error = %error, "VLESS mux sub-session panicked"),
+        }
+    }
+    Ok(())
+}
+
+async fn run_mux_tcp_session<W>(
+    session_id: u16,
+    target: VlessTarget,
+    peer: SocketAddr,
+    local: SocketAddr,
+    handler: ListenerHandler,
+    writer: Arc<Mutex<W>>,
+    mut receiver: mpsc::Receiver<MuxInput>,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let metadata = InboundMetadata::tcp(
+        "vless-mux",
+        "VLESS+MUX",
+        peer,
+        local,
+        target.host,
+        target.port,
+    );
+    let prepared = match handler.prepare_tcp(metadata).await {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            write_mux_frame(
+                &writer,
+                session_id,
+                MUX_STATUS_END,
+                MUX_OPTION_ERROR,
+                None,
+                None,
+            )
+            .await?;
+            return Err(error);
+        }
+    };
+    let (relay_side, mux_side) = tokio::io::duplex(64 * 1024);
+    let relay_handler = handler.clone();
+    let relay =
+        tokio::spawn(async move { relay_handler.relay_prepared_tcp(relay_side, prepared).await });
+    let (mut outbound_reader, mut outbound_writer) = tokio::io::split(mux_side);
+    let mut inbound_open = true;
+    let mut buffer = vec![0u8; MAX_MUX_PAYLOAD_BYTES];
+    loop {
+        if inbound_open {
+            tokio::select! {
+                input = receiver.recv() => {
+                    match input {
+                        Some(input) => outbound_writer.write_all(&input.payload).await?,
+                        None => {
+                            outbound_writer.shutdown().await?;
+                            inbound_open = false;
+                        }
+                    }
+                }
+                read = outbound_reader.read(&mut buffer) => {
+                    let length = read?;
+                    if length == 0 {
+                        break;
+                    }
+                    write_mux_frame(
+                        &writer,
+                        session_id,
+                        MUX_STATUS_KEEP,
+                        MUX_OPTION_DATA,
+                        None,
+                        Some(&buffer[..length]),
+                    ).await?;
+                }
+            }
+        } else {
+            let length = outbound_reader.read(&mut buffer).await?;
+            if length == 0 {
+                break;
+            }
+            write_mux_frame(
+                &writer,
+                session_id,
+                MUX_STATUS_KEEP,
+                MUX_OPTION_DATA,
+                None,
+                Some(&buffer[..length]),
+            )
+            .await?;
+        }
+    }
+    write_mux_frame(&writer, session_id, MUX_STATUS_END, 0, None, None).await?;
+    match relay.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(error),
+        Err(error) => Err(io::Error::other(format!(
+            "VLESS mux relay task failed: {error}"
+        ))),
+    }
+}
+
+#[derive(Clone)]
+struct MuxUdpAssociation {
+    socket: Arc<dyn UdpSocketLike>,
+    guard: Arc<ConnectionGuard>,
+    target_host: String,
+    target_port: u16,
+}
+
+async fn run_mux_udp_session<W>(
+    session_id: u16,
+    initial_target: VlessTarget,
+    peer: SocketAddr,
+    local: SocketAddr,
+    handler: ListenerHandler,
+    writer: Arc<Mutex<W>>,
+    mut receiver: mpsc::Receiver<MuxInput>,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let cancellation = CancellationToken::new();
+    let mut associations: HashMap<VlessTarget, MuxUdpAssociation> = HashMap::new();
+    let mut receive_tasks: Vec<JoinHandle<io::Result<()>>> = Vec::new();
+    let mut session_result = Ok(());
+
+    while let Some(input) = receiver.recv().await {
+        let target = input.target.unwrap_or_else(|| initial_target.clone());
+        if !associations.contains_key(&target) {
+            if associations.len() >= MAX_XUDP_TARGETS_PER_SESSION {
+                session_result = Err(invalid_data(format!(
+                    "VLESS XUDP session exceeds {MAX_XUDP_TARGETS_PER_SESSION} targets"
+                )));
+                break;
+            }
+            let metadata = InboundMetadata::udp(
+                "vless-mux",
+                "VLESS+XUDP",
+                peer,
+                Some(local),
+                target.host.clone(),
+                target.port,
+            );
+            let prepared = match handler.prepare_udp(metadata).await {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    session_result = Err(error);
+                    break;
+                }
+            };
+            let association = MuxUdpAssociation {
+                socket: Arc::from(prepared.socket),
+                guard: Arc::new(prepared.guard),
+                target_host: prepared.target_host,
+                target_port: prepared.target_port,
+            };
+            let receive_socket = association.socket.clone();
+            let receive_guard = association.guard.clone();
+            let receive_writer = writer.clone();
+            let receive_handler = handler.clone();
+            let receive_target = target.clone();
+            let receive_cancellation = cancellation.clone();
+            receive_tasks.push(tokio::spawn(async move {
+                let mut payload = vec![0u8; MAX_MUX_PAYLOAD_BYTES];
+                loop {
+                    let length = tokio::select! {
+                        () = receive_cancellation.cancelled() => return Ok(()),
+                        result = receive_socket.recv_from(&mut payload) => result?,
+                    };
+                    if length == 0 {
+                        continue;
+                    }
+                    receive_handler.record_download(&receive_guard, length as u64);
+                    write_mux_frame(
+                        &receive_writer,
+                        session_id,
+                        MUX_STATUS_KEEP,
+                        MUX_OPTION_DATA,
+                        Some((MUX_NETWORK_UDP, &receive_target)),
+                        Some(&payload[..length]),
+                    )
+                    .await?;
+                }
+            }));
+            associations.insert(target.clone(), association);
+        }
+        let Some(association) = associations.get(&target) else {
+            session_result = Err(io::Error::other(
+                "VLESS XUDP association disappeared after insertion",
+            ));
+            break;
+        };
+        let sent = association
+            .socket
+            .send_to(
+                &input.payload,
+                &association.target_host,
+                association.target_port,
+            )
+            .await?;
+        if sent != input.payload.len() {
+            session_result = Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "VLESS XUDP outbound truncated a datagram",
+            ));
+            break;
+        }
+        handler.record_upload(&association.guard, sent as u64);
+    }
+
+    cancellation.cancel();
+    for association in associations.values() {
+        let _ = association.socket.close().await;
+    }
+    for task in receive_tasks {
+        match task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if session_result.is_ok() => session_result = Err(error),
+            Ok(Err(_)) => {}
+            Err(error) if session_result.is_ok() => {
+                session_result = Err(io::Error::other(format!(
+                    "VLESS XUDP receive task failed: {error}"
+                )));
+            }
+            Err(_) => {}
+        }
+    }
+    let end_option = if session_result.is_ok() {
+        0
+    } else {
+        MUX_OPTION_ERROR
+    };
+    write_mux_frame(&writer, session_id, MUX_STATUS_END, end_option, None, None).await?;
+    session_result
+}
+
+async fn read_mux_frame<R>(reader: &mut R) -> io::Result<Option<MuxFrame>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut encoded_length = [0u8; 2];
+    let first = reader.read(&mut encoded_length[..1]).await?;
+    if first == 0 {
+        return Ok(None);
+    }
+    reader.read_exact(&mut encoded_length[1..]).await?;
+    let metadata_length = usize::from(u16::from_be_bytes(encoded_length));
+    if !(4..=MAX_MUX_METADATA_BYTES).contains(&metadata_length) {
+        return Err(invalid_data(format!(
+            "VLESS mux metadata length {metadata_length} is outside 4..={MAX_MUX_METADATA_BYTES}"
+        )));
+    }
+    let mut metadata = vec![0u8; metadata_length];
+    reader.read_exact(&mut metadata).await?;
+    let session_id = u16::from_be_bytes([metadata[0], metadata[1]]);
+    let status = metadata[2];
+    let option = metadata[3];
+    if !matches!(
+        status,
+        MUX_STATUS_NEW | MUX_STATUS_KEEP | MUX_STATUS_END | MUX_STATUS_KEEPALIVE
+    ) {
+        return Err(invalid_data(format!("unknown VLESS mux status {status}")));
+    }
+    if option & !(MUX_OPTION_DATA | MUX_OPTION_ERROR) != 0 {
+        return Err(invalid_data(format!(
+            "unknown VLESS mux option bits {option:#04x}"
+        )));
+    }
+    let (network, target) = if status == MUX_STATUS_NEW {
+        let network = *metadata
+            .get(4)
+            .ok_or_else(|| invalid_data("new VLESS mux frame has no network"))?;
+        if !matches!(network, MUX_NETWORK_TCP | MUX_NETWORK_UDP) {
+            return Err(invalid_data(format!(
+                "unknown VLESS mux target network {network}"
+            )));
+        }
+        let (target, _) = decode_mux_target(&metadata, 5)?;
+        (Some(network), Some(target))
+    } else if status == MUX_STATUS_KEEP && metadata.get(4).copied() == Some(MUX_NETWORK_UDP) {
+        let (target, _) = decode_mux_target(&metadata, 5)?;
+        (Some(MUX_NETWORK_UDP), Some(target))
+    } else {
+        (None, None)
+    };
+    let payload = if option & MUX_OPTION_DATA != 0 {
+        let length = usize::from(reader.read_u16().await?);
+        if length > MAX_MUX_PAYLOAD_BYTES {
+            return Err(invalid_data(format!(
+                "VLESS mux payload length {length} exceeds {MAX_MUX_PAYLOAD_BYTES}"
+            )));
+        }
+        let mut payload = vec![0u8; length];
+        reader.read_exact(&mut payload).await?;
+        Some(payload)
+    } else {
+        None
+    };
+    Ok(Some(MuxFrame {
+        session_id,
+        status,
+        network,
+        target,
+        payload,
+    }))
+}
+
+fn decode_mux_target(metadata: &[u8], offset: usize) -> io::Result<(VlessTarget, usize)> {
+    if metadata.len() < offset + 3 {
+        return Err(invalid_data("VLESS mux target metadata is truncated"));
+    }
+    let port = u16::from_be_bytes([metadata[offset], metadata[offset + 1]]);
+    if port == 0 {
+        return Err(invalid_data("VLESS mux target port is zero"));
+    }
+    let address_type = metadata[offset + 2];
+    let address_offset = offset + 3;
+    let (host, consumed) = match address_type {
+        1 => {
+            let bytes = metadata
+                .get(address_offset..address_offset + 4)
+                .ok_or_else(|| invalid_data("VLESS mux IPv4 target is truncated"))?;
+            (
+                IpAddr::from([bytes[0], bytes[1], bytes[2], bytes[3]]).to_string(),
+                4,
+            )
+        }
+        2 => {
+            let length = usize::from(
+                *metadata
+                    .get(address_offset)
+                    .ok_or_else(|| invalid_data("VLESS mux domain length is missing"))?,
+            );
+            if length == 0 {
+                return Err(invalid_data("VLESS mux target domain is empty"));
+            }
+            let bytes = metadata
+                .get(address_offset + 1..address_offset + 1 + length)
+                .ok_or_else(|| invalid_data("VLESS mux domain target is truncated"))?;
+            let domain = std::str::from_utf8(bytes)
+                .map_err(|_| invalid_data("VLESS mux target domain is not UTF-8"))?;
+            (normalize_domain(domain)?, length + 1)
+        }
+        3 => {
+            let bytes = metadata
+                .get(address_offset..address_offset + 16)
+                .ok_or_else(|| invalid_data("VLESS mux IPv6 target is truncated"))?;
+            let address: [u8; 16] = bytes
+                .try_into()
+                .map_err(|_| invalid_data("VLESS mux IPv6 target is invalid"))?;
+            (IpAddr::from(address).to_string(), 16)
+        }
+        kind => {
+            return Err(invalid_data(format!(
+                "unsupported VLESS mux address type {kind}"
+            )));
+        }
+    };
+    Ok((VlessTarget { host, port }, address_offset + consumed))
+}
+
+async fn write_mux_frame<W>(
+    writer: &Arc<Mutex<W>>,
+    session_id: u16,
+    status: u8,
+    option: u8,
+    target: Option<(u8, &VlessTarget)>,
+    payload: Option<&[u8]>,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut metadata = Vec::with_capacity(32);
+    metadata.extend_from_slice(&session_id.to_be_bytes());
+    metadata.push(status);
+    metadata.push(option);
+    if let Some((network, target)) = target {
+        metadata.push(network);
+        encode_mux_target(target, &mut metadata)?;
+    }
+    let metadata_length = u16::try_from(metadata.len())
+        .map_err(|_| invalid_data("VLESS mux response metadata is too large"))?;
+    let mut writer = writer.lock().await;
+    writer.write_all(&metadata_length.to_be_bytes()).await?;
+    writer.write_all(&metadata).await?;
+    if let Some(payload) = payload {
+        if payload.len() > MAX_MUX_PAYLOAD_BYTES {
+            return Err(invalid_data("VLESS mux response payload is too large"));
+        }
+        let length = u16::try_from(payload.len())
+            .map_err(|_| invalid_data("VLESS mux response payload exceeds u16"))?;
+        writer.write_all(&length.to_be_bytes()).await?;
+        writer.write_all(payload).await?;
+    }
+    writer.flush().await
+}
+
+fn encode_mux_target(target: &VlessTarget, output: &mut Vec<u8>) -> io::Result<()> {
+    output.extend_from_slice(&target.port.to_be_bytes());
+    if let Ok(address) = target.host.parse::<IpAddr>() {
+        match address {
+            IpAddr::V4(address) => {
+                output.push(1);
+                output.extend_from_slice(&address.octets());
+            }
+            IpAddr::V6(address) => {
+                output.push(3);
+                output.extend_from_slice(&address.octets());
+            }
+        }
+    } else {
+        let length = u8::try_from(target.host.len())
+            .map_err(|_| invalid_data("VLESS mux response domain is too long"))?;
+        output.push(2);
+        output.push(length);
+        output.extend_from_slice(target.host.as_bytes());
+    }
+    Ok(())
+}
+
+fn normalize_domain(value: &str) -> io::Result<String> {
+    let domain = value.trim_end_matches('.').to_ascii_lowercase();
+    if domain.is_empty()
+        || domain.len() > 253
+        || domain
+            .bytes()
+            .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.')))
+        || domain.split('.').any(|label| {
+            label.is_empty() || label.len() > 63 || label.starts_with('-') || label.ends_with('-')
+        })
+    {
+        return Err(invalid_data("invalid VLESS destination domain"));
+    }
+    Ok(domain)
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_config_validates_users_and_bounds_without_reality() {
+        let config = VlessInboundConfig::from_uuid_strings(
+            ["11111111-1111-1111-1111-111111111111"],
+            Duration::from_secs(3),
+            32,
+        )
+        .unwrap();
+        assert_eq!(config.user_count(), 1);
+        assert_eq!(config.handshake_timeout(), Duration::from_secs(3));
+        assert_eq!(config.max_mux_sessions(), 32);
+        assert!(!format!("{config:?}").contains("11111111"));
+
+        assert!(VlessInboundConfig::new(Vec::new(), Duration::from_secs(1), 1).is_err());
+        assert!(VlessInboundConfig::new(vec![[1; 16]], Duration::ZERO, 1).is_err());
+        assert!(VlessInboundConfig::new(vec![[1; 16]], Duration::from_secs(1), 0).is_err());
+        assert!(
+            VlessInboundConfig::from_uuid_strings(["not-a-uuid"], Duration::from_secs(1), 1,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn public_stream_contract_accepts_generic_duplex_streams() {
+        fn assert_compatible<S>()
+        where
+            S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        {
+        }
+        assert_compatible::<tokio::io::DuplexStream>();
+    }
+
+    #[test]
+    fn domain_normalization_rejects_ambiguous_forms() {
+        assert_eq!(normalize_domain("Example.COM.").unwrap(), "example.com");
+        for invalid in ["", ".", "a..b", "-a.example", "a-.example", "exa_mple.com"] {
+            assert!(normalize_domain(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[tokio::test]
+    async fn authentication_and_mux_request_header_stop_after_command_like_xray() {
+        let user = [0x11; 16];
+        let mut wire = vec![0];
+        wire.extend_from_slice(&user);
+        wire.extend_from_slice(&[0, VLESS_COMMAND_MUX]);
+        let mut input = wire.as_slice();
+        let request = read_vless_request(&mut input, &[user]).await.unwrap();
+        assert_eq!(request.command, VLESS_COMMAND_MUX);
+        assert!(request.target.is_none());
+        assert!(input.is_empty());
+
+        let mut unauthorized = wire.as_slice();
+        assert_eq!(
+            read_vless_request(&mut unauthorized, &[[0x22; 16]])
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_pinned_xray_xudp_new_frame() {
+        let wire = [
+            0x00,
+            0x14,
+            0x00,
+            0x00,
+            MUX_STATUS_NEW,
+            MUX_OPTION_DATA,
+            MUX_NETWORK_UDP,
+            0x00,
+            0x35,
+            0x01,
+            0x7f,
+            0x00,
+            0x00,
+            0x01,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            0x00,
+            0x01,
+            b'q',
+        ];
+        let mut input = wire.as_slice();
+        let frame = read_mux_frame(&mut input).await.unwrap().unwrap();
+        assert_eq!(frame.session_id, 0);
+        assert_eq!(frame.status, MUX_STATUS_NEW);
+        assert_eq!(frame.network, Some(MUX_NETWORK_UDP));
+        assert_eq!(
+            frame.target,
+            Some(VlessTarget {
+                host: "127.0.0.1".into(),
+                port: 53,
+            })
+        );
+        assert_eq!(frame.payload.as_deref(), Some(b"q".as_slice()));
+    }
+
+    #[tokio::test]
+    async fn writes_pinned_xray_xudp_keep_frame() {
+        let (writer_side, mut reader_side) = tokio::io::duplex(128);
+        let writer = Arc::new(Mutex::new(writer_side));
+        let target = VlessTarget {
+            host: "127.0.0.1".into(),
+            port: 53,
+        };
+        write_mux_frame(
+            &writer,
+            7,
+            MUX_STATUS_KEEP,
+            MUX_OPTION_DATA,
+            Some((MUX_NETWORK_UDP, &target)),
+            Some(b"answer"),
+        )
+        .await
+        .unwrap();
+        let expected = [
+            0x00,
+            0x0c,
+            0x00,
+            0x07,
+            MUX_STATUS_KEEP,
+            MUX_OPTION_DATA,
+            MUX_NETWORK_UDP,
+            0x00,
+            0x35,
+            0x01,
+            0x7f,
+            0x00,
+            0x00,
+            0x01,
+            0x00,
+            0x06,
+            b'a',
+            b'n',
+            b's',
+            b'w',
+            b'e',
+            b'r',
+        ];
+        let mut actual = vec![0u8; expected.len()];
+        reader_side.read_exact(&mut actual).await.unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn mux_frame_limits_and_unknown_bits_fail_closed() {
+        for wire in [
+            vec![0x02, 0x01],
+            vec![0, 4, 0, 1, 0xff, 0],
+            vec![0, 4, 0, 1, MUX_STATUS_KEEP, 0x80],
+            vec![0, 4, 0, 1, MUX_STATUS_KEEP, MUX_OPTION_DATA, 0x20, 0x01],
+        ] {
+            let mut input = wire.as_slice();
+            assert!(read_mux_frame(&mut input).await.is_err());
+        }
+    }
+}

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 core-config = { workspace = true }
+core-reality = { workspace = true }
 tokio       = { workspace = true }
 async-trait = { workspace = true }
 bytes       = { workspace = true }

--- a/crates/core-outbound/src/loopback.rs
+++ b/crates/core-outbound/src/loopback.rs
@@ -187,6 +187,13 @@ impl<S> TrackedTcpStream<S> {
             _guard: register_tcp(local),
         }
     }
+
+    pub fn with_guard(inner: S, guard: LoopbackTcpGuard) -> Self {
+        Self {
+            inner,
+            _guard: guard,
+        }
+    }
 }
 
 impl TrackedTcpStream<tokio::net::TcpStream> {

--- a/crates/core-outbound/src/proto/hysteria.rs
+++ b/crates/core-outbound/src/proto/hysteria.rs
@@ -94,9 +94,12 @@ impl HysteriaOutbound {
     async fn connect_and_auth(&self) -> std::io::Result<HysteriaSession> {
         let target_addr = resolve_first(&self.host, self.port).await?;
 
-        let mut tls_config = RustlsConfig::builder()
-            .with_root_certificates(root_store())
-            .with_no_client_auth();
+        let mut tls_config =
+            RustlsConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+                .with_safe_default_protocol_versions()
+                .expect("rustls ring default protocols")
+                .with_root_certificates(root_store())
+                .with_no_client_auth();
         tls_config.alpn_protocols = self.alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
         if self.insecure {
             tls_config

--- a/crates/core-outbound/src/proto/hysteria2.rs
+++ b/crates/core-outbound/src/proto/hysteria2.rs
@@ -103,9 +103,12 @@ impl Hysteria2Outbound {
         let target_addr = resolve_first(&self.host, self.port).await?;
 
         // 2) 准备 rustls 客户端配置
-        let mut tls_config = RustlsConfig::builder()
-            .with_root_certificates(root_store())
-            .with_no_client_auth();
+        let mut tls_config =
+            RustlsConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+                .with_safe_default_protocol_versions()
+                .expect("rustls ring default protocols")
+                .with_root_certificates(root_store())
+                .with_no_client_auth();
         tls_config.alpn_protocols = self.alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
         if self.insecure {
             tls_config

--- a/crates/core-outbound/src/proto/tuic.rs
+++ b/crates/core-outbound/src/proto/tuic.rs
@@ -215,9 +215,12 @@ impl TuicOutbound {
     async fn connect_and_auth(&self) -> std::io::Result<Arc<TuicSession>> {
         let target_addr = resolve_first(&self.host, self.port).await?;
 
-        let mut tls_config = RustlsConfig::builder()
-            .with_root_certificates(root_store())
-            .with_no_client_auth();
+        let mut tls_config =
+            RustlsConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+                .with_safe_default_protocol_versions()
+                .expect("rustls ring default protocols")
+                .with_root_certificates(root_store())
+                .with_no_client_auth();
         tls_config.alpn_protocols = self.alpn.iter().map(|s| s.as_bytes().to_vec()).collect();
         if self.insecure {
             tls_config
@@ -1580,10 +1583,14 @@ mod tests {
                 .decode(TEST_KEY_DER)
                 .unwrap(),
         );
-        let mut tls = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(vec![cert], PrivateKeyDer::Pkcs8(key))
-            .unwrap();
+        let mut tls = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("rustls ring default protocols")
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], PrivateKeyDer::Pkcs8(key))
+        .unwrap();
         tls.alpn_protocols = vec![b"h3".to_vec()];
         let crypto = quinn::crypto::rustls::QuicServerConfig::try_from(tls).unwrap();
         let mut server = quinn::ServerConfig::with_crypto(Arc::new(crypto));

--- a/crates/core-outbound/src/proto/vless.rs
+++ b/crates/core-outbound/src/proto/vless.rs
@@ -27,9 +27,10 @@ use uuid::Uuid;
 use crate::{
     adapter::{BoxedStream, Capabilities, DialContext, OutboundAdapter},
     transport::{
-        GrpcOptions, H2Options, HttpOptions, TlsOptions, Transport, WsOptions, XhttpOptions,
-        grpc_transport::GrpcTransport, h2_transport::H2Transport, http_transport::HttpTransport,
-        tcp::TcpTransport, tls::TlsTransport, ws::WsTransport, xhttp_transport::XhttpTransport,
+        GrpcOptions, H2Options, HttpOptions, RealityOptions, RealityTransport, TlsOptions,
+        Transport, WsOptions, XhttpOptions, grpc_transport::GrpcTransport,
+        h2_transport::H2Transport, http_transport::HttpTransport, tcp::TcpTransport,
+        tls::TlsTransport, ws::WsTransport, xhttp_transport::XhttpTransport,
     },
 };
 
@@ -72,6 +73,7 @@ pub struct VlessOutbound {
     pub sni: Option<String>,
     pub insecure: bool,
     pub alpn: Vec<String>,
+    pub reality: Option<RealityOptions>,
     pub network: VlessNetwork,
     pub ws: Option<WsOptions>,
     pub http: Option<HttpOptions>,
@@ -104,7 +106,11 @@ impl VlessOutbound {
     async fn dial_transport(&self) -> std::io::Result<BoxedStream> {
         match self.network {
             VlessNetwork::Tcp => {
-                if self.tls {
+                if let Some(reality) = &self.reality {
+                    RealityTransport::new(reality.clone())?
+                        .connect(&self.host, self.port)
+                        .await
+                } else if self.tls {
                     TlsTransport::new(self.tls_opts())
                         .connect(&self.host, self.port)
                         .await
@@ -113,6 +119,12 @@ impl VlessOutbound {
                 }
             }
             VlessNetwork::Ws => {
+                if self.reality.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "VLESS REALITY over WebSocket requires a carrier-aware WebSocket transport and is not enabled",
+                    ));
+                }
                 let ws = self.ws.clone().unwrap_or_else(|| WsOptions {
                     enabled: true,
                     path: "/".into(),
@@ -124,24 +136,48 @@ impl VlessOutbound {
                     .await
             }
             VlessNetwork::Http => {
+                if self.reality.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "VLESS REALITY over HTTP obfuscation is not enabled",
+                    ));
+                }
                 let opts = self.http.clone().unwrap_or_default();
                 HttpTransport::new(opts, self.tls_opts())
                     .connect(&self.host, self.port)
                     .await
             }
             VlessNetwork::H2 => {
+                if self.reality.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "VLESS REALITY over H2 requires a carrier-aware H2 transport and is not enabled",
+                    ));
+                }
                 let opts = self.h2.clone().unwrap_or_default();
                 H2Transport::new(opts, self.tls_opts())
                     .connect(&self.host, self.port)
                     .await
             }
             VlessNetwork::Grpc => {
+                if self.reality.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "VLESS REALITY over gRPC requires a carrier-aware gRPC transport and is not enabled",
+                    ));
+                }
                 let opts = self.grpc.clone().unwrap_or_default();
                 GrpcTransport::new(opts, self.tls_opts())
                     .connect(&self.host, self.port)
                     .await
             }
             VlessNetwork::Xhttp => {
+                if self.reality.is_some() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "VLESS REALITY over XHTTP is composed by the full XHTTP branch and is not enabled in this isolated REALITY branch",
+                    ));
+                }
                 let opts = self.xhttp.clone().unwrap_or_default();
                 XhttpTransport::new(self.host.clone(), self.port, opts)
                     .connect(&self.host, self.port)

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
+use base64::Engine as _;
 use core_config::node_uri::{NodeProtocol, ParsedNode};
 use uuid::Uuid;
 
@@ -35,7 +36,7 @@ use crate::{
     },
     socks5::Socks5Outbound,
     stub::StubOutbound,
-    transport::{GrpcOptions, H2Options, HttpOptions, WsOptions, XhttpOptions},
+    transport::{GrpcOptions, H2Options, HttpOptions, RealityOptions, WsOptions, XhttpOptions},
 };
 
 pub type ResolveFn = Arc<dyn Fn(&str) -> Option<SharedOutbound> + Send + Sync>;
@@ -322,7 +323,7 @@ fn build_vless(node: &ParsedNode) -> SharedOutbound {
         .and_then(|s| Uuid::parse_str(s).ok())
         .unwrap_or_else(Uuid::nil);
     let mut ob = VlessOutbound::new(&node.name, &node.host, node.port, uuid);
-    ob.tls = node.tls;
+    ob.tls = node.tls && node.reality.is_none();
     ob.sni = node
         .sni
         .clone()
@@ -335,6 +336,38 @@ fn build_vless(node: &ParsedNode) -> SharedOutbound {
         .unwrap_or(false);
     if let Some(alpn) = node.params.get("alpn") {
         ob.alpn = alpn.split(',').map(|s| s.trim().to_string()).collect();
+    }
+    if let Some(reality) = &node.reality {
+        let encoded_public_key = reality
+            .password
+            .as_ref()
+            .or(reality.public_key.as_ref())
+            .expect("core-config validated REALITY password/publicKey");
+        let decoded_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded_public_key)
+            .expect("core-config validated REALITY public key base64url");
+        let public_key: [u8; 32] = decoded_public_key
+            .try_into()
+            .expect("core-config validated REALITY public key length");
+        let short_id = hex::decode(&reality.short_id)
+            .expect("core-config validated REALITY shortId hexadecimal");
+        let mldsa65_verify = reality.mldsa65_verify.as_ref().map(|encoded| {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(encoded)
+                .expect("core-config validated REALITY mldsa65Verify")
+        });
+        ob.sni = Some(reality.server_name.clone());
+        ob.reality = Some(RealityOptions {
+            config: core_reality::RealityClientConfig {
+                server_name: reality.server_name.clone(),
+                fingerprint: reality.fingerprint.clone(),
+                public_key,
+                short_id,
+                spider_x: reality.spider_x.clone(),
+                mldsa65_verify,
+                ..core_reality::RealityClientConfig::default()
+            },
+        });
     }
     let network_str = resolve_network_string(node);
     ob.network = VlessNetwork::parse(&network_str);

--- a/crates/core-outbound/src/transport/mod.rs
+++ b/crates/core-outbound/src/transport/mod.rs
@@ -16,6 +16,7 @@ use crate::adapter::BoxedStream;
 pub mod grpc_transport;
 pub mod h2_transport;
 pub mod http_transport;
+pub mod reality;
 pub mod tcp;
 pub mod tls;
 pub mod ws;
@@ -24,6 +25,7 @@ pub mod xhttp_transport;
 pub use grpc_transport::{GrpcOptions, GrpcTransport};
 pub use h2_transport::{H2Options, H2Transport};
 pub use http_transport::{HttpOptions, HttpTransport};
+pub use reality::{RealityOptions, RealityTransport};
 pub use xhttp_transport::{XhttpOptions, XhttpTransport};
 
 #[async_trait]

--- a/crates/core-outbound/src/transport/reality.rs
+++ b/crates/core-outbound/src/transport/reality.rs
@@ -1,0 +1,132 @@
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use core_reality::{
+    RealityClient, RealityClientConfig, RealityClientError, RealityConnectionLifetime,
+};
+use tracing::{debug, info, warn};
+
+use crate::adapter::{BoxedStream, resolve_host};
+use crate::transport::Transport;
+use crate::transport::tcp::marked_connect_raw;
+
+#[derive(Clone)]
+pub struct RealityOptions {
+    pub config: RealityClientConfig,
+}
+
+impl fmt::Debug for RealityOptions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityOptions")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct RealityTransport {
+    client: RealityClient,
+}
+
+impl fmt::Debug for RealityTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityTransport")
+            .field("client", &self.client)
+            .finish()
+    }
+}
+
+impl RealityTransport {
+    pub fn new(options: RealityOptions) -> io::Result<Self> {
+        let client = RealityClient::new(options.config)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl Transport for RealityTransport {
+    async fn connect(&self, host: &str, port: u16) -> io::Result<BoxedStream> {
+        let started = Instant::now();
+        let addresses = resolve_host(host, port).await?;
+        let mut last_error = None;
+        for (attempt, address) in addresses.iter().copied().enumerate() {
+            let attempt_started = Instant::now();
+            let (stream, guard) = match marked_connect_raw(address, Duration::from_secs(10)).await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    debug!(
+                        target: "dial::reality",
+                        %host,
+                        port,
+                        peer = %address,
+                        attempt = attempt + 1,
+                        error = %error,
+                        "REALITY TCP connect attempt failed",
+                    );
+                    last_error = Some(error);
+                    continue;
+                }
+            };
+            let _ = stream.set_nodelay(true);
+            let lifetime: RealityConnectionLifetime = Arc::new(guard);
+            match self
+                .client
+                .connect_with_lifetime(stream, Some(lifetime))
+                .await
+            {
+                Ok(stream) => {
+                    info!(
+                        target: "dial::reality",
+                        %host,
+                        port,
+                        peer = %address,
+                        attempt = attempt + 1,
+                        handshake_ms = attempt_started.elapsed().as_millis() as u64,
+                        total_ms = started.elapsed().as_millis() as u64,
+                        fingerprint = %self.client.config().fingerprint,
+                        "REALITY authenticated",
+                    );
+                    return Ok(Box::pin(stream));
+                }
+                Err(error) => {
+                    let cover_started =
+                        matches!(error, RealityClientError::InvalidConnectionProcessed);
+                    debug!(
+                        target: "dial::reality",
+                        %host,
+                        port,
+                        peer = %address,
+                        attempt = attempt + 1,
+                        error = %error,
+                        "REALITY handshake attempt failed",
+                    );
+                    let error = io::Error::new(io::ErrorKind::ConnectionAborted, error);
+                    if cover_started {
+                        return Err(error);
+                    }
+                    last_error = Some(error);
+                }
+            }
+        }
+        warn!(
+            target: "dial::reality",
+            %host,
+            port,
+            attempts = addresses.len(),
+            total_ms = started.elapsed().as_millis() as u64,
+            "all REALITY candidates failed",
+        );
+        Err(last_error.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                format!("REALITY connect: no usable address for {host}:{port}"),
+            )
+        }))
+    }
+}

--- a/crates/core-outbound/src/transport/tcp.rs
+++ b/crates/core-outbound/src/transport/tcp.rs
@@ -10,7 +10,7 @@ use crate::{
         BoxedStream, apply_outbound_mark_for_addr, protect_socket, resolve_host,
         resolve_host_for_direct,
     },
-    loopback::TrackedTcpStream,
+    loopback::{LoopbackTcpGuard, TrackedTcpStream, register_tcp},
     transport::Transport,
 };
 
@@ -94,6 +94,17 @@ pub async fn marked_connect(
     addr: std::net::SocketAddr,
     timeout: Duration,
 ) -> std::io::Result<TrackedTcpStream<TcpStream>> {
+    let (stream, guard) = marked_connect_raw(addr, timeout).await?;
+    Ok(TrackedTcpStream::with_guard(stream, guard))
+}
+
+/// 与 [`marked_connect`] 相同地应用 socket 保护、路由标记和接口绑定，
+/// 但把裸 Tokio TCP 流与自抓回环 guard 分开返回。需要接管真实 TCP 类型的
+/// REALITY TLS 引擎使用此入口，并必须把 guard 保留到最终流被丢弃。
+pub async fn marked_connect_raw(
+    addr: std::net::SocketAddr,
+    timeout: Duration,
+) -> std::io::Result<(TcpStream, LoopbackTcpGuard)> {
     let std_stream =
         tokio::task::spawn_blocking(move || -> std::io::Result<std::net::TcpStream> {
             let domain = if addr.is_ipv4() {
@@ -118,5 +129,5 @@ pub async fn marked_connect(
         })??;
     let stream = TcpStream::from_std(std_stream)?;
     let local = stream.local_addr()?;
-    Ok(TrackedTcpStream::new(stream, local))
+    Ok((stream, register_tcp(local)))
 }

--- a/crates/core-reality/Cargo.toml
+++ b/crates/core-reality/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "core-reality"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+aws-lc-rs = { version = "=1.17.3", default-features = false, features = ["non-fips", "unstable"] }
+base64.workspace = true
+bytes.workspace = true
+hex.workspace = true
+http.workspace = true
+http-body-util.workspace = true
+hyper = { workspace = true, features = ["client", "http2"] }
+hyper-util.workspace = true
+log = "0.4"
+rand = "0.9"
+rcgen = { version = "0.14.8", default-features = false, features = ["aws_lc_rs"] }
+regex.workspace = true
+subtle = "2.6"
+thiserror.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tracing.workspace = true
+url.workspace = true
+xray-transport.workspace = true
+xray-utls.workspace = true
+zeroize.workspace = true
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[dev-dependencies]
+hyper = { workspace = true, features = ["http2", "server"] }
+rustls = { workspace = true, features = ["aws_lc_rs", "prefer-post-quantum"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws_lc_rs", "tls12"] }

--- a/crates/core-reality/LICENSE-SHOES
+++ b/crates/core-reality/LICENSE-SHOES
@@ -1,0 +1,20 @@
+Copyright (c) 2021-2023 Alex Lau <github@alau.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/core-reality/NOTICE.md
+++ b/crates/core-reality/NOTICE.md
@@ -1,0 +1,31 @@
+# Third-party notices
+
+The low-level TLS 1.3 record and REALITY state-machine implementation in
+`src/donor/` is adapted from Shoes, commit
+`386b11532424b8665ee3e46340c6236fb3c47595`:
+
+- Project: https://github.com/cfal/shoes
+- Copyright: 2021-2023 Alex Lau
+- License: MIT (see `LICENSE-SHOES`)
+
+The integration layer, bounded framing, authentication policy, hybrid
+X25519MLKEM768 support, ML-DSA-65 certificate extension, PROXY protocol,
+fallback rate limiting and cancellation handling are WutherCore changes.
+Protocol behavior is tested against Xray-core commit
+`6e3322d219140a025285ded1114fe17a5edb74d8` and xtls/reality commit
+`9234c772ba8f`.
+
+The client-side single-ClientHello finalization, current Xray/uTLS profile
+catalogue and TLS completion are provided by xray-rust commit
+`bb3e00da1abfc5fff70487b0dd2ba16054797584` through the vendored,
+locally documented `third_party/xray-transport` crate and the pinned
+`xray-utls` crate:
+
+- Project: https://github.com/aimalygin/xray-rust
+- Declared license: MPL-2.0
+- Vendored license and patch record: `../../third_party/xray-transport/`
+
+Those crates use shaped-rustls commit
+`94f088e210fd2a56e413cce1c6d79c10852d500a` so the authenticated REALITY
+session ID is finalized on the same live ClientHello used by the TLS transcript
+and network write, including a real X25519MLKEM768 key exchange.

--- a/crates/core-reality/src/buffer.rs
+++ b/crates/core-reality/src/buffer.rs
@@ -1,0 +1,160 @@
+use std::io::{self, BufRead, Read};
+
+pub(crate) struct SliceReader<'a> {
+    data: &'a [u8],
+    position: usize,
+}
+
+impl<'a> SliceReader<'a> {
+    pub(crate) fn new(data: &'a [u8]) -> Self {
+        Self { data, position: 0 }
+    }
+
+    pub(crate) fn position(&self) -> usize {
+        self.position
+    }
+
+    pub(crate) fn remaining(&self) -> usize {
+        self.data.len().saturating_sub(self.position)
+    }
+
+    pub(crate) fn read_u8(&mut self) -> io::Result<u8> {
+        Ok(self.read_slice(1)?[0])
+    }
+
+    pub(crate) fn read_u16_be(&mut self) -> io::Result<u16> {
+        let b = self.read_slice(2)?;
+        Ok(u16::from_be_bytes([b[0], b[1]]))
+    }
+
+    pub(crate) fn read_u24_be(&mut self) -> io::Result<usize> {
+        let b = self.read_slice(3)?;
+        Ok(((b[0] as usize) << 16) | ((b[1] as usize) << 8) | b[2] as usize)
+    }
+
+    pub(crate) fn read_slice(&mut self, len: usize) -> io::Result<&'a [u8]> {
+        let end = self
+            .position
+            .checked_add(len)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "length overflow"))?;
+        if end > self.data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "truncated input",
+            ));
+        }
+        let out = &self.data[self.position..end];
+        self.position = end;
+        Ok(out)
+    }
+
+    pub(crate) fn skip(&mut self, len: usize) -> io::Result<()> {
+        self.read_slice(len).map(|_| ())
+    }
+}
+
+pub(crate) struct SlideBuffer {
+    data: Vec<u8>,
+    start: usize,
+    capacity_limit: usize,
+}
+
+impl SlideBuffer {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            start: 0,
+            capacity_limit: capacity,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.data.len() - self.start
+    }
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    pub(crate) fn remaining_capacity(&self) -> usize {
+        self.capacity_limit.saturating_sub(self.len())
+    }
+    pub(crate) fn compact(&mut self) {
+        if self.start > 0 {
+            self.data.drain(..self.start);
+            self.start = 0;
+        }
+    }
+    pub(crate) fn maybe_compact(&mut self, threshold: usize) {
+        if self.start > threshold {
+            self.compact();
+        }
+    }
+    pub(crate) fn extend_from_slice(&mut self, data: &[u8]) {
+        self.compact();
+        self.data.extend_from_slice(data);
+    }
+    pub(crate) fn consume(&mut self, amount: usize) {
+        self.start = (self.start + amount).min(self.data.len());
+        if self.start == self.data.len() {
+            self.data.clear();
+            self.start = 0;
+        }
+    }
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.data[self.start..]
+    }
+    pub(crate) fn get_u16_be(&self, offset: usize) -> Option<u16> {
+        let bytes = self.as_slice().get(offset..offset.checked_add(2)?)?;
+        Some(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+    pub(crate) fn slice_mut(&mut self, range: std::ops::Range<usize>) -> &mut [u8] {
+        let start = self.start + range.start;
+        let end = self.start + range.end;
+        &mut self.data[start..end]
+    }
+}
+
+impl Read for SlideBuffer {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        let n = out.len().min(self.len());
+        out[..n].copy_from_slice(&self.as_slice()[..n]);
+        self.consume(n);
+        Ok(n)
+    }
+}
+
+impl BufRead for SlideBuffer {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        Ok(self.as_slice())
+    }
+    fn consume(&mut self, amt: usize) {
+        SlideBuffer::consume(self, amt);
+    }
+}
+
+impl std::ops::Index<usize> for SlideBuffer {
+    type Output = u8;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl std::ops::Index<std::ops::Range<usize>> for SlideBuffer {
+    type Output = [u8];
+    fn index(&self, index: std::ops::Range<usize>) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl std::ops::Index<std::ops::RangeFrom<usize>> for SlideBuffer {
+    type Output = [u8];
+    fn index(&self, index: std::ops::RangeFrom<usize>) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}
+
+impl std::ops::Index<std::ops::RangeTo<usize>> for SlideBuffer {
+    type Output = [u8];
+    fn index(&self, index: std::ops::RangeTo<usize>) -> &Self::Output {
+        &self.as_slice()[index]
+    }
+}

--- a/crates/core-reality/src/client.rs
+++ b/crates/core-reality/src/client.rs
@@ -1,0 +1,824 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use bytes::Bytes;
+use http::header::{ACCEPT, ACCEPT_LANGUAGE, CACHE_CONTROL, COOKIE, LOCATION, REFERER, USER_AGENT};
+use http::{Method, Request, StatusCode};
+use http_body_util::{BodyExt as _, Empty};
+use hyper::client::conn::http2;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use regex::bytes::Regex;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+use xray_transport::reality_connector::{
+    RealityClientHelloRequest, RealityConnector, RealityHandshakeContext, RealityTlsSessionOutcome,
+    RealityTlsSessionProvider,
+};
+use xray_transport::{
+    BoxedTransportStream, RealityClientConfig as XrayRealityClientConfig,
+    RustlsRealityTlsSessionProvider,
+};
+use zeroize::Zeroize;
+
+/// Xray-core 26.7.11 (`6e3322d`) wire version used in the authenticated
+/// REALITY session ID. It intentionally is not the WutherCore package version:
+/// current Xray servers default to a minimum client version of 26.3.27.
+pub const XRAY_REALITY_WIRE_VERSION: [u8; 3] = [26, 7, 11];
+
+const SPIDER_MAX_PADDING_BYTES: i64 = 4 * 1024;
+const SPIDER_MAX_CONCURRENCY: i64 = 16;
+const SPIDER_MAX_TIMES: i64 = 16;
+const SPIDER_MAX_DELAY_MS: i64 = 60_000;
+const SPIDER_MAX_BODY_BYTES: usize = 1024 * 1024;
+const SPIDER_MAX_PATHS: usize = 256;
+const SPIDER_MAX_PATH_BYTES: usize = 2048;
+const SPIDER_MAX_REDIRECTS: usize = 10;
+const SPIDER_CONNECTION_RETENTION: Duration = Duration::from_secs(5 * 60);
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RealityClientConfig {
+    pub server_name: String,
+    pub fingerprint: String,
+    pub public_key: [u8; 32],
+    pub short_id: Vec<u8>,
+    pub spider_x: String,
+    pub mldsa65_verify: Option<Vec<u8>>,
+    pub handshake_timeout: Duration,
+    pub wire_version: [u8; 3],
+}
+
+impl Default for RealityClientConfig {
+    fn default() -> Self {
+        Self {
+            server_name: String::new(),
+            fingerprint: "chrome".into(),
+            public_key: [0; 32],
+            short_id: Vec::new(),
+            spider_x: "/".into(),
+            mldsa65_verify: None,
+            handshake_timeout: Duration::from_secs(10),
+            wire_version: XRAY_REALITY_WIRE_VERSION,
+        }
+    }
+}
+
+impl fmt::Debug for RealityClientConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityClientConfig")
+            .field("server_name", &self.server_name)
+            .field("fingerprint", &self.fingerprint)
+            .field("public_key", &"<redacted>")
+            .field("short_id", &"<redacted>")
+            .field("spider_x", &self.spider_x)
+            .field(
+                "mldsa65_verify_len",
+                &self.mldsa65_verify.as_ref().map(Vec::len),
+            )
+            .field("handshake_timeout", &self.handshake_timeout)
+            .field("wire_version", &self.wire_version)
+            .finish()
+    }
+}
+
+impl Drop for RealityClientConfig {
+    fn drop(&mut self) {
+        self.public_key.zeroize();
+        self.short_id.zeroize();
+        if let Some(verify) = &mut self.mldsa65_verify {
+            verify.zeroize();
+        }
+    }
+}
+
+impl RealityClientConfig {
+    pub fn validate(&self) -> Result<(), RealityClientError> {
+        if self.server_name.trim().is_empty() {
+            return Err(RealityClientError::Configuration(
+                "serverName is empty".into(),
+            ));
+        }
+        if xray_utls::normalize_reality_supported_fingerprint(&self.fingerprint).is_none() {
+            return Err(RealityClientError::Configuration(format!(
+                "unknown or REALITY-incapable fingerprint `{}`",
+                self.fingerprint
+            )));
+        }
+        if self.public_key.iter().all(|byte| *byte == 0) {
+            return Err(RealityClientError::Configuration(
+                "public key is all zero".into(),
+            ));
+        }
+        if self.short_id.len() > 8 {
+            return Err(RealityClientError::Configuration(
+                "shortId exceeds 8 bytes".into(),
+            ));
+        }
+        if let Some(verify) = &self.mldsa65_verify
+            && verify.len() != 1952
+        {
+            return Err(RealityClientError::Configuration(
+                "mldsa65Verify must contain 1952 bytes".into(),
+            ));
+        }
+        if !self.spider_x.starts_with('/') {
+            return Err(RealityClientError::Configuration(
+                "spiderX must start with '/'".into(),
+            ));
+        }
+        parse_spider_x(&self.spider_x)?;
+        if self.handshake_timeout.is_zero() {
+            return Err(RealityClientError::Configuration(
+                "handshake timeout is zero".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealitySpiderPolicy {
+    pub path: String,
+    pub padding: (i64, i64),
+    pub concurrency: (i64, i64),
+    pub times: (i64, i64),
+    pub interval_ms: (i64, i64),
+    pub return_ms: (i64, i64),
+}
+
+/// Parse Xray's `spiderX` query controls (`p/c/t/i/r`). The controls are kept
+/// separate from the normalized cover path just like Xray's `SpiderX/SpiderY`.
+pub fn parse_spider_x(value: &str) -> Result<RealitySpiderPolicy, RealityClientError> {
+    if !value.starts_with('/') {
+        return Err(RealityClientError::Configuration(
+            "spiderX must start with '/'".into(),
+        ));
+    }
+    let mut url = url::Url::parse(&format!("https://reality.invalid{value}"))
+        .map_err(|error| RealityClientError::Configuration(format!("invalid spiderX: {error}")))?;
+    let mut query: Vec<(String, String)> = url
+        .query_pairs()
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    let take_range = |name: &str| -> (i64, i64) {
+        let value = query
+            .iter()
+            .filter(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+            .next()
+            .unwrap_or_default();
+        if value.is_empty() {
+            return (0, 0);
+        }
+        let values = value.split('-').collect::<Vec<_>>();
+        let minimum = values[0].parse::<i64>().unwrap_or(0);
+        let maximum = if values.len() == 1 {
+            minimum
+        } else {
+            values[1].parse::<i64>().unwrap_or(0)
+        };
+        (minimum, maximum)
+    };
+    let padding = take_range("p");
+    let concurrency = take_range("c");
+    let times = take_range("t");
+    let interval_ms = take_range("i");
+    let return_ms = take_range("r");
+    query.retain(|(key, _)| !matches!(key.as_str(), "p" | "c" | "t" | "i" | "r"));
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.clear();
+        for (key, value) in query {
+            pairs.append_pair(&key, &value);
+        }
+    }
+    let mut path = url.path().to_owned();
+    if let Some(query) = url.query()
+        && !query.is_empty()
+    {
+        path.push('?');
+        path.push_str(query);
+    }
+    let policy = RealitySpiderPolicy {
+        path,
+        padding,
+        concurrency,
+        times,
+        interval_ms,
+        return_ms,
+    };
+    policy.validate_bounds()?;
+    Ok(policy)
+}
+
+impl RealitySpiderPolicy {
+    fn validate_bounds(&self) -> Result<(), RealityClientError> {
+        for (name, range, maximum) in [
+            ("p", self.padding, SPIDER_MAX_PADDING_BYTES),
+            ("c", self.concurrency, SPIDER_MAX_CONCURRENCY),
+            ("t", self.times, SPIDER_MAX_TIMES),
+            ("i", self.interval_ms, SPIDER_MAX_DELAY_MS),
+            ("r", self.return_ms, SPIDER_MAX_DELAY_MS),
+        ] {
+            if range.0 < 0 || range.1 < 0 || range.0 > maximum || range.1 > maximum {
+                return Err(RealityClientError::Configuration(format!(
+                    "spiderX query `{name}` must stay within 0..={maximum}"
+                )));
+            }
+        }
+        if self.path.len() > SPIDER_MAX_PATH_BYTES {
+            return Err(RealityClientError::Configuration(format!(
+                "spiderX path exceeds {SPIDER_MAX_PATH_BYTES} bytes"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RealityClientError {
+    #[error("REALITY client configuration error: {0}")]
+    Configuration(String),
+    #[error("REALITY client handshake timed out")]
+    HandshakeTimeout,
+    #[error("REALITY client handshake failed: {0}")]
+    Handshake(String),
+    #[error("REALITY received a real certificate and started the spiderX cover flow")]
+    InvalidConnectionProcessed,
+}
+
+/// An optional owner token whose lifetime must match the authenticated carrier
+/// or the same-socket spiderX cover flow. The outbound layer uses this to keep
+/// its loop-prevention registration alive after the handshake returns.
+pub type RealityConnectionLifetime = Arc<dyn Send + Sync + 'static>;
+
+#[derive(Clone)]
+pub struct RealityClient {
+    config: Arc<RealityClientConfig>,
+    provider: RustlsRealityTlsSessionProvider,
+    spider_paths: Arc<Mutex<HashSet<String>>>,
+}
+
+impl fmt::Debug for RealityClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityClient")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl RealityClient {
+    pub fn new(config: RealityClientConfig) -> Result<Self, RealityClientError> {
+        config.validate()?;
+        Ok(Self {
+            config: Arc::new(config),
+            provider: RustlsRealityTlsSessionProvider::new(),
+            spider_paths: Arc::new(Mutex::new(HashSet::new())),
+        })
+    }
+
+    pub fn config(&self) -> &RealityClientConfig {
+        &self.config
+    }
+
+    /// Complete a REALITY handshake over an already connected, policy-aware
+    /// TCP socket. The returned stream is the authenticated TLS application
+    /// stream on the original connection, matching Xray's `uConn` behavior.
+    pub async fn connect(
+        &self,
+        stream: TcpStream,
+    ) -> Result<RealityClientStream, RealityClientError> {
+        self.connect_with_lifetime(stream, None).await
+    }
+
+    pub async fn connect_with_lifetime(
+        &self,
+        stream: TcpStream,
+        lifetime: Option<RealityConnectionLifetime>,
+    ) -> Result<RealityClientStream, RealityClientError> {
+        let normalized_fingerprint =
+            xray_utls::normalize_reality_supported_fingerprint(&self.config.fingerprint)
+                .expect("configuration was validated");
+        let xray_config = XrayRealityClientConfig {
+            server_name: self.config.server_name.clone(),
+            fingerprint: normalized_fingerprint.to_owned(),
+            public_key: self.config.public_key,
+            short_id: self.config.short_id.clone(),
+            spider_x: self.config.spider_x.clone(),
+            mldsa65_verify: self.config.mldsa65_verify.clone(),
+        };
+        let connector = RealityConnector::new(xray_config.clone());
+        let session = self
+            .provider
+            .create_session(RealityClientHelloRequest {
+                server_name: &xray_config.server_name,
+                fingerprint: &xray_config.fingerprint,
+            })
+            .map_err(|error| RealityClientError::Handshake(error.to_string()))?;
+        let prepared_client_hello = session
+            .prepared_client_hello()
+            .map_err(|error| RealityClientError::Handshake(error.to_string()))?;
+        let unix_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_secs().min(u32::MAX as u64) as u32);
+        let prepared = connector
+            .prepare_handshake_with_client_hello(
+                prepared_client_hello,
+                RealityHandshakeContext {
+                    version: self.config.wire_version,
+                    unix_time,
+                },
+            )
+            .map_err(|error| RealityClientError::Handshake(error.to_string()))?;
+        let complete =
+            session.complete_with_outcome(stream, prepared, xray_config.mldsa65_verify.clone());
+        let completion = tokio::time::timeout(self.config.handshake_timeout, complete)
+            .await
+            .map_err(|_| RealityClientError::HandshakeTimeout)?;
+        match completion {
+            Ok(RealityTlsSessionOutcome::Verified(inner)) => Ok(RealityClientStream {
+                inner,
+                _lifetime: lifetime,
+            }),
+            Ok(RealityTlsSessionOutcome::NotReality(inner)) => {
+                let policy =
+                    parse_spider_x(&self.config.spider_x).expect("configuration validated spiderX");
+                let server_name = self.config.server_name.clone();
+                let paths = self.spider_paths.clone();
+                let crawler_policy = policy.clone();
+                tokio::spawn(async move {
+                    if let Err(error) =
+                        crawl_cover_site(inner, &server_name, crawler_policy, paths, lifetime).await
+                    {
+                        tracing::debug!(
+                            target: "reality::spider",
+                            %error,
+                            "REALITY spiderX cover flow ended"
+                        );
+                    }
+                });
+                let return_delay = sample_xray_range(policy.return_ms);
+                if return_delay != 0 {
+                    tokio::time::sleep(Duration::from_millis(return_delay)).await;
+                }
+                Err(RealityClientError::InvalidConnectionProcessed)
+            }
+            Err(error) => Err(RealityClientError::Handshake(error.to_string())),
+        }
+    }
+}
+
+fn sample_xray_range(range: (i64, i64)) -> u64 {
+    let (minimum, maximum) = if range.0 <= range.1 {
+        range
+    } else {
+        (range.1, range.0)
+    };
+    let sampled = if minimum == maximum {
+        minimum
+    } else {
+        rand::random_range(minimum..maximum)
+    };
+    u64::try_from(sampled).expect("validated spider range is non-negative")
+}
+
+async fn crawl_cover_site(
+    tls_stream: BoxedTransportStream,
+    server_name: &str,
+    policy: RealitySpiderPolicy,
+    paths: Arc<Mutex<HashSet<String>>>,
+    lifetime: Option<RealityConnectionLifetime>,
+) -> io::Result<()> {
+    let (sender, connection) = http2::Builder::new(TokioExecutor::new())
+        .handshake::<_, Empty<Bytes>>(TokioIo::new(tls_stream))
+        .await
+        .map_err(|error| io::Error::other(format!("spiderX HTTP/2 handshake: {error}")))?;
+    let keepalive_sender = sender.clone();
+    tokio::spawn(async move {
+        // Xray deliberately does not close a non-REALITY connection after its
+        // cover requests. Retain the HTTP/2 sender and outbound owner token for
+        // a bounded interval so malformed peers cannot leak resources forever.
+        let _keepalive_sender = keepalive_sender;
+        let _lifetime = lifetime;
+        match tokio::time::timeout(SPIDER_CONNECTION_RETENTION, connection).await {
+            Ok(Err(error)) => {
+                tracing::debug!(
+                    target: "reality::spider",
+                    %error,
+                    "spiderX HTTP/2 connection closed"
+                );
+            }
+            Ok(Ok(())) | Err(_) => {}
+        }
+    });
+
+    {
+        let mut known = paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        known.insert(policy.path.clone());
+    }
+    let first_path = policy.path.clone();
+    spider_request_series(
+        sender.clone(),
+        server_name.to_owned(),
+        first_path.clone(),
+        first_path.clone(),
+        true,
+        policy.clone(),
+        paths.clone(),
+    )
+    .await?;
+
+    let concurrency = sample_xray_range(policy.concurrency) as usize;
+    for _ in 0..concurrency {
+        let sender = sender.clone();
+        let server_name = server_name.to_owned();
+        let policy = policy.clone();
+        let paths = paths.clone();
+        let first_path = first_path.clone();
+        let start_path = choose_spider_path(&paths);
+        tokio::spawn(async move {
+            if let Err(error) = spider_request_series(
+                sender,
+                server_name,
+                first_path,
+                start_path,
+                false,
+                policy,
+                paths,
+            )
+            .await
+            {
+                tracing::debug!(
+                    target: "reality::spider",
+                    %error,
+                    "spiderX worker ended"
+                );
+            }
+        });
+    }
+    Ok(())
+}
+
+async fn spider_request_series(
+    mut sender: http2::SendRequest<Empty<Bytes>>,
+    server_name: String,
+    first_path: String,
+    mut path: String,
+    first: bool,
+    policy: RealitySpiderPolicy,
+    paths: Arc<Mutex<HashSet<String>>>,
+) -> io::Result<()> {
+    let times = if first {
+        1
+    } else {
+        sample_xray_range(policy.times) as usize
+    };
+    let mut referer = (!first).then(|| absolute_spider_uri(&server_name, &first_path));
+    for _ in 0..times {
+        let padding = sample_xray_range(policy.padding) as usize;
+        let current_uri = absolute_spider_uri(&server_name, &path);
+        let request = spider_request(&current_uri, referer.as_deref(), padding)?;
+        sender
+            .ready()
+            .await
+            .map_err(|error| io::Error::other(format!("spiderX HTTP/2 sender: {error}")))?;
+        let (response_path, body) =
+            send_spider_request_with_redirects(&mut sender, request, &server_name, path.clone())
+                .await?;
+        discover_spider_paths(&server_name, &body, &paths);
+        referer = Some(absolute_spider_uri(&server_name, &response_path));
+        path = choose_spider_path(&paths);
+        if !first {
+            let interval = sample_xray_range(policy.interval_ms);
+            if interval != 0 {
+                tokio::time::sleep(Duration::from_millis(interval)).await;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn spider_request(
+    uri: &str,
+    referer: Option<&str>,
+    padding: usize,
+) -> io::Result<Request<Empty<Bytes>>> {
+    let mut builder = Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header(
+            USER_AGENT,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
+        )
+        .header(ACCEPT_LANGUAGE, "en-US,en;q=0.9")
+        .header(CACHE_CONTROL, "max-age=0")
+        .header("upgrade-insecure-requests", "1")
+        .header(
+            ACCEPT,
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/jxl,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+        )
+        .header("sec-fetch-site", "none")
+        .header("sec-fetch-mode", "navigate")
+        .header("sec-fetch-user", "?1")
+        .header("sec-fetch-dest", "document")
+        .header("priority", "u=0, i")
+        .header("dnt", "1")
+        .header(COOKIE, format!("padding={}", "0".repeat(padding)));
+    if let Some(referer) = referer {
+        builder = builder.header(REFERER, referer);
+    }
+    builder
+        .body(Empty::new())
+        .map_err(|error| invalid_input(format!("invalid spiderX request: {error}")))
+}
+
+async fn send_spider_request_with_redirects(
+    sender: &mut http2::SendRequest<Empty<Bytes>>,
+    mut request: Request<Empty<Bytes>>,
+    server_name: &str,
+    mut current_path: String,
+) -> io::Result<(String, Vec<u8>)> {
+    for redirects in 0..=SPIDER_MAX_REDIRECTS {
+        let response = sender
+            .send_request(request)
+            .await
+            .map_err(|error| io::Error::other(format!("spiderX request: {error}")))?;
+        let status = response.status();
+        let location = response
+            .headers()
+            .get(LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        let body = read_spider_body(response.into_body()).await?;
+        if !is_redirect_status(status) {
+            return Ok((current_path, body));
+        }
+        if redirects == SPIDER_MAX_REDIRECTS {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "spiderX redirect limit exceeded",
+            ));
+        }
+        let location = location
+            .ok_or_else(|| invalid_data("spiderX redirect response has no Location header"))?;
+        current_path = same_origin_spider_path(server_name, &current_path, &location)?;
+        request = spider_request(&absolute_spider_uri(server_name, &current_path), None, 0)?;
+    }
+    unreachable!("redirect loop returns within configured bound")
+}
+
+async fn read_spider_body(mut body: hyper::body::Incoming) -> io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    while let Some(frame) = body.frame().await {
+        let frame = frame.map_err(|error| io::Error::other(format!("spiderX body: {error}")))?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        if output.len().saturating_add(data.len()) > SPIDER_MAX_BODY_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("spiderX response exceeds {SPIDER_MAX_BODY_BYTES} bytes"),
+            ));
+        }
+        output.extend_from_slice(&data);
+    }
+    Ok(output)
+}
+
+fn discover_spider_paths(server_name: &str, body: &[u8], paths: &Arc<Mutex<HashSet<String>>>) {
+    let expression = Regex::new(r#"href="([/h].*?)""#).expect("static spiderX href regex");
+    let prefix = format!("https://{server_name}");
+    let mut paths = paths
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if paths.len() >= SPIDER_MAX_PATHS {
+        return;
+    }
+    for capture in expression.captures_iter(body) {
+        let Some(captured) = capture.get(1) else {
+            continue;
+        };
+        let Ok(captured) = std::str::from_utf8(captured.as_bytes()) else {
+            continue;
+        };
+        let candidate = captured.strip_prefix(&prefix).unwrap_or(captured);
+        if !candidate.starts_with('/')
+            || candidate.contains('.')
+            || candidate.len() > SPIDER_MAX_PATH_BYTES
+        {
+            continue;
+        }
+        paths.insert(candidate.to_owned());
+        if paths.len() >= SPIDER_MAX_PATHS {
+            break;
+        }
+    }
+}
+
+fn choose_spider_path(paths: &Arc<Mutex<HashSet<String>>>) -> String {
+    let paths = paths
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if paths.is_empty() {
+        return "/".to_owned();
+    }
+    let index = if paths.len() == 1 {
+        0
+    } else {
+        rand::random_range(0..paths.len())
+    };
+    paths
+        .iter()
+        .nth(index)
+        .cloned()
+        .unwrap_or_else(|| "/".to_owned())
+}
+
+fn absolute_spider_uri(server_name: &str, path: &str) -> String {
+    format!("https://{server_name}{path}")
+}
+
+fn same_origin_spider_path(
+    server_name: &str,
+    current_path: &str,
+    location: &str,
+) -> io::Result<String> {
+    let base = url::Url::parse(&absolute_spider_uri(server_name, current_path))
+        .map_err(|error| invalid_data(format!("invalid spiderX redirect base: {error}")))?;
+    let redirect = base
+        .join(location)
+        .map_err(|error| invalid_data(format!("invalid spiderX redirect: {error}")))?;
+    if redirect.scheme() != "https"
+        || redirect.host_str() != Some(server_name)
+        || !matches!(redirect.port(), None | Some(443))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "spiderX refused a cross-origin redirect",
+        ));
+    }
+    let mut path = redirect.path().to_owned();
+    if let Some(query) = redirect.query() {
+        path.push('?');
+        path.push_str(query);
+    }
+    if path.len() > SPIDER_MAX_PATH_BYTES {
+        return Err(invalid_data("spiderX redirect path is too long"));
+    }
+    Ok(path)
+}
+
+fn is_redirect_status(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::MOVED_PERMANENTLY
+            | StatusCode::FOUND
+            | StatusCode::SEE_OTHER
+            | StatusCode::TEMPORARY_REDIRECT
+            | StatusCode::PERMANENT_REDIRECT
+    )
+}
+
+/// Authenticated REALITY application stream. Like Xray's `uConn`, inner
+/// VLESS/XHTTP bytes remain TLS application data after the REALITY-specific
+/// certificate binding succeeds.
+pub struct RealityClientStream {
+    inner: BoxedTransportStream,
+    _lifetime: Option<RealityConnectionLifetime>,
+}
+
+impl fmt::Debug for RealityClientStream {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityClientStream")
+            .finish_non_exhaustive()
+    }
+}
+
+impl AsyncRead for RealityClientStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_read(cx, buffer)
+    }
+}
+
+impl AsyncWrite for RealityClientStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut *self.inner).poll_write(cx, buffer)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spider_x_controls_are_removed_from_cover_path() {
+        let policy = parse_spider_x("/news?a=b&p=10-20&c=2&t=3&i=40&r=5").unwrap();
+        assert_eq!(policy.path, "/news?a=b");
+        assert_eq!(policy.padding, (10, 20));
+        assert_eq!(policy.concurrency, (2, 2));
+        assert_eq!(policy.times, (3, 3));
+        assert_eq!(policy.interval_ms, (40, 40));
+        assert_eq!(policy.return_ms, (5, 5));
+    }
+
+    #[test]
+    fn spider_x_parser_matches_xray_first_value_and_parse_zero_behavior() {
+        let policy = parse_spider_x("/x?p=bad&p=4&c=8-2&t=3-9-extra").unwrap();
+        assert_eq!(policy.path, "/x");
+        assert_eq!(policy.padding, (0, 0));
+        assert_eq!(policy.concurrency, (8, 2));
+        assert_eq!(policy.times, (3, 9));
+        for _ in 0..32 {
+            let value = sample_xray_range(policy.concurrency);
+            assert!((2..8).contains(&value));
+        }
+    }
+
+    #[test]
+    fn spider_x_resource_bounds_fail_at_configuration_time() {
+        for value in ["/?p=4097", "/?c=17", "/?t=17", "/?i=60001", "/?r=60001"] {
+            assert!(parse_spider_x(value).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn spider_discovers_only_bounded_same_origin_extensionless_paths() {
+        let paths = Arc::new(Mutex::new(HashSet::new()));
+        discover_spider_paths(
+            "example.com",
+            br#"<a href="/news">ok</a><a href="https://example.com/docs">ok</a><a href="/app.js">no</a><a href="https://evil.test/x">no</a>"#,
+            &paths,
+        );
+        let paths = paths.lock().unwrap();
+        assert!(paths.contains("/news"));
+        assert!(paths.contains("/docs"));
+        assert!(!paths.contains("/app.js"));
+        assert!(!paths.iter().any(|path| path.contains("evil")));
+    }
+
+    #[test]
+    fn spider_redirects_are_same_origin_and_https_only() {
+        assert_eq!(
+            same_origin_spider_path("example.com", "/a/start", "../next?q=1").unwrap(),
+            "/next?q=1"
+        );
+        assert!(same_origin_spider_path("example.com", "/", "https://evil.test/").is_err());
+        assert!(same_origin_spider_path("example.com", "/", "http://example.com/").is_err());
+    }
+
+    #[test]
+    fn config_rejects_known_non_reality_fingerprint() {
+        let mut config = RealityClientConfig::default();
+        config.server_name = "example.com".into();
+        config.fingerprint = "android".into();
+        config.public_key = [1; 32];
+        assert!(matches!(
+            config.validate(),
+            Err(RealityClientError::Configuration(_))
+        ));
+    }
+
+    #[test]
+    fn config_debug_redacts_key_material() {
+        let mut config = RealityClientConfig::default();
+        config.server_name = "example.com".into();
+        config.public_key = [7; 32];
+        config.short_id = vec![1, 2, 3];
+        let debug = format!("{config:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("[7, 7, 7"));
+    }
+}

--- a/crates/core-reality/src/donor/common.rs
+++ b/crates/core-reality/src/donor/common.rs
@@ -1,0 +1,244 @@
+// TLS constants and utilities for REALITY client/server implementations
+
+use std::io::{self, Error, ErrorKind};
+
+// TLS ContentType values
+pub const CONTENT_TYPE_CHANGE_CIPHER_SPEC: u8 = 0x14;
+pub const CONTENT_TYPE_ALERT: u8 = 0x15;
+pub const CONTENT_TYPE_HANDSHAKE: u8 = 0x16;
+pub const CONTENT_TYPE_APPLICATION_DATA: u8 = 0x17;
+
+// TLS alert levels and descriptions
+pub const ALERT_LEVEL_WARNING: u8 = 0x01;
+pub const ALERT_DESC_CLOSE_NOTIFY: u8 = 0x00;
+
+// TLS 1.2 version bytes (0x03, 0x03) used in TLS 1.3 record layer for compatibility
+pub const VERSION_TLS_1_2_MAJOR: u8 = 0x03;
+pub const VERSION_TLS_1_2_MINOR: u8 = 0x03;
+
+// TLS 1.3 handshake message types
+pub const HANDSHAKE_TYPE_SERVER_HELLO: u8 = 2;
+pub const HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS: u8 = 8;
+pub const HANDSHAKE_TYPE_CERTIFICATE: u8 = 11;
+pub const HANDSHAKE_TYPE_CERTIFICATE_VERIFY: u8 = 15;
+pub const HANDSHAKE_TYPE_FINISHED: u8 = 20;
+
+// TLS 1.3 record size limits per RFC 8446
+//
+// The TLS record header's `length` field specifies the size of the ENCRYPTED payload.
+// Per RFC 8446, the TLS 1.3 limit is stricter than TLS 1.2:
+//
+// - TLS 1.3: Plaintext limit = 16,384 bytes (2^14)
+//   Encryption overhead allowance = 256 bytes
+//   Ciphertext limit = 16,384 + 256 = 16,640 bytes
+//
+// - TLS 1.2: Plaintext limit = 16,384 bytes (2^14)
+//   Encryption overhead allowance = 2,048 bytes
+//   Ciphertext limit = 16,384 + 2,048 = 18,432 bytes
+//
+// REALITY uses TLS 1.3, so we MUST use the TLS 1.3 limit. Using the larger
+// TLS 1.2 limit causes "record overflow" errors in libraries like utls.
+
+/// Maximum TLS 1.3 ciphertext payload size (16,640 bytes)
+pub const MAX_TLS_CIPHERTEXT_LEN: usize = 16384 + 256;
+
+/// Maximum plaintext payload size for a single TLS 1.3 record
+///
+/// RFC 8446 Section 5.1: "The record layer fragments information blocks into
+/// TLSPlaintext records carrying data in chunks of 2^14 bytes or less."
+///
+/// This is the hard limit enforced by TLS implementations.
+/// The 256-byte allowance in MAX_TLS_CIPHERTEXT_LEN is for:
+/// - AEAD tag (16 bytes for AES-GCM)
+/// - Content type byte (1 byte)
+/// - Optional padding (up to 239 bytes)
+///
+/// We MUST NOT exceed 16384 bytes of actual plaintext per record, or clients
+/// will reject with "record overflow" error.
+pub const MAX_TLS_PLAINTEXT_LEN: usize = 16384;
+
+/// TLS record header size (ContentType + ProtocolVersion + Length)
+pub const TLS_RECORD_HEADER_SIZE: usize = 5;
+
+/// Maximum TLS record size (ciphertext + header)
+pub const TLS_MAX_RECORD_SIZE: usize = MAX_TLS_CIPHERTEXT_LEN + TLS_RECORD_HEADER_SIZE;
+
+/// Buffer capacity for ciphertext read (2x TLS max record for safety)
+pub const CIPHERTEXT_READ_BUF_CAPACITY: usize = TLS_MAX_RECORD_SIZE * 2;
+
+/// Buffer capacity for plaintext read
+pub const PLAINTEXT_READ_BUF_CAPACITY: usize = TLS_MAX_RECORD_SIZE * 2;
+
+/// Buffer capacity for outgoing data (matches rustls DEFAULT_BUFFER_LIMIT)
+///
+/// This controls the size of both the plaintext write buffer (pre-encryption)
+/// and ciphertext write buffer (post-encryption). rustls uses 64KB for both.
+pub const OUTGOING_BUFFER_LIMIT: usize = 64 * 1024;
+
+/// Strip TLS 1.3 content type trailer from decrypted plaintext slice.
+///
+/// TLS 1.3 format: content || type_byte
+/// Returns (content_type, valid_content_length) without modifying the slice.
+///
+/// This is the zero-allocation version for use with in-place decryption.
+/// NOTE: Does NOT strip padding zeros - our implementation doesn't add padding.
+#[inline]
+pub fn strip_content_type_slice(plaintext: &[u8]) -> io::Result<(u8, usize)> {
+    if plaintext.is_empty() {
+        return Err(Error::new(ErrorKind::InvalidData, "Empty plaintext"));
+    }
+
+    // No padding in our implementation
+    let content_type = plaintext[plaintext.len() - 1];
+
+    if content_type != CONTENT_TYPE_HANDSHAKE
+        && content_type != CONTENT_TYPE_APPLICATION_DATA
+        && content_type != CONTENT_TYPE_ALERT
+    {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("Invalid content type: 0x{:02x}", content_type),
+        ));
+    }
+
+    Ok((content_type, plaintext.len() - 1))
+}
+
+/// Strip TLS 1.3 content type trailer from decrypted plaintext.
+///
+/// TLS 1.3 format: content || type_byte
+/// Returns the actual content type and modifies plaintext to contain only content.
+///
+/// NOTE: This function does NOT strip padding zeros. Our REALITY implementation
+/// does not add padding, so stripping zeros could corrupt data that legitimately
+/// ends with zero bytes. Use `strip_content_type_with_padding` for messages from
+/// external implementations that may use padding.
+///
+/// Only used by tests - the hot path uses `strip_content_type_slice` for zero-allocation.
+#[cfg(test)]
+pub fn strip_content_type(plaintext: &mut Vec<u8>) -> io::Result<u8> {
+    let (content_type, valid_len) = strip_content_type_slice(plaintext)?;
+    plaintext.truncate(valid_len);
+    Ok(content_type)
+}
+
+/// Strip TLS 1.3 content type trailer and padding from decrypted plaintext.
+///
+/// TLS 1.3 format: content || type_byte || padding_zeros
+/// Returns the actual content type and modifies plaintext to contain only content.
+///
+/// Use this for messages from external TLS implementations (e.g., sing-box) that
+/// may add optional padding per RFC 8446 Section 5.4.
+pub fn strip_content_type_with_padding(plaintext: &mut Vec<u8>) -> io::Result<u8> {
+    if plaintext.is_empty() {
+        return Err(Error::new(ErrorKind::InvalidData, "Empty plaintext"));
+    }
+
+    // Remove trailing zeros (padding) per RFC 8446 Section 5.4
+    while !plaintext.is_empty() && *plaintext.last().unwrap() == 0 {
+        plaintext.pop();
+    }
+
+    if plaintext.is_empty() {
+        return Err(Error::new(ErrorKind::InvalidData, "Plaintext is all zeros"));
+    }
+
+    let content_type = plaintext.pop().unwrap();
+
+    if content_type != CONTENT_TYPE_HANDSHAKE
+        && content_type != CONTENT_TYPE_APPLICATION_DATA
+        && content_type != CONTENT_TYPE_ALERT
+    {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("Invalid content type: 0x{:02x}", content_type),
+        ));
+    }
+
+    Ok(content_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_content_type_app_data() {
+        let mut plaintext = vec![0x01, 0x02, 0x03, CONTENT_TYPE_APPLICATION_DATA];
+        let ct = strip_content_type(&mut plaintext).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(plaintext, vec![0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn test_strip_content_type_handshake() {
+        let mut plaintext = vec![0xAA, 0xBB, CONTENT_TYPE_HANDSHAKE];
+        let ct = strip_content_type(&mut plaintext).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_HANDSHAKE);
+        assert_eq!(plaintext, vec![0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn test_strip_content_type_alert() {
+        let mut plaintext = vec![0x01, 0x00, CONTENT_TYPE_ALERT];
+        let ct = strip_content_type(&mut plaintext).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_ALERT);
+        assert_eq!(plaintext, vec![0x01, 0x00]);
+    }
+
+    #[test]
+    fn test_strip_content_type_preserves_zeros() {
+        // Trailing zeros in data should be preserved (not treated as padding)
+        let mut plaintext = vec![0x01, 0x00, 0x00, CONTENT_TYPE_APPLICATION_DATA];
+        let ct = strip_content_type(&mut plaintext).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(plaintext, vec![0x01, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn test_strip_content_type_empty() {
+        let mut plaintext = Vec::new();
+        assert!(strip_content_type(&mut plaintext).is_err());
+    }
+
+    #[test]
+    fn test_strip_content_type_invalid() {
+        let mut plaintext = vec![0x01, 0xFF]; // 0xFF is invalid
+        assert!(strip_content_type(&mut plaintext).is_err());
+    }
+
+    #[test]
+    fn test_strip_with_padding_no_padding() {
+        let mut plaintext = vec![0x01, 0x02, CONTENT_TYPE_APPLICATION_DATA];
+        let ct = strip_content_type_with_padding(&mut plaintext).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(plaintext, vec![0x01, 0x02]);
+    }
+
+    #[test]
+    fn test_strip_with_padding_strips_zeros() {
+        // TLS 1.3 format: content || type || padding
+        let mut plaintext = vec![0x01, 0x02, CONTENT_TYPE_HANDSHAKE, 0x00, 0x00, 0x00];
+        let ct = strip_content_type_with_padding(&mut plaintext).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_HANDSHAKE);
+        assert_eq!(plaintext, vec![0x01, 0x02]);
+    }
+
+    #[test]
+    fn test_strip_with_padding_empty() {
+        let mut plaintext = Vec::new();
+        assert!(strip_content_type_with_padding(&mut plaintext).is_err());
+    }
+
+    #[test]
+    fn test_strip_with_padding_all_zeros() {
+        let mut plaintext = vec![0x00, 0x00, 0x00];
+        assert!(strip_content_type_with_padding(&mut plaintext).is_err());
+    }
+
+    #[test]
+    fn test_strip_with_padding_invalid_type() {
+        let mut plaintext = vec![0x01, 0xFF, 0x00]; // 0xFF with padding
+        assert!(strip_content_type_with_padding(&mut plaintext).is_err());
+    }
+}

--- a/crates/core-reality/src/donor/mod.rs
+++ b/crates/core-reality/src/donor/mod.rs
@@ -1,0 +1,17 @@
+mod common;
+mod reality_aead;
+mod reality_auth;
+mod reality_certificate;
+mod reality_cipher_suite;
+mod reality_io_state;
+mod reality_reader_writer;
+mod reality_records;
+mod reality_server_connection;
+mod reality_tls13_keys;
+mod reality_tls13_messages;
+mod reality_util;
+
+pub(crate) use reality_certificate::mldsa65_verify_from_seed;
+pub use reality_cipher_suite::{CipherSuite, DEFAULT_CIPHER_SUITES};
+pub(crate) use reality_server_connection::{RealityServerConnection, RealityServerCryptoConfig};
+pub(crate) use reality_util::{extract_server_cipher_suite, extract_server_key_share};

--- a/crates/core-reality/src/donor/reality_aead.rs
+++ b/crates/core-reality/src/donor/reality_aead.rs
@@ -1,0 +1,438 @@
+// TLS 1.3 AEAD encryption/decryption using aws-lc-rs.
+// Record framing is handled by reality_records.rs.
+
+use aws_lc_rs::aead::{Aad, LessSafeKey, Nonce, UnboundKey};
+use std::io::{self, Error, ErrorKind};
+
+use super::common::strip_content_type_with_padding;
+use super::reality_cipher_suite::CipherSuite;
+
+/// AEAD key for TLS 1.3 encryption/decryption.
+///
+/// Wraps aws-lc-rs LessSafeKey and provides a cleaner API.
+/// Create once per connection direction and reuse for all records.
+pub struct AeadKey(LessSafeKey);
+
+impl AeadKey {
+    /// Create a new AEAD key from raw key bytes.
+    pub fn new(cipher_suite: CipherSuite, key: &[u8]) -> io::Result<Self> {
+        let algorithm = cipher_suite.algorithm();
+        let expected_len = cipher_suite.key_len();
+
+        if key.len() != expected_len {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!(
+                    "Invalid key length for {:?}: {} (expected {})",
+                    cipher_suite,
+                    key.len(),
+                    expected_len
+                ),
+            ));
+        }
+
+        let unbound = UnboundKey::new(algorithm, key)
+            .map_err(|e| Error::new(ErrorKind::InvalidInput, format!("Invalid key: {:?}", e)))?;
+
+        Ok(Self(LessSafeKey::new(unbound)))
+    }
+
+    /// Encrypt in-place, appending 16-byte auth tag.
+    ///
+    /// The buffer is modified: plaintext -> ciphertext || tag
+    #[inline]
+    pub fn seal_in_place(
+        &self,
+        buf: &mut Vec<u8>,
+        iv: &[u8],
+        seq: u64,
+        aad: &[u8],
+    ) -> io::Result<()> {
+        let nonce = Self::make_nonce(iv, seq)?;
+        self.0
+            .seal_in_place_append_tag(nonce, Aad::from(aad), buf)
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Encryption failed: {:?}", e),
+                )
+            })
+    }
+
+    /// Encrypt with copy, returning new Vec containing ciphertext || tag.
+    ///
+    /// Use this for small buffers where allocation overhead doesn't matter.
+    #[inline]
+    #[cfg_attr(not(test), allow(dead_code))] // Used by test helpers
+    pub fn seal(&self, plaintext: &[u8], iv: &[u8], seq: u64, aad: &[u8]) -> io::Result<Vec<u8>> {
+        let mut buf = plaintext.to_vec();
+        self.seal_in_place(&mut buf, iv, seq, aad)?;
+        Ok(buf)
+    }
+
+    /// Decrypt in-place on a mutable slice, returning the plaintext portion.
+    ///
+    /// This is the zero-allocation decryption API. The slice is decrypted in-place
+    /// and a sub-slice containing only the plaintext (without the auth tag) is returned.
+    ///
+    /// # Arguments
+    /// * `buf` - Mutable slice containing ciphertext + auth tag
+    /// * `iv` - 12-byte IV/nonce base
+    /// * `seq` - Sequence number to XOR with IV
+    /// * `aad` - Additional authenticated data
+    ///
+    /// # Returns
+    /// Sub-slice of `buf` containing only the decrypted plaintext
+    #[inline]
+    pub fn open_in_place_slice<'a>(
+        &self,
+        buf: &'a mut [u8],
+        iv: &[u8],
+        seq: u64,
+        aad: &[u8],
+    ) -> io::Result<&'a mut [u8]> {
+        let nonce = Self::make_nonce(iv, seq)?;
+        self.0
+            .open_in_place(nonce, Aad::from(aad), buf)
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Decryption failed: {:?}", e),
+                )
+            })
+    }
+
+    /// Decrypt with copy, returning new Vec containing plaintext.
+    ///
+    /// Used for handshake decryption and tests where allocation is acceptable.
+    #[inline]
+    pub fn open(&self, ciphertext: &[u8], iv: &[u8], seq: u64, aad: &[u8]) -> io::Result<Vec<u8>> {
+        let mut buf = ciphertext.to_vec();
+        let plaintext = self.open_in_place_slice(&mut buf, iv, seq, aad)?;
+        let plaintext_len = plaintext.len();
+        buf.truncate(plaintext_len);
+        Ok(buf)
+    }
+
+    /// Construct TLS 1.3 nonce: IV XOR sequence_number
+    fn make_nonce(iv: &[u8], seq: u64) -> io::Result<Nonce> {
+        if iv.len() != 12 {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("Invalid IV length: {} (expected 12)", iv.len()),
+            ));
+        }
+
+        let mut nonce_bytes = [0u8; 12];
+        nonce_bytes.copy_from_slice(iv);
+
+        // XOR last 8 bytes with sequence number (big-endian)
+        let seq_bytes = seq.to_be_bytes();
+        for i in 0..8 {
+            nonce_bytes[4 + i] ^= seq_bytes[i];
+        }
+
+        Nonce::try_assume_unique_for_key(&nonce_bytes)
+            .map_err(|e| Error::new(ErrorKind::InvalidInput, format!("Invalid nonce: {:?}", e)))
+    }
+}
+
+/// Decrypt a TLS 1.3 handshake message.
+///
+/// Builds the AAD from the record length and decrypts.
+/// Returns plaintext with content type trailer stripped.
+pub fn decrypt_handshake_message(
+    cipher_suite: CipherSuite,
+    key: &[u8],
+    iv: &[u8],
+    seq: u64,
+    ciphertext: &[u8],
+    record_len: u16,
+) -> io::Result<Vec<u8>> {
+    // Build AAD: TLS record header
+    let aad = [
+        0x17, // ApplicationData
+        0x03,
+        0x03, // TLS 1.2 version
+        (record_len >> 8) as u8,
+        (record_len & 0xff) as u8,
+    ];
+
+    let aead_key = AeadKey::new(cipher_suite, key)?;
+    let mut plaintext = aead_key.open(ciphertext, iv, seq, &aad)?;
+
+    // Strip content type and optional padding (external implementations may pad)
+    let _ = strip_content_type_with_padding(&mut plaintext)?;
+
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+pub(crate) fn encrypt_tls13_record(
+    cipher_suite: CipherSuite,
+    key: &[u8],
+    iv: &[u8],
+    seq: u64,
+    plaintext: &[u8],
+    aad: &[u8],
+) -> io::Result<Vec<u8>> {
+    AeadKey::new(cipher_suite, key)?.seal(plaintext, iv, seq, aad)
+}
+
+#[cfg(test)]
+pub(crate) fn decrypt_tls13_record(
+    cipher_suite: CipherSuite,
+    key: &[u8],
+    iv: &[u8],
+    seq: u64,
+    ciphertext: &[u8],
+    aad: &[u8],
+) -> io::Result<Vec<u8>> {
+    AeadKey::new(cipher_suite, key)?.open(ciphertext, iv, seq, aad)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CS: CipherSuite = CipherSuite::AES_128_GCM_SHA256;
+
+    #[test]
+    fn test_encrypt_decrypt_record() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"Hello, TLS 1.3!";
+        let aad = b"additional data";
+
+        let ciphertext = encrypt_tls13_record(CS, &key, &iv, 0, plaintext, aad).unwrap();
+
+        let decrypted = decrypt_tls13_record(CS, &key, &iv, 0, &ciphertext, aad).unwrap();
+
+        assert_eq!(&decrypted[..], plaintext);
+    }
+
+    #[test]
+    fn test_aead_key_seal_open() {
+        let key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let plaintext = b"Test message";
+        let aad = b"aad";
+
+        let ciphertext = key.seal(plaintext, &iv, 0, aad).unwrap();
+        let decrypted = key.open(&ciphertext, &iv, 0, aad).unwrap();
+
+        assert_eq!(&decrypted[..], plaintext);
+    }
+
+    #[test]
+    fn test_aead_key_in_place() {
+        let key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let plaintext = b"Test in-place";
+        let aad = b"aad";
+
+        let mut buf = plaintext.to_vec();
+        key.seal_in_place(&mut buf, &iv, 0, aad).unwrap();
+
+        // buf now contains ciphertext + tag
+        assert_eq!(buf.len(), plaintext.len() + 16);
+
+        let decrypted = key.open_in_place_slice(&mut buf, &iv, 0, aad).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_with_sequence_number() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"Test with sequence";
+        let aad = b"aad";
+
+        // Test that different sequence numbers produce different ciphertexts
+        let cipher1 = encrypt_tls13_record(CS, &key, &iv, 1, plaintext, aad).unwrap();
+        let cipher2 = encrypt_tls13_record(CS, &key, &iv, 2, plaintext, aad).unwrap();
+        let cipher3 = encrypt_tls13_record(CS, &key, &iv, 100, plaintext, aad).unwrap();
+
+        // Ciphertexts should all be different
+        assert_ne!(cipher1, cipher2);
+        assert_ne!(cipher2, cipher3);
+        assert_ne!(cipher1, cipher3);
+
+        // But they should all decrypt correctly
+        let decrypt1 = decrypt_tls13_record(CS, &key, &iv, 1, &cipher1, aad).unwrap();
+        let decrypt2 = decrypt_tls13_record(CS, &key, &iv, 2, &cipher2, aad).unwrap();
+        let decrypt3 = decrypt_tls13_record(CS, &key, &iv, 100, &cipher3, aad).unwrap();
+
+        assert_eq!(decrypt1, plaintext);
+        assert_eq!(decrypt2, plaintext);
+        assert_eq!(decrypt3, plaintext);
+    }
+
+    #[test]
+    fn test_decrypt_with_wrong_sequence_number() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"Test sequence";
+        let aad = b"aad";
+
+        let ciphertext = encrypt_tls13_record(CS, &key, &iv, 5, plaintext, aad).unwrap();
+
+        // Decrypting with wrong sequence number should fail
+        let result = decrypt_tls13_record(CS, &key, &iv, 6, &ciphertext, aad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_with_wrong_aad() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"Test AAD";
+        let aad = b"correct aad";
+        let wrong_aad = b"wrong aad";
+
+        let ciphertext = encrypt_tls13_record(CS, &key, &iv, 0, plaintext, aad).unwrap();
+
+        // Decrypting with wrong AAD should fail
+        let result = decrypt_tls13_record(CS, &key, &iv, 0, &ciphertext, wrong_aad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encrypt_invalid_key_length() {
+        let invalid_key = vec![0x42u8; 15]; // Wrong length (not 16)
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"Test";
+        let aad = b"aad";
+
+        let result = encrypt_tls13_record(CS, &invalid_key, &iv, 0, plaintext, aad);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_encrypt_invalid_iv_length() {
+        let key = vec![0x42u8; 16];
+        let invalid_iv = vec![0x99u8; 11]; // Wrong length (not 12)
+        let plaintext = b"Test";
+        let aad = b"aad";
+
+        let result = encrypt_tls13_record(CS, &key, &invalid_iv, 0, plaintext, aad);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_decrypt_corrupted_ciphertext() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"Test corruption";
+        let aad = b"aad";
+
+        let mut ciphertext = encrypt_tls13_record(CS, &key, &iv, 0, plaintext, aad).unwrap();
+
+        // Corrupt the ciphertext
+        ciphertext[5] ^= 0xFF;
+
+        let result = decrypt_tls13_record(CS, &key, &iv, 0, &ciphertext, aad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encrypt_empty_plaintext() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = b"";
+        let aad = b"aad";
+
+        let ciphertext = encrypt_tls13_record(CS, &key, &iv, 0, plaintext, aad).unwrap();
+
+        // Should still produce a ciphertext with auth tag
+        assert!(ciphertext.len() >= 16); // At least the auth tag
+
+        let decrypted = decrypt_tls13_record(CS, &key, &iv, 0, &ciphertext, aad).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_large_plaintext() {
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let plaintext = vec![0xAB; 16384]; // 16KB
+        let aad = b"aad";
+
+        let ciphertext = encrypt_tls13_record(CS, &key, &iv, 42, &plaintext, aad).unwrap();
+        let decrypted = decrypt_tls13_record(CS, &key, &iv, 42, &ciphertext, aad).unwrap();
+
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_decrypt_handshake_message() {
+        use super::decrypt_handshake_message;
+        use crate::donor::common::CONTENT_TYPE_HANDSHAKE;
+
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let handshake_msg = vec![0xABu8; 100]; // Simulated handshake message
+
+        // Build plaintext: handshake_msg || content_type
+        let mut plaintext_with_type = handshake_msg.clone();
+        plaintext_with_type.push(CONTENT_TYPE_HANDSHAKE);
+
+        // Calculate ciphertext length for AAD
+        let ciphertext_len = (plaintext_with_type.len() + 16) as u16;
+
+        // Build AAD (TLS record header)
+        let aad = [
+            0x17, // ApplicationData
+            0x03,
+            0x03, // TLS 1.2 version
+            (ciphertext_len >> 8) as u8,
+            (ciphertext_len & 0xff) as u8,
+        ];
+
+        // Encrypt
+        let ciphertext =
+            encrypt_tls13_record(CS, &key, &iv, 0, &plaintext_with_type, &aad).unwrap();
+
+        // Decrypt using decrypt_handshake_message
+        let decrypted =
+            decrypt_handshake_message(CS, &key, &iv, 0, &ciphertext, ciphertext_len).unwrap();
+
+        assert_eq!(decrypted, handshake_msg);
+    }
+
+    #[test]
+    fn test_decrypt_handshake_message_with_padding() {
+        use super::decrypt_handshake_message;
+        use crate::donor::common::CONTENT_TYPE_HANDSHAKE;
+
+        let key = vec![0x42u8; 16];
+        let iv = vec![0x99u8; 12];
+        let handshake_msg = vec![0xCDu8; 50];
+
+        // Build plaintext with padding: handshake_msg || content_type || padding_zeros
+        let mut plaintext_with_type_and_padding = handshake_msg.clone();
+        plaintext_with_type_and_padding.push(CONTENT_TYPE_HANDSHAKE);
+        plaintext_with_type_and_padding.extend_from_slice(&[0x00, 0x00, 0x00]); // 3 bytes padding
+
+        let ciphertext_len = (plaintext_with_type_and_padding.len() + 16) as u16;
+
+        let aad = [
+            0x17,
+            0x03,
+            0x03,
+            (ciphertext_len >> 8) as u8,
+            (ciphertext_len & 0xff) as u8,
+        ];
+
+        let ciphertext =
+            encrypt_tls13_record(CS, &key, &iv, 0, &plaintext_with_type_and_padding, &aad).unwrap();
+
+        // Padding should be stripped
+        let decrypted =
+            decrypt_handshake_message(CS, &key, &iv, 0, &ciphertext, ciphertext_len).unwrap();
+
+        assert_eq!(decrypted, handshake_msg);
+    }
+}

--- a/crates/core-reality/src/donor/reality_auth.rs
+++ b/crates/core-reality/src/donor/reality_auth.rs
@@ -1,0 +1,552 @@
+use aws_lc_rs::aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey};
+use aws_lc_rs::agreement;
+use aws_lc_rs::hkdf::{HKDF_SHA256, Salt};
+
+#[cfg(test)]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Custom error type for REALITY cryptographic operations
+#[derive(Debug)]
+pub enum CryptoError {
+    InvalidKeyLength,
+    InvalidNonceLength,
+    InvalidCiphertextLength,
+    EncryptionFailed,
+    DecryptionFailed,
+    EcdhFailed,
+    HkdfFailed,
+    CertificateGenerationFailed(String),
+}
+
+impl std::fmt::Display for CryptoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CryptoError::InvalidKeyLength => write!(f, "Invalid key length"),
+            CryptoError::InvalidNonceLength => write!(f, "Invalid nonce length"),
+            CryptoError::InvalidCiphertextLength => write!(f, "Invalid ciphertext length"),
+            CryptoError::EncryptionFailed => write!(f, "Encryption failed"),
+            CryptoError::DecryptionFailed => write!(f, "Decryption failed"),
+            CryptoError::EcdhFailed => write!(f, "ECDH key exchange failed"),
+            CryptoError::HkdfFailed => write!(f, "HKDF derivation failed"),
+            CryptoError::CertificateGenerationFailed(e) => {
+                write!(f, "Certificate generation failed: {}", e)
+            }
+        }
+    }
+}
+
+impl std::error::Error for CryptoError {}
+
+impl From<CryptoError> for std::io::Error {
+    fn from(err: CryptoError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, err.to_string())
+    }
+}
+
+/// Performs X25519 ECDH key exchange
+///
+/// # Arguments
+/// * `private_key` - 32-byte X25519 private key
+/// * `public_key` - 32-byte X25519 public key
+///
+/// # Returns
+/// 32-byte shared secret
+pub fn perform_ecdh(
+    private_key: &[u8; 32],
+    public_key: &[u8; 32],
+) -> Result<[u8; 32], CryptoError> {
+    // Create private key from raw bytes
+    let my_private_key = agreement::PrivateKey::from_private_key(&agreement::X25519, private_key)
+        .map_err(|_| CryptoError::EcdhFailed)?;
+
+    // Compute public key from private key (not used, but verifies key is valid)
+    let _my_public_key = my_private_key
+        .compute_public_key()
+        .map_err(|_| CryptoError::EcdhFailed)?;
+
+    // Create unparsed public key
+    let peer_public_key =
+        agreement::UnparsedPublicKey::new(&agreement::X25519, public_key.as_ref());
+
+    // Perform ECDH
+    let mut shared_secret = [0u8; 32];
+    agreement::agree(
+        &my_private_key,
+        peer_public_key,
+        CryptoError::EcdhFailed,
+        |key_material| {
+            shared_secret.copy_from_slice(key_material);
+            Ok(())
+        },
+    )?;
+
+    Ok(shared_secret)
+}
+
+/// Derives authentication key using HKDF-SHA256
+///
+/// # Arguments
+/// * `shared_secret` - 32-byte shared secret from ECDH
+/// * `salt` - Salt bytes (must be exactly 20 bytes, from ClientHello.Random[0..20])
+/// * `info` - Context string (should be b"REALITY")
+///
+/// # Returns
+/// 32-byte derived authentication key
+///
+/// # Panics
+/// Panics if salt is not exactly 20 bytes.
+pub fn derive_auth_key(
+    shared_secret: &[u8; 32],
+    salt: &[u8],
+    info: &[u8],
+) -> Result<[u8; 32], CryptoError> {
+    debug_assert_eq!(salt.len(), 20, "salt must be exactly 20 bytes");
+    let salt = Salt::new(HKDF_SHA256, salt);
+    let prk = salt.extract(shared_secret);
+    let info_pieces = [info];
+    let okm = prk
+        .expand(&info_pieces, HKDF_SHA256)
+        .map_err(|_| CryptoError::HkdfFailed)?;
+    let mut auth_key = [0u8; 32];
+    okm.fill(&mut auth_key)
+        .map_err(|_| CryptoError::HkdfFailed)?;
+    Ok(auth_key)
+}
+
+/// Encrypts SessionId using AES-256-GCM
+///
+/// # Arguments
+/// * `plaintext` - 16-byte plaintext (first 16 bytes of SessionId)
+/// * `auth_key` - 32-byte authentication key
+/// * `nonce` - 12-byte nonce (ClientHello.Random[20..32])
+/// * `aad` - Additional authenticated data (entire ClientHello)
+///
+/// # Returns
+/// 32-byte result (16 bytes ciphertext + 16 bytes GCM tag)
+///
+/// # Panics
+/// Panics if nonce is not exactly 12 bytes.
+pub fn encrypt_session_id(
+    plaintext: &[u8; 16],
+    auth_key: &[u8; 32],
+    nonce: &[u8],
+    aad: &[u8],
+) -> Result<[u8; 32], CryptoError> {
+    debug_assert_eq!(nonce.len(), 12, "nonce must be exactly 12 bytes");
+    let unbound_key =
+        UnboundKey::new(&AES_256_GCM, auth_key).map_err(|_| CryptoError::EncryptionFailed)?;
+    let sealing_key = LessSafeKey::new(unbound_key);
+
+    let nonce_obj =
+        Nonce::try_assume_unique_for_key(nonce).map_err(|_| CryptoError::InvalidNonceLength)?;
+
+    let aad_obj = Aad::from(aad);
+
+    // aws-lc-rs requires in-place encryption
+    let mut in_out = plaintext.to_vec();
+    sealing_key
+        .seal_in_place_append_tag(nonce_obj, aad_obj, &mut in_out)
+        .map_err(|_| CryptoError::EncryptionFailed)?;
+
+    if in_out.len() != 32 {
+        return Err(CryptoError::EncryptionFailed);
+    }
+
+    let mut result = [0u8; 32];
+    result.copy_from_slice(&in_out);
+    Ok(result)
+}
+
+/// Decrypts SessionId using AES-256-GCM
+///
+/// # Arguments
+/// * `ciphertext_and_tag` - 32-byte encrypted data (16 ciphertext + 16 tag)
+/// * `auth_key` - 32-byte authentication key
+/// * `nonce` - 12-byte nonce (ClientHello.Random[20..32])
+/// * `aad` - Additional authenticated data (entire ClientHello)
+///
+/// # Returns
+/// 16-byte decrypted plaintext
+///
+/// # Panics
+/// Panics if nonce is not exactly 12 bytes.
+pub fn decrypt_session_id(
+    ciphertext_and_tag: &[u8; 32],
+    auth_key: &[u8; 32],
+    nonce: &[u8],
+    aad: &[u8],
+) -> Result<[u8; 16], CryptoError> {
+    debug_assert_eq!(nonce.len(), 12, "nonce must be exactly 12 bytes");
+    let unbound_key =
+        UnboundKey::new(&AES_256_GCM, auth_key).map_err(|_| CryptoError::DecryptionFailed)?;
+    let opening_key = LessSafeKey::new(unbound_key);
+
+    let nonce_obj =
+        Nonce::try_assume_unique_for_key(nonce).map_err(|_| CryptoError::InvalidNonceLength)?;
+
+    let aad_obj = Aad::from(aad);
+
+    // aws-lc-rs requires in-place decryption
+    let mut in_out = ciphertext_and_tag.to_vec();
+    let plaintext = opening_key
+        .open_in_place(nonce_obj, aad_obj, &mut in_out)
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    if plaintext.len() != 16 {
+        return Err(CryptoError::DecryptionFailed);
+    }
+
+    let mut result = [0u8; 16];
+    result.copy_from_slice(plaintext);
+    Ok(result)
+}
+
+#[cfg(test)]
+/// Creates a REALITY SessionId (test helper)
+fn create_session_id(version: [u8; 3], timestamp: u32, short_id: &[u8; 8]) -> [u8; 32] {
+    let mut session_id = [0u8; 32];
+    session_id[0] = version[0]; // Major version
+    session_id[1] = version[1]; // Minor version
+    session_id[2] = version[2]; // Patch version
+    // session_id[3] = 0 (reserved)
+    session_id[4..8].copy_from_slice(&timestamp.to_be_bytes());
+    session_id[8..16].copy_from_slice(short_id);
+    // session_id[16..32] remain zeros
+    session_id
+}
+
+#[cfg(test)]
+/// Gets current Unix timestamp (test helper)
+fn get_current_timestamp() -> u32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ecdh() {
+        // Test vectors
+        let private_key_a = [1u8; 32];
+        let private_key_b = [2u8; 32];
+
+        // Compute public keys using aws-lc-rs
+        let priv_a =
+            agreement::PrivateKey::from_private_key(&agreement::X25519, &private_key_a).unwrap();
+        let pub_a = priv_a.compute_public_key().unwrap();
+
+        let priv_b =
+            agreement::PrivateKey::from_private_key(&agreement::X25519, &private_key_b).unwrap();
+        let pub_b = priv_b.compute_public_key().unwrap();
+
+        // Perform ECDH both ways
+        let mut shared_a_bytes = [0u8; 32];
+        agreement::agree(
+            &priv_a,
+            agreement::UnparsedPublicKey::new(&agreement::X25519, pub_b.as_ref()),
+            (),
+            |key_material| {
+                shared_a_bytes.copy_from_slice(key_material);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        let mut shared_b_bytes = [0u8; 32];
+        agreement::agree(
+            &priv_b,
+            agreement::UnparsedPublicKey::new(&agreement::X25519, pub_a.as_ref()),
+            (),
+            |key_material| {
+                shared_b_bytes.copy_from_slice(key_material);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(shared_a_bytes, shared_b_bytes);
+    }
+
+    #[test]
+    fn test_session_id_structure() {
+        // Test that session ID has the correct structure
+        let version = [1, 8, 1]; // major, minor, patch
+        let timestamp = get_current_timestamp();
+        let short_id = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0];
+
+        let session_id = create_session_id(version, timestamp, &short_id);
+
+        // Verify structure
+        assert_eq!(session_id[0], 1); // version major
+        assert_eq!(session_id[1], 8); // version minor
+        assert_eq!(session_id[2], 1); // version patch
+        assert_eq!(session_id[3], 0); // reserved
+
+        // Verify timestamp
+        let extracted_timestamp =
+            u32::from_be_bytes([session_id[4], session_id[5], session_id[6], session_id[7]]);
+        assert_eq!(extracted_timestamp, timestamp);
+
+        // Verify short_id
+        assert_eq!(&session_id[8..16], &short_id[..]);
+
+        // Verify remaining bytes are zero
+        for byte in session_id.iter().skip(16) {
+            assert_eq!(*byte, 0);
+        }
+    }
+
+    #[test]
+    fn test_version_comparison() {
+        // Test version comparison logic (same as used in reality_server_handler.rs)
+        let v1_8_1 = [1u8, 8, 1];
+        let v1_8_0 = [1u8, 8, 0];
+        let v1_9_0 = [1u8, 9, 0];
+        let v2_0_0 = [2u8, 0, 0];
+
+        assert!(v1_8_0 < v1_8_1);
+        assert!(v1_8_1 < v1_9_0);
+        assert!(v1_9_0 < v2_0_0);
+        assert!(v1_8_1 > v1_8_0);
+    }
+
+    #[test]
+    fn test_timestamp_validation_logic() {
+        // Test the timestamp validation logic used in reality_server_handler.rs
+        let now = get_current_timestamp();
+
+        // Test within bounds (60 seconds = 60000 milliseconds)
+        let max_diff_ms = 60000u64;
+        let max_diff_secs = max_diff_ms / 1000;
+
+        // Current time - should pass
+        let diff = now.abs_diff(now);
+        assert!((diff as u64) <= max_diff_secs);
+
+        // 30 seconds ago - should pass
+        let past_timestamp = now - 30;
+        let diff = now.abs_diff(past_timestamp);
+        assert!((diff as u64) <= max_diff_secs);
+
+        // 30 seconds future - should pass
+        let future_timestamp = now + 30;
+        let diff = now.abs_diff(future_timestamp);
+        assert!((diff as u64) <= max_diff_secs);
+
+        // 2 minutes ago - should fail
+        let old_timestamp = now.saturating_sub(120);
+        let diff = now.abs_diff(old_timestamp);
+        assert!((diff as u64) > max_diff_secs);
+
+        // 2 minutes future - should fail
+        let future_timestamp = now + 120;
+        let diff = now.abs_diff(future_timestamp);
+        assert!((diff as u64) > max_diff_secs);
+    }
+
+    #[test]
+    fn test_session_id_encryption_preserves_structure() {
+        // Create session ID with known values
+        let version = [1, 8, 1];
+        let timestamp = 1234567890u32;
+        let short_id = [0xAB; 8];
+
+        let session_id = create_session_id(version, timestamp, &short_id);
+
+        // Perform ECDH
+        let client_private = [0x01; 32];
+        let server_public = [0x02; 32];
+        let shared_secret = perform_ecdh(&client_private, &server_public).unwrap();
+
+        // Derive auth key
+        let salt = [0x03; 20];
+        let auth_key = derive_auth_key(&shared_secret, &salt, b"REALITY").unwrap();
+
+        // Encrypt session ID (first 16 bytes)
+        let plaintext: [u8; 16] = session_id[0..16].try_into().unwrap();
+        let nonce = [0x04; 12];
+        let aad = b"test additional authenticated data";
+
+        let encrypted = encrypt_session_id(&plaintext, &auth_key, &nonce, aad).unwrap();
+
+        // Decrypt session ID
+        let decrypted = decrypt_session_id(&encrypted, &auth_key, &nonce, aad).unwrap();
+
+        // Verify we can recover the structure
+        assert_eq!(decrypted[0], version[0]);
+        assert_eq!(decrypted[1], version[1]);
+        assert_eq!(decrypted[2], version[2]);
+        assert_eq!(decrypted[3], 0); // reserved
+
+        let recovered_timestamp =
+            u32::from_be_bytes([decrypted[4], decrypted[5], decrypted[6], decrypted[7]]);
+        assert_eq!(recovered_timestamp, timestamp);
+
+        assert_eq!(&decrypted[8..16], &short_id[..]);
+    }
+
+    #[test]
+    fn test_hkdf() {
+        let shared_secret = [0x42u8; 32];
+        let salt = [0x43u8; 20];
+        let info = b"REALITY";
+
+        let auth_key = derive_auth_key(&shared_secret, &salt, info).unwrap();
+
+        // Verify length
+        assert_eq!(auth_key.len(), 32);
+
+        // Verify deterministic
+        let auth_key2 = derive_auth_key(&shared_secret, &salt, info).unwrap();
+        assert_eq!(auth_key, auth_key2);
+
+        // Verify different salt produces different key
+        let salt2 = [0x44u8; 20];
+        let auth_key3 = derive_auth_key(&shared_secret, &salt2, info).unwrap();
+        assert_ne!(auth_key, auth_key3);
+    }
+
+    #[test]
+    fn test_aes_gcm_roundtrip() {
+        let plaintext = [0x55u8; 16];
+        let auth_key = [0x66u8; 32];
+        let nonce = [0x77u8; 12];
+        let aad = b"additional authenticated data";
+
+        let encrypted = encrypt_session_id(&plaintext, &auth_key, &nonce, aad).unwrap();
+        assert_eq!(encrypted.len(), 32);
+
+        let decrypted = decrypt_session_id(&encrypted, &auth_key, &nonce, aad).unwrap();
+        assert_eq!(plaintext, decrypted);
+    }
+
+    #[test]
+    fn test_aes_gcm_wrong_key_fails() {
+        let plaintext = [0x55u8; 16];
+        let auth_key = [0x66u8; 32];
+        let wrong_key = [0x67u8; 32];
+        let nonce = [0x77u8; 12];
+        let aad = b"additional authenticated data";
+
+        let encrypted = encrypt_session_id(&plaintext, &auth_key, &nonce, aad).unwrap();
+
+        let result = decrypt_session_id(&encrypted, &wrong_key, &nonce, aad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_aes_gcm_wrong_aad_fails() {
+        let plaintext = [0x55u8; 16];
+        let auth_key = [0x66u8; 32];
+        let nonce = [0x77u8; 12];
+        let aad = b"additional authenticated data";
+        let wrong_aad = b"wrong additional authenticated data";
+
+        let encrypted = encrypt_session_id(&plaintext, &auth_key, &nonce, aad).unwrap();
+
+        let result = decrypt_session_id(&encrypted, &auth_key, &nonce, wrong_aad);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_session_id() {
+        let version = [1, 8, 1];
+        let timestamp = 1234567890u32;
+        let short_id = [0xAB; 8];
+
+        let session_id = create_session_id(version, timestamp, &short_id);
+
+        assert_eq!(session_id[0], 1);
+        assert_eq!(session_id[1], 8);
+        assert_eq!(session_id[2], 1);
+        assert_eq!(session_id[3], 0);
+
+        let ts = u32::from_be_bytes([session_id[4], session_id[5], session_id[6], session_id[7]]);
+        assert_eq!(ts, timestamp);
+
+        assert_eq!(&session_id[8..16], &short_id[..]);
+
+        // Verify remaining bytes are zeros
+        for byte in session_id.iter().skip(16) {
+            assert_eq!(*byte, 0);
+        }
+    }
+
+    #[test]
+    fn test_validation_scenarios() {
+        println!("\n=== REALITY Validation Test Scenarios ===\n");
+
+        // Scenario 1: Version validation
+        println!("Scenario 1: Version Validation");
+        println!("  Client version: [1, 8, 1]");
+        println!("  Min version: [1, 8, 0]");
+        println!("  Max version: [1, 9, 0]");
+        println!("  Expected: PASS ✓");
+
+        let client_version = [1u8, 8, 1];
+        let min_version = [1u8, 8, 0];
+        let max_version = [1u8, 9, 0];
+        assert!(client_version >= min_version);
+        assert!(client_version <= max_version);
+
+        // Scenario 2: Version below minimum
+        println!("\nScenario 2: Version Below Minimum");
+        println!("  Client version: [1, 7, 5]");
+        println!("  Min version: [1, 8, 0]");
+        println!("  Expected: FAIL ✗");
+
+        let old_client_version = [1u8, 7, 5];
+        assert!(old_client_version < min_version);
+
+        // Scenario 3: Version above maximum
+        println!("\nScenario 3: Version Above Maximum");
+        println!("  Client version: [2, 0, 0]");
+        println!("  Max version: [1, 9, 0]");
+        println!("  Expected: FAIL ✗");
+
+        let new_client_version = [2u8, 0, 0];
+        assert!(new_client_version > max_version);
+
+        // Scenario 4: Timestamp validation (within bounds)
+        println!("\nScenario 4: Timestamp Within Bounds");
+        let now = get_current_timestamp();
+        let client_timestamp = now - 30; // 30 seconds ago
+        let max_diff_ms = 60000u64; // 60 seconds
+
+        let diff = now.abs_diff(client_timestamp);
+        println!("  Server time: {}", now);
+        println!("  Client time: {} (30 seconds ago)", client_timestamp);
+        println!("  Max allowed: {} seconds", max_diff_ms / 1000);
+        println!("  Actual diff: {} seconds", diff);
+        println!("  Expected: PASS ✓");
+        assert!((diff as u64) <= (max_diff_ms / 1000));
+
+        // Scenario 5: Timestamp validation (out of bounds)
+        println!("\nScenario 5: Timestamp Out of Bounds");
+        let old_timestamp = now - 120; // 2 minutes ago
+        let diff = now.abs_diff(old_timestamp);
+        println!("  Server time: {}", now);
+        println!("  Client time: {} (2 minutes ago)", old_timestamp);
+        println!("  Max allowed: {} seconds", max_diff_ms / 1000);
+        println!("  Actual diff: {} seconds", diff);
+        println!("  Expected: FAIL ✗");
+        assert!((diff as u64) > (max_diff_ms / 1000));
+
+        // Scenario 6: Future timestamp validation
+        println!("\nScenario 6: Future Timestamp Validation");
+        let future_timestamp = now + 45; // 45 seconds in future
+        let diff = now.abs_diff(future_timestamp);
+        println!("  Server time: {}", now);
+        println!("  Client time: {} (45 seconds in future)", future_timestamp);
+        println!("  Max allowed: {} seconds", max_diff_ms / 1000);
+        println!("  Actual diff: {} seconds", diff);
+        println!("  Expected: PASS ✓");
+        assert!((diff as u64) <= (max_diff_ms / 1000));
+
+        println!("\n=== All Validation Scenarios Passed ===\n");
+    }
+}

--- a/crates/core-reality/src/donor/reality_certificate.rs
+++ b/crates/core-reality/src/donor/reality_certificate.rs
@@ -1,0 +1,257 @@
+use aws_lc_rs::hmac;
+use aws_lc_rs::signature::{Ed25519KeyPair, KeyPair};
+use aws_lc_rs::unstable::signature::{ML_DSA_65_SIGNING, PqdsaKeyPair};
+use rcgen::SignatureAlgorithm;
+use std::io::{Error, ErrorKind, Result};
+
+/// A signing key that computes HMAC-SHA512(auth_key, public_key) as the "signature".
+///
+/// This implements rcgen's SigningKey trait but ignores the TBS (to-be-signed) data,
+/// instead computing the REALITY HMAC. This allows rcgen to place our HMAC directly
+/// into the certificate signature field.
+struct HmacSigningKey {
+    /// The HMAC key derived from auth_key
+    hmac_key: hmac::Key,
+    /// The Ed25519 public key bytes (32 bytes)
+    public_key: [u8; 32],
+}
+
+impl rcgen::SigningKey for HmacSigningKey {
+    fn sign(&self, _msg: &[u8]) -> std::result::Result<Vec<u8>, rcgen::Error> {
+        // Ignore the TBS data - compute HMAC-SHA512(auth_key, public_key)
+        let tag = hmac::sign(&self.hmac_key, &self.public_key);
+        Ok(tag.as_ref().to_vec())
+    }
+}
+
+impl rcgen::PublicKeyData for HmacSigningKey {
+    fn der_bytes(&self) -> &[u8] {
+        &self.public_key
+    }
+
+    fn algorithm(&self) -> &'static SignatureAlgorithm {
+        &rcgen::PKCS_ED25519
+    }
+}
+
+/// Generate HMAC-signed Ed25519 certificate.
+///
+/// This creates a minimal X.509 certificate where:
+/// - The public key is a real Ed25519 public key
+/// - The signature is HMAC-SHA512(auth_key, public_key) instead of a real signature
+///
+/// The returned Ed25519KeyPair is used for:
+/// 1. Its public key goes in the certificate (and HMAC is computed over it)
+/// 2. Its private key signs the CertificateVerify message during TLS handshake
+///
+/// The client verifies both the HMAC and the CertificateVerify signature.
+///
+/// Returns the certificate (call `.der()` to get DER bytes) and the signing keypair.
+pub fn generate_hmac_certificate(
+    auth_key: &[u8; 32],
+    mldsa65_seed: Option<&[u8; 32]>,
+    client_hello: &[u8],
+    server_hello: &[u8],
+) -> Result<(rcgen::Certificate, Ed25519KeyPair)> {
+    // Keypair is needed for CertificateVerify signing
+    let ed25519_keypair = Ed25519KeyPair::generate()
+        .map_err(|_| Error::other("Failed to generate Ed25519 keypair"))?;
+
+    let public_key: [u8; 32] = ed25519_keypair
+        .public_key()
+        .as_ref()
+        .try_into()
+        .map_err(|_| Error::new(ErrorKind::InvalidData, "Ed25519 public key is not 32 bytes"))?;
+
+    let hmac_key = HmacSigningKey {
+        hmac_key: hmac::Key::new(hmac::HMAC_SHA512, auth_key),
+        public_key,
+    };
+
+    // Create minimal certificate params matching the reference implementation.
+    // It intentionally carries no SAN: when ML-DSA is enabled the 0.0 custom
+    // extension must be the first parsed X.509 extension for Xray clients.
+    let mut params = rcgen::CertificateParams::default();
+    params.subject_alt_names.clear();
+    params.distinguished_name = rcgen::DistinguishedName::new();
+    params.serial_number = Some(rcgen::SerialNumber::from(vec![0u8]));
+    if let Some(seed) = mldsa65_seed {
+        let key_pair = PqdsaKeyPair::from_seed(&ML_DSA_65_SIGNING, seed)
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "invalid ML-DSA-65 seed"))?;
+        let mut proof_hmac = hmac::Context::with_key(&hmac::Key::new(hmac::HMAC_SHA512, auth_key));
+        proof_hmac.update(&public_key);
+        proof_hmac.update(client_hello);
+        proof_hmac.update(server_hello);
+        let proof = proof_hmac.sign();
+        let mut signature = vec![0u8; ML_DSA_65_SIGNING.signature_len()];
+        let written = key_pair
+            .sign(proof.as_ref(), &mut signature)
+            .map_err(|_| Error::other("failed to sign ML-DSA-65 REALITY proof"))?;
+        signature.truncate(written);
+        params
+            .custom_extensions
+            .push(rcgen::CustomExtension::from_oid_content(&[0, 0], signature));
+    }
+
+    let cert = params
+        .self_signed(&hmac_key)
+        .map_err(|e| Error::other(format!("Failed to create certificate: {e}")))?;
+
+    log::debug!(
+        "REALITY: Generated HMAC certificate ({} bytes)",
+        cert.der().len()
+    );
+
+    Ok((cert, ed25519_keypair))
+}
+
+/// Derive the 1,952-byte ML-DSA-65 verification key published to clients.
+pub fn mldsa65_verify_from_seed(seed: &[u8; 32]) -> Result<Vec<u8>> {
+    let key_pair = PqdsaKeyPair::from_seed(&ML_DSA_65_SIGNING, seed)
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "invalid ML-DSA-65 seed"))?;
+    Ok(key_pair.public_key().as_ref().to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_lc_rs::signature::KeyPair;
+
+    /// Find the signature bytes in a DER-encoded certificate.
+    /// Returns the offset where the 64-byte Ed25519 signature starts.
+    fn find_signature_offset(cert_der: &[u8]) -> Option<usize> {
+        // The signature is the last BIT STRING in the certificate DER
+        // For Ed25519, it's always 64 bytes
+        // BIT STRING tag = 0x03
+        // Length = 0x41 (65 bytes: 1 byte unused bits + 64 bytes signature)
+        for i in (0..cert_der.len().saturating_sub(66)).rev() {
+            if cert_der[i] == 0x03 && cert_der[i + 1] == 0x41 && cert_der[i + 2] == 0x00 {
+                return Some(i + 3); // Skip tag, length, unused bits
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_generate_hmac_certificate() {
+        let auth_key = [42u8; 32];
+        let result = generate_hmac_certificate(&auth_key, None, b"client", b"server");
+
+        assert!(result.is_ok());
+
+        let (cert, _signing_key) = result.unwrap();
+        let cert_der = cert.der();
+
+        // Certificate should be a reasonable size
+        assert!(cert_der.len() > 100);
+        assert!(cert_der.len() < 1000);
+
+        // Should start with SEQUENCE tag
+        assert_eq!(cert_der[0], 0x30);
+    }
+
+    #[test]
+    fn test_hmac_placed_at_correct_offset() {
+        // This test verifies that our HmacSigningKey places the HMAC bytes
+        // at exactly the same location that find_signature_offset() identifies.
+
+        let auth_key = [0x42u8; 32];
+
+        let (cert, signing_key) =
+            generate_hmac_certificate(&auth_key, None, b"client", b"server").unwrap();
+        let cert_der = cert.der();
+
+        // Find where the signature should be
+        let sig_offset =
+            find_signature_offset(cert_der).expect("Should find signature offset in certificate");
+
+        // Compute what the HMAC should be
+        let public_key_bytes = signing_key.public_key().as_ref();
+        let key = hmac::Key::new(hmac::HMAC_SHA512, &auth_key);
+        let expected_hmac = hmac::sign(&key, public_key_bytes);
+
+        // Extract the signature bytes from the certificate
+        let actual_signature = &cert_der[sig_offset..sig_offset + 64];
+
+        // They should match exactly
+        assert_eq!(
+            actual_signature,
+            expected_hmac.as_ref(),
+            "HMAC signature should be placed at the correct offset in the certificate"
+        );
+    }
+
+    #[test]
+    fn test_different_keys_produce_different_hmacs() {
+        let auth_key = [99u8; 32];
+
+        let (cert1, key1) =
+            generate_hmac_certificate(&auth_key, None, b"client", b"server").unwrap();
+        let (cert2, key2) =
+            generate_hmac_certificate(&auth_key, None, b"client", b"server").unwrap();
+        let cert1_der = cert1.der();
+        let cert2_der = cert2.der();
+
+        // Different Ed25519 keys (random generation)
+        assert_ne!(
+            key1.public_key().as_ref(),
+            key2.public_key().as_ref(),
+            "Each call should generate a new random keypair"
+        );
+
+        // Different certificates (different public keys -> different HMACs)
+        assert_ne!(cert1_der.as_ref(), cert2_der.as_ref());
+
+        // But both should have valid HMAC signatures
+        let sig_offset1 = find_signature_offset(cert1_der).unwrap();
+        let sig_offset2 = find_signature_offset(cert2_der).unwrap();
+
+        // Verify HMAC for cert1
+        let hmac_key = hmac::Key::new(hmac::HMAC_SHA512, &auth_key);
+        let expected1 = hmac::sign(&hmac_key, key1.public_key().as_ref());
+        assert_eq!(
+            &cert1_der[sig_offset1..sig_offset1 + 64],
+            expected1.as_ref()
+        );
+
+        // Verify HMAC for cert2
+        let expected2 = hmac::sign(&hmac_key, key2.public_key().as_ref());
+        assert_eq!(
+            &cert2_der[sig_offset2..sig_offset2 + 64],
+            expected2.as_ref()
+        );
+    }
+
+    #[test]
+    fn test_signature_offset_consistent() {
+        // Generate multiple certificates and verify the signature is always
+        // at the same relative position (since cert structure is identical)
+        let auth_key = [0xABu8; 32];
+
+        let mut offsets = Vec::new();
+        let mut sizes = Vec::new();
+
+        for _ in 0..5 {
+            let (cert, _) =
+                generate_hmac_certificate(&auth_key, None, b"client", b"server").unwrap();
+            let cert_der = cert.der();
+            let offset = find_signature_offset(cert_der).unwrap();
+            offsets.push(offset);
+            sizes.push(cert_der.len());
+        }
+
+        // All certificates should have the same size
+        assert!(
+            sizes.iter().all(|&s| s == sizes[0]),
+            "All certificates should have identical size: {:?}",
+            sizes
+        );
+
+        // All signatures should be at the same offset
+        assert!(
+            offsets.iter().all(|&o| o == offsets[0]),
+            "All signatures should be at the same offset: {:?}",
+            offsets
+        );
+    }
+}

--- a/crates/core-reality/src/donor/reality_cipher_suite.rs
+++ b/crates/core-reality/src/donor/reality_cipher_suite.rs
@@ -1,0 +1,155 @@
+//! TLS 1.3 Cipher Suite definitions for REALITY protocol
+//!
+//! This module defines the CipherSuite type which bundles cipher suite ID
+//! with its associated algorithms for AEAD encryption, transcript hashing,
+//! and HKDF key derivation.
+
+use aws_lc_rs::{
+    aead::{AES_128_GCM, AES_256_GCM, Algorithm, CHACHA20_POLY1305},
+    digest,
+    hmac::{self, HMAC_SHA256, HMAC_SHA384},
+};
+
+/// Default TLS 1.3 cipher suites in preference order
+pub const DEFAULT_CIPHER_SUITES: &[CipherSuite] = &[
+    CipherSuite::AES_128_GCM_SHA256,
+    CipherSuite::AES_256_GCM_SHA384,
+    CipherSuite::CHACHA20_POLY1305_SHA256,
+];
+
+/// TLS 1.3 Cipher Suite with all associated algorithms
+///
+/// This struct bundles the cipher suite ID with its corresponding AEAD algorithm,
+/// digest algorithm (for transcript hashing), and HMAC algorithm (for HKDF operations).
+/// Per RFC 8446, different cipher suites require different hash algorithms:
+/// - TLS_AES_128_GCM_SHA256 (0x1301): SHA256
+/// - TLS_AES_256_GCM_SHA384 (0x1302): SHA384
+/// - TLS_CHACHA20_POLY1305_SHA256 (0x1303): SHA256
+#[derive(Clone, Copy)]
+pub struct CipherSuite {
+    id: u16,
+    algorithm: &'static Algorithm,
+    digest_algorithm: &'static digest::Algorithm,
+    hmac_algorithm: hmac::Algorithm,
+}
+
+impl PartialEq for CipherSuite {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for CipherSuite {}
+
+impl CipherSuite {
+    pub const AES_128_GCM_SHA256: Self = Self {
+        id: 0x1301,
+        algorithm: &AES_128_GCM,
+        digest_algorithm: &digest::SHA256,
+        hmac_algorithm: HMAC_SHA256,
+    };
+
+    pub const AES_256_GCM_SHA384: Self = Self {
+        id: 0x1302,
+        algorithm: &AES_256_GCM,
+        digest_algorithm: &digest::SHA384,
+        hmac_algorithm: HMAC_SHA384,
+    };
+
+    pub const CHACHA20_POLY1305_SHA256: Self = Self {
+        id: 0x1303,
+        algorithm: &CHACHA20_POLY1305,
+        digest_algorithm: &digest::SHA256,
+        hmac_algorithm: HMAC_SHA256,
+    };
+
+    /// Get CipherSuite from wire format ID
+    pub fn from_id(id: u16) -> Option<Self> {
+        match id {
+            0x1301 => Some(Self::AES_128_GCM_SHA256),
+            0x1302 => Some(Self::AES_256_GCM_SHA384),
+            0x1303 => Some(Self::CHACHA20_POLY1305_SHA256),
+            _ => None,
+        }
+    }
+
+    /// Get CipherSuite from standard TLS name
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "TLS_AES_128_GCM_SHA256" => Some(Self::AES_128_GCM_SHA256),
+            "TLS_AES_256_GCM_SHA384" => Some(Self::AES_256_GCM_SHA384),
+            "TLS_CHACHA20_POLY1305_SHA256" => Some(Self::CHACHA20_POLY1305_SHA256),
+            _ => None,
+        }
+    }
+
+    /// Get standard TLS name for this cipher suite
+    pub fn name(&self) -> &'static str {
+        match self.id {
+            0x1301 => "TLS_AES_128_GCM_SHA256",
+            0x1302 => "TLS_AES_256_GCM_SHA384",
+            0x1303 => "TLS_CHACHA20_POLY1305_SHA256",
+            _ => unreachable!(),
+        }
+    }
+
+    /// Wire format ID (e.g., 0x1301)
+    #[inline]
+    pub fn id(&self) -> u16 {
+        self.id
+    }
+
+    /// AEAD algorithm (AES_128_GCM, AES_256_GCM, or CHACHA20_POLY1305)
+    #[inline]
+    pub fn algorithm(&self) -> &'static Algorithm {
+        self.algorithm
+    }
+
+    /// Key length in bytes (16 for AES-128, 32 for AES-256/ChaCha20)
+    #[inline]
+    pub fn key_len(&self) -> usize {
+        self.algorithm.key_len()
+    }
+
+    /// Nonce/IV length in bytes (always 12 for TLS 1.3)
+    #[inline]
+    pub fn nonce_len(&self) -> usize {
+        self.algorithm.nonce_len()
+    }
+
+    /// Hash output length in bytes (32 for SHA256, 48 for SHA384)
+    #[inline]
+    pub fn hash_len(&self) -> usize {
+        self.digest_algorithm.output_len()
+    }
+
+    /// Digest algorithm for transcript hashing
+    #[inline]
+    pub fn digest_algorithm(&self) -> &'static digest::Algorithm {
+        self.digest_algorithm
+    }
+
+    /// HMAC algorithm for HKDF operations
+    #[inline]
+    pub fn hmac_algorithm(&self) -> hmac::Algorithm {
+        self.hmac_algorithm
+    }
+}
+
+impl std::fmt::Debug for CipherSuite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl std::fmt::Display for CipherSuite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl std::fmt::LowerHex for CipherSuite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::LowerHex::fmt(&self.id, f)
+    }
+}

--- a/crates/core-reality/src/donor/reality_io_state.rs
+++ b/crates/core-reality/src/donor/reality_io_state.rs
@@ -1,0 +1,20 @@
+/// Represents the I/O state after processing packets
+#[derive(Debug, Clone, Copy)]
+pub struct RealityIoState {
+    /// Number of plaintext bytes available to read
+    plaintext_bytes_to_read: usize,
+}
+
+impl RealityIoState {
+    /// Create a new RealityIoState
+    pub fn new(plaintext_bytes_to_read: usize) -> Self {
+        Self {
+            plaintext_bytes_to_read,
+        }
+    }
+
+    /// How many plaintext bytes could be obtained via Read without further I/O
+    pub fn plaintext_bytes_to_read(&self) -> usize {
+        self.plaintext_bytes_to_read
+    }
+}

--- a/crates/core-reality/src/donor/reality_reader_writer.rs
+++ b/crates/core-reality/src/donor/reality_reader_writer.rs
@@ -1,0 +1,155 @@
+use std::io::{BufRead, Read, Write};
+
+use crate::buffer::SlideBuffer;
+
+/// Reader for accessing decrypted plaintext from REALITY connections
+///
+/// This reader provides a view over a SlideBuffer and consumes data from it
+/// as it is read. The SlideBuffer handles efficient memory management.
+///
+/// Mirrors rustls::Reader behavior for fill_buf():
+/// - Ok(data) when data is available
+/// - Ok(&[]) when close_notify received (clean EOF)
+/// - Err(WouldBlock) when no data and connection still active
+pub struct RealityReader<'a> {
+    buffer: &'a mut SlideBuffer,
+    received_close_notify: bool,
+}
+
+impl<'a> RealityReader<'a> {
+    pub fn new(buffer: &'a mut SlideBuffer, received_close_notify: bool) -> Self {
+        RealityReader {
+            buffer,
+            received_close_notify,
+        }
+    }
+}
+
+impl<'a> Read for RealityReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let available = self.buffer.len();
+        let to_read = buf.len().min(available);
+        if to_read > 0 {
+            buf[..to_read].copy_from_slice(&self.buffer[..to_read]);
+            self.buffer.consume(to_read);
+        }
+        Ok(to_read)
+    }
+}
+
+impl<'a> BufRead for RealityReader<'a> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        if !self.buffer.is_empty() {
+            // Data available
+            Ok(self.buffer.as_slice())
+        } else if self.received_close_notify {
+            // Clean EOF - close_notify received (mirrors rustls behavior)
+            Ok(&[])
+        } else {
+            // No data, connection still active
+            Err(std::io::ErrorKind::WouldBlock.into())
+        }
+    }
+
+    fn consume(&mut self, amt: usize) {
+        let actual = amt.min(self.buffer.len());
+        self.buffer.consume(actual);
+    }
+}
+
+/// Writer for buffering plaintext to be encrypted in REALITY connections
+pub struct RealityWriter<'a> {
+    buffer: &'a mut Vec<u8>,
+}
+
+impl<'a> RealityWriter<'a> {
+    pub fn new(buffer: &'a mut Vec<u8>) -> Self {
+        RealityWriter { buffer }
+    }
+}
+
+impl<'a> Write for RealityWriter<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reality_crypto_reader() {
+        let mut buffer = SlideBuffer::new(1024);
+        buffer.extend_from_slice(b"hello world");
+
+        {
+            let mut reader = RealityReader::new(&mut buffer, false);
+            let mut buf = [0u8; 5];
+            assert_eq!(reader.read(&mut buf).unwrap(), 5);
+            assert_eq!(&buf, b"hello");
+        }
+
+        // Buffer should have consumed 5 bytes
+        assert_eq!(buffer.len(), 6); // " world" remaining
+
+        {
+            let mut reader = RealityReader::new(&mut buffer, false);
+            let mut buf = [0u8; 5];
+            assert_eq!(reader.read(&mut buf).unwrap(), 5);
+            assert_eq!(&buf[..5], b" worl");
+        }
+
+        assert_eq!(buffer.len(), 1); // "d" remaining
+    }
+
+    #[test]
+    fn test_reality_crypto_reader_bufread() {
+        let mut buffer = SlideBuffer::new(1024);
+        buffer.extend_from_slice(b"test data");
+
+        let mut reader = RealityReader::new(&mut buffer, false);
+
+        let buf = reader.fill_buf().unwrap();
+        assert_eq!(buf, b"test data");
+
+        reader.consume(5);
+        let buf = reader.fill_buf().unwrap();
+        assert_eq!(buf, b"data");
+    }
+
+    #[test]
+    fn test_reality_crypto_reader_empty_would_block() {
+        let mut buffer = SlideBuffer::new(1024);
+        // Empty buffer, no close_notify -> WouldBlock
+        let mut reader = RealityReader::new(&mut buffer, false);
+        let result = reader.fill_buf();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn test_reality_crypto_reader_close_notify_eof() {
+        let mut buffer = SlideBuffer::new(1024);
+        // Empty buffer, close_notify received -> Ok(&[]) (EOF)
+        let mut reader = RealityReader::new(&mut buffer, true);
+        let result = reader.fill_buf();
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_reality_crypto_writer() {
+        let mut buffer = Vec::new();
+        let mut writer = RealityWriter::new(&mut buffer);
+
+        assert_eq!(writer.write(b"hello").unwrap(), 5);
+        assert_eq!(writer.write(b" world").unwrap(), 6);
+        assert_eq!(buffer.as_slice(), b"hello world");
+    }
+}

--- a/crates/core-reality/src/donor/reality_records.rs
+++ b/crates/core-reality/src/donor/reality_records.rs
@@ -1,0 +1,1012 @@
+// TLS 1.3 record layer encryption/decryption.
+//
+// Handles framing plaintext into TLS records, including:
+// - Adding/stripping ContentType trailer byte
+// - Fragmenting large data into multiple records (max 16KB plaintext each)
+// - Building TLS record headers
+// - Managing sequence numbers
+
+use std::io::{self, Error, ErrorKind};
+
+use super::common::{
+    CONTENT_TYPE_ALERT, CONTENT_TYPE_APPLICATION_DATA, CONTENT_TYPE_HANDSHAKE,
+    MAX_TLS_CIPHERTEXT_LEN, MAX_TLS_PLAINTEXT_LEN, TLS_RECORD_HEADER_SIZE,
+};
+use super::reality_aead::AeadKey;
+#[cfg(test)]
+use super::reality_cipher_suite::CipherSuite;
+
+/// Encrypts plaintext into TLS 1.3 records.
+///
+/// Manages the write-side sequence number and handles record framing.
+pub struct RecordEncryptor<'a> {
+    key: &'a AeadKey,
+    iv: &'a [u8],
+    seq: &'a mut u64,
+}
+
+impl<'a> RecordEncryptor<'a> {
+    #[inline]
+    pub fn new(key: &'a AeadKey, iv: &'a [u8], seq: &'a mut u64) -> Self {
+        Self { key, iv, seq }
+    }
+
+    /// Encrypt application data into TLS 1.3 records.
+    ///
+    /// For data <= 16KB: encrypts in-place in the plaintext buffer (zero-copy).
+    /// For data > 16KB: fragments into multiple records.
+    ///
+    /// Clears the plaintext buffer after encryption.
+    #[inline]
+    pub fn encrypt_app_data(
+        &mut self,
+        plaintext: &mut Vec<u8>,
+        out: &mut Vec<u8>,
+    ) -> io::Result<()> {
+        if plaintext.is_empty() {
+            return Ok(());
+        }
+
+        if plaintext.len() <= MAX_TLS_PLAINTEXT_LEN {
+            // Fast path: single record, encrypt in-place
+            self.encrypt_record_in_place(plaintext, out, CONTENT_TYPE_APPLICATION_DATA)?;
+        } else {
+            // Slow path: fragment into multiple records
+            self.encrypt_fragmented(plaintext, out, CONTENT_TYPE_APPLICATION_DATA)?;
+        }
+
+        plaintext.clear();
+        Ok(())
+    }
+
+    /// Encrypt handshake data into TLS 1.3 records.
+    #[inline]
+    pub fn encrypt_handshake(&mut self, data: &[u8], out: &mut Vec<u8>) -> io::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        if data.len() <= MAX_TLS_PLAINTEXT_LEN {
+            let mut buf = data.to_vec();
+            self.encrypt_record_in_place(&mut buf, out, CONTENT_TYPE_HANDSHAKE)?;
+        } else {
+            for chunk in data.chunks(MAX_TLS_PLAINTEXT_LEN) {
+                let mut buf = chunk.to_vec();
+                self.encrypt_record_in_place(&mut buf, out, CONTENT_TYPE_HANDSHAKE)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Encrypt handshake data with padding to match a target record size.
+    ///
+    /// Uses TLS 1.3 inner padding (zeros after content type byte) to pad
+    /// the encrypted record to match the target size from the destination server.
+    ///
+    /// If target_size is 0 or smaller than our minimum, no padding is added.
+    #[inline]
+    pub fn encrypt_handshake_with_padding(
+        &mut self,
+        data: &[u8],
+        out: &mut Vec<u8>,
+        target_record_size: usize,
+    ) -> io::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        // For very large data, fragment without padding
+        if data.len() > MAX_TLS_PLAINTEXT_LEN {
+            // Fragment into multiple records - only pad the last one if needed
+            let chunks: Vec<_> = data.chunks(MAX_TLS_PLAINTEXT_LEN).collect();
+            for (i, chunk) in chunks.iter().enumerate() {
+                let mut buf = chunk.to_vec();
+                if i == chunks.len() - 1 && target_record_size > 0 {
+                    // Last chunk - apply padding
+                    self.encrypt_record_with_padding(
+                        &mut buf,
+                        out,
+                        CONTENT_TYPE_HANDSHAKE,
+                        target_record_size,
+                    )?;
+                } else {
+                    self.encrypt_record_in_place(&mut buf, out, CONTENT_TYPE_HANDSHAKE)?;
+                }
+            }
+            return Ok(());
+        }
+
+        let mut buf = data.to_vec();
+        if target_record_size > 0 {
+            self.encrypt_record_with_padding(
+                &mut buf,
+                out,
+                CONTENT_TYPE_HANDSHAKE,
+                target_record_size,
+            )?;
+        } else {
+            self.encrypt_record_in_place(&mut buf, out, CONTENT_TYPE_HANDSHAKE)?;
+        }
+
+        Ok(())
+    }
+
+    /// Encrypt a close_notify alert.
+    #[inline]
+    pub fn encrypt_close_notify(&mut self, out: &mut Vec<u8>) -> io::Result<()> {
+        let mut buf = vec![0x01, 0x00]; // level=warning, desc=close_notify
+        self.encrypt_record_in_place(&mut buf, out, CONTENT_TYPE_ALERT)
+    }
+
+    /// Encrypt a single record in-place.
+    ///
+    /// 1. Appends content type byte to buffer
+    /// 2. Encrypts in-place (appends 16-byte tag)
+    /// 3. Writes TLS record header + ciphertext to output
+    /// 4. Increments sequence number
+    #[inline]
+    fn encrypt_record_in_place(
+        &mut self,
+        buf: &mut Vec<u8>,
+        out: &mut Vec<u8>,
+        content_type: u8,
+    ) -> io::Result<()> {
+        // Append inner content type
+        buf.push(content_type);
+
+        // Build header (need ciphertext length = plaintext + content_type + tag)
+        let ciphertext_len = buf.len() + 16;
+
+        debug_assert!(
+            ciphertext_len <= MAX_TLS_CIPHERTEXT_LEN,
+            "BUG: ciphertext_len {} exceeds MAX_TLS_CIPHERTEXT_LEN {}",
+            ciphertext_len,
+            MAX_TLS_CIPHERTEXT_LEN
+        );
+
+        let header = make_record_header(ciphertext_len);
+
+        // Encrypt in-place
+        self.key.seal_in_place(buf, self.iv, *self.seq, &header)?;
+        *self.seq = self
+            .seq
+            .checked_add(1)
+            .ok_or_else(|| Error::other("TLS sequence number exhausted"))?;
+
+        // Write to output
+        out.reserve(TLS_RECORD_HEADER_SIZE + buf.len());
+        out.extend_from_slice(&header);
+        out.extend_from_slice(buf);
+
+        Ok(())
+    }
+
+    /// Encrypt a single record with padding to match a target size.
+    ///
+    /// TLS 1.3 inner plaintext format: [content] [content_type] [zero_padding...]
+    /// The padding is added after the content type byte and before encryption.
+    #[inline]
+    fn encrypt_record_with_padding(
+        &mut self,
+        buf: &mut Vec<u8>,
+        out: &mut Vec<u8>,
+        content_type: u8,
+        target_record_size: usize,
+    ) -> io::Result<()> {
+        // Append inner content type
+        buf.push(content_type);
+
+        // Calculate padding needed to match target record size
+        // target_record_size = header(5) + inner_plaintext_with_padding + tag(16)
+        // So: inner_plaintext_with_padding = target_record_size - 5 - 16 = target_record_size - 21
+        // Padding = inner_plaintext_with_padding - buf.len()
+        let current_inner_len = buf.len();
+        let target_inner_len = target_record_size.saturating_sub(TLS_RECORD_HEADER_SIZE + 16);
+
+        if target_inner_len > current_inner_len && target_inner_len <= MAX_TLS_PLAINTEXT_LEN + 1 {
+            let padding = target_inner_len - current_inner_len;
+            buf.resize(buf.len() + padding, 0);
+            log::trace!(
+                "REALITY: Added {} bytes of TLS 1.3 inner padding (target={}, current={})",
+                padding,
+                target_record_size,
+                TLS_RECORD_HEADER_SIZE + current_inner_len + 16
+            );
+        }
+
+        // Build header with actual ciphertext length
+        let ciphertext_len = buf.len() + 16;
+
+        debug_assert!(
+            ciphertext_len <= MAX_TLS_CIPHERTEXT_LEN,
+            "BUG: ciphertext_len {} exceeds MAX_TLS_CIPHERTEXT_LEN {}",
+            ciphertext_len,
+            MAX_TLS_CIPHERTEXT_LEN
+        );
+
+        let header = make_record_header(ciphertext_len);
+
+        // Encrypt in-place
+        self.key.seal_in_place(buf, self.iv, *self.seq, &header)?;
+        *self.seq = self
+            .seq
+            .checked_add(1)
+            .ok_or_else(|| Error::other("TLS sequence number exhausted"))?;
+
+        // Write to output
+        out.reserve(TLS_RECORD_HEADER_SIZE + buf.len());
+        out.extend_from_slice(&header);
+        out.extend_from_slice(buf);
+
+        Ok(())
+    }
+
+    /// Encrypt data larger than 16KB by fragmenting into multiple records.
+    #[inline]
+    fn encrypt_fragmented(
+        &mut self,
+        data: &[u8],
+        out: &mut Vec<u8>,
+        content_type: u8,
+    ) -> io::Result<()> {
+        for chunk in data.chunks(MAX_TLS_PLAINTEXT_LEN) {
+            let mut buf = chunk.to_vec();
+            self.encrypt_record_in_place(&mut buf, out, content_type)?;
+        }
+        Ok(())
+    }
+}
+
+/// Decrypts TLS 1.3 records into plaintext.
+///
+/// Manages the read-side sequence number and handles content type extraction.
+pub struct RecordDecryptor<'a> {
+    key: &'a AeadKey,
+    iv: &'a [u8],
+    seq: &'a mut u64,
+}
+
+impl<'a> RecordDecryptor<'a> {
+    #[inline]
+    pub fn new(key: &'a AeadKey, iv: &'a [u8], seq: &'a mut u64) -> Self {
+        Self { key, iv, seq }
+    }
+
+    /// Decrypt a TLS 1.3 record in-place, returning (content_type, plaintext_slice).
+    ///
+    /// Zero-allocation decryption: decrypts directly in the provided buffer
+    /// and returns a slice to the plaintext within that buffer.
+    ///
+    /// # Arguments
+    /// * `ciphertext` - Mutable slice containing ciphertext + auth tag (will be decrypted in-place)
+    /// * `record_len` - Length from TLS record header (ciphertext + tag length)
+    ///
+    /// # Returns
+    /// Tuple of (content_type, plaintext_slice) where plaintext_slice borrows from ciphertext
+    #[inline]
+    pub fn decrypt_record_in_place<'b>(
+        &mut self,
+        ciphertext: &'b mut [u8],
+        record_len: u16,
+    ) -> io::Result<(u8, &'b [u8])> {
+        let aad = make_record_header(record_len as usize);
+
+        let plaintext = self
+            .key
+            .open_in_place_slice(ciphertext, self.iv, *self.seq, &aad)?;
+        *self.seq = self
+            .seq
+            .checked_add(1)
+            .ok_or_else(|| Error::other("TLS sequence number exhausted"))?;
+
+        // TLSInnerPlaintext is content || ContentType || zeros*.
+        // Reference REALITY implementations may add trailing zero padding.
+        let mut valid_end = plaintext.len();
+        while valid_end > 0 && plaintext[valid_end - 1] == 0 {
+            valid_end -= 1;
+        }
+        if valid_end == 0 {
+            return Err(Error::new(ErrorKind::InvalidData, "Plaintext is all zeros"));
+        }
+
+        let content_type = plaintext[valid_end - 1];
+        valid_end -= 1;
+
+        if content_type != CONTENT_TYPE_HANDSHAKE
+            && content_type != CONTENT_TYPE_APPLICATION_DATA
+            && content_type != CONTENT_TYPE_ALERT
+        {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid content type: 0x{:02x}", content_type),
+            ));
+        }
+
+        Ok((content_type, &plaintext[..valid_end]))
+    }
+}
+
+/// Build a TLS record header for the given ciphertext length.
+#[inline]
+fn make_record_header(ciphertext_len: usize) -> [u8; TLS_RECORD_HEADER_SIZE] {
+    [
+        CONTENT_TYPE_APPLICATION_DATA, // Outer type is always ApplicationData in TLS 1.3
+        0x03,
+        0x03, // TLS 1.2 version (for compatibility)
+        (ciphertext_len >> 8) as u8,
+        (ciphertext_len & 0xff) as u8,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CS: CipherSuite = CipherSuite::AES_128_GCM_SHA256;
+
+    fn encrypt_plaintext_to_records(
+        cipher_suite: CipherSuite,
+        plaintext: &mut Vec<u8>,
+        key: &[u8],
+        iv: &[u8],
+        write_seq: &mut u64,
+        ciphertext_buf: &mut Vec<u8>,
+    ) -> io::Result<()> {
+        let aead_key = AeadKey::new(cipher_suite, key)?;
+        let mut encryptor = RecordEncryptor::new(&aead_key, iv, write_seq);
+        encryptor.encrypt_app_data(plaintext, ciphertext_buf)
+    }
+
+    fn encrypt_handshake_to_records(
+        cipher_suite: CipherSuite,
+        handshake_data: &[u8],
+        key: &[u8],
+        iv: &[u8],
+        write_seq: &mut u64,
+        ciphertext_buf: &mut Vec<u8>,
+    ) -> io::Result<()> {
+        let aead_key = AeadKey::new(cipher_suite, key)?;
+        let mut encryptor = RecordEncryptor::new(&aead_key, iv, write_seq);
+        encryptor.encrypt_handshake(handshake_data, ciphertext_buf)
+    }
+
+    /// Test helper: decrypt a record by allocating and calling decrypt_record_in_place
+    fn decrypt_record(
+        decryptor: &mut RecordDecryptor<'_>,
+        ciphertext: &[u8],
+        record_len: u16,
+    ) -> io::Result<(u8, Vec<u8>)> {
+        let mut buf = ciphertext.to_vec();
+        let (content_type, plaintext) = decryptor.decrypt_record_in_place(&mut buf, record_len)?;
+        Ok((content_type, plaintext.to_vec()))
+    }
+
+    #[test]
+    fn test_encrypt_empty_plaintext() {
+        let mut plaintext = Vec::new();
+        let key = [0u8; 16];
+        let iv = [0u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(ciphertext_buf.is_empty());
+        assert_eq!(seq, 0); // No records encrypted
+    }
+
+    #[test]
+    fn test_encrypt_small_plaintext_single_record() {
+        let mut plaintext = vec![0x41u8; 100]; // 100 bytes of 'A'
+        let key = [0x01u8; 16];
+        let iv = [0x02u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(plaintext.is_empty()); // Should be cleared
+
+        // Should have one record: header(5) + plaintext(100) + content_type(1) + tag(16)
+        let expected_len = TLS_RECORD_HEADER_SIZE + 100 + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), expected_len);
+        assert_eq!(seq, 1); // One record encrypted
+
+        // Verify TLS header
+        assert_eq!(ciphertext_buf[0], CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(ciphertext_buf[1], 0x03);
+        assert_eq!(ciphertext_buf[2], 0x03);
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]) as usize;
+        assert_eq!(record_len, 100 + 1 + 16);
+    }
+
+    #[test]
+    fn test_encrypt_max_single_record() {
+        // Test exactly at the boundary - should still be single record
+        let mut plaintext = vec![0x42u8; MAX_TLS_PLAINTEXT_LEN];
+        let key = [0x03u8; 16];
+        let iv = [0x04u8; 12];
+        let mut seq = 5u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(plaintext.is_empty());
+
+        // Should have one record
+        let expected_len = TLS_RECORD_HEADER_SIZE + MAX_TLS_PLAINTEXT_LEN + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), expected_len);
+        assert_eq!(seq, 6); // One record encrypted
+    }
+
+    #[test]
+    fn test_encrypt_fragmentation_two_records() {
+        // One byte over the limit - should produce two records
+        let mut plaintext = vec![0x43u8; MAX_TLS_PLAINTEXT_LEN + 1];
+        let key = [0x05u8; 16];
+        let iv = [0x06u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(plaintext.is_empty());
+        assert_eq!(seq, 2); // Two records encrypted
+
+        // First record: full MAX_TLS_PLAINTEXT_LEN
+        let first_record_len = TLS_RECORD_HEADER_SIZE + MAX_TLS_PLAINTEXT_LEN + 1 + 16;
+        // Second record: 1 byte
+        let second_record_len = TLS_RECORD_HEADER_SIZE + 1 + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), first_record_len + second_record_len);
+
+        // Verify first record header
+        assert_eq!(ciphertext_buf[0], CONTENT_TYPE_APPLICATION_DATA);
+        let first_payload_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]) as usize;
+        assert_eq!(first_payload_len, MAX_TLS_PLAINTEXT_LEN + 1 + 16);
+
+        // Verify second record header
+        let second_header_offset = first_record_len;
+        assert_eq!(
+            ciphertext_buf[second_header_offset],
+            CONTENT_TYPE_APPLICATION_DATA
+        );
+        let second_payload_len = u16::from_be_bytes([
+            ciphertext_buf[second_header_offset + 3],
+            ciphertext_buf[second_header_offset + 4],
+        ]) as usize;
+        assert_eq!(second_payload_len, 1 + 1 + 16);
+    }
+
+    #[test]
+    fn test_encrypt_fragmentation_multiple_records() {
+        // Test 3x the max size - should produce 3 records
+        let size = MAX_TLS_PLAINTEXT_LEN * 3;
+        let mut plaintext = vec![0x44u8; size];
+        let key = [0x07u8; 16];
+        let iv = [0x08u8; 12];
+        let mut seq = 10u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(plaintext.is_empty());
+        assert_eq!(seq, 13); // Three records encrypted
+
+        // Each record: header(5) + MAX_TLS_PLAINTEXT_LEN + content_type(1) + tag(16)
+        let record_len = TLS_RECORD_HEADER_SIZE + MAX_TLS_PLAINTEXT_LEN + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), record_len * 3);
+    }
+
+    #[test]
+    fn test_sequence_number_increments() {
+        let key = [0x0Bu8; 16];
+        let iv = [0x0Cu8; 12];
+        let mut seq = 100u64;
+        let mut ciphertext_buf = Vec::new();
+
+        // First call with small data
+        let mut plaintext1 = vec![0x46u8; 50];
+        encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext1,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        )
+        .unwrap();
+        assert_eq!(seq, 101);
+
+        // Second call with data requiring fragmentation
+        let mut plaintext2 = vec![0x47u8; MAX_TLS_PLAINTEXT_LEN + 500];
+        encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext2,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        )
+        .unwrap();
+        assert_eq!(seq, 103); // Two more records
+    }
+
+    #[test]
+    fn test_ciphertext_buf_appends() {
+        let key = [0x0Du8; 16];
+        let iv = [0x0Eu8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        // Pre-populate buffer
+        ciphertext_buf.extend_from_slice(b"existing data");
+        let initial_len = ciphertext_buf.len();
+
+        let mut plaintext = vec![0x48u8; 100];
+        encrypt_plaintext_to_records(CS, &mut plaintext, &key, &iv, &mut seq, &mut ciphertext_buf)
+            .unwrap();
+
+        // Should append, not overwrite
+        assert!(ciphertext_buf.len() > initial_len);
+        assert_eq!(&ciphertext_buf[..initial_len], b"existing data");
+    }
+
+    #[test]
+    fn test_encrypt_single_byte() {
+        // Minimum non-empty plaintext
+        let mut plaintext = vec![0x42u8; 1];
+        let key = [0x0Fu8; 16];
+        let iv = [0x10u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_plaintext_to_records(
+            CS,
+            &mut plaintext,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(plaintext.is_empty());
+        assert_eq!(seq, 1);
+
+        // header(5) + plaintext(1) + content_type(1) + tag(16) = 23
+        assert_eq!(ciphertext_buf.len(), 23);
+    }
+
+    #[test]
+    fn test_handshake_encrypt_empty() {
+        let handshake_data: &[u8] = &[];
+        let key = [0u8; 16];
+        let iv = [0u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_handshake_to_records(
+            CS,
+            handshake_data,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert!(ciphertext_buf.is_empty());
+        assert_eq!(seq, 0); // No records encrypted
+    }
+
+    #[test]
+    fn test_handshake_encrypt_small_single_record() {
+        // Typical small handshake (EncryptedExtensions + small cert + CV + Finished)
+        let handshake_data = vec![0x16u8; 500];
+        let key = [0x01u8; 16];
+        let iv = [0x02u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_handshake_to_records(
+            CS,
+            &handshake_data,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert_eq!(seq, 1); // One record encrypted
+
+        // Should have one record: header(5) + handshake(500) + content_type(1) + tag(16)
+        let expected_len = TLS_RECORD_HEADER_SIZE + 500 + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), expected_len);
+
+        // Verify TLS header - outer type is ApplicationData (0x17)
+        assert_eq!(ciphertext_buf[0], CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(ciphertext_buf[1], 0x03);
+        assert_eq!(ciphertext_buf[2], 0x03);
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]) as usize;
+        assert_eq!(record_len, 500 + 1 + 16);
+    }
+
+    #[test]
+    fn test_handshake_encrypt_max_single_record() {
+        // Exactly at the boundary - should still be single record
+        let handshake_data = vec![0x16u8; MAX_TLS_PLAINTEXT_LEN];
+        let key = [0x03u8; 16];
+        let iv = [0x04u8; 12];
+        let mut seq = 5u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_handshake_to_records(
+            CS,
+            &handshake_data,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert_eq!(seq, 6); // One record encrypted
+
+        let expected_len = TLS_RECORD_HEADER_SIZE + MAX_TLS_PLAINTEXT_LEN + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), expected_len);
+    }
+
+    #[test]
+    fn test_handshake_encrypt_fragmentation_two_records() {
+        // One byte over the limit - should produce two records
+        let handshake_data = vec![0x16u8; MAX_TLS_PLAINTEXT_LEN + 1];
+        let key = [0x05u8; 16];
+        let iv = [0x06u8; 12];
+        let mut seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let result = encrypt_handshake_to_records(
+            CS,
+            &handshake_data,
+            &key,
+            &iv,
+            &mut seq,
+            &mut ciphertext_buf,
+        );
+        assert!(result.is_ok());
+        assert_eq!(seq, 2); // Two records encrypted
+
+        // First record: full MAX_TLS_PLAINTEXT_LEN
+        let first_record_len = TLS_RECORD_HEADER_SIZE + MAX_TLS_PLAINTEXT_LEN + 1 + 16;
+        // Second record: 1 byte
+        let second_record_len = TLS_RECORD_HEADER_SIZE + 1 + 1 + 16;
+        assert_eq!(ciphertext_buf.len(), first_record_len + second_record_len);
+    }
+
+    #[test]
+    fn test_record_encryptor_app_data() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut seq = 0u64;
+        let mut out = Vec::new();
+
+        let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut seq);
+
+        let mut plaintext = vec![0xAAu8; 100];
+        encryptor
+            .encrypt_app_data(&mut plaintext, &mut out)
+            .unwrap();
+
+        assert!(plaintext.is_empty());
+        assert_eq!(seq, 1);
+        assert_eq!(out.len(), 5 + 100 + 1 + 16);
+    }
+
+    #[test]
+    fn test_record_encryptor_handshake() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut seq = 0u64;
+        let mut out = Vec::new();
+
+        let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut seq);
+
+        let handshake = vec![0xBBu8; 200];
+        encryptor.encrypt_handshake(&handshake, &mut out).unwrap();
+
+        assert_eq!(seq, 1);
+        assert_eq!(out.len(), 5 + 200 + 1 + 16);
+    }
+
+    #[test]
+    fn test_record_encryptor_close_notify() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut seq = 0u64;
+        let mut out = Vec::new();
+
+        let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut seq);
+        encryptor.encrypt_close_notify(&mut out).unwrap();
+
+        assert_eq!(seq, 1);
+        // header(5) + alert(2) + content_type(1) + tag(16) = 24
+        assert_eq!(out.len(), 24);
+    }
+
+    #[test]
+    fn test_record_decryptor_roundtrip() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut enc_seq = 0u64;
+        let mut dec_seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        // Encrypt
+        let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut enc_seq);
+        let mut plaintext = vec![0xCCu8; 100];
+        let original = plaintext.clone();
+        encryptor
+            .encrypt_app_data(&mut plaintext, &mut ciphertext_buf)
+            .unwrap();
+
+        // Decrypt - extract ciphertext from record
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]);
+        let ciphertext = &ciphertext_buf[5..];
+
+        let mut decryptor = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let (content_type, decrypted) =
+            decrypt_record(&mut decryptor, ciphertext, record_len).unwrap();
+
+        assert_eq!(content_type, CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(decrypted, original);
+        assert_eq!(dec_seq, 1);
+    }
+
+    #[test]
+    fn test_record_decryptor_handshake_roundtrip() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut enc_seq = 0u64;
+        let mut dec_seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        // Encrypt handshake
+        let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut enc_seq);
+        let handshake = vec![0xDDu8; 150];
+        encryptor
+            .encrypt_handshake(&handshake, &mut ciphertext_buf)
+            .unwrap();
+
+        // Decrypt
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]);
+        let ciphertext = &ciphertext_buf[5..];
+
+        let mut decryptor = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let (content_type, decrypted) =
+            decrypt_record(&mut decryptor, ciphertext, record_len).unwrap();
+
+        assert_eq!(content_type, CONTENT_TYPE_HANDSHAKE);
+        assert_eq!(decrypted, handshake);
+    }
+
+    #[test]
+    fn test_roundtrip_single_byte() {
+        let key_bytes = [0x11u8; 16];
+        let iv = [0x22u8; 12];
+        let mut enc_seq = 0u64;
+        let mut dec_seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let aead_key = AeadKey::new(CS, &key_bytes).unwrap();
+
+        // Encrypt single byte
+        let mut plaintext = vec![0x42u8];
+        let original = plaintext.clone();
+        {
+            let mut enc = RecordEncryptor::new(&aead_key, &iv, &mut enc_seq);
+            enc.encrypt_app_data(&mut plaintext, &mut ciphertext_buf)
+                .unwrap();
+        }
+
+        // Decrypt
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]);
+        let ciphertext = &ciphertext_buf[5..];
+
+        let mut dec = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let (ct, decrypted) = decrypt_record(&mut dec, ciphertext, record_len).unwrap();
+
+        assert_eq!(ct, CONTENT_TYPE_APPLICATION_DATA);
+        assert_eq!(decrypted, original);
+    }
+
+    #[test]
+    fn test_roundtrip_large_64kb() {
+        let key_bytes = [0x33u8; 16];
+        let iv = [0x44u8; 12];
+        let mut enc_seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        let aead_key = AeadKey::new(CS, &key_bytes).unwrap();
+
+        // 64KB will be fragmented into 4 records
+        let mut plaintext = vec![0x55u8; 65536];
+        let original = plaintext.clone();
+        {
+            let mut enc = RecordEncryptor::new(&aead_key, &iv, &mut enc_seq);
+            enc.encrypt_app_data(&mut plaintext, &mut ciphertext_buf)
+                .unwrap();
+        }
+
+        assert_eq!(enc_seq, 4); // 64KB / 16KB = 4 records
+
+        // Decrypt all records and reassemble
+        let mut dec_seq = 0u64;
+        let mut dec = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let mut reassembled = Vec::new();
+        let mut offset = 0;
+
+        while offset < ciphertext_buf.len() {
+            let record_len =
+                u16::from_be_bytes([ciphertext_buf[offset + 3], ciphertext_buf[offset + 4]]);
+            let ciphertext = &ciphertext_buf[offset + 5..offset + 5 + record_len as usize];
+
+            let (ct, decrypted) = decrypt_record(&mut dec, ciphertext, record_len).unwrap();
+            assert_eq!(ct, CONTENT_TYPE_APPLICATION_DATA);
+            reassembled.extend_from_slice(&decrypted);
+
+            offset += 5 + record_len as usize;
+        }
+
+        assert_eq!(reassembled, original);
+    }
+
+    #[test]
+    fn test_encryptor_sequence_exhaustion() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut seq = u64::MAX; // Start at max
+        let mut out = Vec::new();
+
+        let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut seq);
+        let mut plaintext = vec![0xAAu8; 10];
+
+        // First encryption should succeed (uses seq = MAX)
+        let result = encryptor.encrypt_app_data(&mut plaintext, &mut out);
+        assert!(result.is_err()); // Should fail because MAX + 1 would overflow
+        assert!(result.unwrap_err().to_string().contains("exhausted"));
+    }
+
+    #[test]
+    fn test_decryptor_sequence_exhaustion() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+
+        // First encrypt with seq=0 to get valid ciphertext
+        let mut enc_seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+        {
+            let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut enc_seq);
+            let mut plaintext = vec![0xBBu8; 10];
+            encryptor
+                .encrypt_app_data(&mut plaintext, &mut ciphertext_buf)
+                .unwrap();
+        }
+
+        // Try to decrypt with seq at MAX - decryption will fail due to wrong nonce,
+        // but even if it succeeded, seq increment would fail
+        let mut dec_seq = u64::MAX;
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]);
+        let ciphertext = &ciphertext_buf[5..];
+
+        let mut decryptor = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let result = decrypt_record(&mut decryptor, ciphertext, record_len);
+        // Will fail either due to decryption (wrong nonce) or seq exhaustion
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_record_with_zero_padding() {
+        let key = [0x01u8; 16];
+        let iv = [0x02u8; 12];
+        let aead_key = AeadKey::new(CS, &key).unwrap();
+
+        let content = vec![0xAAu8; 50];
+        let mut padded = content.clone();
+        padded.push(CONTENT_TYPE_HANDSHAKE);
+        padded.extend_from_slice(&[0x00u8; 5]);
+
+        let ciphertext_len = padded.len() + 16;
+        let aad = make_record_header(ciphertext_len);
+        let ciphertext = aead_key.seal(&padded, &iv, 0, &aad).unwrap();
+
+        let mut dec_seq = 0u64;
+        let mut decryptor = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let (content_type, plaintext) =
+            decrypt_record(&mut decryptor, &ciphertext, ciphertext_len as u16).unwrap();
+
+        assert_eq!(content_type, CONTENT_TYPE_HANDSHAKE);
+        assert_eq!(plaintext, content);
+    }
+
+    #[test]
+    fn test_decrypt_all_zeros_plaintext_fails() {
+        let key = [0x03u8; 16];
+        let iv = [0x04u8; 12];
+        let aead_key = AeadKey::new(CS, &key).unwrap();
+
+        let all_zeros = vec![0x00u8; 16];
+        let ciphertext_len = all_zeros.len() + 16;
+        let aad = make_record_header(ciphertext_len);
+        let ciphertext = aead_key.seal(&all_zeros, &iv, 0, &aad).unwrap();
+
+        let mut dec_seq = 0u64;
+        let mut decryptor = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let result = decrypt_record(&mut decryptor, &ciphertext, ciphertext_len as u16);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("all zeros"));
+    }
+
+    #[test]
+    fn test_alert_roundtrip() {
+        let aead_key = AeadKey::new(CS, &[0x42u8; 16]).unwrap();
+        let iv = [0x99u8; 12];
+        let mut enc_seq = 0u64;
+        let mut dec_seq = 0u64;
+        let mut ciphertext_buf = Vec::new();
+
+        // Encrypt close_notify alert
+        {
+            let mut encryptor = RecordEncryptor::new(&aead_key, &iv, &mut enc_seq);
+            encryptor.encrypt_close_notify(&mut ciphertext_buf).unwrap();
+        }
+
+        assert_eq!(enc_seq, 1);
+
+        // Decrypt and verify
+        let record_len = u16::from_be_bytes([ciphertext_buf[3], ciphertext_buf[4]]);
+        let ciphertext = &ciphertext_buf[5..];
+
+        let mut decryptor = RecordDecryptor::new(&aead_key, &iv, &mut dec_seq);
+        let (content_type, plaintext) =
+            decrypt_record(&mut decryptor, ciphertext, record_len).unwrap();
+
+        assert_eq!(content_type, CONTENT_TYPE_ALERT);
+        assert_eq!(plaintext.len(), 2);
+        assert_eq!(plaintext[0], 0x01); // level = warning
+        assert_eq!(plaintext[1], 0x00); // desc = close_notify
+    }
+}

--- a/crates/core-reality/src/donor/reality_server_connection.rs
+++ b/crates/core-reality/src/donor/reality_server_connection.rs
@@ -1,0 +1,1458 @@
+// REALITY server-side connection
+//
+// This implements a rustls-compatible API for REALITY protocol server connections,
+// allowing REALITY to be used as a drop-in replacement for rustls.
+
+use aws_lc_rs::kem::{EncapsulationKey, ML_KEM_768};
+use aws_lc_rs::{agreement, digest};
+use rand::RngCore;
+use std::io::{self, Read, Write};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use subtle::ConstantTimeEq;
+use zeroize::Zeroize;
+
+use super::common::{
+    ALERT_DESC_CLOSE_NOTIFY, ALERT_LEVEL_WARNING, CIPHERTEXT_READ_BUF_CAPACITY, CONTENT_TYPE_ALERT,
+    CONTENT_TYPE_APPLICATION_DATA, CONTENT_TYPE_CHANGE_CIPHER_SPEC, CONTENT_TYPE_HANDSHAKE,
+    HANDSHAKE_TYPE_FINISHED, OUTGOING_BUFFER_LIMIT, PLAINTEXT_READ_BUF_CAPACITY,
+    TLS_MAX_RECORD_SIZE, TLS_RECORD_HEADER_SIZE,
+};
+use super::reality_aead::{AeadKey, decrypt_handshake_message};
+use super::reality_auth::{decrypt_session_id, derive_auth_key, perform_ecdh};
+use super::reality_certificate::generate_hmac_certificate;
+use super::reality_cipher_suite::{CipherSuite, DEFAULT_CIPHER_SUITES};
+use super::reality_io_state::RealityIoState;
+use super::reality_reader_writer::{RealityReader, RealityWriter};
+use super::reality_records::{RecordDecryptor, RecordEncryptor};
+use super::reality_tls13_keys::{
+    compute_finished_verify_data, derive_application_secrets, derive_handshake_keys,
+    derive_next_traffic_secret, derive_traffic_keys,
+};
+use super::reality_tls13_messages::{
+    construct_certificate, construct_certificate_verify, construct_encrypted_extensions,
+    construct_finished, write_record_header,
+};
+use super::reality_util::{
+    extract_client_cipher_suites, extract_client_key_share, extract_client_public_key,
+    extract_client_random, extract_server_cipher_suite, extract_server_key_share,
+    extract_session_id_slice, mirror_server_hello_with_key_share, negotiate_cipher_suite,
+};
+use crate::buffer::SlideBuffer;
+
+const HANDSHAKE_TYPE_KEY_UPDATE: u8 = 24;
+const KEY_UPDATE_NOT_REQUESTED: u8 = 0;
+const KEY_UPDATE_REQUESTED: u8 = 1;
+
+fn validate_encrypted_record_len(record_len: usize) -> io::Result<()> {
+    let max_ciphertext = TLS_MAX_RECORD_SIZE - TLS_RECORD_HEADER_SIZE;
+    if !(17..=max_ciphertext).contains(&record_len) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TLS 1.3 ciphertext record length is out of bounds",
+        ));
+    }
+    Ok(())
+}
+
+/// Configuration for REALITY server connections
+#[derive(Clone)]
+pub struct RealityServerCryptoConfig {
+    /// Server's X25519 private key (32 bytes)
+    pub private_key: [u8; 32],
+    /// List of valid short IDs for authentication (8 bytes each)
+    pub short_ids: Vec<[u8; 8]>,
+    /// Destination server for certificate generation
+    pub certificate_server_name: String,
+    /// Maximum allowed time difference (None = no check)
+    pub max_time_diff: Option<Duration>,
+    /// Minimum accepted client version (3 bytes: major.minor.patch)
+    pub min_client_version: Option<[u8; 3]>,
+    /// Maximum accepted client version (3 bytes: major.minor.patch)
+    pub max_client_version: Option<[u8; 3]>,
+    /// Supported TLS 1.3 cipher suites (empty = use defaults)
+    pub cipher_suites: Vec<CipherSuite>,
+    /// Optional ML-DSA-65 seed for the REALITY certificate extension.
+    pub mldsa65_seed: Option<[u8; 32]>,
+}
+
+/// Handshake state machine for REALITY server
+enum HandshakeState {
+    /// Initial state, waiting for ClientHello
+    Initial,
+    /// ClientHello validated, waiting to build response with dest structure
+    ClientHelloValidated { info: ClientHelloInfo },
+    /// ServerHello and encrypted handshake messages sent, waiting for client Finished
+    ServerHelloSent {
+        handshake_hash_with_server_finished: Vec<u8>, // Hash including server Finished (for verifying client Finished)
+        client_handshake_traffic_secret: Vec<u8>,
+        master_secret: Vec<u8>,
+        cipher_suite: CipherSuite,
+    },
+    /// Handshake complete, ready for application data
+    Complete,
+}
+
+/// Information extracted from ClientHello during validation phase
+/// This is passed to build_server_response() to construct the reply
+#[derive(Clone)]
+pub struct ClientHelloInfo {
+    /// Session ID from ClientHello (echoed back in ServerHello)
+    pub session_id: Vec<u8>,
+    /// Client's X25519 public key from key_share extension
+    pub client_public_key: [u8; 32],
+    /// Derived auth key for HMAC certificate
+    pub auth_key: [u8; 32],
+    /// Raw ClientHello handshake bytes (for transcript hash)
+    pub client_hello_handshake: Vec<u8>,
+    /// Client's complete X25519MLKEM768 key share, when offered.
+    pub hybrid_client_key_share: Option<Vec<u8>>,
+    /// Cipher suites offered by the client, used to validate the target template.
+    pub client_cipher_suites: Vec<u16>,
+}
+
+impl Drop for ClientHelloInfo {
+    fn drop(&mut self) {
+        self.auth_key.zeroize();
+    }
+}
+
+/// REALITY server-side connection implementing rustls-compatible API
+pub struct RealityServerConnection {
+    // Configuration
+    config: RealityServerCryptoConfig,
+
+    // Handshake state
+    handshake_state: HandshakeState,
+
+    // TLS 1.3 application traffic encryption (post-handshake)
+    // Keys are cached as AeadKey to avoid per-record key setup overhead
+    app_read_key: Option<AeadKey>,
+    app_read_iv: Option<Vec<u8>>,
+    app_read_secret: Option<Vec<u8>>,
+    app_write_key: Option<AeadKey>,
+    app_write_iv: Option<Vec<u8>>,
+    app_write_secret: Option<Vec<u8>>,
+    read_seq: u64,
+    write_seq: u64,
+    cipher_suite: Option<CipherSuite>,
+
+    // Pre-allocated buffer for TLS read operations (reused across calls)
+    tls_read_buffer: Box<[u8]>,
+
+    // Buffers for I/O - using SlideBuffer for efficient zero-alloc operations
+    ciphertext_read_buf: SlideBuffer, // Incoming encrypted TLS records
+    ciphertext_write_buf: Vec<u8>,    // Outgoing encrypted TLS records
+    plaintext_read_buf: SlideBuffer,  // Decrypted application data
+    plaintext_write_buf: Vec<u8>,     // Application data to encrypt
+    post_handshake_buf: Vec<u8>,      // Fragmented post-handshake KeyUpdate
+
+    // Connection state flags (mirrors rustls patterns)
+    received_close_notify: bool,        // Peer sent close_notify alert
+    fatal_error: Option<io::ErrorKind>, // Fatal error occurred, connection unusable
+    authenticated_client: Option<AuthenticatedClient>,
+    negotiated_group: Option<u16>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AuthenticatedClient {
+    pub(crate) version: [u8; 3],
+    pub(crate) short_id: [u8; 8],
+}
+
+impl RealityServerConnection {
+    /// Create a new REALITY server connection
+    pub fn new(config: RealityServerCryptoConfig) -> io::Result<Self> {
+        Ok(RealityServerConnection {
+            config,
+            handshake_state: HandshakeState::Initial,
+            app_read_key: None,
+            app_read_iv: None,
+            app_read_secret: None,
+            app_write_key: None,
+            app_write_iv: None,
+            app_write_secret: None,
+            read_seq: 0,
+            write_seq: 0,
+            cipher_suite: None,
+            tls_read_buffer: vec![0; TLS_MAX_RECORD_SIZE].into_boxed_slice(),
+            ciphertext_read_buf: SlideBuffer::new(CIPHERTEXT_READ_BUF_CAPACITY),
+            ciphertext_write_buf: Vec::with_capacity(OUTGOING_BUFFER_LIMIT),
+            plaintext_read_buf: SlideBuffer::new(PLAINTEXT_READ_BUF_CAPACITY),
+            plaintext_write_buf: Vec::with_capacity(OUTGOING_BUFFER_LIMIT),
+            post_handshake_buf: Vec::with_capacity(5),
+            received_close_notify: false,
+            fatal_error: None,
+            authenticated_client: None,
+            negotiated_group: None,
+        })
+    }
+
+    /// Read TLS messages from the provided reader into internal buffer
+    ///
+    /// This does NOT decrypt - call process_new_packets() for that.
+    /// Uses pre-allocated buffer to avoid allocation on every call.
+    pub fn read_tls(&mut self, rd: &mut dyn Read) -> io::Result<usize> {
+        // Compact if remaining capacity is insufficient for a full TLS record
+        if self.ciphertext_read_buf.remaining_capacity() < TLS_MAX_RECORD_SIZE {
+            self.ciphertext_read_buf.compact();
+        }
+
+        // Read into pre-allocated buffer
+        let n = rd.read(&mut self.tls_read_buffer[..])?;
+        if n > 0 {
+            self.ciphertext_read_buf
+                .extend_from_slice(&self.tls_read_buffer[..n]);
+        }
+        Ok(n)
+    }
+
+    /// Process buffered TLS messages and advance handshake/decrypt data
+    ///
+    /// Returns I/O state with available plaintext bytes and write status.
+    /// Like rustls, this loops until no more progress can be made, ensuring
+    /// that piggybacked application data (e.g., VLESS request sent with TLS Finished)
+    /// is processed in the same call.
+    pub fn process_new_packets(&mut self) -> io::Result<RealityIoState> {
+        // Return persisted error if connection is in fatal error state (rustls pattern)
+        if let Some(error_kind) = self.fatal_error {
+            return Err(io::Error::new(error_kind, "connection previously failed"));
+        }
+
+        // Don't process more data after receiving close_notify (RFC 8446)
+        if self.received_close_notify {
+            return Ok(RealityIoState::new(self.plaintext_read_buf.len()));
+        }
+
+        let result = self.process_new_packets_inner();
+
+        // Persist fatal errors
+        if let Err(ref e) = result {
+            // Persist error for certain error kinds that indicate fatal connection failure
+            match e.kind() {
+                io::ErrorKind::InvalidData
+                | io::ErrorKind::PermissionDenied
+                | io::ErrorKind::ConnectionAborted => {
+                    self.fatal_error = Some(e.kind());
+                }
+                _ => {}
+            }
+        }
+
+        result
+    }
+
+    /// Inner implementation of process_new_packets
+    fn process_new_packets_inner(&mut self) -> io::Result<RealityIoState> {
+        loop {
+            match &self.handshake_state {
+                HandshakeState::Initial | HandshakeState::ClientHelloValidated { .. } => {
+                    // Initial: ClientHello must be passed via validate_client_hello()
+                    // ClientHelloValidated: Response must be built via build_server_response()
+                    // Neither should be reached during process_new_packets
+                    break;
+                }
+                HandshakeState::ServerHelloSent { .. } => {
+                    if !self.process_client_finished()? {
+                        break;
+                    }
+                }
+                HandshakeState::Complete => {
+                    self.process_application_data()?;
+                    break;
+                }
+            }
+        }
+
+        Ok(RealityIoState::new(self.plaintext_read_buf.len()))
+    }
+
+    /// Public API: Validate ClientHello
+    ///
+    /// This performs authentication (ECDH, decrypt session_id, validate short_id/timestamp/version)
+    /// but does NOT build the server response. Call build_server_response() after to complete.
+    ///
+    /// Returns Ok(()) on success, Err(PermissionDenied) on auth failure.
+    pub fn validate_client_hello(&mut self, client_hello: &[u8]) -> io::Result<()> {
+        // Return persisted error if connection is in fatal error state
+        if let Some(error_kind) = self.fatal_error {
+            return Err(io::Error::new(error_kind, "connection previously failed"));
+        }
+
+        // Must be in Initial state
+        if !matches!(self.handshake_state, HandshakeState::Initial) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "validate_client_hello called in wrong state",
+            ));
+        }
+
+        // Process ClientHello validation
+        let result = self.process_client_hello_validation(client_hello);
+
+        // Persist fatal errors
+        if let Err(ref e) = result {
+            match e.kind() {
+                io::ErrorKind::InvalidData
+                | io::ErrorKind::PermissionDenied
+                | io::ErrorKind::ConnectionAborted => {
+                    self.fatal_error = Some(e.kind());
+                }
+                _ => {}
+            }
+        }
+
+        result
+    }
+
+    /// Public API: Build server response using dest's record structure as template
+    ///
+    /// Call this after validate_client_hello() succeeds. Pass the TLS records
+    /// received from the destination server to match their structure.
+    ///
+    /// dest_records should contain: [ServerHello, CCS, encrypted_handshake..., NewSessionTicket...]
+    pub fn build_server_response(&mut self, dest_records: Vec<bytes::Bytes>) -> io::Result<()> {
+        // Must be in ClientHelloValidated state
+        if !matches!(
+            self.handshake_state,
+            HandshakeState::ClientHelloValidated { .. }
+        ) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "build_server_response called in wrong state",
+            ));
+        }
+
+        self.build_server_response_internal(&dest_records)
+    }
+
+    /// Phase 1: Validate ClientHello and extract info for later response building
+    #[inline]
+    fn process_client_hello_validation(&mut self, client_hello: &[u8]) -> io::Result<()> {
+        // Validate minimum length (TLS record header + some content)
+        if client_hello.len() < TLS_RECORD_HEADER_SIZE + 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ClientHello too short",
+            ));
+        }
+
+        // Extract fields from ClientHello
+        let client_random = extract_client_random(client_hello)?;
+        let session_id = extract_session_id_slice(client_hello)?;
+        let client_public_key = extract_client_public_key(client_hello)?;
+
+        // Perform ECDH to derive auth key
+        let mut shared_secret = perform_ecdh(&self.config.private_key, &client_public_key)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        let salt = &client_random[0..20];
+        let mut auth_key = derive_auth_key(&shared_secret, salt, b"REALITY")
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        shared_secret.zeroize();
+
+        // Validate session ID (contains encrypted metadata)
+        if session_id.len() != 32 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid session ID length",
+            ));
+        }
+
+        let nonce = &client_random[20..32];
+        let mut encrypted_session_id_arr = [0u8; 32];
+        encrypted_session_id_arr.copy_from_slice(session_id);
+
+        // Reconstruct AAD with zeros at SessionId location
+        let client_hello_handshake = &client_hello[TLS_RECORD_HEADER_SIZE..];
+        let mut aad_for_decryption = client_hello_handshake.to_vec();
+        if aad_for_decryption.len() >= 39 + 32 {
+            aad_for_decryption[39..39 + 32].fill(0);
+        }
+
+        let mut decrypted_session_id = decrypt_session_id(
+            &encrypted_session_id_arr,
+            &auth_key,
+            nonce,
+            &aad_for_decryption,
+        )
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("Session ID decrypt failed: {:?}", e),
+            )
+        })?;
+
+        // Validate session ID contents
+        let client_version = &decrypted_session_id[0..3];
+        let client_timestamp = u32::from_be_bytes([
+            decrypted_session_id[4],
+            decrypted_session_id[5],
+            decrypted_session_id[6],
+            decrypted_session_id[7],
+        ]) as u64;
+        let client_short_id = &decrypted_session_id[8..16];
+
+        // Validate short ID using constant-time comparison
+        let mut client_short_id_arr = [0u8; 8];
+        client_short_id_arr.copy_from_slice(client_short_id);
+        let short_id_ok = self.config.short_ids.iter().fold(false, |acc, valid_id| {
+            acc | (client_short_id_arr.ct_eq(valid_id).unwrap_u8() == 1)
+        });
+
+        if !short_id_ok {
+            log::warn!("REALITY: Client short_id is not in the configured list");
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Invalid short_id",
+            ));
+        }
+
+        // Validate timestamp if max_time_diff is configured
+        if let Some(max_diff) = self.config.max_time_diff {
+            let now = SystemTime::now();
+            let client_time = UNIX_EPOCH
+                .checked_add(Duration::from_secs(client_timestamp))
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Client timestamp overflow")
+                })?;
+            let time_diff = now
+                .duration_since(client_time)
+                .or_else(|_| client_time.duration_since(now))
+                .map_err(|_| io::Error::other("System time difference error"))?;
+
+            if time_diff > max_diff {
+                log::warn!("REALITY: Client timestamp exceeds maxTimeDiff");
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "Timestamp difference {:?} exceeds maximum {:?}",
+                        time_diff, max_diff
+                    ),
+                ));
+            }
+        }
+
+        // Validate client version (min)
+        if let Some(min_ver) = &self.config.min_client_version
+            && client_version < &min_ver[..]
+        {
+            log::warn!(
+                "REALITY: Client version {:?} is below minimum {:?}",
+                client_version,
+                min_ver
+            );
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "Client version {:?} is below minimum {:?}",
+                    client_version, min_ver
+                ),
+            ));
+        }
+
+        // Validate client version (max)
+        if let Some(max_ver) = &self.config.max_client_version
+            && client_version > &max_ver[..]
+        {
+            log::warn!(
+                "REALITY: Client version {:?} is above maximum {:?}",
+                client_version,
+                max_ver
+            );
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "Client version {:?} is above maximum {:?}",
+                    client_version, max_ver
+                ),
+            ));
+        }
+
+        log::debug!(
+            "REALITY: Client authentication successful for version {:?}",
+            client_version
+        );
+
+        self.authenticated_client = Some(AuthenticatedClient {
+            version: client_version
+                .try_into()
+                .expect("three-byte client version"),
+            short_id: client_short_id_arr,
+        });
+
+        // Negotiate cipher suite with client
+        let client_cipher_suites = extract_client_cipher_suites(client_hello)?;
+        let hybrid_client_key_share = extract_client_key_share(client_hello, 0x11ec).ok();
+        let server_cipher_suites = if self.config.cipher_suites.is_empty() {
+            DEFAULT_CIPHER_SUITES.to_vec()
+        } else {
+            self.config.cipher_suites.clone()
+        };
+        let negotiated_cipher_suite =
+            negotiate_cipher_suite(&server_cipher_suites, &client_cipher_suites).ok_or_else(
+                || {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "No common TLS 1.3 cipher suite found",
+                    )
+                },
+            )?;
+        log::debug!(
+            "REALITY: Negotiated cipher suite {:?} (client offered: {:04x?})",
+            negotiated_cipher_suite,
+            client_cipher_suites
+        );
+
+        // Store validated info for response building
+        self.handshake_state = HandshakeState::ClientHelloValidated {
+            info: ClientHelloInfo {
+                session_id: session_id.to_vec(),
+                client_public_key,
+                auth_key,
+                client_hello_handshake: client_hello_handshake.to_vec(),
+                hybrid_client_key_share,
+                client_cipher_suites,
+            },
+        };
+        auth_key.zeroize();
+        decrypted_session_id.zeroize();
+
+        Ok(())
+    }
+
+    /// Phase 2: Build server response using dest's record structure as template
+    fn build_server_response_internal(&mut self, dest_records: &[bytes::Bytes]) -> io::Result<()> {
+        // Take ownership of info from state (state already validated by caller)
+        let HandshakeState::ClientHelloValidated { info } =
+            std::mem::replace(&mut self.handshake_state, HandshakeState::Initial)
+        else {
+            unreachable!()
+        };
+
+        let target_server_hello = dest_records.first().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "camouflage target returned no ServerHello",
+            )
+        })?;
+        let target_cipher_id = extract_server_cipher_suite(target_server_hello)?;
+        if !info.client_cipher_suites.contains(&target_cipher_id) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "target selected a cipher not offered by client",
+            ));
+        }
+        let configured_suites = if self.config.cipher_suites.is_empty() {
+            DEFAULT_CIPHER_SUITES
+        } else {
+            self.config.cipher_suites.as_slice()
+        };
+        let cipher_suite = CipherSuite::from_id(target_cipher_id)
+            .filter(|suite| configured_suites.contains(suite))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "unsupported target TLS 1.3 cipher",
+                )
+            })?;
+        let (named_group, target_key_share) = extract_server_key_share(target_server_hello)?;
+        self.negotiated_group = Some(named_group);
+
+        // Generate our server X25519 keypair. For the hybrid group, the X25519
+        // contribution is concatenated after the ML-KEM shared secret.
+        let mut rng = rand::rng();
+        let mut our_private_bytes = [0u8; 32];
+        rng.fill_bytes(&mut our_private_bytes);
+
+        let our_private_key =
+            agreement::PrivateKey::from_private_key(&agreement::X25519, &our_private_bytes)
+                .map_err(|_| io::Error::other("Failed to create X25519 key"))?;
+        our_private_bytes.zeroize();
+        let our_public_key_bytes = our_private_key
+            .compute_public_key()
+            .map_err(|_| io::Error::other("Failed to compute public key"))?;
+
+        let (client_x25519, mut tls_shared_secret, server_key_share) = match named_group {
+            0x001d => {
+                if target_key_share.len() != 32 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid target X25519 key-share length",
+                    ));
+                }
+                (
+                    info.client_public_key,
+                    Vec::with_capacity(32),
+                    our_public_key_bytes.as_ref().to_vec(),
+                )
+            }
+            0x11ec => {
+                if target_key_share.len() != 1088 + 32 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid target X25519MLKEM768 key-share length",
+                    ));
+                }
+                let client_hybrid = info.hybrid_client_key_share.as_deref().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "target selected X25519MLKEM768 not offered by client",
+                    )
+                })?;
+                if client_hybrid.len() != 1184 + 32 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid client X25519MLKEM768 key-share length",
+                    ));
+                }
+                let encapsulation_key = EncapsulationKey::new(&ML_KEM_768, &client_hybrid[..1184])
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "invalid ML-KEM-768 encapsulation key",
+                        )
+                    })?;
+                let (ciphertext, shared_secret) = encapsulation_key
+                    .encapsulate()
+                    .map_err(|_| io::Error::other("ML-KEM-768 encapsulation failed"))?;
+                let mut shared = shared_secret.as_ref().to_vec();
+                let mut share = ciphertext.as_ref().to_vec();
+                share.extend_from_slice(our_public_key_bytes.as_ref());
+                let x25519: [u8; 32] = client_hybrid[1184..].try_into().map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "invalid hybrid X25519 key")
+                })?;
+                (x25519, std::mem::take(&mut shared), share)
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "camouflage target selected an unsupported key-share group",
+                ));
+            }
+        };
+
+        // Preserve the destination's ServerHello random, extensions and exact
+        // key-share shape, replacing only the key exchange bytes.
+        let server_hello = mirror_server_hello_with_key_share(
+            target_server_hello,
+            &info.session_id,
+            named_group,
+            &server_key_share,
+        )?;
+
+        // Compute transcript hashes using cipher suite's digest algorithm
+        let digest_alg = cipher_suite.digest_algorithm();
+
+        let mut ch_transcript = digest::Context::new(digest_alg);
+        ch_transcript.update(&info.client_hello_handshake);
+        let client_hello_hash = ch_transcript.finish();
+
+        let mut ch_sh_transcript = digest::Context::new(digest_alg);
+        ch_sh_transcript.update(&info.client_hello_handshake);
+        ch_sh_transcript.update(&server_hello);
+
+        let mut handshake_transcript = ch_sh_transcript.clone();
+        let server_hello_hash = ch_sh_transcript.finish();
+
+        // Perform ECDH for TLS 1.3 key derivation
+        let peer_public_key = agreement::UnparsedPublicKey::new(&agreement::X25519, &client_x25519);
+        let mut x25519_shared_secret = [0u8; 32];
+        agreement::agree(
+            &our_private_key,
+            peer_public_key,
+            io::Error::other("ECDH failed"),
+            |key_material| {
+                x25519_shared_secret.copy_from_slice(key_material);
+                Ok(())
+            },
+        )?;
+        tls_shared_secret.extend_from_slice(&x25519_shared_secret);
+        x25519_shared_secret.zeroize();
+
+        // Derive TLS 1.3 keys
+        let hs_keys = derive_handshake_keys(
+            cipher_suite,
+            &tls_shared_secret,
+            client_hello_hash.as_ref(),
+            server_hello_hash.as_ref(),
+        )?;
+        tls_shared_secret.zeroize();
+
+        // Get destination hostname for certificate
+        if self.config.certificate_server_name.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "REALITY requires a certificate server name",
+            ));
+        }
+
+        // Generate HMAC-signed certificate
+        let (cert, signing_key) = generate_hmac_certificate(
+            &info.auth_key,
+            self.config.mldsa65_seed.as_ref(),
+            &info.client_hello_handshake,
+            &server_hello,
+        )?;
+
+        // Build encrypted handshake messages
+        let encrypted_extensions = construct_encrypted_extensions()?;
+        handshake_transcript.update(&encrypted_extensions);
+
+        let certificate = construct_certificate(cert)?;
+        handshake_transcript.update(&certificate);
+
+        let cert_verify_hash = handshake_transcript.clone().finish();
+        let certificate_verify =
+            construct_certificate_verify(&signing_key, cert_verify_hash.as_ref())?;
+        handshake_transcript.update(&certificate_verify);
+
+        let handshake_hash_before_finished = handshake_transcript.clone().finish();
+
+        // Derive server handshake traffic keys for encryption
+        let (server_hs_key, server_hs_iv) =
+            derive_traffic_keys(&hs_keys.server_handshake_traffic_secret, cipher_suite)?;
+
+        // Build server Finished message
+        let server_verify_data = compute_finished_verify_data(
+            cipher_suite,
+            &hs_keys.server_handshake_traffic_secret,
+            handshake_hash_before_finished.as_ref(),
+        )?;
+        let server_finished = construct_finished(&server_verify_data)?;
+
+        // Analyze dest's record structure to determine how to encrypt
+        // dest_records: [0]=ServerHello, [1]=CCS, [2..]=encrypted handshake, possibly NewSessionTicket
+        let dest_encrypted_records: Vec<&bytes::Bytes> = dest_records
+            .iter()
+            .filter(|record| record.first() == Some(&CONTENT_TYPE_APPLICATION_DATA))
+            .collect();
+
+        // Build handshake messages array
+        let messages: [&[u8]; 4] = [
+            &encrypted_extensions,
+            &certificate,
+            &certificate_verify,
+            &server_finished,
+        ];
+
+        // Encrypt handshake messages, matching dest's structure exactly
+        let mut handshake_ciphertext = Vec::new();
+        let mut handshake_seq = 0u64;
+        let hs_aead_key = AeadKey::new(cipher_suite, &server_hs_key)?;
+
+        // Determine if dest uses combined mode or separate mode using 512-byte heuristic
+        // Like XTLS/REALITY: if first encrypted record > 512 bytes, it's combined mode
+        let is_combined_mode = match dest_encrypted_records.first() {
+            Some(first_record) => first_record.len() > 512,
+            None => true, // No encrypted records = default to combined mode
+        };
+
+        if is_combined_mode {
+            // Combined mode: all messages in one record (with optional padding)
+            let mut combined_plaintext = Vec::new();
+            for msg in &messages {
+                combined_plaintext.extend_from_slice(msg);
+            }
+
+            let target_size = dest_encrypted_records.first().map(|r| r.len()).unwrap_or(0);
+
+            log::debug!(
+                "REALITY SERVER: Combined mode - EE={}, Cert={}, CV={}, Fin={}, Total={}, target={}",
+                encrypted_extensions.len(),
+                certificate.len(),
+                certificate_verify.len(),
+                server_finished.len(),
+                combined_plaintext.len(),
+                target_size
+            );
+
+            let mut encryptor =
+                RecordEncryptor::new(&hs_aead_key, &server_hs_iv, &mut handshake_seq);
+            encryptor.encrypt_handshake_with_padding(
+                &combined_plaintext,
+                &mut handshake_ciphertext,
+                target_size,
+            )?;
+        } else {
+            // Separate mode: encrypt each message as its own record, matching dest's sizes
+            log::debug!(
+                "REALITY SERVER: Separate mode - {} dest records, encrypting {} messages separately",
+                dest_encrypted_records.len(),
+                messages.len()
+            );
+
+            let mut encryptor =
+                RecordEncryptor::new(&hs_aead_key, &server_hs_iv, &mut handshake_seq);
+
+            for (i, msg) in messages.iter().enumerate() {
+                let target_size = dest_encrypted_records.get(i).map(|r| r.len()).unwrap_or(0);
+                encryptor.encrypt_handshake_with_padding(
+                    msg,
+                    &mut handshake_ciphertext,
+                    target_size,
+                )?;
+            }
+        }
+
+        // Update transcript with server Finished
+        handshake_transcript.update(&server_finished);
+        let handshake_hash_with_server_finished = handshake_transcript.finish();
+
+        // Buffer all handshake messages to write buffer
+        // ServerHello (plaintext)
+        self.ciphertext_write_buf
+            .extend_from_slice(&write_record_header(
+                CONTENT_TYPE_HANDSHAKE,
+                server_hello.len() as u16,
+            ));
+        self.ciphertext_write_buf.extend_from_slice(&server_hello);
+
+        // ChangeCipherSpec (for compatibility)
+        if dest_records
+            .iter()
+            .any(|record| record.first() == Some(&CONTENT_TYPE_CHANGE_CIPHER_SPEC))
+        {
+            self.ciphertext_write_buf
+                .extend_from_slice(&write_record_header(CONTENT_TYPE_CHANGE_CIPHER_SPEC, 1));
+            self.ciphertext_write_buf.push(0x01);
+        }
+
+        // Encrypted handshake record(s)
+        self.ciphertext_write_buf
+            .extend_from_slice(&handshake_ciphertext);
+
+        log::debug!(
+            "REALITY: ServerHello and encrypted handshake messages buffered ({} bytes)",
+            self.ciphertext_write_buf.len()
+        );
+
+        // Update handshake state
+        self.handshake_state = HandshakeState::ServerHelloSent {
+            handshake_hash_with_server_finished: handshake_hash_with_server_finished
+                .as_ref()
+                .to_vec(),
+            client_handshake_traffic_secret: hs_keys.client_handshake_traffic_secret.clone(),
+            master_secret: hs_keys.master_secret,
+            cipher_suite,
+        };
+
+        Ok(())
+    }
+
+    /// Process client's Finished message and complete handshake
+    /// Returns true if a complete record was processed, false if more data needed
+    #[inline]
+    fn process_client_finished(&mut self) -> io::Result<bool> {
+        // Check if we have enough data for a TLS record header BEFORE extracting state
+        if self.ciphertext_read_buf.len() < TLS_RECORD_HEADER_SIZE {
+            return Ok(false); // Need more data
+        }
+
+        // Check for ChangeCipherSpec (TLS 1.3 compatibility message)
+        if self.ciphertext_read_buf[0] == CONTENT_TYPE_CHANGE_CIPHER_SPEC {
+            // ChangeCipherSpec record
+            let ccs_len = self
+                .ciphertext_read_buf
+                .get_u16_be(3)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Buffer too short"))?
+                as usize;
+
+            if ccs_len != 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid ChangeCipherSpec record length",
+                ));
+            }
+
+            // Need complete ChangeCipherSpec record
+            if self.ciphertext_read_buf.len() < TLS_RECORD_HEADER_SIZE + ccs_len {
+                return Ok(false); // Need more data
+            }
+            if self.ciphertext_read_buf[5] != 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid ChangeCipherSpec payload",
+                ));
+            }
+
+            // Skip ChangeCipherSpec (compatibility message)
+            log::debug!("REALITY: Skipping ChangeCipherSpec (compatibility message)");
+            self.ciphertext_read_buf
+                .consume(TLS_RECORD_HEADER_SIZE + ccs_len);
+
+            // Check if we have the next record header
+            if self.ciphertext_read_buf.len() < TLS_RECORD_HEADER_SIZE {
+                return Ok(false); // Need more data
+            }
+        }
+
+        // Parse TLS record length
+        let record_len = self
+            .ciphertext_read_buf
+            .get_u16_be(3)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Buffer too short"))?
+            as usize;
+        validate_encrypted_record_len(record_len)?;
+
+        // Check if we have the complete record
+        let total_record_len = TLS_RECORD_HEADER_SIZE + record_len;
+        if self.ciphertext_read_buf.len() < total_record_len {
+            return Ok(false); // Need more data
+        }
+
+        // Verify it's ApplicationData (encrypted Finished)
+        if self.ciphertext_read_buf[0] != CONTENT_TYPE_APPLICATION_DATA {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Expected ApplicationData (0x17), got 0x{:02x}",
+                    self.ciphertext_read_buf[0]
+                ),
+            ));
+        }
+
+        // NOW we're committed to processing - take ownership of handshake state
+        // This avoids cloning Vec<u8> fields
+        let old_state = std::mem::replace(&mut self.handshake_state, HandshakeState::Complete);
+        let HandshakeState::ServerHelloSent {
+            client_handshake_traffic_secret,
+            master_secret,
+            cipher_suite,
+            handshake_hash_with_server_finished,
+        } = old_state
+        else {
+            unreachable!()
+        };
+
+        // Extract the encrypted Finished record (copy to Vec for decryption)
+        let record: Vec<u8> = self.ciphertext_read_buf[..total_record_len].to_vec();
+        self.ciphertext_read_buf.consume(total_record_len);
+        let ciphertext = &record[TLS_RECORD_HEADER_SIZE..]; // Skip TLS record header
+
+        // Derive client handshake traffic keys for decryption
+        let (client_hs_key, client_hs_iv) =
+            derive_traffic_keys(&client_handshake_traffic_secret, cipher_suite)?;
+
+        // Decrypt the Finished message (sequence number = 0 for client's first encrypted record)
+        let plaintext = decrypt_handshake_message(
+            cipher_suite,
+            &client_hs_key,
+            &client_hs_iv,
+            0, // Client's first encrypted record
+            ciphertext,
+            record_len as u16,
+        )?;
+
+        // Verify it's a Finished message (type 0x14)
+        if plaintext.is_empty() || plaintext[0] != HANDSHAKE_TYPE_FINISHED {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Expected Finished message",
+            ));
+        }
+
+        // Extract verify_data (skip type(1) + length(3) = 4 bytes)
+        if plaintext.len() < 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Finished message too short",
+            ));
+        }
+        let client_verify_data = &plaintext[4..];
+
+        // Compute expected client Finished verify_data
+        // Use hash that includes server Finished (per TLS 1.3 RFC 8446)
+        let expected_verify_data = compute_finished_verify_data(
+            cipher_suite,
+            &client_handshake_traffic_secret,
+            &handshake_hash_with_server_finished,
+        )?;
+
+        // Verify it matches using constant-time comparison to prevent timing attacks
+        if client_verify_data
+            .ct_eq(expected_verify_data.as_slice())
+            .unwrap_u8()
+            == 0
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Client Finished verify_data mismatch",
+            ));
+        }
+
+        log::debug!("REALITY: Client Finished verified successfully");
+
+        // Derive application secrets
+        // Use hash that includes server Finished (per TLS 1.3 RFC 8446)
+        let (client_app_secret, server_app_secret) = derive_application_secrets(
+            cipher_suite,
+            &master_secret,
+            &handshake_hash_with_server_finished,
+        )?;
+
+        // Derive application traffic keys
+        let (client_app_key_bytes, client_app_iv) =
+            derive_traffic_keys(&client_app_secret, cipher_suite)?;
+        let (server_app_key_bytes, server_app_iv) =
+            derive_traffic_keys(&server_app_secret, cipher_suite)?;
+
+        // Create cached AeadKey objects to avoid per-record key setup overhead
+        let client_app_key = AeadKey::new(cipher_suite, &client_app_key_bytes)?;
+        let server_app_key = AeadKey::new(cipher_suite, &server_app_key_bytes)?;
+
+        // Store application traffic keys (as cached AeadKey)
+        self.app_read_key = Some(client_app_key);
+        self.app_read_iv = Some(client_app_iv);
+        self.app_read_secret = Some(client_app_secret);
+        self.app_write_key = Some(server_app_key);
+        self.app_write_iv = Some(server_app_iv);
+        self.app_write_secret = Some(server_app_secret);
+        self.read_seq = 0;
+        self.write_seq = 0;
+        self.cipher_suite = Some(cipher_suite);
+
+        // Handshake state already set to Complete above
+
+        log::debug!("REALITY: Handshake complete, application keys derived");
+
+        Ok(true)
+    }
+
+    /// Decrypt application data using TLS 1.3 keys
+    /// Processes all complete TLS records in the buffer
+    #[inline]
+    fn process_application_data(&mut self) -> io::Result<()> {
+        if self.app_read_key.is_none() || self.app_read_iv.is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "application read keys are unavailable",
+            ));
+        }
+
+        // Process all complete TLS records in the buffer
+        while self.ciphertext_read_buf.len() >= 5 {
+            if self.ciphertext_read_buf[0] != CONTENT_TYPE_APPLICATION_DATA
+                || self.ciphertext_read_buf[1] != 0x03
+                || self.ciphertext_read_buf[2] != 0x03
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid TLS 1.3 application record header",
+                ));
+            }
+            // Parse TLS record header
+            let record_len = self
+                .ciphertext_read_buf
+                .get_u16_be(3)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Buffer too short"))?
+                as usize;
+            validate_encrypted_record_len(record_len)?;
+
+            // Check if we have the complete record
+            let total_record_len = TLS_RECORD_HEADER_SIZE + record_len;
+            if self.ciphertext_read_buf.len() < total_record_len {
+                break; // Need more data
+            }
+
+            // Decrypt in-place: get mutable slice of ciphertext, decrypt, copy plaintext out
+            let (content_type, plaintext) = {
+                let app_read_key = self.app_read_key.as_ref().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "application read key is unavailable",
+                    )
+                })?;
+                let app_read_iv = self.app_read_iv.as_deref().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "application read IV is unavailable",
+                    )
+                })?;
+                let ciphertext_slice = self
+                    .ciphertext_read_buf
+                    .slice_mut(TLS_RECORD_HEADER_SIZE..total_record_len);
+                let mut decryptor =
+                    RecordDecryptor::new(app_read_key, app_read_iv, &mut self.read_seq);
+                let (content_type, plaintext) =
+                    decryptor.decrypt_record_in_place(ciphertext_slice, record_len as u16)?;
+                (content_type, plaintext.to_vec())
+            };
+
+            match content_type {
+                CONTENT_TYPE_APPLICATION_DATA => {
+                    // Compact plaintext buffer if needed before extending
+                    self.plaintext_read_buf.maybe_compact(4096);
+                    self.plaintext_read_buf.extend_from_slice(&plaintext);
+                }
+                CONTENT_TYPE_ALERT => {
+                    // Parse alert: level (1 byte) + description (1 byte)
+                    if plaintext.len() != 2 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "invalid TLS alert length",
+                        ));
+                    }
+                    let alert_level = plaintext[0];
+                    let alert_desc = plaintext[1];
+
+                    if alert_desc == ALERT_DESC_CLOSE_NOTIFY {
+                        log::debug!("REALITY: Received close_notify alert");
+                        self.received_close_notify = true;
+                        // Per RFC 8446: "Any data received after a closure alert
+                        // has been received MUST be ignored."
+                        return Ok(());
+                    } else if alert_level != ALERT_LEVEL_WARNING {
+                        // Fatal alert - connection must be terminated
+                        log::warn!(
+                            "REALITY: Received fatal alert: level={}, desc={}",
+                            alert_level,
+                            alert_desc
+                        );
+                        return Err(io::Error::new(
+                            io::ErrorKind::ConnectionAborted,
+                            format!("received fatal alert: {}", alert_desc),
+                        ));
+                    } else {
+                        log::debug!("REALITY: Received warning alert: desc={}", alert_desc);
+                    }
+                }
+                CONTENT_TYPE_HANDSHAKE => self.process_post_handshake(&plaintext)?,
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("unexpected TLS inner content type: 0x{content_type:02x}"),
+                    ));
+                }
+            }
+
+            // Consume the processed record from the buffer (after plaintext borrow ends)
+            self.ciphertext_read_buf.consume(total_record_len);
+        }
+
+        Ok(())
+    }
+
+    fn process_post_handshake(&mut self, fragment: &[u8]) -> io::Result<()> {
+        if self.post_handshake_buf.len().saturating_add(fragment.len()) > 5 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "coalesced or oversized post-handshake message",
+            ));
+        }
+        self.post_handshake_buf.extend_from_slice(fragment);
+        if self.post_handshake_buf.len() < 4 {
+            return Ok(());
+        }
+        if self.post_handshake_buf[0] != HANDSHAKE_TYPE_KEY_UPDATE
+            || self.post_handshake_buf[1..4] != [0, 0, 1]
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid post-handshake KeyUpdate header",
+            ));
+        }
+        if self.post_handshake_buf.len() < 5 {
+            return Ok(());
+        }
+        let request = self.post_handshake_buf[4];
+        self.post_handshake_buf.clear();
+        if request > KEY_UPDATE_REQUESTED {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid KeyUpdate request value",
+            ));
+        }
+
+        let cipher_suite = self.cipher_suite.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "cipher suite unavailable for KeyUpdate",
+            )
+        })?;
+        let mut current_read_secret = self.app_read_secret.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "read traffic secret unavailable",
+            )
+        })?;
+        let next_read_secret_result =
+            derive_next_traffic_secret(&current_read_secret, cipher_suite);
+        current_read_secret.zeroize();
+        let next_read_secret = next_read_secret_result?;
+        let (next_read_key, next_read_iv) = derive_traffic_keys(&next_read_secret, cipher_suite)?;
+        self.app_read_key = Some(AeadKey::new(cipher_suite, &next_read_key)?);
+        self.app_read_iv = Some(next_read_iv);
+        self.app_read_secret = Some(next_read_secret);
+        self.read_seq = 0;
+
+        if request == KEY_UPDATE_REQUESTED {
+            let response = [HANDSHAKE_TYPE_KEY_UPDATE, 0, 0, 1, KEY_UPDATE_NOT_REQUESTED];
+            let current_write_key = self.app_write_key.as_ref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "write key unavailable for KeyUpdate",
+                )
+            })?;
+            let current_write_iv = self.app_write_iv.as_deref().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "write IV unavailable for KeyUpdate",
+                )
+            })?;
+            RecordEncryptor::new(current_write_key, current_write_iv, &mut self.write_seq)
+                .encrypt_handshake(&response, &mut self.ciphertext_write_buf)?;
+
+            let mut current_write_secret = self.app_write_secret.take().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "write traffic secret unavailable",
+                )
+            })?;
+            let next_write_secret_result =
+                derive_next_traffic_secret(&current_write_secret, cipher_suite);
+            current_write_secret.zeroize();
+            let next_write_secret = next_write_secret_result?;
+            let (next_write_key, next_write_iv) =
+                derive_traffic_keys(&next_write_secret, cipher_suite)?;
+            self.app_write_key = Some(AeadKey::new(cipher_suite, &next_write_key)?);
+            self.app_write_iv = Some(next_write_iv);
+            self.app_write_secret = Some(next_write_secret);
+            self.write_seq = 0;
+        }
+
+        Ok(())
+    }
+
+    /// Get a reader for accessing decrypted plaintext
+    pub fn reader(&mut self) -> RealityReader<'_> {
+        // SlideBuffer handles compaction internally via maybe_compact()
+        // Compact before returning reader if we've consumed significant data
+        self.plaintext_read_buf.maybe_compact(4096);
+        RealityReader::new(&mut self.plaintext_read_buf, self.received_close_notify)
+    }
+
+    pub(crate) fn plaintext_bytes_to_read(&self) -> usize {
+        self.plaintext_read_buf.len()
+    }
+
+    /// Get a writer for buffering plaintext to be encrypted
+    pub fn writer(&mut self) -> RealityWriter<'_> {
+        RealityWriter::new(&mut self.plaintext_write_buf)
+    }
+
+    /// Write buffered TLS messages to the provided writer
+    ///
+    /// This encrypts any pending plaintext and writes ciphertext.
+    /// Large plaintext is automatically fragmented into multiple TLS records
+    /// to comply with the TLS 1.3 record size limit.
+    pub fn write_tls(&mut self, wr: &mut dyn Write) -> io::Result<usize> {
+        // If handshake not complete, just write buffered handshake data
+        if !matches!(self.handshake_state, HandshakeState::Complete) {
+            let n = wr.write(&self.ciphertext_write_buf)?;
+            self.ciphertext_write_buf.drain(..n);
+            return Ok(n);
+        }
+
+        // Encrypt any pending plaintext (with automatic fragmentation for large data)
+        if !self.plaintext_write_buf.is_empty() {
+            let (app_write_key, app_write_iv) = match (&self.app_write_key, &self.app_write_iv) {
+                (Some(key), Some(iv)) => (key, iv),
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Application keys not available",
+                    ));
+                }
+            };
+
+            let mut encryptor =
+                RecordEncryptor::new(app_write_key, app_write_iv, &mut self.write_seq);
+            encryptor.encrypt_app_data(
+                &mut self.plaintext_write_buf,
+                &mut self.ciphertext_write_buf,
+            )?;
+        }
+
+        // Write buffered ciphertext
+        let n = wr.write(&self.ciphertext_write_buf)?;
+        self.ciphertext_write_buf.drain(..n);
+        Ok(n)
+    }
+
+    /// Check if the connection wants to write data
+    pub fn wants_write(&self) -> bool {
+        !self.ciphertext_write_buf.is_empty() || !self.plaintext_write_buf.is_empty()
+    }
+
+    pub(crate) fn authenticated_client(&self) -> Option<AuthenticatedClient> {
+        self.authenticated_client
+    }
+
+    pub(crate) fn negotiated_group(&self) -> Option<u16> {
+        self.negotiated_group
+    }
+
+    /// Check if handshake is still in progress
+    pub fn is_handshaking(&self) -> bool {
+        !matches!(self.handshake_state, HandshakeState::Complete)
+    }
+
+    /// Check if the connection wants to read more TLS data
+    ///
+    /// Returns true if we need more data to make progress (handshake or decryption).
+    /// This mirrors rustls::Connection::wants_read().
+    pub fn wants_read(&self) -> bool {
+        // Don't read more after receiving close_notify (RFC 8446)
+        if self.received_close_notify {
+            return false;
+        }
+
+        // Don't read more if we're in a fatal error state
+        if self.fatal_error.is_some() {
+            return false;
+        }
+
+        // During handshake, we always want to read
+        if self.is_handshaking() {
+            return true;
+        }
+
+        // After handshake, we want to read if:
+        // 1. Plaintext buffer is empty (need more application data), OR
+        // 2. Ciphertext buffer has incomplete records that need more data
+        //
+        // Note: If plaintext buffer has data, the caller should consume it first.
+        // If ciphertext buffer has complete records, process_new_packets should be called.
+        self.plaintext_read_buf.is_empty()
+    }
+
+    /// Queue a close notification alert
+    pub fn send_close_notify(&mut self) {
+        // In TLS 1.3, alerts must be encrypted like application data
+        if !matches!(self.handshake_state, HandshakeState::Complete) {
+            log::debug!("REALITY: Cannot send close_notify - handshake not complete");
+            return;
+        }
+
+        // Get application keys
+        let (app_write_key, app_write_iv) = match (&self.app_write_key, &self.app_write_iv) {
+            (Some(key), Some(iv)) => (key, iv),
+            _ => {
+                log::debug!("REALITY: Cannot send close_notify - application keys not available");
+                return;
+            }
+        };
+
+        // Encrypt close_notify alert using RecordEncryptor
+        let mut encryptor = RecordEncryptor::new(app_write_key, app_write_iv, &mut self.write_seq);
+        match encryptor.encrypt_close_notify(&mut self.ciphertext_write_buf) {
+            Ok(()) => {
+                log::debug!("REALITY: Encrypted close_notify alert queued");
+            }
+            Err(e) => {
+                log::error!("REALITY: Failed to encrypt close_notify: {}", e);
+            }
+        }
+    }
+}
+
+impl Drop for RealityServerConnection {
+    fn drop(&mut self) {
+        self.config.private_key.zeroize();
+        self.config.short_ids.zeroize();
+        if let Some(seed) = &mut self.config.mldsa65_seed {
+            seed.zeroize();
+        }
+        if let Some(secret) = &mut self.app_read_secret {
+            secret.zeroize();
+        }
+        if let Some(secret) = &mut self.app_write_secret {
+            secret.zeroize();
+        }
+        if let Some(iv) = &mut self.app_read_iv {
+            iv.zeroize();
+        }
+        if let Some(iv) = &mut self.app_write_iv {
+            iv.zeroize();
+        }
+        if let Some(client) = &mut self.authenticated_client {
+            client.short_id.zeroize();
+        }
+        self.plaintext_write_buf.zeroize();
+        self.post_handshake_buf.zeroize();
+        match &mut self.handshake_state {
+            HandshakeState::ClientHelloValidated { info } => info.auth_key.zeroize(),
+            HandshakeState::ServerHelloSent {
+                client_handshake_traffic_secret,
+                master_secret,
+                ..
+            } => {
+                client_handshake_traffic_secret.zeroize();
+                master_secret.zeroize();
+            }
+            HandshakeState::Initial | HandshakeState::Complete => {}
+        }
+    }
+}
+
+#[inline]
+pub fn feed_reality_server_connection(
+    server_connection: &mut RealityServerConnection,
+    data: &[u8],
+) -> std::io::Result<()> {
+    let mut cursor = std::io::Cursor::new(data);
+    let mut i = 0;
+    while i < data.len() {
+        let n = server_connection.read_tls(&mut cursor).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to feed TLS connection: {e}"),
+            )
+        })?;
+        i += n;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reality_server_connection_creation() {
+        let config = RealityServerCryptoConfig {
+            private_key: [0u8; 32],
+            short_ids: vec![[0u8; 8]],
+            certificate_server_name: "example.com".to_owned(),
+            max_time_diff: Some(Duration::from_secs(60)),
+            min_client_version: None,
+            max_client_version: None,
+            cipher_suites: Vec::new(),
+            mldsa65_seed: None,
+        };
+
+        let conn = RealityServerConnection::new(config).unwrap();
+        assert!(conn.is_handshaking());
+        assert!(!conn.wants_write());
+    }
+
+    #[test]
+    fn test_io_state() {
+        let config = RealityServerCryptoConfig {
+            private_key: [0u8; 32],
+            short_ids: vec![[0u8; 8]],
+            certificate_server_name: "example.com".to_owned(),
+            max_time_diff: None,
+            min_client_version: None,
+            max_client_version: None,
+            cipher_suites: Vec::new(),
+            mldsa65_seed: None,
+        };
+
+        let mut conn = RealityServerConnection::new(config).unwrap();
+        let state = conn.process_new_packets().unwrap();
+
+        assert_eq!(state.plaintext_bytes_to_read(), 0);
+        assert!(!conn.wants_write());
+    }
+}

--- a/crates/core-reality/src/donor/reality_tls13_keys.rs
+++ b/crates/core-reality/src/donor/reality_tls13_keys.rs
@@ -1,0 +1,462 @@
+// TLS 1.3 Key Schedule Implementation
+//
+// Implements RFC 8446 key derivation for TLS 1.3
+// Supports both SHA256 and SHA384 based cipher suites
+
+use super::reality_cipher_suite::CipherSuite;
+use aws_lc_rs::{digest, hmac};
+use std::io::{Error, ErrorKind, Result};
+
+/// Intermediate TLS 1.3 keys (handshake secrets + master secret)
+/// Used for two-phase key derivation where application secrets
+/// must be derived after server Finished message
+#[derive(Debug, Clone)]
+pub struct Tls13HandshakeKeys {
+    /// Client handshake traffic secret
+    pub client_handshake_traffic_secret: Vec<u8>,
+    /// Server handshake traffic secret
+    pub server_handshake_traffic_secret: Vec<u8>,
+    /// Master secret (for deriving application secrets later)
+    pub master_secret: Vec<u8>,
+}
+
+/// HKDF-Expand implementation with configurable HMAC algorithm
+/// This follows RFC 5869 Section 2.3
+pub fn hkdf_expand(
+    hmac_algorithm: hmac::Algorithm,
+    prk: &[u8],
+    info: &[u8],
+    length: usize,
+) -> Result<Vec<u8>> {
+    let hash_len = hmac_algorithm.digest_algorithm().output_len();
+    let n = length.div_ceil(hash_len); // Number of iterations
+
+    if n > 255 {
+        return Err(Error::new(ErrorKind::InvalidData, "HKDF output too long"));
+    }
+
+    let mut output = Vec::new();
+    let mut prev = Vec::new();
+
+    for i in 1..=n {
+        let key = hmac::Key::new(hmac_algorithm, prk);
+        let mut ctx = hmac::Context::with_key(&key);
+
+        ctx.update(&prev);
+        ctx.update(info);
+        ctx.update(&[i as u8]);
+        let tag = ctx.sign();
+
+        prev = tag.as_ref().to_vec();
+        output.extend_from_slice(tag.as_ref());
+    }
+
+    output.truncate(length);
+    Ok(output)
+}
+
+/// HKDF-Expand-Label as defined in RFC 8446 Section 7.1
+fn hkdf_expand_label_with_algorithm(
+    hmac_algorithm: hmac::Algorithm,
+    secret: &[u8],
+    label: &[u8],
+    context: &[u8],
+    length: usize,
+) -> Result<Vec<u8>> {
+    // HkdfLabel structure:
+    // struct {
+    //     uint16 length = Length;
+    //     opaque label<7..255> = "tls13 " + Label;
+    //     opaque context<0..255> = Context;
+    // } HkdfLabel;
+
+    let mut hkdf_label = Vec::new();
+
+    // Length (2 bytes, big-endian)
+    hkdf_label.extend_from_slice(&(length as u16).to_be_bytes());
+
+    // Label length and content
+    let full_label = format!("tls13 {}", std::str::from_utf8(label).unwrap());
+    hkdf_label.push(full_label.len() as u8);
+    hkdf_label.extend_from_slice(full_label.as_bytes());
+
+    // Context length and content
+    hkdf_label.push(context.len() as u8);
+    hkdf_label.extend_from_slice(context);
+
+    hkdf_expand(hmac_algorithm, secret, &hkdf_label, length)
+}
+
+/// Derive-Secret as defined in RFC 8446 Section 7.1 (with configurable hash)
+fn derive_secret_with_algorithm(
+    hmac_algorithm: hmac::Algorithm,
+    secret: &[u8],
+    label: &[u8],
+    messages_hash: &[u8],
+) -> Result<Vec<u8>> {
+    let hash_len = hmac_algorithm.digest_algorithm().output_len();
+    hkdf_expand_label_with_algorithm(hmac_algorithm, secret, label, messages_hash, hash_len)
+}
+
+/// HKDF-Extract operation with configurable HMAC algorithm
+fn hkdf_extract_with_algorithm(
+    hmac_algorithm: hmac::Algorithm,
+    salt: &[u8],
+    ikm: &[u8],
+) -> Vec<u8> {
+    let key = hmac::Key::new(hmac_algorithm, salt);
+    let tag = hmac::sign(&key, ikm);
+    tag.as_ref().to_vec()
+}
+
+/// Derive traffic keys and IV from traffic secret using CipherSuite
+///
+/// # Arguments
+/// * `traffic_secret` - Traffic secret (hash_len bytes)
+/// * `cipher_suite` - CipherSuite with key/IV lengths and HMAC algorithm
+///
+/// # Returns
+/// (key, iv) tuple for AEAD
+pub fn derive_traffic_keys(
+    traffic_secret: &[u8],
+    cipher_suite: CipherSuite,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let key_length = cipher_suite.key_len();
+    let iv_length = cipher_suite.nonce_len();
+    let hmac_algorithm = cipher_suite.hmac_algorithm();
+
+    // key = HKDF-Expand-Label(Secret, "key", "", key_length)
+    let key =
+        hkdf_expand_label_with_algorithm(hmac_algorithm, traffic_secret, b"key", b"", key_length)?;
+
+    // iv = HKDF-Expand-Label(Secret, "iv", "", iv_length)
+    let iv =
+        hkdf_expand_label_with_algorithm(hmac_algorithm, traffic_secret, b"iv", b"", iv_length)?;
+
+    Ok((key, iv))
+}
+
+/// Advance a TLS 1.3 application traffic secret for KeyUpdate.
+pub fn derive_next_traffic_secret(
+    traffic_secret: &[u8],
+    cipher_suite: CipherSuite,
+) -> Result<Vec<u8>> {
+    let hash_len = cipher_suite.hash_len();
+    if traffic_secret.len() != hash_len {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "Traffic secret length mismatch: {} (expected {})",
+                traffic_secret.len(),
+                hash_len
+            ),
+        ));
+    }
+    hkdf_expand_label_with_algorithm(
+        cipher_suite.hmac_algorithm(),
+        traffic_secret,
+        b"traffic upd",
+        b"",
+        hash_len,
+    )
+}
+
+/// Derive TLS 1.3 handshake keys and master secret using CipherSuite (Phase 1)
+///
+/// This function derives handshake traffic secrets and the master secret,
+/// but NOT the application traffic secrets. Application secrets must be
+/// derived separately after the server Finished message is sent (Phase 2).
+///
+/// # Arguments
+/// * `cipher_suite` - CipherSuite with HMAC/digest algorithms
+/// * `shared_secret` - 32-byte X25519 or 64-byte ML-KEM-768 || X25519 secret
+/// * `client_hello_hash` - Hash of ClientHello (hash_len bytes)
+/// * `server_hello_hash` - Hash of ClientHello...ServerHello (hash_len bytes)
+///
+/// # Returns
+/// Handshake traffic secrets and master secret
+pub fn derive_handshake_keys(
+    cipher_suite: CipherSuite,
+    shared_secret: &[u8],
+    _client_hello_hash: &[u8], // Not used in TLS 1.3 key derivation - kept for API consistency
+    server_hello_hash: &[u8],
+) -> Result<Tls13HandshakeKeys> {
+    let hash_len = cipher_suite.hash_len();
+    let hmac_algorithm = cipher_suite.hmac_algorithm();
+    let digest_algorithm = cipher_suite.digest_algorithm();
+
+    // Validate input lengths
+    if !matches!(shared_secret.len(), 32 | 64) {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "Invalid shared_secret length: {} (expected 32 or 64)",
+                shared_secret.len()
+            ),
+        ));
+    }
+    if server_hello_hash.len() != hash_len {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "Hash length mismatch: {} (expected {})",
+                server_hello_hash.len(),
+                hash_len
+            ),
+        ));
+    }
+
+    // 1. Early Secret = HKDF-Extract(salt=0, IKM=0)
+    let zero_salt = vec![0u8; hash_len];
+    let early_secret = hkdf_extract_with_algorithm(hmac_algorithm, &zero_salt, &zero_salt);
+
+    // 2. Derive-Secret(., "derived", "")
+    let mut empty_ctx = digest::Context::new(digest_algorithm);
+    empty_ctx.update(b"");
+    let empty_hash = empty_ctx.finish();
+    let derived_secret = derive_secret_with_algorithm(
+        hmac_algorithm,
+        &early_secret,
+        b"derived",
+        empty_hash.as_ref(),
+    )?;
+
+    // 3. Handshake Secret = HKDF-Extract(salt=derived_secret, IKM=shared_secret)
+    let handshake_secret =
+        hkdf_extract_with_algorithm(hmac_algorithm, &derived_secret, shared_secret);
+
+    // 4. Client Handshake Traffic Secret
+    let client_handshake_traffic_secret = derive_secret_with_algorithm(
+        hmac_algorithm,
+        &handshake_secret,
+        b"c hs traffic",
+        server_hello_hash,
+    )?;
+
+    // 5. Server Handshake Traffic Secret
+    let server_handshake_traffic_secret = derive_secret_with_algorithm(
+        hmac_algorithm,
+        &handshake_secret,
+        b"s hs traffic",
+        server_hello_hash,
+    )?;
+
+    // 6. Derive-Secret(., "derived", "")
+    let mut empty_ctx_2 = digest::Context::new(digest_algorithm);
+    empty_ctx_2.update(b"");
+    let empty_hash_2 = empty_ctx_2.finish();
+    let derived_secret_2 = derive_secret_with_algorithm(
+        hmac_algorithm,
+        &handshake_secret,
+        b"derived",
+        empty_hash_2.as_ref(),
+    )?;
+
+    // 7. Master Secret = HKDF-Extract(salt=derived_secret, IKM=0)
+    let master_secret = hkdf_extract_with_algorithm(hmac_algorithm, &derived_secret_2, &zero_salt);
+
+    Ok(Tls13HandshakeKeys {
+        client_handshake_traffic_secret,
+        server_handshake_traffic_secret,
+        master_secret,
+    })
+}
+
+/// Derive TLS 1.3 application traffic secrets using CipherSuite (Phase 2)
+///
+/// This function must be called AFTER the server Finished message is sent,
+/// with a transcript hash that includes the Finished message.
+///
+/// # Arguments
+/// * `cipher_suite` - CipherSuite with HMAC algorithm
+/// * `master_secret` - Master secret from Phase 1 (hash_len bytes)
+/// * `handshake_hash` - Hash including server Finished (hash_len bytes)
+///
+/// # Returns
+/// (client_application_traffic_secret, server_application_traffic_secret)
+pub fn derive_application_secrets(
+    cipher_suite: CipherSuite,
+    master_secret: &[u8],
+    handshake_hash: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let hash_len = cipher_suite.hash_len();
+    let hmac_algorithm = cipher_suite.hmac_algorithm();
+
+    if master_secret.len() != hash_len || handshake_hash.len() != hash_len {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "Master secret and handshake hash must be {} bytes",
+                hash_len
+            ),
+        ));
+    }
+
+    // Client Application Traffic Secret
+    let client_application_traffic_secret = derive_secret_with_algorithm(
+        hmac_algorithm,
+        master_secret,
+        b"c ap traffic",
+        handshake_hash,
+    )?;
+
+    // Server Application Traffic Secret
+    let server_application_traffic_secret = derive_secret_with_algorithm(
+        hmac_algorithm,
+        master_secret,
+        b"s ap traffic",
+        handshake_hash,
+    )?;
+
+    Ok((
+        client_application_traffic_secret,
+        server_application_traffic_secret,
+    ))
+}
+
+/// Compute "Finished" verify data using CipherSuite
+///
+/// finished_key = HKDF-Expand-Label(BaseKey, "finished", "", Hash.length)
+/// verify_data = HMAC(finished_key, Transcript-Hash(Handshake Context))
+pub fn compute_finished_verify_data(
+    cipher_suite: CipherSuite,
+    base_key: &[u8],
+    handshake_hash: &[u8],
+) -> Result<Vec<u8>> {
+    let hash_len = cipher_suite.hash_len();
+    let hmac_algorithm = cipher_suite.hmac_algorithm();
+
+    // finished_key = HKDF-Expand-Label(BaseKey, "finished", "", hash_len)
+    let finished_key =
+        hkdf_expand_label_with_algorithm(hmac_algorithm, base_key, b"finished", b"", hash_len)?;
+
+    // verify_data = HMAC(finished_key, handshake_hash)
+    let key = hmac::Key::new(hmac_algorithm, &finished_key);
+    let tag = hmac::sign(&key, handshake_hash);
+    let verify_data = tag.as_ref().to_vec();
+
+    Ok(verify_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CS_SHA256: CipherSuite = CipherSuite::AES_128_GCM_SHA256;
+
+    // Test vectors from RFC 5869 Appendix A
+    #[test]
+    fn test_hkdf_expand_sha256_rfc_vector() {
+        // Test Case 1 from RFC 5869 (simplified - using extracted PRK directly)
+        let prk = [
+            0x07, 0x77, 0x09, 0x36, 0x2c, 0x2e, 0x32, 0xdf, 0x0d, 0xdc, 0x3f, 0x0d, 0xc4, 0x7b,
+            0xba, 0x63, 0x90, 0xb6, 0xc7, 0x3b, 0xb5, 0x0f, 0x9c, 0x31, 0x22, 0xec, 0x84, 0x4a,
+            0xd7, 0xc2, 0xb3, 0xe5,
+        ];
+        let info = [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9];
+
+        let result = hkdf_expand(hmac::HMAC_SHA256, &prk, &info, 42).unwrap();
+        assert_eq!(result.len(), 42);
+
+        // Check first few bytes match expected pattern
+        assert_eq!(result[0], 0x3c);
+        assert_eq!(result[1], 0xb2);
+        assert_eq!(result[2], 0x5f);
+    }
+
+    #[test]
+    fn test_hkdf_expand_sha256_empty_info() {
+        let prk = vec![0x42u8; 32];
+        let result = hkdf_expand(hmac::HMAC_SHA256, &prk, &[], 16);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 16);
+    }
+
+    #[test]
+    fn test_hkdf_expand_sha256_max_length() {
+        let prk = vec![0x42u8; 32];
+        let info = b"test info";
+
+        // Maximum output length is 255 * hash_len (32 for SHA256) = 8160 bytes
+        let result = hkdf_expand(hmac::HMAC_SHA256, &prk, info, 8160);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 8160);
+
+        // Should fail for length > 8160
+        let result = hkdf_expand(hmac::HMAC_SHA256, &prk, info, 8161);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_hkdf_expand_label() {
+        let secret = vec![0x42u8; 32];
+        let result = hkdf_expand_label_with_algorithm(hmac::HMAC_SHA256, &secret, b"test", b"", 16);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 16);
+    }
+
+    #[test]
+    fn test_hkdf_expand_label_with_context() {
+        let secret = vec![0x42u8; 32];
+        let context = vec![0x11u8; 32];
+        let result =
+            hkdf_expand_label_with_algorithm(hmac::HMAC_SHA256, &secret, b"finished", &context, 32);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert_eq!(output.len(), 32);
+
+        // Result should be deterministic
+        let result2 =
+            hkdf_expand_label_with_algorithm(hmac::HMAC_SHA256, &secret, b"finished", &context, 32)
+                .unwrap();
+        assert_eq!(output, result2);
+    }
+
+    #[test]
+    fn test_hkdf_extract() {
+        let salt = vec![0x11u8; 32];
+        let ikm = vec![0x22u8; 32];
+
+        let result1 = hkdf_extract_with_algorithm(hmac::HMAC_SHA256, &salt, &ikm);
+        assert_eq!(result1.len(), 32); // SHA256 output length
+
+        // Should be deterministic
+        let result2 = hkdf_extract_with_algorithm(hmac::HMAC_SHA256, &salt, &ikm);
+        assert_eq!(result1, result2);
+
+        // Different input should give different output
+        let ikm2 = vec![0x33u8; 32];
+        let result3 = hkdf_extract_with_algorithm(hmac::HMAC_SHA256, &salt, &ikm2);
+        assert_ne!(result1, result3);
+    }
+
+    #[test]
+    fn test_derive_traffic_keys() {
+        let traffic_secret = vec![0x99u8; 32];
+
+        // Test TLS_AES_128_GCM_SHA256
+        let result = derive_traffic_keys(&traffic_secret, CS_SHA256);
+        assert!(result.is_ok());
+        let (key, iv) = result.unwrap();
+        assert_eq!(key.len(), 16);
+        assert_eq!(iv.len(), 12);
+    }
+
+    #[test]
+    fn key_update_advances_secret_at_hash_length() {
+        let current = vec![0x5a; CS_SHA256.hash_len()];
+        let next = derive_next_traffic_secret(&current, CS_SHA256).unwrap();
+        assert_eq!(next.len(), CS_SHA256.hash_len());
+        assert_ne!(next, current);
+    }
+
+    #[test]
+    fn test_compute_finished_verify_data() {
+        let base_key = vec![0xAAu8; 32];
+        let handshake_hash = vec![0xBBu8; 32];
+
+        let result = compute_finished_verify_data(CS_SHA256, &base_key, &handshake_hash);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 32);
+    }
+}

--- a/crates/core-reality/src/donor/reality_tls13_messages.rs
+++ b/crates/core-reality/src/donor/reality_tls13_messages.rs
@@ -1,0 +1,549 @@
+// TLS 1.3 Message Construction
+//
+// Construct TLS 1.3 handshake messages for REALITY protocol
+
+use super::common::{
+    HANDSHAKE_TYPE_CERTIFICATE, HANDSHAKE_TYPE_CERTIFICATE_VERIFY,
+    HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS, HANDSHAKE_TYPE_FINISHED, HANDSHAKE_TYPE_SERVER_HELLO,
+    VERSION_TLS_1_2_MAJOR, VERSION_TLS_1_2_MINOR,
+};
+use aws_lc_rs::signature::Ed25519KeyPair;
+use std::io::Result;
+
+/// Construct ServerHello message
+///
+/// # Arguments
+/// * `server_random` - 32 bytes of server random
+/// * `session_id` - Session ID from ClientHello (for compatibility)
+/// * `cipher_suite` - Selected cipher suite (e.g., 0x1301)
+/// * `key_share_data` - Server's X25519 public key (32 bytes)
+pub fn construct_server_hello(
+    server_random: &[u8; 32],
+    session_id: &[u8],
+    cipher_suite: u16,
+    named_group: u16,
+    key_share_data: &[u8],
+) -> Result<Vec<u8>> {
+    let mut server_hello = Vec::new();
+
+    // ServerHello structure:
+    // - handshake_type (1 byte) = 2
+    // - length (3 bytes)
+    // - version (2 bytes) = 0x0303 (TLS 1.2 for compatibility)
+    // - random (32 bytes)
+    // - session_id_length (1 byte)
+    // - session_id (variable)
+    // - cipher_suite (2 bytes)
+    // - compression_method (1 byte) = 0
+    // - extensions_length (2 bytes)
+    // - extensions (variable)
+
+    let mut payload = Vec::new();
+
+    // Version: 0x0303 (TLS 1.2 for compatibility)
+    payload.extend_from_slice(&[VERSION_TLS_1_2_MAJOR, VERSION_TLS_1_2_MINOR]);
+
+    // Random (32 bytes)
+    payload.extend_from_slice(server_random);
+
+    // Session ID
+    payload.push(session_id.len() as u8);
+    payload.extend_from_slice(session_id);
+
+    // Cipher suite
+    payload.extend_from_slice(&cipher_suite.to_be_bytes());
+
+    // Compression method = 0
+    payload.push(0x00);
+
+    // Extensions
+    let mut extensions = Vec::new();
+
+    // supported_versions extension (type=43)
+    extensions.extend_from_slice(&[0x00, 0x2b]); // type = 43
+    extensions.extend_from_slice(&[0x00, 0x02]); // length = 2
+    extensions.extend_from_slice(&[0x03, 0x04]); // TLS 1.3
+
+    // key_share extension (type=51)
+    let key_share_length = 2 + 2 + key_share_data.len(); // group + length + data
+    extensions.extend_from_slice(&[0x00, 0x33]); // type = 51
+    extensions.extend_from_slice(&(key_share_length as u16).to_be_bytes());
+    extensions.extend_from_slice(&named_group.to_be_bytes());
+    extensions.extend_from_slice(&(key_share_data.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(key_share_data);
+
+    // Extensions length
+    payload.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+    payload.extend_from_slice(&extensions);
+
+    // Handshake header
+    server_hello.push(HANDSHAKE_TYPE_SERVER_HELLO);
+
+    // Payload length (3 bytes, big-endian)
+    let length_bytes = [
+        ((payload.len() >> 16) & 0xff) as u8,
+        ((payload.len() >> 8) & 0xff) as u8,
+        (payload.len() & 0xff) as u8,
+    ];
+    server_hello.extend_from_slice(&length_bytes);
+    server_hello.extend_from_slice(&payload);
+
+    Ok(server_hello)
+}
+
+/// Construct EncryptedExtensions message
+pub fn construct_encrypted_extensions() -> Result<Vec<u8>> {
+    let mut encrypted_extensions = Vec::new();
+
+    // EncryptedExtensions structure:
+    // - handshake_type (1 byte) = 8
+    // - length (3 bytes)
+    // - extensions_length (2 bytes)
+    // - extensions (variable, usually empty for minimal setup)
+
+    encrypted_extensions.push(HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS);
+
+    // Empty extensions for minimal setup
+    let extensions_length: u16 = 0;
+    let payload_length = 2; // Just the extensions_length field
+
+    // Payload length (3 bytes)
+    encrypted_extensions.extend_from_slice(&[0x00, 0x00, payload_length as u8]);
+
+    // Extensions length (2 bytes)
+    encrypted_extensions.extend_from_slice(&extensions_length.to_be_bytes());
+
+    Ok(encrypted_extensions)
+}
+
+/// Construct Certificate message with HMAC-signed Ed25519 certificate
+///
+/// # Arguments
+/// * `cert` - Certificate from rcgen (takes ownership to avoid allocation)
+pub fn construct_certificate(cert: rcgen::Certificate) -> Result<Vec<u8>> {
+    let cert_der = cert.der();
+
+    // Certificate structure:
+    // - handshake_type (1 byte) = 11
+    // - length (3 bytes)
+    // - certificate_request_context (1 byte length + data, usually empty)
+    // - certificate_list (3 bytes length + entries)
+    //   - certificate_entry:
+    //     - cert_data (3 bytes length + DER)
+    //     - extensions (2 bytes length, usually empty)
+
+    // Pre-calculate sizes to allocate exact capacity
+    // cert_list = 3 (len) + cert_der.len() + 2 (extensions)
+    let cert_list_len = 3 + cert_der.len() + 2;
+    // payload = 1 (context) + 3 (list len) + cert_list_len
+    let payload_len = 1 + 3 + cert_list_len;
+    // total = 1 (type) + 3 (payload len) + payload_len
+    let total_len = 1 + 3 + payload_len;
+
+    let mut certificate = Vec::with_capacity(total_len);
+
+    // Handshake header
+    certificate.push(HANDSHAKE_TYPE_CERTIFICATE);
+
+    // Payload length (3 bytes)
+    certificate.extend_from_slice(&[
+        ((payload_len >> 16) & 0xff) as u8,
+        ((payload_len >> 8) & 0xff) as u8,
+        (payload_len & 0xff) as u8,
+    ]);
+
+    // Certificate request context (empty for server certificates)
+    certificate.push(0x00);
+
+    // Certificate list length (3 bytes)
+    certificate.extend_from_slice(&[
+        ((cert_list_len >> 16) & 0xff) as u8,
+        ((cert_list_len >> 8) & 0xff) as u8,
+        (cert_list_len & 0xff) as u8,
+    ]);
+
+    // Certificate entry - cert data length (3 bytes)
+    certificate.extend_from_slice(&[
+        ((cert_der.len() >> 16) & 0xff) as u8,
+        ((cert_der.len() >> 8) & 0xff) as u8,
+        (cert_der.len() & 0xff) as u8,
+    ]);
+
+    // Certificate DER data
+    certificate.extend_from_slice(cert_der);
+
+    // Extensions (empty)
+    certificate.extend_from_slice(&[0x00, 0x00]);
+
+    Ok(certificate)
+}
+
+/// Construct CertificateVerify message
+///
+/// # Arguments
+/// * `signing_key` - Ed25519 signing key
+/// * `handshake_hash` - Hash of all handshake messages up to this point (32 or 48 bytes depending on cipher suite)
+pub fn construct_certificate_verify(
+    signing_key: &Ed25519KeyPair,
+    handshake_hash: &[u8],
+) -> Result<Vec<u8>> {
+    let mut certificate_verify = Vec::new();
+
+    // CertificateVerify structure:
+    // - handshake_type (1 byte) = 15
+    // - length (3 bytes)
+    // - signature_algorithm (2 bytes) = 0x0807 for Ed25519
+    // - signature (2 bytes length + data)
+
+    // Construct the signed content
+    // TLS 1.3 uses a specific prefix for CertificateVerify:
+    // "  " * 64 + "TLS 1.3, server CertificateVerify" + 0x00 + handshake_hash
+    let mut signed_content = Vec::new();
+    signed_content.extend_from_slice(&[0x20u8; 64]); // 64 spaces
+    signed_content.extend_from_slice(b"TLS 1.3, server CertificateVerify");
+    signed_content.push(0x00);
+    signed_content.extend_from_slice(handshake_hash);
+
+    // Sign the content
+    let signature = signing_key.sign(&signed_content);
+    let signature_bytes = signature.as_ref();
+
+    let mut payload = Vec::new();
+
+    // Signature algorithm: Ed25519 (0x0807)
+    payload.extend_from_slice(&[0x08, 0x07]);
+
+    // Signature length and data
+    payload.extend_from_slice(&(signature_bytes.len() as u16).to_be_bytes());
+    payload.extend_from_slice(signature_bytes);
+
+    // Handshake header
+    certificate_verify.push(HANDSHAKE_TYPE_CERTIFICATE_VERIFY);
+
+    // Payload length (3 bytes)
+    certificate_verify.extend_from_slice(&[
+        ((payload.len() >> 16) & 0xff) as u8,
+        ((payload.len() >> 8) & 0xff) as u8,
+        (payload.len() & 0xff) as u8,
+    ]);
+    certificate_verify.extend_from_slice(&payload);
+
+    Ok(certificate_verify)
+}
+
+/// Construct Finished message
+///
+/// # Arguments
+/// * `verify_data` - HMAC of handshake transcript (32 bytes for SHA256)
+pub fn construct_finished(verify_data: &[u8]) -> Result<Vec<u8>> {
+    let mut finished = Vec::new();
+
+    // Finished structure:
+    // - handshake_type (1 byte) = 20
+    // - length (3 bytes)
+    // - verify_data (variable, 32 bytes for SHA256)
+
+    finished.push(HANDSHAKE_TYPE_FINISHED);
+
+    // Payload length (3 bytes)
+    finished.extend_from_slice(&[
+        ((verify_data.len() >> 16) & 0xff) as u8,
+        ((verify_data.len() >> 8) & 0xff) as u8,
+        (verify_data.len() & 0xff) as u8,
+    ]);
+
+    finished.extend_from_slice(verify_data);
+
+    Ok(finished)
+}
+
+/// Default ALPN protocols for REALITY client (matches browser fingerprints)
+pub const DEFAULT_ALPN_PROTOCOLS: &[&str] = &["h2", "http/1.1"];
+
+/// Construct TLS 1.3 ClientHello message
+///
+/// Returns handshake message bytes (without record header)
+///
+/// # Arguments
+/// * `client_random` - 32 bytes client random
+/// * `session_id` - 32 bytes session ID
+/// * `client_public_key` - X25519 public key bytes
+/// * `server_name` - SNI hostname
+/// * `cipher_suites` - Cipher suite IDs to offer (e.g., &[0x1301, 0x1302, 0x1303])
+/// * `alpn_protocols` - ALPN protocols to offer (e.g., &["h2", "http/1.1"])
+pub fn construct_client_hello(
+    client_random: &[u8; 32],
+    session_id: &[u8; 32],
+    client_public_key: &[u8],
+    server_name: &str,
+    cipher_suites: &[u16],
+    alpn_protocols: &[&str],
+) -> Result<Vec<u8>> {
+    let mut hello = Vec::with_capacity(512);
+
+    // Handshake message type: ClientHello (0x01)
+    hello.push(0x01);
+
+    // Placeholder for handshake message length (3 bytes)
+    let length_offset = hello.len();
+    hello.extend_from_slice(&[0u8; 3]);
+
+    // TLS version: 3.3 (TLS 1.2 for compatibility)
+    hello.extend_from_slice(&[VERSION_TLS_1_2_MAJOR, VERSION_TLS_1_2_MINOR]);
+
+    // Client random (32 bytes)
+    hello.extend_from_slice(client_random);
+
+    // Session ID length (1 byte) + Session ID (32 bytes)
+    hello.push(32);
+    hello.extend_from_slice(session_id);
+
+    // Cipher suites
+    let cipher_suites_len = (cipher_suites.len() * 2) as u16;
+    hello.extend_from_slice(&cipher_suites_len.to_be_bytes());
+    for &suite in cipher_suites {
+        hello.extend_from_slice(&suite.to_be_bytes());
+    }
+
+    // Compression methods (1 method: null)
+    hello.extend_from_slice(&[0x01, 0x00]);
+
+    // Extensions
+    let extensions_offset = hello.len();
+    hello.extend_from_slice(&[0u8; 2]); // Placeholder for extensions length
+
+    let mut extensions = Vec::new();
+
+    // server_name extension (type 0)
+    {
+        let server_name_bytes = server_name.as_bytes();
+        let server_name_len = server_name_bytes.len();
+
+        extensions.extend_from_slice(&[0x00, 0x00]); // Extension type: server_name
+        let ext_len = 5 + server_name_len;
+        extensions.extend_from_slice(&(ext_len as u16).to_be_bytes()); // Extension length
+        extensions.extend_from_slice(&((server_name_len + 3) as u16).to_be_bytes()); // Server name list length
+        extensions.push(0x00); // Name type: host_name
+        extensions.extend_from_slice(&(server_name_len as u16).to_be_bytes()); // Name length
+        extensions.extend_from_slice(server_name_bytes); // Server name
+    }
+
+    // supported_versions extension (type 43)
+    {
+        extensions.extend_from_slice(&[0x00, 0x2b]); // Extension type: supported_versions
+        extensions.extend_from_slice(&[0x00, 0x03]); // Extension length: 3
+        extensions.push(0x02); // Supported versions length: 2
+        extensions.extend_from_slice(&[0x03, 0x04]); // TLS 1.3
+    }
+
+    // supported_groups extension (type 10)
+    {
+        extensions.extend_from_slice(&[0x00, 0x0a]); // Extension type: supported_groups
+        extensions.extend_from_slice(&[0x00, 0x04]); // Extension length: 4
+        extensions.extend_from_slice(&[0x00, 0x02]); // Supported groups length: 2
+        extensions.extend_from_slice(&[0x00, 0x1d]); // x25519
+    }
+
+    // key_share extension (type 51)
+    {
+        extensions.extend_from_slice(&[0x00, 0x33]); // Extension type: key_share
+        let key_share_len = 2 + 4 + client_public_key.len();
+        extensions.extend_from_slice(&(key_share_len as u16).to_be_bytes()); // Extension length
+        let key_share_list_len = 4 + client_public_key.len();
+        extensions.extend_from_slice(&(key_share_list_len as u16).to_be_bytes()); // Key share list length
+        extensions.extend_from_slice(&[0x00, 0x1d]); // Group: x25519
+        extensions.extend_from_slice(&(client_public_key.len() as u16).to_be_bytes()); // Key length
+        extensions.extend_from_slice(client_public_key); // Public key
+    }
+
+    // signature_algorithms extension (type 13)
+    // Matches the Chrome 133 uTLS fingerprints used by Xray-core and sing-box.
+    // https://github.com/refraction-networking/utls/blob/aa6edf4b11af82e110eea845bb2983d30138d651/u_parrots.go#L935-L944
+    // https://github.com/metacubex/utls/blob/cf49b0864331e156689feec6363ef9bf518a5ac7/u_parrots.go#L925-L934
+    {
+        extensions.extend_from_slice(&[0x00, 0x0d]); // Extension type: signature_algorithms
+        extensions.extend_from_slice(&[0x00, 0x12]); // Extension length: 18
+        extensions.extend_from_slice(&[0x00, 0x10]); // Signature algorithms length: 16
+        extensions.extend_from_slice(&[0x04, 0x03]); // ecdsa_secp256r1_sha256
+        extensions.extend_from_slice(&[0x08, 0x04]); // rsa_pss_rsae_sha256
+        extensions.extend_from_slice(&[0x04, 0x01]); // rsa_pkcs1_sha256
+        extensions.extend_from_slice(&[0x05, 0x03]); // ecdsa_secp384r1_sha384
+        extensions.extend_from_slice(&[0x08, 0x05]); // rsa_pss_rsae_sha384
+        extensions.extend_from_slice(&[0x05, 0x01]); // rsa_pkcs1_sha384
+        extensions.extend_from_slice(&[0x08, 0x06]); // rsa_pss_rsae_sha512
+        extensions.extend_from_slice(&[0x06, 0x01]); // rsa_pkcs1_sha512
+    }
+
+    // ALPN extension (type 16)
+    if !alpn_protocols.is_empty() {
+        extensions.extend_from_slice(&[0x00, 0x10]); // Extension type: ALPN (16)
+
+        // Calculate total length of protocol list
+        let protocols_list_len: usize = alpn_protocols
+            .iter()
+            .map(|p| 1 + p.len()) // 1 byte length prefix + protocol bytes
+            .sum();
+
+        // Extension length = 2 (list length field) + protocols_list_len
+        let ext_len = 2 + protocols_list_len;
+        extensions.extend_from_slice(&(ext_len as u16).to_be_bytes());
+
+        // Protocol list length
+        extensions.extend_from_slice(&(protocols_list_len as u16).to_be_bytes());
+
+        // Each protocol: 1 byte length + protocol string
+        for protocol in alpn_protocols {
+            extensions.push(protocol.len() as u8);
+            extensions.extend_from_slice(protocol.as_bytes());
+        }
+    }
+
+    // Write extensions length
+    let extensions_length = extensions.len();
+    hello[extensions_offset..extensions_offset + 2]
+        .copy_from_slice(&(extensions_length as u16).to_be_bytes());
+
+    // Append extensions
+    hello.extend_from_slice(&extensions);
+
+    // Write handshake message length
+    let message_length = hello.len() - 4; // Exclude type (1) and length (3)
+    hello[length_offset..length_offset + 3]
+        .copy_from_slice(&(message_length as u32).to_be_bytes()[1..]);
+
+    Ok(hello)
+}
+
+/// Write TLS record header
+///
+/// # Arguments
+/// * `record_type` - TLS record type (0x16 for Handshake, 0x17 for ApplicationData)
+/// * `length` - Length of record payload
+pub fn write_record_header(record_type: u8, length: u16) -> Vec<u8> {
+    let mut header = Vec::new();
+    header.push(record_type);
+    header.extend_from_slice(&[VERSION_TLS_1_2_MAJOR, VERSION_TLS_1_2_MINOR]); // Version: TLS 1.2
+    header.extend_from_slice(&length.to_be_bytes());
+    header
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::donor::common::CONTENT_TYPE_HANDSHAKE;
+
+    #[test]
+    fn test_construct_server_hello() {
+        let server_random = [0x42u8; 32];
+        let session_id = vec![0x99u8; 32];
+        let cipher_suite = 0x1301; // TLS_AES_128_GCM_SHA256
+        let key_share = vec![0xAAu8; 32];
+
+        let result = construct_server_hello(
+            &server_random,
+            &session_id,
+            cipher_suite,
+            0x001d,
+            &key_share,
+        );
+
+        assert!(result.is_ok());
+        let msg = result.unwrap();
+        assert_eq!(msg[0], HANDSHAKE_TYPE_SERVER_HELLO);
+    }
+
+    #[test]
+    fn test_construct_encrypted_extensions() {
+        let result = construct_encrypted_extensions();
+        assert!(result.is_ok());
+        let msg = result.unwrap();
+        assert_eq!(msg[0], HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS);
+    }
+
+    #[test]
+    fn test_construct_certificate() {
+        use crate::donor::reality_certificate::generate_hmac_certificate;
+        let auth_key = [0x42u8; 32];
+        let (cert, _) = generate_hmac_certificate(&auth_key, None, b"client", b"server").unwrap();
+        let result = construct_certificate(cert);
+        assert!(result.is_ok());
+        let msg = result.unwrap();
+        assert_eq!(msg[0], HANDSHAKE_TYPE_CERTIFICATE);
+    }
+
+    #[test]
+    fn test_construct_finished() {
+        let verify_data = vec![0xCCu8; 32];
+        let result = construct_finished(&verify_data);
+        assert!(result.is_ok());
+        let msg = result.unwrap();
+        assert_eq!(msg[0], HANDSHAKE_TYPE_FINISHED);
+        assert_eq!(msg.len(), 1 + 3 + 32); // type + length + verify_data
+    }
+
+    #[test]
+    fn test_write_record_header() {
+        let header = write_record_header(CONTENT_TYPE_HANDSHAKE, 100);
+        assert_eq!(header.len(), 5);
+        assert_eq!(header[0], 0x16); // Handshake
+        assert_eq!(header[1], 0x03); // TLS 1.2
+        assert_eq!(header[2], 0x03);
+        assert_eq!(u16::from_be_bytes([header[3], header[4]]), 100);
+    }
+
+    #[test]
+    fn test_client_hello_signature_algorithms_match_chrome_utls() {
+        let client_random = [0u8; 32];
+        let session_id = [0u8; 32];
+        let client_public_key = [0u8; 32];
+
+        let hello = construct_client_hello(
+            &client_random,
+            &session_id,
+            &client_public_key,
+            "example.com",
+            &[0x1301],
+            &["h2"],
+        )
+        .unwrap();
+
+        let mut offset = 1 + 3 + 2 + 32;
+        let session_id_len = hello[offset] as usize;
+        offset += 1 + session_id_len;
+        let cipher_suites_len = u16::from_be_bytes([hello[offset], hello[offset + 1]]) as usize;
+        offset += 2 + cipher_suites_len;
+        let compression_methods_len = hello[offset] as usize;
+        offset += 1 + compression_methods_len;
+        let extensions_len = u16::from_be_bytes([hello[offset], hello[offset + 1]]) as usize;
+        offset += 2;
+        let extensions_end = offset + extensions_len;
+
+        let mut signature_algorithms = None;
+        while offset < extensions_end {
+            let extension_type = u16::from_be_bytes([hello[offset], hello[offset + 1]]);
+            let extension_len = u16::from_be_bytes([hello[offset + 2], hello[offset + 3]]) as usize;
+            offset += 4;
+            if extension_type == 0x000d {
+                signature_algorithms = Some(&hello[offset..offset + extension_len]);
+                break;
+            }
+            offset += extension_len;
+        }
+
+        let extension = signature_algorithms.expect("missing signature_algorithms extension");
+        assert_eq!(u16::from_be_bytes([extension[0], extension[1]]), 16);
+        assert_eq!(
+            &extension[2..],
+            &[
+                0x04, 0x03, // ecdsa_secp256r1_sha256
+                0x08, 0x04, // rsa_pss_rsae_sha256
+                0x04, 0x01, // rsa_pkcs1_sha256
+                0x05, 0x03, // ecdsa_secp384r1_sha384
+                0x08, 0x05, // rsa_pss_rsae_sha384
+                0x05, 0x01, // rsa_pkcs1_sha384
+                0x08, 0x06, // rsa_pss_rsae_sha512
+                0x06, 0x01, // rsa_pkcs1_sha512
+            ]
+        );
+    }
+}

--- a/crates/core-reality/src/donor/reality_util.rs
+++ b/crates/core-reality/src/donor/reality_util.rs
@@ -1,0 +1,655 @@
+use aws_lc_rs::agreement;
+use base64::engine::{Engine as _, general_purpose::URL_SAFE_NO_PAD};
+use rand::RngCore;
+
+use super::reality_cipher_suite::CipherSuite;
+use crate::buffer::SliceReader as BufReader;
+
+/// Decodes a base64url-encoded public key
+pub fn decode_public_key(encoded: &str) -> Result<[u8; 32], std::io::Error> {
+    let decoded = URL_SAFE_NO_PAD.decode(encoded).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid base64: {}", e),
+        )
+    })?;
+
+    if decoded.len() != 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid public key length: {} (expected 32)", decoded.len()),
+        ));
+    }
+
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&decoded);
+    Ok(key)
+}
+
+/// Decodes a base64url-encoded private key
+pub fn decode_private_key(encoded: &str) -> Result<[u8; 32], std::io::Error> {
+    let decoded = URL_SAFE_NO_PAD.decode(encoded).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid base64: {}", e),
+        )
+    })?;
+
+    if decoded.len() != 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "Invalid private key length: {} (expected 32)",
+                decoded.len()
+            ),
+        ));
+    }
+
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&decoded);
+    Ok(key)
+}
+
+/// Decodes a hex-encoded short ID with zero-padding
+///
+/// Short IDs can be 0-16 hex characters (0-8 bytes).
+/// If shorter than 16 characters, they are right-padded with zeros.
+pub fn decode_short_id(hex: &str) -> Result<[u8; 8], std::io::Error> {
+    if hex.len() > 16 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Short ID too long: {} (max 16 hex chars)", hex.len()),
+        ));
+    }
+
+    // Right-pad with zeros to make 16 chars (compatible with other REALITY clients)
+    let padded = format!("{:0<16}", hex);
+
+    let mut short_id = [0u8; 8];
+    decode_hex_to_slice(&padded, &mut short_id).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid hex: {}", e),
+        )
+    })?;
+
+    Ok(short_id)
+}
+
+/// Decode hex string to byte slice
+fn decode_hex_to_slice(hex: &str, output: &mut [u8]) -> Result<(), &'static str> {
+    if hex.len() != output.len() * 2 {
+        return Err("Invalid hex length");
+    }
+
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let high = hex_char_to_value(chunk[0])?;
+        let low = hex_char_to_value(chunk[1])?;
+        output[i] = (high << 4) | low;
+    }
+
+    Ok(())
+}
+
+/// Convert hex character to its numeric value
+fn hex_char_to_value(c: u8) -> Result<u8, &'static str> {
+    match c {
+        b'0'..=b'9' => Ok(c - b'0'),
+        b'a'..=b'f' => Ok(c - b'a' + 10),
+        b'A'..=b'F' => Ok(c - b'A' + 10),
+        _ => Err("Invalid hex character"),
+    }
+}
+
+/// Extracts ClientRandom from ClientHello
+///
+/// ClientHello structure (simplified):
+/// - TLS Header: 5 bytes
+/// - Handshake Type: 1 byte
+/// - Length: 3 bytes
+/// - Protocol Version: 2 bytes
+/// - ClientRandom: 32 bytes (starts at offset 11)
+pub fn extract_client_random(client_hello: &[u8]) -> Result<[u8; 32], std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+    const HANDSHAKE_HEADER_LEN: usize = 4; // type(1) + length(3)
+    const PROTOCOL_VERSION_LEN: usize = 2;
+    const RANDOM_OFFSET: usize = TLS_HEADER_LEN + HANDSHAKE_HEADER_LEN + PROTOCOL_VERSION_LEN;
+
+    if client_hello.len() < RANDOM_OFFSET + 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ClientHello too short to extract random",
+        ));
+    }
+
+    let mut random = [0u8; 32];
+    random.copy_from_slice(&client_hello[RANDOM_OFFSET..RANDOM_OFFSET + 32]);
+    Ok(random)
+}
+
+/// Extracts SessionId slice from ClientHello without allocation
+///
+/// SessionId comes after ClientRandom and has a 1-byte length prefix.
+/// Returns a slice pointing into the original buffer.
+pub fn extract_session_id_slice(client_hello: &[u8]) -> Result<&[u8], std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+    const HANDSHAKE_HEADER_LEN: usize = 4;
+    const PROTOCOL_VERSION_LEN: usize = 2;
+    const RANDOM_LEN: usize = 32;
+    const SESSION_ID_LEN_OFFSET: usize =
+        TLS_HEADER_LEN + HANDSHAKE_HEADER_LEN + PROTOCOL_VERSION_LEN + RANDOM_LEN;
+
+    if client_hello.len() < SESSION_ID_LEN_OFFSET + 1 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ClientHello too short to extract session ID",
+        ));
+    }
+
+    let session_id_len = client_hello[SESSION_ID_LEN_OFFSET] as usize;
+
+    if client_hello.len() < SESSION_ID_LEN_OFFSET + 1 + session_id_len {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ClientHello session ID extends past end",
+        ));
+    }
+
+    Ok(&client_hello[SESSION_ID_LEN_OFFSET + 1..SESSION_ID_LEN_OFFSET + 1 + session_id_len])
+}
+
+/// Extracts X25519 public key from ClientHello KeyShare extension
+///
+/// This parses the TLS 1.3 extensions to find the KeyShare extension
+/// and extracts the X25519 public key (group 0x001d).
+pub fn extract_client_public_key(client_hello: &[u8]) -> Result<[u8; 32], std::io::Error> {
+    if let Ok(key) = extract_client_key_share(client_hello, 0x001d) {
+        return key.as_slice().try_into().map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid X25519 key length")
+        });
+    }
+    let hybrid = extract_client_key_share(client_hello, 0x11ec)?;
+    if hybrid.len() != 1184 + 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "invalid X25519MLKEM768 client key length",
+        ));
+    }
+    hybrid[1184..].try_into().map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid hybrid X25519 key")
+    })
+}
+
+/// Extract a complete client key share for the requested named group.
+pub fn extract_client_key_share(
+    client_hello: &[u8],
+    requested_group: u16,
+) -> Result<Vec<u8>, std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+
+    if client_hello.len() < TLS_HEADER_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ClientHello too short",
+        ));
+    }
+
+    let mut reader = BufReader::new(&client_hello[TLS_HEADER_LEN..]);
+
+    // Parse handshake header
+    let _handshake_type = reader.read_u8()?;
+    let _handshake_len = reader.read_u24_be()?;
+    let _protocol_version = reader.read_u16_be()?;
+
+    // Skip random
+    reader.skip(32)?;
+
+    // Read session ID
+    let session_id_len = reader.read_u8()? as usize;
+    reader.skip(session_id_len)?;
+
+    // Read cipher suites
+    let cipher_suites_len = reader.read_u16_be()? as usize;
+    reader.skip(cipher_suites_len)?;
+
+    // Read compression methods
+    let compression_len = reader.read_u8()? as usize;
+    reader.skip(compression_len)?;
+
+    // Parse extensions
+    let extensions_len = reader.read_u16_be()? as usize;
+    let extensions_start = reader.position();
+    let extensions_end = extensions_start + extensions_len;
+
+    while reader.position() < extensions_end {
+        let ext_type = reader.read_u16_be()?;
+        let ext_len = reader.read_u16_be()? as usize;
+
+        if ext_type == 51 {
+            // KeyShare extension (0x0033)
+            return parse_keyshare_extension(reader.read_slice(ext_len)?, requested_group);
+        } else {
+            reader.skip(ext_len)?;
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "KeyShare extension not found in ClientHello",
+    ))
+}
+
+/// Parses the KeyShare extension to extract X25519 public key
+fn parse_keyshare_extension(data: &[u8], requested_group: u16) -> Result<Vec<u8>, std::io::Error> {
+    let mut reader = BufReader::new(data);
+
+    // KeyShare extension format (client):
+    // - Client Key Share Length: 2 bytes
+    // - Key Share Entries (repeated):
+    //   - Group: 2 bytes
+    //   - Key Exchange Length: 2 bytes
+    //   - Key Exchange Data: variable
+
+    let _client_shares_len = reader.read_u16_be()?;
+
+    // Find X25519 key share (group 0x001d = 29)
+    loop {
+        // Check if we have at least 4 bytes for group and length
+        if reader.position() + 4 > data.len() {
+            break;
+        }
+
+        let group = reader.read_u16_be()?;
+        let key_len = reader.read_u16_be()? as usize;
+
+        if reader.position() + key_len > data.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "KeyShare entry extends past end",
+            ));
+        }
+
+        if group == requested_group {
+            return Ok(reader.read_slice(key_len)?.to_vec());
+        } else {
+            reader.skip(key_len)?;
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        format!("key share group {requested_group:#06x} not found"),
+    ))
+}
+
+/// Extract server's X25519 public key from ServerHello message
+///
+/// This parses the TLS 1.3 ServerHello to find the KeyShare extension
+/// and extracts the X25519 public key (group 0x001d).
+pub fn extract_server_public_key(server_hello: &[u8]) -> Result<[u8; 32], std::io::Error> {
+    let (group, key) = extract_server_key_share(server_hello)?;
+    if group != 0x001d || key.len() != 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "server did not select X25519",
+        ));
+    }
+    key.as_slice()
+        .try_into()
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid X25519 key"))
+}
+
+/// Extract the selected named group and complete key exchange from ServerHello.
+pub fn extract_server_key_share(server_hello: &[u8]) -> Result<(u16, Vec<u8>), std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+
+    if server_hello.len() < TLS_HEADER_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ServerHello too short",
+        ));
+    }
+
+    let mut reader = BufReader::new(&server_hello[TLS_HEADER_LEN..]);
+
+    // Parse handshake header
+    let _handshake_type = reader.read_u8()?;
+    let _handshake_len = reader.read_u24_be()?;
+    let _protocol_version = reader.read_u16_be()?;
+
+    // Skip random
+    reader.skip(32)?;
+
+    // Read session ID (ServerHello can echo it back)
+    let session_id_len = reader.read_u8()? as usize;
+    reader.skip(session_id_len)?;
+
+    // Read cipher suite (single 2-byte value in ServerHello)
+    reader.skip(2)?;
+
+    // Read compression method (single byte in ServerHello)
+    reader.skip(1)?;
+
+    // Parse extensions
+    let extensions_len = reader.read_u16_be()? as usize;
+    let extensions_start = reader.position();
+    let extensions_end = extensions_start + extensions_len;
+
+    while reader.position() < extensions_end {
+        let ext_type = reader.read_u16_be()?;
+        let ext_len = reader.read_u16_be()? as usize;
+
+        if ext_type == 51 {
+            // KeyShare extension (0x0033)
+            return parse_server_keyshare_extension(reader.read_slice(ext_len)?);
+        } else {
+            reader.skip(ext_len)?;
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "KeyShare extension not found in ServerHello",
+    ))
+}
+
+/// Copy a destination ServerHello handshake and replace only its key share.
+/// The replacement must keep the target's record shape and key-share length.
+pub fn mirror_server_hello_with_key_share(
+    server_hello_record: &[u8],
+    client_session_id: &[u8],
+    expected_group: u16,
+    replacement: &[u8],
+) -> Result<Vec<u8>, std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+    if server_hello_record.len() < TLS_HEADER_LEN + 4 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "truncated ServerHello",
+        ));
+    }
+    let mut message = server_hello_record[TLS_HEADER_LEN..].to_vec();
+    let mut reader = BufReader::new(&message);
+    if reader.read_u8()? != 2 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "target first record is not ServerHello",
+        ));
+    }
+    let declared = reader.read_u24_be()?;
+    if declared + 4 != message.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "target ServerHello length mismatch",
+        ));
+    }
+    reader.skip(2 + 32)?;
+    let session_len = reader.read_u8()? as usize;
+    if session_len != client_session_id.len() || session_len > 32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "target ServerHello session ID shape mismatch",
+        ));
+    }
+    let session_start = reader.position();
+    reader.skip(session_len + 2 + 1)?;
+    let extensions_len = reader.read_u16_be()? as usize;
+    let extensions_end = reader
+        .position()
+        .checked_add(extensions_len)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "target extensions overflow",
+            )
+        })?;
+    if extensions_end != message.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "target extensions length mismatch",
+        ));
+    }
+    let replacement_range = loop {
+        if reader.position() >= extensions_end {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "target ServerHello key share missing",
+            ));
+        }
+        let kind = reader.read_u16_be()?;
+        let len = reader.read_u16_be()? as usize;
+        let value_start = reader.position();
+        let value = reader.read_slice(len)?;
+        if kind == 51 {
+            let mut share = BufReader::new(value);
+            let group = share.read_u16_be()?;
+            let key_len = share.read_u16_be()? as usize;
+            if group != expected_group
+                || key_len != replacement.len()
+                || key_len != share.remaining()
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "target key-share shape mismatch",
+                ));
+            }
+            let start = value_start + 4;
+            break start..start + key_len;
+        }
+    };
+    message[session_start..session_start + session_len].copy_from_slice(client_session_id);
+    message[replacement_range].copy_from_slice(replacement);
+    Ok(message)
+}
+
+/// Parses the ServerHello KeyShare extension to extract X25519 public key
+fn parse_server_keyshare_extension(data: &[u8]) -> Result<(u16, Vec<u8>), std::io::Error> {
+    let mut reader = BufReader::new(data);
+
+    // ServerHello KeyShare extension format:
+    // - Group: 2 bytes
+    // - Key Exchange Length: 2 bytes
+    // - Key Exchange Data: variable
+
+    let group = reader.read_u16_be()?;
+    let key_len = reader.read_u16_be()? as usize;
+
+    let key = reader.read_slice(key_len)?.to_vec();
+    if reader.remaining() != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "trailing server key share bytes",
+        ));
+    }
+    Ok((group, key))
+}
+
+/// Extract the cipher suite selected by the server from ServerHello message
+///
+/// This parses the TLS 1.3 ServerHello to find the cipher suite.
+/// ServerHello contains a single cipher suite (the server's choice).
+pub fn extract_server_cipher_suite(server_hello: &[u8]) -> Result<u16, std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+
+    if server_hello.len() < TLS_HEADER_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ServerHello too short",
+        ));
+    }
+
+    let mut reader = BufReader::new(&server_hello[TLS_HEADER_LEN..]);
+
+    // Parse handshake header
+    let _handshake_type = reader.read_u8()?;
+    let _handshake_len = reader.read_u24_be()?;
+    let _protocol_version = reader.read_u16_be()?;
+
+    // Skip random (32 bytes)
+    reader.skip(32)?;
+
+    // Read session ID (ServerHello can echo it back)
+    let session_id_len = reader.read_u8()? as usize;
+    reader.skip(session_id_len)?;
+
+    // Read cipher suite (single 2-byte value in ServerHello)
+    let cipher_suite = reader.read_u16_be()?;
+
+    Ok(cipher_suite)
+}
+
+/// Extracts cipher suites offered by client from ClientHello
+///
+/// Returns a Vec of cipher suite IDs in the order they appear in the ClientHello.
+pub fn extract_client_cipher_suites(client_hello: &[u8]) -> Result<Vec<u16>, std::io::Error> {
+    const TLS_HEADER_LEN: usize = 5;
+
+    if client_hello.len() < TLS_HEADER_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "ClientHello too short",
+        ));
+    }
+
+    let mut reader = BufReader::new(&client_hello[TLS_HEADER_LEN..]);
+
+    // Parse handshake header
+    let _handshake_type = reader.read_u8()?;
+    let _handshake_len = reader.read_u24_be()?;
+    let _protocol_version = reader.read_u16_be()?;
+
+    // Skip random (32 bytes)
+    reader.skip(32)?;
+
+    // Skip session ID
+    let session_id_len = reader.read_u8()? as usize;
+    reader.skip(session_id_len)?;
+
+    // Read cipher suites
+    let cipher_suites_len = reader.read_u16_be()? as usize;
+    if cipher_suites_len % 2 != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Invalid cipher suites length (not even)",
+        ));
+    }
+
+    let cipher_suites_data = reader.read_slice(cipher_suites_len)?;
+    let mut cipher_suites = Vec::with_capacity(cipher_suites_len / 2);
+
+    for chunk in cipher_suites_data.chunks(2) {
+        let suite = u16::from_be_bytes([chunk[0], chunk[1]]);
+        cipher_suites.push(suite);
+    }
+
+    Ok(cipher_suites)
+}
+
+/// Negotiate cipher suite between server preferences and client offers (CipherSuite version)
+///
+/// Returns the first CipherSuite from server_preferences that the client supports,
+/// or None if no common cipher suite is found.
+pub fn negotiate_cipher_suite(
+    server_preferences: &[CipherSuite],
+    client_cipher_suite_ids: &[u16],
+) -> Option<CipherSuite> {
+    for server_suite in server_preferences {
+        if client_cipher_suite_ids.contains(&server_suite.id()) {
+            return Some(*server_suite);
+        }
+    }
+    None
+}
+
+pub fn generate_keypair() -> std::io::Result<(String, String)> {
+    // Generate 32 random bytes for private key
+    let mut private_key_bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut private_key_bytes);
+
+    // Create X25519 private key from the random bytes
+    let private_key =
+        agreement::PrivateKey::from_private_key(&agreement::X25519, &private_key_bytes)
+            .map_err(|_| std::io::Error::other("Failed to create X25519 key"))?;
+
+    // Derive public key from private key
+    let public_key_bytes = private_key
+        .compute_public_key()
+        .map_err(|_| std::io::Error::other("Failed to compute public key"))?;
+
+    // Encode both keys as base64url (no padding)
+    let private_key_b64 = URL_SAFE_NO_PAD.encode(private_key_bytes);
+    let public_key_b64 = URL_SAFE_NO_PAD.encode(public_key_bytes.as_ref());
+
+    Ok((private_key_b64, public_key_b64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_short_id() {
+        // Full 16-char hex
+        let short_id = decode_short_id("0123456789abcdef").unwrap();
+        assert_eq!(short_id, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+
+        // Partial hex (should be zero-padded on right)
+        let short_id2 = decode_short_id("abcdef").unwrap();
+        assert_eq!(short_id2, [0xab, 0xcd, 0xef, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        // Empty (all zeros)
+        let short_id3 = decode_short_id("").unwrap();
+        assert_eq!(short_id3, [0; 8]);
+
+        // Too long should error
+        let result = decode_short_id("0123456789abcdef0");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_extract_client_random() {
+        // Create a minimal ClientHello with random
+        let mut client_hello = vec![0u8; 100];
+
+        // TLS Header
+        client_hello[0] = 0x16; // Handshake
+        client_hello[1] = 0x03; // Version major
+        client_hello[2] = 0x03; // Version minor (TLS 1.2)
+
+        // Handshake header
+        client_hello[5] = 0x01; // ClientHello type
+
+        // Protocol version in handshake
+        client_hello[9] = 0x03; // Major
+        client_hello[10] = 0x03; // Minor
+
+        // ClientRandom starts at offset 11
+        for i in 0..32 {
+            client_hello[11 + i] = (i + 1) as u8;
+        }
+
+        let random = extract_client_random(&client_hello).unwrap();
+        for (i, byte) in random.iter().enumerate() {
+            assert_eq!(*byte, (i + 1) as u8);
+        }
+    }
+
+    #[test]
+    fn test_decode_public_key() {
+        use base64::engine::{Engine as _, general_purpose::URL_SAFE_NO_PAD};
+
+        // Valid 32-byte key
+        let key_bytes = [0x42u8; 32];
+        let encoded = URL_SAFE_NO_PAD.encode(key_bytes);
+        let decoded = decode_public_key(&encoded).unwrap();
+        assert_eq!(decoded, key_bytes);
+
+        // Invalid length
+        let short_key = [0x42u8; 16];
+        let encoded_short = URL_SAFE_NO_PAD.encode(short_key);
+        assert!(decode_public_key(&encoded_short).is_err());
+
+        // Invalid base64
+        assert!(decode_public_key("not-valid-base64!!!").is_err());
+    }
+}

--- a/crates/core-reality/src/framing.rs
+++ b/crates/core-reality/src/framing.rs
@@ -1,0 +1,518 @@
+use std::collections::HashSet;
+use std::io;
+
+use bytes::{Bytes, BytesMut};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::buffer::SliceReader;
+
+const TLS_HEADER_LEN: usize = 5;
+const TLS_HANDSHAKE: u8 = 22;
+const CLIENT_HELLO: u8 = 1;
+const TLS_1_3: u16 = 0x0304;
+const RFC8446_MAX_CIPHERTEXT: usize = 16_640;
+
+/// Resource bounds applied before authentication.
+#[derive(Clone, Copy, Debug)]
+pub struct ClientHelloLimits {
+    pub max_record_payload: usize,
+    pub max_handshake_bytes: usize,
+    pub max_wire_bytes: usize,
+    pub max_records: usize,
+}
+
+impl Default for ClientHelloLimits {
+    fn default() -> Self {
+        Self {
+            max_record_payload: RFC8446_MAX_CIPHERTEXT,
+            max_handshake_bytes: u16::MAX as usize,
+            max_wire_bytes: 96 * 1024,
+            max_records: 16,
+        }
+    }
+}
+
+/// A complete, possibly TLS-record-fragmented ClientHello.
+#[derive(Clone, Debug)]
+pub struct ClientHello {
+    wire: Bytes,
+    handshake: Bytes,
+    server_name: String,
+    supports_tls13: bool,
+    alpn_protocols: Vec<Vec<u8>>,
+    key_shares: Vec<(u16, Bytes)>,
+}
+
+impl ClientHello {
+    pub fn wire_bytes(&self) -> &[u8] {
+        &self.wire
+    }
+    pub fn handshake_bytes(&self) -> &[u8] {
+        &self.handshake
+    }
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+    pub fn supports_tls13(&self) -> bool {
+        self.supports_tls13
+    }
+    pub fn alpn_protocols(&self) -> &[Vec<u8>] {
+        &self.alpn_protocols
+    }
+    pub fn key_share(&self, group: u16) -> Option<&[u8]> {
+        self.key_shares
+            .iter()
+            .find_map(|(candidate, data)| (*candidate == group).then_some(data.as_ref()))
+    }
+
+    pub(crate) fn canonical_record(&self) -> io::Result<Vec<u8>> {
+        let len = u16::try_from(self.handshake.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ClientHello exceeds one canonical TLS record",
+            )
+        })?;
+        let mut out = Vec::with_capacity(TLS_HEADER_LEN + self.handshake.len());
+        out.extend_from_slice(&[TLS_HANDSHAKE, 0x03, 0x01]);
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&self.handshake);
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn read_client_hello<R>(
+    stream: &mut R,
+    limits: ClientHelloLimits,
+) -> io::Result<ClientHello>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
+    let mut sink = tokio::io::sink();
+    let mut forwarded = 0;
+    read_client_hello_forwarded(stream, &mut sink, limits, &mut forwarded).await
+}
+
+/// Read and parse a ClientHello while relaying every complete TLS record chunk
+/// to the camouflage target. `forwarded` allows the caller to relay only the
+/// not-yet-forwarded suffix if a timeout interrupts a partial read.
+pub(crate) async fn read_client_hello_forwarded<R, W>(
+    stream: &mut R,
+    target: &mut W,
+    limits: ClientHelloLimits,
+    forwarded: &mut usize,
+) -> io::Result<ClientHello>
+where
+    R: AsyncRead + Unpin + ?Sized,
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    if limits.max_records == 0
+        || limits.max_record_payload == 0
+        || limits.max_handshake_bytes < 4
+        || limits.max_wire_bytes < TLS_HEADER_LEN
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid ClientHello limits",
+        ));
+    }
+
+    let mut wire = BytesMut::new();
+    let mut handshake = BytesMut::new();
+    let mut expected_handshake_len = None;
+
+    for _ in 0..limits.max_records {
+        let mut header = [0u8; TLS_HEADER_LEN];
+        stream.read_exact(&mut header).await?;
+        write_forwarded(target, &header, forwarded).await?;
+        if header[0] != TLS_HANDSHAKE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "non-handshake TLS record before complete ClientHello",
+            ));
+        }
+        let payload_len = u16::from_be_bytes([header[3], header[4]]) as usize;
+        if payload_len == 0
+            || payload_len > limits.max_record_payload
+            || payload_len > RFC8446_MAX_CIPHERTEXT
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid TLS record length",
+            ));
+        }
+        if wire.len().saturating_add(TLS_HEADER_LEN + payload_len) > limits.max_wire_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ClientHello wire limit exceeded",
+            ));
+        }
+
+        let mut payload = vec![0; payload_len];
+        stream.read_exact(&mut payload).await?;
+        write_forwarded(target, &payload, forwarded).await?;
+
+        wire.extend_from_slice(&header);
+        wire.extend_from_slice(&payload);
+        handshake.extend_from_slice(&payload);
+
+        if handshake.len() >= 4 && expected_handshake_len.is_none() {
+            if handshake[0] != CLIENT_HELLO {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "first handshake message is not ClientHello",
+                ));
+            }
+            let body_len = ((handshake[1] as usize) << 16)
+                | ((handshake[2] as usize) << 8)
+                | handshake[3] as usize;
+            let total = body_len.checked_add(4).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "ClientHello length overflow")
+            })?;
+            if total > limits.max_handshake_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "ClientHello handshake limit exceeded",
+                ));
+            }
+            expected_handshake_len = Some(total);
+        }
+
+        if let Some(total) = expected_handshake_len {
+            if handshake.len() >= total {
+                handshake.truncate(total);
+                return parse_client_hello(wire.freeze(), handshake.freeze());
+            }
+        } else if handshake.len() > limits.max_handshake_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "ClientHello header limit exceeded",
+            ));
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "ClientHello record-count limit exceeded",
+    ))
+}
+
+async fn write_forwarded<W>(
+    target: &mut W,
+    mut bytes: &[u8],
+    forwarded: &mut usize,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    while !bytes.is_empty() {
+        // A single Tokio `write` is cancellation-safe. Accounting after each
+        // partial write prevents a timeout from duplicating a relayed prefix.
+        let written = target.write(bytes).await?;
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "camouflage target stopped accepting ClientHello bytes",
+            ));
+        }
+        *forwarded = forwarded.saturating_add(written);
+        bytes = &bytes[written..];
+    }
+    Ok(())
+}
+
+fn parse_client_hello(wire: Bytes, handshake: Bytes) -> io::Result<ClientHello> {
+    let mut reader = SliceReader::new(&handshake);
+    if reader.read_u8()? != CLIENT_HELLO {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a ClientHello",
+        ));
+    }
+    let declared = reader.read_u24_be()?;
+    if declared != reader.remaining() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "ClientHello length mismatch",
+        ));
+    }
+    if reader.read_u16_be()? != 0x0303 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid ClientHello legacy version",
+        ));
+    }
+    reader.skip(32)?;
+    let session_len = reader.read_u8()? as usize;
+    if session_len > 32 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid legacy session id",
+        ));
+    }
+    reader.skip(session_len)?;
+    let suites_len = reader.read_u16_be()? as usize;
+    if suites_len < 2 || suites_len % 2 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid cipher suites",
+        ));
+    }
+    reader.skip(suites_len)?;
+    let compression_len = reader.read_u8()? as usize;
+    if compression_len != 1 || reader.read_u8()? != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid TLS 1.3 legacy compression methods",
+        ));
+    }
+    let extensions_len = reader.read_u16_be()? as usize;
+    if extensions_len != reader.remaining() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "ClientHello extensions length mismatch",
+        ));
+    }
+
+    let extensions = reader.read_slice(extensions_len)?;
+    let mut extensions = SliceReader::new(extensions);
+    let mut server_name = None;
+    let mut supports_tls13 = false;
+    let mut alpn_protocols = Vec::new();
+    let mut key_shares = Vec::new();
+    let mut seen_extensions = HashSet::new();
+
+    while extensions.remaining() != 0 {
+        if extensions.remaining() < 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "truncated extension",
+            ));
+        }
+        let kind = extensions.read_u16_be()?;
+        let len = extensions.read_u16_be()? as usize;
+        let value = extensions.read_slice(len)?;
+        if !seen_extensions.insert(kind) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "duplicate ClientHello extension",
+            ));
+        }
+        match kind {
+            0 => server_name = Some(parse_server_name(value)?),
+            16 => alpn_protocols = parse_alpn(value)?,
+            43 => supports_tls13 = parse_supported_versions(value)?.contains(&TLS_1_3),
+            51 => key_shares = parse_key_shares(value)?,
+            _ => {}
+        }
+    }
+
+    let server_name = server_name
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "ClientHello has no SNI"))?;
+    if server_name.len() > 253 || server_name.bytes().any(|b| b == 0 || !b.is_ascii()) {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid SNI"));
+    }
+
+    Ok(ClientHello {
+        wire,
+        handshake,
+        server_name,
+        supports_tls13,
+        alpn_protocols,
+        key_shares,
+    })
+}
+
+fn parse_server_name(data: &[u8]) -> io::Result<String> {
+    let mut r = SliceReader::new(data);
+    let list_len = r.read_u16_be()? as usize;
+    if list_len != r.remaining() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid SNI list",
+        ));
+    }
+    let mut host_name = None;
+    while r.remaining() != 0 {
+        let kind = r.read_u8()?;
+        let len = r.read_u16_be()? as usize;
+        let name = r.read_slice(len)?;
+        if kind == 0 {
+            if host_name.is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "duplicate SNI host_name",
+                ));
+            }
+            host_name = Some(
+                std::str::from_utf8(name)
+                    .map(str::to_owned)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-UTF8 SNI"))?,
+            );
+        }
+    }
+    host_name.ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "SNI host_name missing"))
+}
+
+fn parse_supported_versions(data: &[u8]) -> io::Result<Vec<u16>> {
+    let mut r = SliceReader::new(data);
+    let len = r.read_u8()? as usize;
+    if len != r.remaining() || len % 2 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid supported_versions",
+        ));
+    }
+    let mut out = Vec::with_capacity(len / 2);
+    while r.remaining() != 0 {
+        out.push(r.read_u16_be()?);
+    }
+    Ok(out)
+}
+
+fn parse_alpn(data: &[u8]) -> io::Result<Vec<Vec<u8>>> {
+    let mut r = SliceReader::new(data);
+    let len = r.read_u16_be()? as usize;
+    if len != r.remaining() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid ALPN list",
+        ));
+    }
+    let mut out = Vec::new();
+    while r.remaining() != 0 {
+        let item_len = r.read_u8()? as usize;
+        if item_len == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "empty ALPN protocol",
+            ));
+        }
+        out.push(r.read_slice(item_len)?.to_vec());
+    }
+    Ok(out)
+}
+
+fn parse_key_shares(data: &[u8]) -> io::Result<Vec<(u16, Bytes)>> {
+    let mut r = SliceReader::new(data);
+    let len = r.read_u16_be()? as usize;
+    if len != r.remaining() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid key_share list",
+        ));
+    }
+    let mut out = Vec::new();
+    let mut groups = HashSet::new();
+    while r.remaining() != 0 {
+        let group = r.read_u16_be()?;
+        let key_len = r.read_u16_be()? as usize;
+        if key_len == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "empty key share",
+            ));
+        }
+        if !groups.insert(group) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "duplicate key-share group",
+            ));
+        }
+        out.push((group, Bytes::copy_from_slice(r.read_slice(key_len)?)));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    fn client_hello_handshake() -> Vec<u8> {
+        let mut extensions = Vec::new();
+        let host = b"example.com";
+        let mut sni = Vec::new();
+        sni.extend_from_slice(&((host.len() + 3) as u16).to_be_bytes());
+        sni.push(0);
+        sni.extend_from_slice(&(host.len() as u16).to_be_bytes());
+        sni.extend_from_slice(host);
+        extensions.extend_from_slice(&0u16.to_be_bytes());
+        extensions.extend_from_slice(&(sni.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(&sni);
+        extensions.extend_from_slice(&43u16.to_be_bytes());
+        extensions.extend_from_slice(&3u16.to_be_bytes());
+        extensions.extend_from_slice(&[2, 3, 4]);
+        let mut shares = Vec::new();
+        shares.extend_from_slice(&36u16.to_be_bytes());
+        shares.extend_from_slice(&29u16.to_be_bytes());
+        shares.extend_from_slice(&32u16.to_be_bytes());
+        shares.extend_from_slice(&[7; 32]);
+        extensions.extend_from_slice(&51u16.to_be_bytes());
+        extensions.extend_from_slice(&(shares.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(&shares);
+
+        let mut body = Vec::new();
+        body.extend_from_slice(&0x0303u16.to_be_bytes());
+        body.extend_from_slice(&[3; 32]);
+        body.push(32);
+        body.extend_from_slice(&[0; 32]);
+        body.extend_from_slice(&2u16.to_be_bytes());
+        body.extend_from_slice(&0x1301u16.to_be_bytes());
+        body.extend_from_slice(&[1, 0]);
+        body.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        body.extend_from_slice(&extensions);
+        let mut msg = vec![
+            1,
+            ((body.len() >> 16) & 255) as u8,
+            ((body.len() >> 8) & 255) as u8,
+            (body.len() & 255) as u8,
+        ];
+        msg.extend_from_slice(&body);
+        msg
+    }
+
+    fn record(fragment: &[u8]) -> Vec<u8> {
+        let mut out = vec![22, 3, 1];
+        out.extend_from_slice(&(fragment.len() as u16).to_be_bytes());
+        out.extend_from_slice(fragment);
+        out
+    }
+
+    #[tokio::test]
+    async fn reads_fragmented_client_hello_without_losing_wire_bytes() {
+        let hello = client_hello_handshake();
+        let split = 31;
+        let mut wire = record(&hello[..split]);
+        wire.extend_from_slice(&record(&hello[split..]));
+        let (mut tx, mut rx) = tokio::io::duplex(wire.len());
+        tx.write_all(&wire).await.unwrap();
+        drop(tx);
+        let parsed = read_client_hello(&mut rx, ClientHelloLimits::default())
+            .await
+            .unwrap();
+        assert_eq!(parsed.wire_bytes(), wire);
+        assert_eq!(parsed.handshake_bytes(), hello);
+        assert_eq!(parsed.server_name(), "example.com");
+        assert!(parsed.supports_tls13());
+        assert_eq!(parsed.key_share(29), Some(&[7; 32][..]));
+    }
+
+    #[tokio::test]
+    async fn rejects_record_over_bound_before_allocating_payload() {
+        let header = [22, 3, 1, 0x40, 0x01];
+        let (mut tx, mut rx) = tokio::io::duplex(header.len());
+        tx.write_all(&header).await.unwrap();
+        drop(tx);
+        let err = read_client_hello(
+            &mut rx,
+            ClientHelloLimits {
+                max_record_payload: 1024,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/core-reality/src/keys.rs
+++ b/crates/core-reality/src/keys.rs
@@ -1,0 +1,75 @@
+use std::io;
+
+use aws_lc_rs::agreement;
+use base64::Engine as _;
+use rand::RngCore as _;
+
+pub fn x25519_public_key(private_key: &[u8; 32]) -> io::Result<[u8; 32]> {
+    let private = agreement::PrivateKey::from_private_key(&agreement::X25519, private_key)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid X25519 private key"))?;
+    private
+        .compute_public_key()
+        .map_err(|_| io::Error::other("failed to derive X25519 public key"))?
+        .as_ref()
+        .try_into()
+        .map_err(|_| io::Error::other("X25519 public key has unexpected length"))
+}
+
+pub fn generate_x25519_keypair() -> io::Result<([u8; 32], [u8; 32])> {
+    let mut private = [0u8; 32];
+    rand::rng().fill_bytes(&mut private);
+    let public = x25519_public_key(&private)?;
+    Ok((private, public))
+}
+
+pub fn decode_private_key(encoded: &str) -> io::Result<[u8; 32]> {
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid base64url private key: {error}"),
+            )
+        })?;
+    decoded.as_slice().try_into().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "REALITY private key must decode to 32 bytes",
+        )
+    })
+}
+
+pub fn decode_short_id(encoded: &str) -> io::Result<[u8; 8]> {
+    if encoded.len() > 16 || encoded.len() % 2 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "shortId must contain 0 to 16 even hex digits",
+        ));
+    }
+    let mut output = [0u8; 8];
+    hex::decode_to_slice(encoded, &mut output[..encoded.len() / 2]).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid shortId: {error}"),
+        )
+    })?;
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_id_is_right_padded_like_xray() {
+        assert_eq!(decode_short_id("0102").unwrap(), [1, 2, 0, 0, 0, 0, 0, 0]);
+        assert!(decode_short_id("0").is_err());
+    }
+
+    #[test]
+    fn generated_keypair_roundtrips() {
+        let (private, public) = generate_x25519_keypair().unwrap();
+        assert_eq!(x25519_public_key(&private).unwrap(), public);
+        assert_ne!(public, [0; 32]);
+    }
+}

--- a/crates/core-reality/src/lib.rs
+++ b/crates/core-reality/src/lib.rs
@@ -1,0 +1,28 @@
+//! Generic REALITY server transport.
+//!
+//! The public API terminates an authenticated REALITY TLS 1.3 stream while
+//! transparently forwarding unauthenticated probes to a configured camouflage
+//! target. It deliberately has no dependency on XHTTP or an inner proxy
+//! protocol.
+
+mod buffer;
+mod client;
+// The attributed Shoes-derived module intentionally retains small standalone
+// protocol primitives and test vectors beyond the production server call path.
+#[allow(dead_code)]
+mod donor;
+mod framing;
+mod keys;
+mod server;
+
+pub use client::{
+    RealityClient, RealityClientConfig, RealityClientError, RealityClientStream,
+    RealityConnectionLifetime, RealitySpiderPolicy, XRAY_REALITY_WIRE_VERSION, parse_spider_x,
+};
+pub use donor::{CipherSuite, DEFAULT_CIPHER_SUITES};
+pub use framing::{ClientHello, ClientHelloLimits};
+pub use keys::{decode_private_key, decode_short_id, generate_x25519_keypair, x25519_public_key};
+pub use server::{
+    AcceptedRealityStream, FallbackLimit, ProxyProtocolVersion, RealityServer, RealityServerConfig,
+    RealityServerError, RealityServerLimits,
+};

--- a/crates/core-reality/src/server.rs
+++ b/crates/core-reality/src/server.rs
@@ -1,0 +1,1372 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::io::{self, Read as _, Write as _};
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use bytes::Bytes;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf};
+use tokio::net::TcpStream;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use zeroize::Zeroize;
+
+use crate::buffer::SliceReader;
+use crate::donor::{
+    CipherSuite, RealityServerConnection, RealityServerCryptoConfig, extract_server_cipher_suite,
+    extract_server_key_share, mldsa65_verify_from_seed,
+};
+use crate::framing::{ClientHelloLimits, read_client_hello_forwarded};
+
+const X25519: u16 = 0x001d;
+const X25519_MLKEM768: u16 = 0x11ec;
+const MAX_TLS13_RECORD: usize = 16_640;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ProxyProtocolVersion {
+    #[default]
+    None,
+    V1,
+    V2,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct FallbackLimit {
+    pub after_bytes: u64,
+    pub bytes_per_second: u64,
+    pub burst_bytes: u64,
+}
+
+impl FallbackLimit {
+    fn validate(self) -> Result<(), RealityServerError> {
+        if self.bytes_per_second == 0 && (self.after_bytes != 0 || self.burst_bytes != 0) {
+            return Err(RealityServerError::Configuration(
+                "fallback after/burst requires a non-zero byte rate".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RealityServerLimits {
+    pub client_hello: ClientHelloLimits,
+    pub handshake_timeout: Duration,
+    pub target_handshake_timeout: Duration,
+    pub idle_timeout: Duration,
+    pub max_target_records: usize,
+    pub max_target_handshake_bytes: usize,
+    pub application_buffer_bytes: usize,
+    pub max_concurrent_handshakes: usize,
+}
+
+impl Default for RealityServerLimits {
+    fn default() -> Self {
+        Self {
+            client_hello: ClientHelloLimits::default(),
+            handshake_timeout: Duration::from_secs(10),
+            target_handshake_timeout: Duration::from_secs(5),
+            idle_timeout: Duration::from_secs(300),
+            max_target_records: 12,
+            max_target_handshake_bytes: 96 * 1024,
+            application_buffer_bytes: 256 * 1024,
+            max_concurrent_handshakes: 1024,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RealityServerConfig {
+    pub camouflage_target: String,
+    pub private_key: [u8; 32],
+    pub server_names: HashSet<String>,
+    pub short_ids: Vec<[u8; 8]>,
+    pub min_client_version: Option<[u8; 3]>,
+    pub max_client_version: Option<[u8; 3]>,
+    pub max_time_difference: Option<Duration>,
+    pub mldsa65_seed: Option<[u8; 32]>,
+    pub cipher_suites: Vec<CipherSuite>,
+    pub proxy_protocol: ProxyProtocolVersion,
+    pub fallback_upload: FallbackLimit,
+    pub fallback_download: FallbackLimit,
+    pub limits: RealityServerLimits,
+}
+
+impl fmt::Debug for RealityServerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityServerConfig")
+            .field("camouflage_target", &self.camouflage_target)
+            .field("private_key", &"<redacted>")
+            .field("server_names", &self.server_names)
+            .field("short_id_count", &self.short_ids.len())
+            .field("min_client_version", &self.min_client_version)
+            .field("max_client_version", &self.max_client_version)
+            .field("max_time_difference", &self.max_time_difference)
+            .field("has_mldsa65_seed", &self.mldsa65_seed.is_some())
+            .field("cipher_suites", &self.cipher_suites)
+            .field("proxy_protocol", &self.proxy_protocol)
+            .field("fallback_upload", &self.fallback_upload)
+            .field("fallback_download", &self.fallback_download)
+            .field("limits", &self.limits)
+            .finish()
+    }
+}
+
+impl Drop for RealityServerConfig {
+    fn drop(&mut self) {
+        self.private_key.zeroize();
+        self.short_ids.zeroize();
+        if let Some(seed) = &mut self.mldsa65_seed {
+            seed.zeroize();
+        }
+    }
+}
+
+impl RealityServerConfig {
+    fn validate(&self) -> Result<(), RealityServerError> {
+        if self.camouflage_target.trim().is_empty() {
+            return Err(RealityServerError::Configuration(
+                "camouflage target is empty".into(),
+            ));
+        }
+        if self.private_key.iter().all(|byte| *byte == 0) {
+            return Err(RealityServerError::Configuration(
+                "X25519 private key is all zero".into(),
+            ));
+        }
+        if self.server_names.is_empty() || self.server_names.iter().any(|name| name.is_empty()) {
+            return Err(RealityServerError::Configuration(
+                "serverNames must not be empty".into(),
+            ));
+        }
+        if self.short_ids.is_empty() {
+            return Err(RealityServerError::Configuration(
+                "shortIds must not be empty".into(),
+            ));
+        }
+        if let (Some(min), Some(max)) = (self.min_client_version, self.max_client_version)
+            && min > max
+        {
+            return Err(RealityServerError::Configuration(
+                "minimum client version exceeds maximum".into(),
+            ));
+        }
+        if self.mldsa65_seed.as_ref() == Some(&self.private_key) {
+            return Err(RealityServerError::Configuration(
+                "ML-DSA-65 seed must differ from the X25519 private key".into(),
+            ));
+        }
+        if self.limits.handshake_timeout.is_zero()
+            || self.limits.target_handshake_timeout.is_zero()
+            || self.limits.idle_timeout.is_zero()
+            || self.limits.max_target_records < 3
+            || self.limits.max_target_handshake_bytes < 1024
+            || self.limits.application_buffer_bytes == 0
+            || self.limits.max_concurrent_handshakes == 0
+        {
+            return Err(RealityServerError::Configuration(
+                "invalid REALITY resource limits".into(),
+            ));
+        }
+        let hello = self.limits.client_hello;
+        if hello.max_records == 0
+            || hello.max_record_payload == 0
+            || hello.max_record_payload > MAX_TLS13_RECORD
+            || hello.max_handshake_bytes < 4
+            || hello.max_handshake_bytes > u16::MAX as usize
+            || hello.max_wire_bytes < 5
+        {
+            return Err(RealityServerError::Configuration(
+                "invalid ClientHello resource limits".into(),
+            ));
+        }
+        self.fallback_upload.validate()?;
+        self.fallback_download.validate()?;
+        if let Some(seed) = &self.mldsa65_seed {
+            mldsa65_verify_from_seed(seed).map_err(RealityServerError::Io)?;
+        }
+        Ok(())
+    }
+
+    /// Derive the base64-ready 1,952-byte verification key for clients.
+    pub fn mldsa65_verify_key(&self) -> Result<Option<Vec<u8>>, RealityServerError> {
+        self.mldsa65_seed
+            .as_ref()
+            .map(mldsa65_verify_from_seed)
+            .transpose()
+            .map_err(RealityServerError::Io)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RealityServerError {
+    #[error("REALITY configuration error: {0}")]
+    Configuration(String),
+    #[error("REALITY I/O error: {0}")]
+    Io(#[source] io::Error),
+    #[error("REALITY connection cancelled")]
+    Cancelled,
+    #[error("REALITY handshake timed out")]
+    HandshakeTimeout,
+    #[error("REALITY camouflage fallback started: {reason}")]
+    FallbackStarted { reason: String },
+}
+
+impl From<io::Error> for RealityServerError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[derive(Clone)]
+pub struct RealityServer {
+    config: Arc<RealityServerConfig>,
+    handshakes: Arc<Semaphore>,
+}
+
+impl RealityServer {
+    pub fn new(config: RealityServerConfig) -> Result<Self, RealityServerError> {
+        config.validate()?;
+        let max = config.limits.max_concurrent_handshakes;
+        Ok(Self {
+            config: Arc::new(config),
+            handshakes: Arc::new(Semaphore::new(max)),
+        })
+    }
+
+    pub fn config(&self) -> &RealityServerConfig {
+        &self.config
+    }
+
+    /// Accept a generic inbound stream and dial the configured camouflage TCP target.
+    pub async fn accept<S>(
+        &self,
+        client: S,
+        peer_addr: SocketAddr,
+        local_addr: SocketAddr,
+        cancellation: CancellationToken,
+    ) -> Result<AcceptedRealityStream, RealityServerError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let permit = self.acquire_permit(&cancellation).await?;
+        let connect = TcpStream::connect(&self.config.camouflage_target);
+        let target = tokio::select! {
+            _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+            result = tokio::time::timeout(self.config.limits.target_handshake_timeout, connect) => {
+                result.map_err(|_| RealityServerError::HandshakeTimeout)??
+            }
+        };
+        self.accept_with_target_inner(client, target, peer_addr, local_addr, cancellation, permit)
+            .await
+    }
+
+    /// Accept a generic inbound stream using an already connected camouflage stream.
+    /// This is the protocol-neutral API used by inbounds and deterministic tests.
+    pub async fn accept_with_target<S, T>(
+        &self,
+        client: S,
+        target: T,
+        peer_addr: SocketAddr,
+        local_addr: SocketAddr,
+        cancellation: CancellationToken,
+    ) -> Result<AcceptedRealityStream, RealityServerError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let permit = self.acquire_permit(&cancellation).await?;
+        self.accept_with_target_inner(client, target, peer_addr, local_addr, cancellation, permit)
+            .await
+    }
+
+    async fn acquire_permit(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<OwnedSemaphorePermit, RealityServerError> {
+        let permit = tokio::select! {
+            _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+            permit = self.handshakes.clone().acquire_owned() => permit.map_err(|_| RealityServerError::Cancelled)?,
+        };
+        Ok(permit)
+    }
+
+    async fn accept_with_target_inner<S, T>(
+        &self,
+        mut client: S,
+        mut target: T,
+        peer_addr: SocketAddr,
+        local_addr: SocketAddr,
+        cancellation: CancellationToken,
+        permit: OwnedSemaphorePermit,
+    ) -> Result<AcceptedRealityStream, RealityServerError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let proxy_header = write_proxy_header(
+            &mut target,
+            self.config.proxy_protocol,
+            peer_addr,
+            local_addr,
+        );
+        tokio::select! {
+            _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+            result = tokio::time::timeout(self.config.limits.target_handshake_timeout, proxy_header) => {
+                result.map_err(|_| RealityServerError::HandshakeTimeout)??;
+            }
+        }
+
+        let mut recorded = Vec::new();
+        let mut forwarded = 0usize;
+        let hello_result = {
+            let mut recording = RecordingRead::new(&mut client, &mut recorded);
+            tokio::select! {
+                _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+                result = tokio::time::timeout(
+                    self.config.limits.handshake_timeout,
+                    read_client_hello_forwarded(
+                        &mut recording,
+                        &mut target,
+                        self.config.limits.client_hello,
+                        &mut forwarded,
+                    ),
+                ) => result,
+            }
+        };
+
+        let hello = match hello_result {
+            Err(_) => {
+                let forward = forward_recorded_suffix(&mut target, &recorded, forwarded);
+                tokio::select! {
+                    _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+                    result = tokio::time::timeout(self.config.limits.target_handshake_timeout, forward) => {
+                        result.map_err(|_| RealityServerError::HandshakeTimeout)??;
+                    }
+                }
+                self.start_fallback(
+                    client,
+                    target,
+                    Vec::new(),
+                    permit,
+                    cancellation,
+                    "ClientHello timeout".to_owned(),
+                );
+                return Err(RealityServerError::FallbackStarted {
+                    reason: "ClientHello timeout".into(),
+                });
+            }
+            Ok(Err(error)) => {
+                let forward = forward_recorded_suffix(&mut target, &recorded, forwarded);
+                tokio::select! {
+                    _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+                    result = tokio::time::timeout(self.config.limits.target_handshake_timeout, forward) => {
+                        result.map_err(|_| RealityServerError::HandshakeTimeout)??;
+                    }
+                }
+                let reason = format!("invalid ClientHello: {error}");
+                self.start_fallback(
+                    client,
+                    target,
+                    Vec::new(),
+                    permit,
+                    cancellation,
+                    reason.clone(),
+                );
+                return Err(RealityServerError::FallbackStarted { reason });
+            }
+            Ok(Ok(hello)) => hello,
+        };
+
+        tokio::select! {
+            _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+            result = tokio::time::timeout(self.config.limits.target_handshake_timeout, target.flush()) => {
+                result.map_err(|_| RealityServerError::HandshakeTimeout)??;
+            }
+        }
+
+        if !hello.supports_tls13() {
+            return self.fallback(
+                client,
+                target,
+                permit,
+                cancellation,
+                "client does not support TLS 1.3",
+            );
+        }
+        if !self.config.server_names.contains(hello.server_name()) {
+            return self.fallback(
+                client,
+                target,
+                permit,
+                cancellation,
+                "SNI is not authorized",
+            );
+        }
+
+        let canonical = match hello.canonical_record() {
+            Ok(record) => record,
+            Err(error) => {
+                return self.fallback(client, target, permit, cancellation, error.to_string());
+            }
+        };
+        let mut crypto = RealityServerConnection::new(RealityServerCryptoConfig {
+            private_key: self.config.private_key,
+            short_ids: self.config.short_ids.clone(),
+            certificate_server_name: hello.server_name().to_owned(),
+            max_time_diff: self.config.max_time_difference,
+            min_client_version: self.config.min_client_version,
+            max_client_version: self.config.max_client_version,
+            cipher_suites: self.config.cipher_suites.clone(),
+            mldsa65_seed: self.config.mldsa65_seed,
+        })?;
+
+        if let Err(error) = crypto.validate_client_hello(&canonical) {
+            return self.fallback(
+                client,
+                target,
+                permit,
+                cancellation,
+                format!("authentication rejected: {error}"),
+            );
+        }
+
+        let target_records =
+            match collect_target_template(&mut target, &self.config.limits, &cancellation).await {
+                Ok(records) => records,
+                Err((records, error)) => {
+                    if cancellation.is_cancelled() {
+                        return Err(RealityServerError::Cancelled);
+                    }
+                    let reason = format!("camouflage target handshake unusable: {error}");
+                    self.start_fallback(
+                        client,
+                        target,
+                        records,
+                        permit,
+                        cancellation,
+                        reason.clone(),
+                    );
+                    return Err(RealityServerError::FallbackStarted { reason });
+                }
+            };
+
+        if let Err(error) = crypto.build_server_response(target_records.clone()) {
+            let reason = format!("failed to mirror camouflage handshake: {error}");
+            self.start_fallback(
+                client,
+                target,
+                target_records,
+                permit,
+                cancellation,
+                reason.clone(),
+            );
+            return Err(RealityServerError::FallbackStarted { reason });
+        }
+        drop(target);
+
+        let handshake = perform_crypto_handshake(&mut client, &mut crypto, &cancellation);
+        tokio::select! {
+            _ = cancellation.cancelled() => return Err(RealityServerError::Cancelled),
+            result = tokio::time::timeout(self.config.limits.handshake_timeout, handshake) => {
+                result.map_err(|_| RealityServerError::HandshakeTimeout)??;
+            }
+        }
+
+        let authenticated = crypto.authenticated_client().ok_or_else(|| {
+            RealityServerError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "authenticated metadata missing",
+            ))
+        })?;
+        let negotiated_group = crypto.negotiated_group().unwrap_or(X25519);
+        let (application, pump_side) =
+            tokio::io::duplex(self.config.limits.application_buffer_bytes);
+        let idle_timeout = self.config.limits.idle_timeout;
+        tokio::spawn(run_crypto_pump(
+            client,
+            pump_side,
+            crypto,
+            cancellation,
+            idle_timeout,
+            permit,
+        ));
+
+        Ok(AcceptedRealityStream {
+            stream: application,
+            server_name: hello.server_name().to_owned(),
+            client_version: authenticated.version,
+            short_id: authenticated.short_id,
+            hybrid_key_exchange: negotiated_group == X25519_MLKEM768,
+            mldsa65: self.config.mldsa65_seed.is_some(),
+        })
+    }
+
+    fn fallback<S, T, R>(
+        &self,
+        client: S,
+        target: T,
+        permit: OwnedSemaphorePermit,
+        cancellation: CancellationToken,
+        reason: R,
+    ) -> Result<AcceptedRealityStream, RealityServerError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        R: Into<String>,
+    {
+        let reason = reason.into();
+        self.start_fallback(
+            client,
+            target,
+            Vec::new(),
+            permit,
+            cancellation,
+            reason.clone(),
+        );
+        Err(RealityServerError::FallbackStarted { reason })
+    }
+
+    fn start_fallback<S, T>(
+        &self,
+        client: S,
+        target: T,
+        target_prefix: Vec<Bytes>,
+        permit: OwnedSemaphorePermit,
+        cancellation: CancellationToken,
+        reason: String,
+    ) where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let policy = FallbackPolicy {
+            upload: self.config.fallback_upload,
+            download: self.config.fallback_download,
+            idle_timeout: self.config.limits.idle_timeout,
+        };
+        tokio::spawn(async move {
+            tracing::debug!(%reason, "REALITY transparent fallback started");
+            run_fallback(client, target, target_prefix, policy, cancellation, permit).await;
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FallbackPolicy {
+    upload: FallbackLimit,
+    download: FallbackLimit,
+    idle_timeout: Duration,
+}
+
+async fn forward_recorded_suffix<W: AsyncWrite + Unpin + ?Sized>(
+    target: &mut W,
+    recorded: &[u8],
+    forwarded: usize,
+) -> io::Result<()> {
+    let suffix = recorded.get(forwarded..).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "forwarded ClientHello byte count overflow",
+        )
+    })?;
+    if !suffix.is_empty() {
+        target.write_all(suffix).await?;
+    }
+    target.flush().await
+}
+
+pub struct AcceptedRealityStream {
+    stream: DuplexStream,
+    server_name: String,
+    client_version: [u8; 3],
+    short_id: [u8; 8],
+    hybrid_key_exchange: bool,
+    mldsa65: bool,
+}
+
+impl AcceptedRealityStream {
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+    pub fn client_version(&self) -> [u8; 3] {
+        self.client_version
+    }
+    pub fn short_id(&self) -> [u8; 8] {
+        self.short_id
+    }
+    pub fn used_hybrid_key_exchange(&self) -> bool {
+        self.hybrid_key_exchange
+    }
+    pub fn used_mldsa65(&self) -> bool {
+        self.mldsa65
+    }
+}
+
+impl Drop for AcceptedRealityStream {
+    fn drop(&mut self) {
+        self.short_id.zeroize();
+    }
+}
+
+impl AsyncRead for AcceptedRealityStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for AcceptedRealityStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.stream).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_shutdown(cx)
+    }
+}
+
+struct RecordingRead<'a, S> {
+    inner: &'a mut S,
+    recorded: &'a mut Vec<u8>,
+}
+
+impl<'a, S> RecordingRead<'a, S> {
+    fn new(inner: &'a mut S, recorded: &'a mut Vec<u8>) -> Self {
+        Self { inner, recorded }
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for RecordingRead<'_, S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let result = Pin::new(&mut *self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &result {
+            self.recorded.extend_from_slice(&buf.filled()[before..]);
+        }
+        result
+    }
+}
+
+async fn write_proxy_header<W: AsyncWrite + Unpin + ?Sized>(
+    target: &mut W,
+    version: ProxyProtocolVersion,
+    source: SocketAddr,
+    destination: SocketAddr,
+) -> io::Result<()> {
+    let header = proxy_header(version, source, destination)?;
+    if !header.is_empty() {
+        target.write_all(&header).await?;
+    }
+    Ok(())
+}
+
+fn proxy_header(
+    version: ProxyProtocolVersion,
+    source: SocketAddr,
+    destination: SocketAddr,
+) -> io::Result<Vec<u8>> {
+    match version {
+        ProxyProtocolVersion::None => Ok(Vec::new()),
+        ProxyProtocolVersion::V1 => match (source.ip(), destination.ip()) {
+            (IpAddr::V4(src), IpAddr::V4(dst)) => Ok(format!(
+                "PROXY TCP4 {src} {dst} {} {}\r\n",
+                source.port(),
+                destination.port()
+            )
+            .into_bytes()),
+            (IpAddr::V6(src), IpAddr::V6(dst)) => Ok(format!(
+                "PROXY TCP6 {src} {dst} {} {}\r\n",
+                source.port(),
+                destination.port()
+            )
+            .into_bytes()),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "PROXY protocol source and destination address families differ",
+            )),
+        },
+        ProxyProtocolVersion::V2 => {
+            let mut out = b"\r\n\r\n\0\r\nQUIT\n".to_vec();
+            out.push(0x21);
+            match (source.ip(), destination.ip()) {
+                (IpAddr::V4(src), IpAddr::V4(dst)) => {
+                    out.push(0x11);
+                    out.extend_from_slice(&12u16.to_be_bytes());
+                    out.extend_from_slice(&src.octets());
+                    out.extend_from_slice(&dst.octets());
+                }
+                (IpAddr::V6(src), IpAddr::V6(dst)) => {
+                    out.push(0x21);
+                    out.extend_from_slice(&36u16.to_be_bytes());
+                    out.extend_from_slice(&src.octets());
+                    out.extend_from_slice(&dst.octets());
+                }
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "PROXY protocol source and destination address families differ",
+                    ));
+                }
+            }
+            out.extend_from_slice(&source.port().to_be_bytes());
+            out.extend_from_slice(&destination.port().to_be_bytes());
+            Ok(out)
+        }
+    }
+}
+
+async fn collect_target_template<T: AsyncRead + Unpin + ?Sized>(
+    target: &mut T,
+    limits: &RealityServerLimits,
+    cancellation: &CancellationToken,
+) -> Result<Vec<Bytes>, (Vec<Bytes>, io::Error)> {
+    let deadline = Instant::now() + limits.target_handshake_timeout;
+    let mut records = Vec::new();
+    let mut total = 0usize;
+    let mut encrypted = 0usize;
+
+    for _ in 0..limits.max_target_records {
+        let mut header = [0u8; 5];
+        if let Err((filled, error)) =
+            read_exact_until(target, &mut header, deadline, cancellation).await
+        {
+            if filled != 0 {
+                records.push(Bytes::copy_from_slice(&header[..filled]));
+            }
+            return Err((records, error));
+        }
+        let body_len = u16::from_be_bytes([header[3], header[4]]) as usize;
+        if body_len == 0 || body_len > MAX_TLS13_RECORD {
+            records.push(Bytes::copy_from_slice(&header));
+            return Err((
+                records,
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid target TLS record length",
+                ),
+            ));
+        }
+        total = match total.checked_add(5 + body_len) {
+            Some(total) if total <= limits.max_target_handshake_bytes => total,
+            _ => {
+                records.push(Bytes::copy_from_slice(&header));
+                return Err((
+                    records,
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "target handshake byte limit exceeded",
+                    ),
+                ));
+            }
+        };
+        let mut record = Vec::with_capacity(5 + body_len);
+        record.extend_from_slice(&header);
+        record.resize(5 + body_len, 0);
+        if let Err((filled, error)) =
+            read_exact_until(target, &mut record[5..], deadline, cancellation).await
+        {
+            record.truncate(5 + filled);
+            records.push(Bytes::from(record));
+            return Err((records, error));
+        }
+        let record = Bytes::from(record);
+        if records.is_empty() {
+            if let Err(error) = validate_target_server_hello(&record) {
+                records.push(record);
+                return Err((records, error));
+            }
+        }
+        if record[0] == 23 {
+            encrypted += 1;
+        }
+        let combined = record[0] == 23 && record.len() > 512;
+        records.push(record);
+        if combined || encrypted >= 4 {
+            return Ok(records);
+        }
+    }
+    Err((
+        records,
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target TLS record-count limit exceeded",
+        ),
+    ))
+}
+
+async fn read_exact_until<T: AsyncRead + Unpin + ?Sized>(
+    stream: &mut T,
+    buffer: &mut [u8],
+    deadline: Instant,
+    cancellation: &CancellationToken,
+) -> Result<(), (usize, io::Error)> {
+    let mut filled = 0usize;
+    while filled < buffer.len() {
+        let read = tokio::select! {
+            _ = cancellation.cancelled() => {
+                return Err((filled, io::Error::new(io::ErrorKind::Interrupted, "cancelled")));
+            }
+            result = tokio::time::timeout_at(deadline, stream.read(&mut buffer[filled..])) => result,
+        };
+        let count = match read {
+            Err(_) => {
+                return Err((
+                    filled,
+                    io::Error::new(io::ErrorKind::TimedOut, "target handshake timeout"),
+                ));
+            }
+            Ok(Err(error)) => return Err((filled, error)),
+            Ok(Ok(0)) => {
+                return Err((
+                    filled,
+                    io::Error::new(io::ErrorKind::UnexpectedEof, "camouflage target closed"),
+                ));
+            }
+            Ok(Ok(count)) => count,
+        };
+        filled += count;
+    }
+    Ok(())
+}
+
+fn validate_target_server_hello(record: &[u8]) -> io::Result<()> {
+    if record.len() < 9 || record[0] != 22 || record[5] != 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target did not return ServerHello",
+        ));
+    }
+    let record_len = u16::from_be_bytes([record[3], record[4]]) as usize;
+    if record_len + 5 != record.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target ServerHello record length mismatch",
+        ));
+    }
+    let mut hello = SliceReader::new(&record[5..]);
+    if hello.read_u8()? != 2 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target first handshake is not ServerHello",
+        ));
+    }
+    let handshake_len = hello.read_u24_be()?;
+    if handshake_len != hello.remaining() || hello.read_u16_be()? != 0x0303 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid target ServerHello framing",
+        ));
+    }
+    hello.skip(32)?;
+    let session_len = hello.read_u8()? as usize;
+    if session_len > 32 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid target ServerHello session ID",
+        ));
+    }
+    hello.skip(session_len)?;
+    let parsed_cipher = hello.read_u16_be()?;
+    if hello.read_u8()? != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target selected non-null compression",
+        ));
+    }
+    let extensions_len = hello.read_u16_be()? as usize;
+    if extensions_len != hello.remaining() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target ServerHello extensions length mismatch",
+        ));
+    }
+    let mut extensions = SliceReader::new(hello.read_slice(extensions_len)?);
+    let mut tls13 = false;
+    let mut key_share = None;
+    while extensions.remaining() != 0 {
+        if extensions.remaining() < 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "truncated target ServerHello extension",
+            ));
+        }
+        let kind = extensions.read_u16_be()?;
+        let value_len = extensions.read_u16_be()? as usize;
+        let value = extensions.read_slice(value_len)?;
+        match kind {
+            43 => {
+                if tls13 || value != TLS_1_3_VERSION {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "target did not negotiate TLS 1.3",
+                    ));
+                }
+                tls13 = true;
+            }
+            51 => {
+                if key_share.is_some() || value.len() < 4 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid target ServerHello key share",
+                    ));
+                }
+                let group = u16::from_be_bytes([value[0], value[1]]);
+                let len = u16::from_be_bytes([value[2], value[3]]) as usize;
+                if len != value.len() - 4 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "target key-share length mismatch",
+                    ));
+                }
+                key_share = Some((group, len));
+            }
+            _ => {}
+        }
+    }
+    if !tls13 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target ServerHello lacks TLS 1.3 version",
+        ));
+    }
+    let cipher = extract_server_cipher_suite(record)?;
+    if cipher != parsed_cipher || CipherSuite::from_id(cipher).is_none() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target selected unsupported TLS cipher",
+        ));
+    }
+    let (group, key) = extract_server_key_share(record)?;
+    if key_share != Some((group, key.len())) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "inconsistent target key share",
+        ));
+    }
+    match (group, key.len()) {
+        (X25519, 32) | (X25519_MLKEM768, 1120) => Ok(()),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "target selected unsupported TLS key share",
+        )),
+    }
+}
+
+async fn perform_crypto_handshake<S: AsyncRead + AsyncWrite + Unpin>(
+    stream: &mut S,
+    crypto: &mut RealityServerConnection,
+    cancellation: &CancellationToken,
+) -> io::Result<()> {
+    flush_crypto(stream, crypto, cancellation).await?;
+    let mut input = vec![0u8; MAX_TLS13_RECORD + 5];
+    while crypto.is_handshaking() {
+        let n = tokio::select! {
+            _ = cancellation.cancelled() => return Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+            result = stream.read(&mut input) => result?,
+        };
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "client closed during REALITY handshake",
+            ));
+        }
+        feed_crypto(crypto, &input[..n])?;
+        crypto.process_new_packets()?;
+        flush_crypto(stream, crypto, cancellation).await?;
+    }
+    Ok(())
+}
+
+fn feed_crypto(crypto: &mut RealityServerConnection, data: &[u8]) -> io::Result<()> {
+    let mut cursor = io::Cursor::new(data);
+    while cursor.position() < data.len() as u64 {
+        let n = crypto.read_tls(&mut cursor)?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "REALITY TLS input stalled",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn flush_crypto<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    crypto: &mut RealityServerConnection,
+    cancellation: &CancellationToken,
+) -> io::Result<()> {
+    while crypto.wants_write() {
+        let mut ciphertext = Vec::new();
+        let n = crypto.write_tls(&mut ciphertext)?;
+        if n == 0 {
+            break;
+        }
+        tokio::select! {
+            _ = cancellation.cancelled() => return Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+            result = stream.write_all(&ciphertext) => result?,
+        }
+    }
+    stream.flush().await
+}
+
+async fn flush_crypto_with_timeout<S: AsyncWrite + Unpin>(
+    stream: &mut S,
+    crypto: &mut RealityServerConnection,
+    cancellation: &CancellationToken,
+    idle_timeout: Duration,
+) -> io::Result<()> {
+    tokio::time::timeout(idle_timeout, flush_crypto(stream, crypto, cancellation))
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "REALITY network write idle timeout",
+            )
+        })?
+}
+
+enum PumpEvent {
+    Network(io::Result<usize>),
+    Application(io::Result<usize>),
+    Cancelled,
+}
+
+async fn run_crypto_pump<S>(
+    network: S,
+    mut application: DuplexStream,
+    mut crypto: RealityServerConnection,
+    cancellation: CancellationToken,
+    idle_timeout: Duration,
+    _permit: OwnedSemaphorePermit,
+) where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let (mut network_read, mut network_write) = tokio::io::split(network);
+    let mut network_buffer = vec![0u8; MAX_TLS13_RECORD + 5];
+    let mut application_buffer = vec![0u8; 32 * 1024];
+    let mut network_open = true;
+    let mut application_open = true;
+
+    while network_open || application_open {
+        let plaintext = match take_plaintext(&mut crypto) {
+            Ok(plaintext) => plaintext,
+            Err(_) => break,
+        };
+        if !plaintext.is_empty() {
+            let result = tokio::select! {
+                _ = cancellation.cancelled() => Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+                result = tokio::time::timeout(idle_timeout, application.write_all(&plaintext)) => {
+                    result.unwrap_or_else(|_| {
+                        Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "application write idle timeout",
+                        ))
+                    })
+                }
+            };
+            if result.is_err() {
+                break;
+            }
+        }
+        let event = tokio::time::timeout(idle_timeout, async {
+            tokio::select! {
+                _ = cancellation.cancelled() => PumpEvent::Cancelled,
+                result = network_read.read(&mut network_buffer), if network_open => PumpEvent::Network(result),
+                result = application.read(&mut application_buffer), if application_open => PumpEvent::Application(result),
+            }
+        }).await;
+        let Ok(event) = event else { break };
+        match event {
+            PumpEvent::Cancelled => break,
+            PumpEvent::Network(Ok(0)) | PumpEvent::Network(Err(_)) => {
+                network_open = false;
+                let _ = application.shutdown().await;
+            }
+            PumpEvent::Network(Ok(n)) => {
+                if feed_crypto(&mut crypto, &network_buffer[..n]).is_err()
+                    || crypto.process_new_packets().is_err()
+                {
+                    break;
+                }
+                if flush_crypto_with_timeout(
+                    &mut network_write,
+                    &mut crypto,
+                    &cancellation,
+                    idle_timeout,
+                )
+                .await
+                .is_err()
+                {
+                    break;
+                }
+            }
+            PumpEvent::Application(Ok(0)) | PumpEvent::Application(Err(_)) => {
+                application_open = false;
+                crypto.send_close_notify();
+                let _ = flush_crypto_with_timeout(
+                    &mut network_write,
+                    &mut crypto,
+                    &cancellation,
+                    idle_timeout,
+                )
+                .await;
+                let _ = tokio::time::timeout(idle_timeout, network_write.shutdown()).await;
+            }
+            PumpEvent::Application(Ok(n)) => {
+                let write = crypto.writer().write_all(&application_buffer[..n]);
+                if write.is_err()
+                    || flush_crypto_with_timeout(
+                        &mut network_write,
+                        &mut crypto,
+                        &cancellation,
+                        idle_timeout,
+                    )
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn take_plaintext(crypto: &mut RealityServerConnection) -> io::Result<Vec<u8>> {
+    let available = crypto.plaintext_bytes_to_read();
+    let mut plaintext = vec![0; available];
+    if available != 0 {
+        crypto.reader().read_exact(&mut plaintext)?;
+    }
+    Ok(plaintext)
+}
+
+async fn run_fallback<S, T>(
+    client: S,
+    target: T,
+    target_prefix: Vec<Bytes>,
+    policy: FallbackPolicy,
+    cancellation: CancellationToken,
+    _permit: OwnedSemaphorePermit,
+) where
+    S: AsyncRead + AsyncWrite + Unpin,
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    let (client_read, mut client_write) = tokio::io::split(client);
+    let (target_read, target_write) = tokio::io::split(target);
+    for record in target_prefix {
+        let write =
+            tokio::time::timeout(policy.idle_timeout, client_write.write_all(&record)).await;
+        if !matches!(write, Ok(Ok(()))) {
+            return;
+        }
+    }
+    let upload_cancel = cancellation.clone();
+    let download_cancel = cancellation.clone();
+    let upload_task = copy_limited(
+        client_read,
+        target_write,
+        policy.upload,
+        policy.idle_timeout,
+        upload_cancel,
+    );
+    let download_task = copy_limited(
+        target_read,
+        client_write,
+        policy.download,
+        policy.idle_timeout,
+        download_cancel,
+    );
+    let _ = tokio::join!(upload_task, download_task);
+}
+
+struct TokenBucket {
+    exempt_remaining: u64,
+    rate: u64,
+    capacity: f64,
+    tokens: f64,
+    updated: Instant,
+}
+
+impl TokenBucket {
+    fn new(limit: FallbackLimit) -> Self {
+        let capacity = limit.burst_bytes.max(limit.bytes_per_second) as f64;
+        Self {
+            exempt_remaining: limit.after_bytes,
+            rate: limit.bytes_per_second,
+            capacity,
+            tokens: capacity,
+            updated: Instant::now(),
+        }
+    }
+
+    async fn account(&mut self, bytes: usize, cancellation: &CancellationToken) -> io::Result<()> {
+        if self.rate == 0 {
+            return Ok(());
+        }
+        if self.exempt_remaining > 0 {
+            self.exempt_remaining = self.exempt_remaining.saturating_sub(bytes as u64);
+            return Ok(());
+        }
+        let now = Instant::now();
+        self.tokens = (self.tokens
+            + now.duration_since(self.updated).as_secs_f64() * self.rate as f64)
+            .min(self.capacity);
+        self.updated = now;
+        let needed = bytes as f64;
+        if self.tokens < needed {
+            let wait = Duration::from_secs_f64((needed - self.tokens) / self.rate as f64);
+            tokio::select! {
+                _ = cancellation.cancelled() => return Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+                _ = tokio::time::sleep(wait) => {}
+            }
+            self.tokens = 0.0;
+            self.updated = Instant::now();
+        } else {
+            self.tokens -= needed;
+        }
+        Ok(())
+    }
+}
+
+async fn copy_limited<R, W>(
+    mut reader: R,
+    mut writer: W,
+    limit: FallbackLimit,
+    idle_timeout: Duration,
+    cancellation: CancellationToken,
+) -> io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut bucket = TokenBucket::new(limit);
+    let mut buffer = vec![0u8; 16 * 1024];
+    let mut copied = 0u64;
+    loop {
+        let n = tokio::select! {
+            _ = cancellation.cancelled() => return Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+            result = tokio::time::timeout(idle_timeout, reader.read(&mut buffer)) => {
+                result.map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "fallback read idle timeout"))??
+            },
+        };
+        if n == 0 {
+            tokio::time::timeout(idle_timeout, writer.shutdown())
+                .await
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::TimedOut, "fallback shutdown timeout")
+                })??;
+            return Ok(copied);
+        }
+        bucket.account(n, &cancellation).await?;
+        tokio::select! {
+            _ = cancellation.cancelled() => return Err(io::Error::new(io::ErrorKind::Interrupted, "cancelled")),
+            result = tokio::time::timeout(idle_timeout, writer.write_all(&buffer[..n])) => {
+                result.map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "fallback write idle timeout"))??;
+            },
+        }
+        copied = copied.saturating_add(n as u64);
+    }
+}
+
+const TLS_1_3_VERSION: &[u8] = &[0x03, 0x04];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use tokio::io::AsyncWriteExt;
+
+    #[test]
+    fn proxy_v1_ipv4_golden() {
+        let source = SocketAddr::new(Ipv4Addr::new(192, 0, 2, 1).into(), 1234);
+        let destination = SocketAddr::new(Ipv4Addr::new(198, 51, 100, 2).into(), 443);
+        assert_eq!(
+            proxy_header(ProxyProtocolVersion::V1, source, destination).unwrap(),
+            b"PROXY TCP4 192.0.2.1 198.51.100.2 1234 443\r\n"
+        );
+    }
+
+    #[test]
+    fn proxy_v2_ipv6_golden() {
+        let source = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 7);
+        let destination = SocketAddr::new("2001:db8::1".parse().unwrap(), 443);
+        let header = proxy_header(ProxyProtocolVersion::V2, source, destination).unwrap();
+        assert_eq!(&header[..12], b"\r\n\r\n\0\r\nQUIT\n");
+        assert_eq!(&header[12..16], &[0x21, 0x21, 0, 36]);
+        assert_eq!(&header[48..], &[0, 7, 1, 187]);
+    }
+
+    #[test]
+    fn proxy_header_rejects_mixed_address_families() {
+        let source = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+        let destination = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 443);
+        assert!(proxy_header(ProxyProtocolVersion::V1, source, destination).is_err());
+        assert!(proxy_header(ProxyProtocolVersion::V2, source, destination).is_err());
+    }
+
+    #[tokio::test]
+    async fn target_partial_record_is_preserved_for_fallback() {
+        let partial = [22, 3, 3, 0, 10, 2, 0, 0];
+        let (mut writer, mut reader) = tokio::io::duplex(partial.len());
+        writer.write_all(&partial).await.unwrap();
+        drop(writer);
+
+        let error = collect_target_template(
+            &mut reader,
+            &RealityServerLimits::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+        let preserved: Vec<u8> = error
+            .0
+            .iter()
+            .flat_map(|bytes| bytes.iter().copied())
+            .collect();
+        assert_eq!(preserved, partial);
+        assert_eq!(error.1.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn configuration_rejects_equal_secret_seeds() {
+        let secret = [9; 32];
+        let config = RealityServerConfig {
+            camouflage_target: "127.0.0.1:443".into(),
+            private_key: secret,
+            server_names: HashSet::from(["example.com".into()]),
+            short_ids: vec![[0; 8]],
+            min_client_version: None,
+            max_client_version: None,
+            max_time_difference: None,
+            mldsa65_seed: Some(secret),
+            cipher_suites: Vec::new(),
+            proxy_protocol: ProxyProtocolVersion::None,
+            fallback_upload: FallbackLimit::default(),
+            fallback_download: FallbackLimit::default(),
+            limits: RealityServerLimits::default(),
+        };
+        let debug = format!("{config:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("short_ids"));
+        assert!(RealityServer::new(config).is_err());
+    }
+}

--- a/crates/core-reality/tests/spider_same_connection.rs
+++ b/crates/core-reality/tests/spider_same_connection.rs
@@ -1,0 +1,130 @@
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use bytes::Bytes;
+use core_reality::{
+    RealityClient, RealityClientConfig, RealityClientError, generate_x25519_keypair,
+};
+use http_body_util::Full;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
+use rustls::pki_types::PrivatePkcs8KeyDer;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio::time::{sleep, timeout};
+use tokio_rustls::TlsAcceptor;
+
+const SERVER_NAME: &str = "spider.example";
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+struct ObservedRequest {
+    path: String,
+    cookie: Option<String>,
+}
+
+fn ordinary_h2_server_config() -> Arc<rustls::ServerConfig> {
+    let CertifiedKey { cert, signing_key } =
+        generate_simple_self_signed(vec![SERVER_NAME.into()]).unwrap();
+    let mut config = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(
+        vec![cert.der().clone()],
+        PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+    )
+    .unwrap();
+    config.alpn_protocols = vec![b"h2".to_vec()];
+    Arc::new(config)
+}
+
+#[tokio::test]
+async fn not_reality_spider_get_reuses_the_original_tcp_connection() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let accepts = Arc::new(AtomicUsize::new(0));
+    let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+    let acceptor = TlsAcceptor::from(ordinary_h2_server_config());
+    let server_accepts = accepts.clone();
+    let server_task = tokio::spawn(async move {
+        loop {
+            let (tcp, _) = listener.accept().await.unwrap();
+            server_accepts.fetch_add(1, Ordering::SeqCst);
+            let acceptor = acceptor.clone();
+            let request_tx = request_tx.clone();
+            tokio::spawn(async move {
+                let tls = match acceptor.accept(tcp).await {
+                    Ok(tls) => tls,
+                    Err(_) => return,
+                };
+                let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+                    let request_tx = request_tx.clone();
+                    async move {
+                        let observed = ObservedRequest {
+                            path: request
+                                .uri()
+                                .path_and_query()
+                                .map_or_else(|| "/".to_owned(), ToString::to_string),
+                            cookie: request
+                                .headers()
+                                .get(http::header::COOKIE)
+                                .and_then(|value| value.to_str().ok())
+                                .map(str::to_owned),
+                        };
+                        let _ = request_tx.send(observed);
+                        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from_static(
+                            br#"<a href="/next">next</a>"#,
+                        ))))
+                    }
+                });
+                let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(tls), service)
+                    .await;
+            });
+        }
+    });
+
+    let (_, public_key) = generate_x25519_keypair().unwrap();
+    let client = RealityClient::new(RealityClientConfig {
+        server_name: SERVER_NAME.into(),
+        fingerprint: "chrome".into(),
+        public_key,
+        short_id: Vec::new(),
+        spider_x: "/cover?p=8&c=0&t=0&i=0&r=1".into(),
+        mldsa65_verify: None,
+        handshake_timeout: Duration::from_secs(5),
+        ..RealityClientConfig::default()
+    })
+    .unwrap();
+    let stream = TcpStream::connect(address).await.unwrap();
+    let result = timeout(TEST_TIMEOUT, client.connect(stream))
+        .await
+        .expect("REALITY invalid-certificate flow timed out");
+    assert!(matches!(
+        result,
+        Err(RealityClientError::InvalidConnectionProcessed)
+    ));
+
+    let observed = timeout(TEST_TIMEOUT, request_rx.recv())
+        .await
+        .expect("spiderX GET timed out")
+        .expect("spiderX request channel closed");
+    assert_eq!(observed.path, "/cover");
+    assert_eq!(observed.cookie.as_deref(), Some("padding=00000000"));
+
+    // Give a forbidden reconnect enough time to reach the local listener.
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "spiderX must reuse the TLS connection that received the real certificate"
+    );
+    server_task.abort();
+}

--- a/crates/core-reality/tests/transparent_fallback.rs
+++ b/crates/core-reality/tests/transparent_fallback.rs
@@ -1,0 +1,142 @@
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use core_reality::{
+    FallbackLimit, ProxyProtocolVersion, RealityServer, RealityServerConfig, RealityServerError,
+    RealityServerLimits,
+};
+use rcgen::{CertifiedKey, generate_simple_self_signed};
+use rustls::RootCertStore;
+use rustls::pki_types::{PrivatePkcs8KeyDer, ServerName};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::time::timeout;
+use tokio_rustls::{TlsAcceptor, TlsConnector};
+use tokio_util::sync::CancellationToken;
+
+const SERVER_NAME: &str = "fallback.example";
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+const PAYLOAD: &[u8] = b"transparent-fallback-ok";
+
+fn tls13_server_config() -> (
+    Arc<rustls::ServerConfig>,
+    rustls::pki_types::CertificateDer<'static>,
+) {
+    let CertifiedKey { cert, signing_key } =
+        generate_simple_self_signed(vec![SERVER_NAME.into()]).unwrap();
+    let certificate = cert.der().clone();
+    let config = rustls::ServerConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(&[&rustls::version::TLS13])
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(
+        vec![certificate.clone()],
+        PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+    )
+    .unwrap();
+    (Arc::new(config), certificate)
+}
+
+fn tls13_client_config(
+    certificate: rustls::pki_types::CertificateDer<'static>,
+) -> Arc<rustls::ClientConfig> {
+    let mut roots = RootCertStore::empty();
+    roots.add(certificate).unwrap();
+    Arc::new(
+        rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_root_certificates(roots)
+        .with_no_client_auth(),
+    )
+}
+
+fn reality_config(target: SocketAddr) -> RealityServerConfig {
+    let limits = RealityServerLimits {
+        handshake_timeout: Duration::from_secs(3),
+        target_handshake_timeout: Duration::from_secs(3),
+        idle_timeout: Duration::from_secs(3),
+        ..RealityServerLimits::default()
+    };
+    RealityServerConfig {
+        camouflage_target: target.to_string(),
+        private_key: [0x42; 32],
+        server_names: HashSet::from([SERVER_NAME.into()]),
+        short_ids: vec![[0x13; 8]],
+        min_client_version: None,
+        max_client_version: None,
+        max_time_difference: Some(Duration::from_secs(60)),
+        mldsa65_seed: None,
+        cipher_suites: Vec::new(),
+        proxy_protocol: ProxyProtocolVersion::None,
+        fallback_upload: FallbackLimit::default(),
+        fallback_download: FallbackLimit::default(),
+        limits,
+    }
+}
+
+#[tokio::test]
+async fn ordinary_tls_probe_is_transparently_forwarded_to_camouflage_target() {
+    let (target_config, certificate) = tls13_server_config();
+    let target_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let target_address = target_listener.local_addr().unwrap();
+    let target_task = tokio::spawn(async move {
+        let (stream, _) = target_listener.accept().await.unwrap();
+        let mut tls = TlsAcceptor::from(target_config)
+            .accept(stream)
+            .await
+            .unwrap();
+        let mut payload = vec![0; PAYLOAD.len()];
+        tls.read_exact(&mut payload).await.unwrap();
+        assert_eq!(payload, PAYLOAD);
+        tls.write_all(&payload).await.unwrap();
+        tls.flush().await.unwrap();
+    });
+
+    let reality_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let reality_address = reality_listener.local_addr().unwrap();
+    let reality = RealityServer::new(reality_config(target_address)).unwrap();
+    let reality_task = tokio::spawn(async move {
+        let (stream, peer) = reality_listener.accept().await.unwrap();
+        let local = stream.local_addr().unwrap();
+        let result = reality
+            .accept(stream, peer, local, CancellationToken::new())
+            .await;
+        assert!(matches!(
+            result,
+            Err(RealityServerError::FallbackStarted { .. })
+        ));
+    });
+
+    let connector = TlsConnector::from(tls13_client_config(certificate));
+    let stream = TcpStream::connect(reality_address).await.unwrap();
+    let name = ServerName::try_from(SERVER_NAME).unwrap().to_owned();
+    let mut tls = timeout(TEST_TIMEOUT, connector.connect(name, stream))
+        .await
+        .expect("fallback TLS handshake timed out")
+        .expect("fallback TLS handshake failed");
+    tls.write_all(PAYLOAD).await.unwrap();
+    tls.flush().await.unwrap();
+    let mut echoed = vec![0; PAYLOAD.len()];
+    timeout(TEST_TIMEOUT, tls.read_exact(&mut echoed))
+        .await
+        .expect("fallback echo timed out")
+        .expect("fallback echo failed");
+    assert_eq!(echoed, PAYLOAD);
+    let _ = tls.shutdown().await;
+
+    timeout(TEST_TIMEOUT, reality_task)
+        .await
+        .expect("REALITY accept task timed out")
+        .expect("REALITY accept task panicked");
+    timeout(TEST_TIMEOUT, target_task)
+        .await
+        .expect("camouflage target timed out")
+        .expect("camouflage target panicked");
+}

--- a/crates/core-reality/tests/xray_interop.rs
+++ b/crates/core-reality/tests/xray_interop.rs
@@ -1,0 +1,669 @@
+//! Official Xray client -> Rust REALITY server interoperability.
+//!
+//! Run with the pinned binary:
+//! `XRAY_BIN=/path/to/xray cargo test -p core-reality --test xray_interop -- --ignored --nocapture`
+
+use std::collections::HashSet;
+use std::env;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use core_reality::{
+    FallbackLimit, ProxyProtocolVersion, RealityClient, RealityClientConfig, RealityServer,
+    RealityServerConfig, RealityServerLimits, x25519_public_key,
+};
+use rcgen::{
+    CertificateParams, CertifiedKey, CustomExtension, KeyPair, generate_simple_self_signed,
+};
+use rustls::crypto::aws_lc_rs::kx_group::{X25519, X25519MLKEM768};
+use rustls::pki_types::PrivatePkcs8KeyDer;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout};
+use tokio_rustls::TlsAcceptor;
+use tokio_util::sync::CancellationToken;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(20);
+const XRAY_PINNED_VERSION: &str = "26.7.11";
+const XRAY_PINNED_COMMIT: &str = "6e3322d";
+const XRAY_UUID: &str = "11111111-1111-1111-1111-111111111111";
+const SERVER_NAME: &str = "www.example.com";
+const SHORT_ID: [u8; 8] = [1, 35, 69, 103, 137, 171, 205, 239];
+static XRAY_INTEROP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct XrayProcess {
+    child: Child,
+    config: PathBuf,
+    cleanup: Vec<PathBuf>,
+}
+
+impl Drop for XrayProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = fs::remove_file(&self.config);
+        for path in &self.cleanup {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+fn xray_binary() -> PathBuf {
+    let binary = env::var_os("XRAY_BIN")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .expect("set XRAY_BIN to the pinned official Xray executable");
+    let output = Command::new(&binary)
+        .arg("version")
+        .output()
+        .expect("run xray version");
+    assert!(output.status.success());
+    let version = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        version.contains(&format!("Xray {XRAY_PINNED_VERSION}"))
+            && version.contains(XRAY_PINNED_COMMIT),
+        "unexpected Xray build: {version}"
+    );
+    binary
+}
+
+fn temp_config(body: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = env::temp_dir().join(format!(
+        "wuthercore-reality-{}-{nonce}.json",
+        std::process::id()
+    ));
+    fs::write(&path, body).expect("write Xray config");
+    path
+}
+
+fn temp_artifact(suffix: &str, body: &[u8]) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = env::temp_dir().join(format!(
+        "wuthercore-reality-{}-{nonce}-{suffix}",
+        std::process::id()
+    ));
+    fs::write(&path, body).expect("write Xray test artifact");
+    path
+}
+
+fn pem(label: &str, der: &[u8]) -> Vec<u8> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(der);
+    let mut output = format!("-----BEGIN {label}-----\n");
+    for chunk in encoded.as_bytes().chunks(64) {
+        output.push_str(std::str::from_utf8(chunk).unwrap());
+        output.push('\n');
+    }
+    output.push_str(&format!("-----END {label}-----\n"));
+    output.into_bytes()
+}
+
+fn spawn_xray(binary: &Path, config: String) -> XrayProcess {
+    spawn_xray_with_cleanup(binary, config, Vec::new())
+}
+
+fn spawn_xray_with_cleanup(binary: &Path, config: String, cleanup: Vec<PathBuf>) -> XrayProcess {
+    let config = temp_config(&config);
+    let child = Command::new(binary)
+        .arg("run")
+        .arg("-c")
+        .arg(&config)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("start Xray");
+    XrayProcess {
+        child,
+        config,
+        cleanup,
+    }
+}
+
+async fn reserve_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+async fn wait_for_listener(port: u16, process: &mut XrayProcess) {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            if let Some(status) = process.child.try_wait().expect("query Xray") {
+                panic!("Xray exited early: {status}");
+            }
+            if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+                return;
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("Xray listener timeout");
+}
+
+async fn spawn_camouflage_target(hybrid: bool) -> (SocketAddr, JoinHandle<()>) {
+    let mut params = CertificateParams::new(vec![SERVER_NAME.into()]).unwrap();
+    // A one-certificate rcgen flight is otherwise smaller than Xray's
+    // encrypted-flight detection threshold. Real public sites have a larger
+    // certificate chain; padding this deterministic fixture gives both Xray
+    // and this implementation the same realistic, self-delimiting template.
+    params
+        .custom_extensions
+        .push(CustomExtension::from_oid_content(
+            &[1, 3, 6, 1, 4, 1, 55555, 2],
+            {
+                let mut state = 0x9e37_79b9_7f4a_7c15u64;
+                (0..if hybrid { 4096 } else { 2048 })
+                    .map(|_| {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        state as u8
+                    })
+                    .collect()
+            },
+        ));
+    let signing_key = KeyPair::generate().unwrap();
+    let cert = params.self_signed(&signing_key).unwrap();
+    let mut provider = rustls::crypto::aws_lc_rs::default_provider();
+    provider.kx_groups = if hybrid {
+        vec![X25519MLKEM768]
+    } else {
+        vec![X25519]
+    };
+    let config = rustls::ServerConfig::builder_with_provider(Arc::new(provider))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![cert.der().clone()],
+            PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+        )
+        .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            // REALITY intentionally abandons this target handshake after using
+            // the first server flight as its wire-shape template.
+            let _ = acceptor.accept(stream).await;
+        }
+    });
+    (address, task)
+}
+
+async fn spawn_xray_tls_camouflage_target(
+    binary: &Path,
+    hybrid: bool,
+) -> (SocketAddr, XrayProcess) {
+    let CertifiedKey { cert, signing_key } = if hybrid {
+        let mut params = CertificateParams::new(vec![SERVER_NAME.into()]).unwrap();
+        // ML-DSA-65 adds a large certificate extension. Xray preserves the
+        // target site's TLS record shape, so the camouflage certificate record
+        // needs enough room for that extension instead of negative padding.
+        params
+            .custom_extensions
+            .push(CustomExtension::from_oid_content(
+                &[1, 3, 6, 1, 4, 1, 55555, 1],
+                vec![0; 4096],
+            ));
+        let signing_key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&signing_key).unwrap();
+        CertifiedKey { cert, signing_key }
+    } else {
+        generate_simple_self_signed(vec![SERVER_NAME.into()]).unwrap()
+    };
+    let certificate_path =
+        temp_artifact("certificate.pem", &pem("CERTIFICATE", cert.der().as_ref()));
+    let key_path = temp_artifact(
+        "private-key.pem",
+        &pem("PRIVATE KEY", &signing_key.serialize_der()),
+    );
+    let certificate_json = format!("{:?}", certificate_path.to_string_lossy());
+    let key_json = format!("{:?}", key_path.to_string_lossy());
+    let port = reserve_port().await;
+    let curve = if hybrid { "X25519MLKEM768" } else { "X25519" };
+    let config = format!(
+        r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {port},
+    "protocol": "http",
+    "settings": {{}},
+    "streamSettings": {{
+      "network": "raw",
+      "security": "tls",
+      "tlsSettings": {{
+        "minVersion": "1.3",
+        "maxVersion": "1.3",
+        "curvePreferences": ["{curve}"],
+        "certificates": [{{
+          "certificateFile": {certificate_json},
+          "keyFile": {key_json}
+        }}]
+      }}
+    }}
+  }}],
+  "outbounds": [{{
+    "protocol": "freedom",
+    "settings": {{ "finalRules": [{{ "action": "allow" }}] }}
+  }}]
+}}"#
+    );
+    let mut process = spawn_xray_with_cleanup(binary, config, vec![certificate_path, key_path]);
+    wait_for_listener(port, &mut process).await;
+    (format!("127.0.0.1:{port}").parse().unwrap(), process)
+}
+
+fn server_config(target: SocketAddr, hybrid_mldsa: bool) -> RealityServerConfig {
+    RealityServerConfig {
+        camouflage_target: target.to_string(),
+        private_key: [0x42; 32],
+        server_names: HashSet::from([SERVER_NAME.into()]),
+        short_ids: vec![SHORT_ID],
+        min_client_version: Some([26, 3, 27]),
+        max_client_version: None,
+        max_time_difference: Some(Duration::from_secs(60)),
+        mldsa65_seed: hybrid_mldsa.then_some([0x24; 32]),
+        cipher_suites: Vec::new(),
+        proxy_protocol: ProxyProtocolVersion::None,
+        fallback_upload: FallbackLimit::default(),
+        fallback_download: FallbackLimit::default(),
+        limits: RealityServerLimits::default(),
+    }
+}
+
+async fn spawn_reality_server(
+    config: RealityServerConfig,
+    payload: Vec<u8>,
+) -> (SocketAddr, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = RealityServer::new(config).unwrap();
+    let task = tokio::spawn(async move {
+        let (stream, peer) = listener.accept().await.expect("accept Xray REALITY client");
+        let local = stream.local_addr().unwrap();
+        let mut accepted = timeout(
+            TEST_TIMEOUT,
+            server.accept(stream, peer, local, CancellationToken::new()),
+        )
+        .await
+        .expect("REALITY accept timeout")
+        .expect("authenticate official Xray client");
+        read_vless_request(&mut accepted).await;
+        accepted.write_all(&[0, 0]).await.expect("VLESS response");
+        accepted.flush().await.unwrap();
+        let mut received = vec![0; payload.len()];
+        accepted
+            .read_exact(&mut received)
+            .await
+            .expect("VLESS application payload");
+        assert_eq!(received, payload);
+        accepted.write_all(&received).await.expect("echo response");
+        accepted.flush().await.unwrap();
+    });
+    (address, task)
+}
+
+fn xray_config(
+    socks_port: u16,
+    reality_addr: SocketAddr,
+    public_key: &[u8; 32],
+    mldsa_verify: Option<&[u8]>,
+) -> String {
+    let public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key);
+    let mldsa = mldsa_verify
+        .map(|key| {
+            format!(
+                ",\n          \"mldsa65Verify\": \"{}\"",
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key)
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {socks_port},
+    "protocol": "socks",
+    "settings": {{ "auth": "noauth", "udp": false }}
+  }}],
+  "outbounds": [{{
+    "protocol": "vless",
+    "settings": {{
+      "vnext": [{{
+        "address": "127.0.0.1",
+        "port": {},
+        "users": [{{ "id": "{XRAY_UUID}", "encryption": "none" }}]
+      }}]
+    }},
+    "streamSettings": {{
+      "network": "raw",
+      "security": "reality",
+      "realitySettings": {{
+        "serverName": "{SERVER_NAME}",
+        "fingerprint": "chrome",
+        "password": "{public_key}",
+        "shortId": "0123456789abcdef",
+        "spiderX": "/"{mldsa}
+      }}
+    }}
+  }}]
+}}"#,
+        reality_addr.port()
+    )
+}
+
+async fn run_case(hybrid_mldsa: bool) {
+    let binary = xray_binary();
+    let (target, target_task) = spawn_camouflage_target(hybrid_mldsa).await;
+    let config = server_config(target, hybrid_mldsa);
+    let verify = config.mldsa65_verify_key().unwrap();
+    let public_key = x25519_public_key(&config.private_key).unwrap();
+    let payload = if hybrid_mldsa {
+        b"xray-hybrid-mldsa".to_vec()
+    } else {
+        b"xray-x25519".to_vec()
+    };
+    let (reality_addr, server_task) = spawn_reality_server(config, payload.clone()).await;
+    let socks_port = reserve_port().await;
+    let mut xray = spawn_xray(
+        &binary,
+        xray_config(socks_port, reality_addr, &public_key, verify.as_deref()),
+    );
+    wait_for_listener(socks_port, &mut xray).await;
+
+    let mut socks = TcpStream::connect(("127.0.0.1", socks_port)).await.unwrap();
+    socks.write_all(&[5, 1, 0]).await.unwrap();
+    let mut greeting = [0; 2];
+    socks.read_exact(&mut greeting).await.unwrap();
+    assert_eq!(greeting, [5, 0]);
+    socks
+        .write_all(&[5, 1, 0, 1, 127, 0, 0, 1, 0, 80])
+        .await
+        .unwrap();
+    read_socks_reply(&mut socks).await;
+    socks.write_all(&payload).await.unwrap();
+    socks.flush().await.unwrap();
+    let mut echoed = vec![0; payload.len()];
+    timeout(TEST_TIMEOUT, socks.read_exact(&mut echoed))
+        .await
+        .expect("SOCKS echo timeout")
+        .expect("SOCKS echo");
+    assert_eq!(echoed, payload);
+
+    timeout(TEST_TIMEOUT, server_task)
+        .await
+        .expect("server task timeout")
+        .expect("join server");
+    let _ = timeout(TEST_TIMEOUT, target_task).await;
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to Xray 26.7.11 (6e3322d)"]
+async fn official_xray_client_interoperates_over_x25519() {
+    let _guard = XRAY_INTEROP_LOCK.lock().await;
+    run_case(false).await;
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to Xray 26.7.11 (6e3322d)"]
+async fn official_xray_client_interoperates_over_x25519_mlkem768_and_mldsa65() {
+    let _guard = XRAY_INTEROP_LOCK.lock().await;
+    run_case(true).await;
+}
+
+fn xray_reality_server_config(
+    reality_port: u16,
+    camouflage: SocketAddr,
+    private_key: &[u8; 32],
+    mldsa65_seed: Option<&[u8; 32]>,
+) -> String {
+    let private_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(private_key);
+    let mldsa65_seed = mldsa65_seed
+        .map(|seed| {
+            format!(
+                ",\n        \"mldsa65Seed\": \"{}\"",
+                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(seed)
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {reality_port},
+    "protocol": "vless",
+    "settings": {{
+      "clients": [{{ "id": "{XRAY_UUID}" }}],
+      "decryption": "none"
+    }},
+    "streamSettings": {{
+      "network": "raw",
+      "security": "reality",
+      "realitySettings": {{
+        "target": "{camouflage}",
+        "serverNames": ["{SERVER_NAME}"],
+        "privateKey": "{private_key}",
+        "shortIds": ["0123456789abcdef"]{mldsa65_seed}
+      }}
+    }}
+  }}],
+  "outbounds": [{{
+    "protocol": "freedom",
+    "settings": {{ "finalRules": [{{ "action": "allow" }}] }}
+  }}]
+}}"#
+    )
+}
+
+async fn spawn_tcp_echo() -> (SocketAddr, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("echo accept");
+        let mut buffer = [0u8; 4096];
+        loop {
+            let length = match stream.read(&mut buffer).await {
+                Ok(length) => length,
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted
+                    ) =>
+                {
+                    break;
+                }
+                Err(error) => panic!("echo read: {error}"),
+            };
+            if length == 0 {
+                break;
+            }
+            stream
+                .write_all(&buffer[..length])
+                .await
+                .expect("echo write");
+            stream.flush().await.expect("echo flush");
+        }
+    });
+    (address, task)
+}
+
+async fn write_vless_tcp_request(stream: &mut (impl AsyncWrite + Unpin), destination: SocketAddr) {
+    let mut request = Vec::with_capacity(26);
+    request.push(0); // protocol version
+    request.extend_from_slice(&[0x11; 16]); // XRAY_UUID
+    request.push(0); // addons length
+    request.push(1); // TCP command
+    request.extend_from_slice(&destination.port().to_be_bytes());
+    match destination.ip() {
+        std::net::IpAddr::V4(address) => {
+            request.push(1);
+            request.extend_from_slice(&address.octets());
+        }
+        std::net::IpAddr::V6(address) => {
+            request.push(3);
+            request.extend_from_slice(&address.octets());
+        }
+    }
+    stream.write_all(&request).await.expect("VLESS request");
+    stream.flush().await.expect("VLESS request flush");
+}
+
+async fn run_project_client_case(hybrid_mldsa: bool) {
+    let binary = xray_binary();
+    let (camouflage, camouflage_process) =
+        spawn_xray_tls_camouflage_target(&binary, hybrid_mldsa).await;
+    let (echo, echo_task) = spawn_tcp_echo().await;
+    let private_key = [0x42; 32];
+    let public_key = x25519_public_key(&private_key).unwrap();
+    let mldsa65_seed = hybrid_mldsa.then_some([0x24; 32]);
+    let verify = server_config(camouflage, hybrid_mldsa)
+        .mldsa65_verify_key()
+        .unwrap();
+    let reality_port = reserve_port().await;
+    let mut xray = spawn_xray(
+        &binary,
+        xray_reality_server_config(
+            reality_port,
+            camouflage,
+            &private_key,
+            mldsa65_seed.as_ref(),
+        ),
+    );
+    wait_for_listener(reality_port, &mut xray).await;
+
+    let client = RealityClient::new(RealityClientConfig {
+        server_name: SERVER_NAME.into(),
+        fingerprint: "chrome".into(),
+        public_key,
+        short_id: SHORT_ID.to_vec(),
+        spider_x: "/".into(),
+        mldsa65_verify: verify,
+        handshake_timeout: TEST_TIMEOUT,
+        ..RealityClientConfig::default()
+    })
+    .unwrap();
+    let tcp = TcpStream::connect(("127.0.0.1", reality_port))
+        .await
+        .unwrap();
+    let mut reality = timeout(TEST_TIMEOUT, client.connect(tcp))
+        .await
+        .expect("WutherCore REALITY client timeout")
+        .expect("WutherCore client authenticates official Xray server");
+    write_vless_tcp_request(&mut reality, echo).await;
+
+    let payload: &[u8] = if hybrid_mldsa {
+        b"wuther-client-hybrid-mldsa"
+    } else {
+        b"wuther-client-x25519"
+    };
+    reality.write_all(payload).await.unwrap();
+    reality.flush().await.unwrap();
+    let mut response_header = [0u8; 2];
+    timeout(TEST_TIMEOUT, reality.read_exact(&mut response_header))
+        .await
+        .expect("VLESS response timeout")
+        .expect("VLESS response header");
+    assert_eq!(response_header[0], 0);
+    let mut addons = vec![0; response_header[1] as usize];
+    reality.read_exact(&mut addons).await.unwrap();
+    let mut echoed = vec![0; payload.len()];
+    timeout(TEST_TIMEOUT, reality.read_exact(&mut echoed))
+        .await
+        .expect("official Xray echo timeout")
+        .expect("official Xray echo");
+    assert_eq!(echoed, payload);
+
+    drop(reality);
+    drop(xray);
+    timeout(TEST_TIMEOUT, echo_task)
+        .await
+        .expect("echo task timeout")
+        .expect("echo task join");
+    drop(camouflage_process);
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to Xray 26.7.11 (6e3322d)"]
+async fn wuthercore_client_interoperates_with_official_xray_server_over_x25519() {
+    let _guard = XRAY_INTEROP_LOCK.lock().await;
+    run_project_client_case(false).await;
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to Xray 26.7.11 (6e3322d)"]
+async fn wuthercore_client_interoperates_with_official_xray_server_over_hybrid_mldsa65() {
+    let _guard = XRAY_INTEROP_LOCK.lock().await;
+    run_project_client_case(true).await;
+}
+
+async fn read_vless_request(stream: &mut (impl AsyncRead + Unpin)) {
+    let mut fixed = [0u8; 18];
+    stream
+        .read_exact(&mut fixed)
+        .await
+        .expect("VLESS request header");
+    assert_eq!(fixed[0], 0);
+    let mut addons = vec![0; fixed[17] as usize];
+    stream.read_exact(&mut addons).await.expect("VLESS addons");
+    let mut destination = [0u8; 4];
+    stream
+        .read_exact(&mut destination)
+        .await
+        .expect("VLESS destination header");
+    assert_eq!(destination[0], 1, "VLESS TCP command");
+    match destination[3] {
+        1 => {
+            let mut address = [0; 4];
+            stream.read_exact(&mut address).await.unwrap();
+        }
+        2 => {
+            let len = stream.read_u8().await.unwrap();
+            let mut address = vec![0; len as usize];
+            stream.read_exact(&mut address).await.unwrap();
+        }
+        3 => {
+            let mut address = [0; 16];
+            stream.read_exact(&mut address).await.unwrap();
+        }
+        kind => panic!("unexpected VLESS address kind {kind}"),
+    }
+}
+
+async fn read_socks_reply(stream: &mut TcpStream) {
+    let mut head = [0u8; 4];
+    timeout(TEST_TIMEOUT, stream.read_exact(&mut head))
+        .await
+        .expect("SOCKS reply timeout")
+        .expect("SOCKS reply");
+    assert_eq!(&head[..2], &[5, 0]);
+    let address_length = match head[3] {
+        1 => 4,
+        3 => stream.read_u8().await.unwrap() as usize,
+        4 => 16,
+        kind => panic!("unexpected SOCKS address kind {kind}"),
+    };
+    let mut tail = vec![0; address_length + 2];
+    stream.read_exact(&mut tail).await.unwrap();
+}

--- a/crates/core-resolver/src/upstream/marked.rs
+++ b/crates/core-resolver/src/upstream/marked.rs
@@ -414,9 +414,13 @@ fn build_tls_connector() -> Arc<rustls::ClientConfig> {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     Arc::new(
-        rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth(),
+        rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("rustls ring default protocols")
+        .with_root_certificates(root_store)
+        .with_no_client_auth(),
     )
 }
 

--- a/crates/core-resolver/src/upstream/quic.rs
+++ b/crates/core-resolver/src/upstream/quic.rs
@@ -248,9 +248,13 @@ impl DnsUpstream for QuicDnsUpstream {
 }
 
 fn build_tls_config(skip_cert_verify: bool) -> rustls::ClientConfig {
-    let mut config = rustls::ClientConfig::builder()
-        .with_root_certificates(root_store())
-        .with_no_client_auth();
+    let mut config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("rustls ring default protocols")
+    .with_root_certificates(root_store())
+    .with_no_client_auth();
     config.alpn_protocols = DOQ_ALPN.iter().map(|a| a.to_vec()).collect();
     if skip_cert_verify {
         config

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -14,7 +14,9 @@ use clap::{Parser, Subcommand};
 use core_api::ApiServer;
 use core_config::loader::load_from_path;
 use core_feeds::{FeedDiskCache, FeedManager, FeedSink, FeedUpdate};
-use core_inbound::{MixedListener, ensure_best_effort_privilege, run_mixed};
+use core_inbound::{
+    MixedListener, RealityListener, ensure_best_effort_privilege, run_mixed, run_reality,
+};
 use core_ruleset::{RulesetManager, RulesetSpec, RulesetType};
 use core_runtime::{Runtime, UrlTestConfig, UrlTester};
 use core_store::Store;
@@ -744,6 +746,21 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         info!(addr = %addr, udp = mixed.udp, "mixed inbound: HTTP+SOCKS5 ready");
     } else {
         info!("listen.local 未配置，跳过 Mixed 入站");
+    }
+
+    // REALITY 入站。构造阶段会再次做密钥与资源上限的防御性校验；监听
+    // future 直接持有真实 RealityServer，不存在普通 TLS 或占位回退路径。
+    for config in &plan.listen.reality {
+        let listener = RealityListener::from_config(config)
+            .map_err(|error| anyhow::anyhow!("REALITY listener configuration failed: {error}"))?;
+        let address = listener.listen_addr();
+        let rt = runtime.clone();
+        handles.push(tokio::spawn(async move {
+            if let Err(error) = run_reality(listener, rt).await {
+                warn!(target: "inbound::reality", %address, %error, "REALITY listener exited");
+            }
+        }));
+        info!(addr = %address, "VLESS-over-REALITY inbound ready");
     }
 
     // 控制面板/API

--- a/third_party/xray-transport/Cargo.toml
+++ b/third_party/xray-transport/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "xray-transport"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+repository = "https://github.com/aimalygin/xray-rust"
+
+[dependencies]
+aes = { version = "0.8", features = ["zeroize"] }
+aes-gcm = { version = "0.10", features = ["zeroize"] }
+async-trait = "0.1"
+bytes = "1"
+ghash = { version = "0.5", features = ["zeroize"] }
+hkdf = "0.12"
+hmac = "0.12"
+ml-dsa = { version = "0.1.1", default-features = false, features = ["alloc"] }
+polyval = { version = "0.6", features = ["zeroize"] }
+regex = "1"
+rustls = { version = "=0.23.40", default-features = false, features = ["aws_lc_rs", "brotli", "logging", "ring", "std", "tls12"] }
+sha2 = "0.10"
+thiserror = "2"
+tokio = { version = "1.41", features = ["full"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws_lc_rs", "logging", "ring", "tls12"] }
+webpki-roots = "1"
+x25519-dalek = { version = "2", features = ["static_secrets", "zeroize"] }
+x509-parser = { version = "0.18", default-features = false }
+xray-routing = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584" }
+xray-utls = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584" }
+zeroize = "1"
+
+[dev-dependencies]
+rcgen = { version = "0.14", default-features = false, features = ["ring"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/third_party/xray-transport/LICENSE-MPL-2.0
+++ b/third_party/xray-transport/LICENSE-MPL-2.0
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/third_party/xray-transport/PATCHES.md
+++ b/third_party/xray-transport/PATCHES.md
@@ -1,0 +1,19 @@
+# 本地补丁
+
+WutherCore 需要完整对齐 Xray REALITY 的 invalid-certificate `spiderX` 行为：
+TLS 握手成功但证书不带 REALITY 绑定时，必须在**同一条 TLS 连接**上执行 HTTP/2
+伪装抓取，不能丢弃连接后重新拨号。
+
+相对上游 `bb3e00da1abfc5fff70487b0dd2ba16054797584` 的最小修改：
+
+1. `src/reality_connector.rs`：增加 `RealityTlsSessionOutcome`，让会话完成结果区分
+   `Verified` 与 `NotReality`，两种结果都携带已握手流。
+2. `src/reality_rustls.rs`：证书校验器以共享状态记录 REALITY 绑定结果；
+   `NotReality` 不再中断 TLS 握手，而是返回带原连接的 outcome。证书解析错误、
+   TLS 签名错误仍然失败关闭。
+3. `src/lib.rs`：增加明确的 `RealityNotVerified` 错误类别。
+4. `RealityTlsSession::complete` 的默认实现保持原通用运行时的 fail-closed 行为；
+   `src/reality_runtime.rs` 无需改动。只有显式调用 `complete_with_outcome` 的
+   WutherCore REALITY 客户端会把原连接交给 spiderX。
+
+补丁不改变 ClientHello、X25519/X25519MLKEM768、ML-DSA-65、密钥派生或直通流语义。

--- a/third_party/xray-transport/UPSTREAM.md
+++ b/third_party/xray-transport/UPSTREAM.md
@@ -1,0 +1,9 @@
+# 上游来源
+
+- 仓库：`https://github.com/aimalygin/xray-rust.git`
+- 固定提交：`bb3e00da1abfc5fff70487b0dd2ba16054797584`
+- 原始目录：`crates/xray-transport`
+- 许可证：MPL-2.0（完整文本见 `LICENSE-MPL-2.0`）
+
+本目录保留上游文件级 MPL-2.0 授权。除 `PATCHES.md` 明确列出的文件外，
+`src/` 内容与上述提交逐字节一致。

--- a/third_party/xray-transport/src/dialer.rs
+++ b/third_party/xray-transport/src/dialer.rs
@@ -1,0 +1,92 @@
+use std::{fmt, sync::Arc};
+
+use crate::{
+    connect_tcp_target, BoxedTransportStream, ConnectorConfig, RealityRuntimeEngine,
+    RealityTlsEngine, RustlsRealityTlsSessionProvider, SocketProtector, TlsConnector,
+    TransportError,
+};
+use xray_routing::Target;
+
+#[derive(Clone)]
+pub struct TransportDialer {
+    tls: TlsConnector,
+    reality: Option<Arc<dyn RealityTlsEngine>>,
+    socket_protector: Option<Arc<dyn SocketProtector>>,
+}
+
+impl fmt::Debug for TransportDialer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TransportDialer")
+            .field("tls", &self.tls)
+            .field("reality_engine", &self.reality.is_some())
+            .field("socket_protector", &self.socket_protector.is_some())
+            .finish()
+    }
+}
+
+impl TransportDialer {
+    pub fn system() -> Result<Self, TransportError> {
+        Self::system_with_socket_protector(None)
+    }
+
+    pub fn system_with_socket_protector(
+        socket_protector: Option<Arc<dyn SocketProtector>>,
+    ) -> Result<Self, TransportError> {
+        let tls = match socket_protector.clone() {
+            Some(protector) => TlsConnector::system()?.with_socket_protector(protector),
+            None => TlsConnector::system()?,
+        };
+        let mut reality =
+            RealityRuntimeEngine::new(Arc::new(RustlsRealityTlsSessionProvider::new()));
+        if let Some(protector) = socket_protector.clone() {
+            reality = reality.with_socket_protector(protector);
+        }
+
+        Ok(Self {
+            tls,
+            reality: Some(Arc::new(reality)),
+            socket_protector,
+        })
+    }
+
+    pub fn with_tls_connector(tls: TlsConnector) -> Self {
+        Self {
+            tls,
+            reality: None,
+            socket_protector: None,
+        }
+    }
+
+    pub fn with_reality_engine(mut self, reality: Arc<dyn RealityTlsEngine>) -> Self {
+        self.reality = Some(reality);
+        self
+    }
+
+    pub fn with_socket_protector(mut self, protector: Arc<dyn SocketProtector>) -> Self {
+        self.tls = self.tls.with_socket_protector(Arc::clone(&protector));
+        self.socket_protector = Some(protector);
+        self
+    }
+
+    pub fn socket_protector(&self) -> Option<&dyn SocketProtector> {
+        self.socket_protector.as_deref()
+    }
+
+    pub async fn connect(
+        &self,
+        config: &ConnectorConfig,
+        target: &Target,
+    ) -> Result<BoxedTransportStream, TransportError> {
+        match config {
+            ConnectorConfig::Tcp => Ok(Box::new(
+                connect_tcp_target(target, self.socket_protector.as_deref()).await?,
+            )),
+            ConnectorConfig::Tls(tls_config) => self.tls.connect(target, tls_config).await,
+            ConnectorConfig::Reality(reality_config) => match &self.reality {
+                Some(reality) => reality.connect(reality_config, target).await,
+                None => Err(TransportError::UnsupportedConnectorConfig("reality")),
+            },
+        }
+    }
+}

--- a/third_party/xray-transport/src/dns.rs
+++ b/third_party/xray-transport/src/dns.rs
@@ -1,0 +1,615 @@
+use std::collections::HashMap;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
+use tokio::time;
+
+use crate::TransportError;
+
+/// Resolves a domain and configured port into the concrete socket address to dial.
+///
+/// Callers pass the configured port and dial the returned `SocketAddr` as-is.
+/// This keeps platform-specific DNS and deterministic test resolvers explicit.
+#[async_trait]
+pub trait DnsResolver: Send + Sync {
+    async fn resolve(&self, domain: &str, port: u16) -> Result<SocketAddr, TransportError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SystemDnsResolver;
+
+#[async_trait]
+impl DnsResolver for SystemDnsResolver {
+    async fn resolve(&self, domain: &str, port: u16) -> Result<SocketAddr, TransportError> {
+        let mut addrs = tokio::net::lookup_host((domain, port))
+            .await
+            .map_err(|source| TransportError::Dns {
+                domain: domain.to_owned(),
+                port,
+                source,
+            })?;
+
+        addrs
+            .next()
+            .ok_or_else(|| TransportError::NoResolvedAddress(domain.to_owned(), port))
+    }
+}
+
+const DNS_CACHE_TTL: Duration = Duration::from_secs(60);
+const DNS_CACHE_MAX_ENTRIES: usize = 256;
+
+/// TTL cache over another resolver. Proxy clients open a new outbound
+/// connection per session; resolving the (usually single) server domain on
+/// every connect adds tens of milliseconds on mobile networks.
+pub struct CachingDnsResolver {
+    inner: Arc<dyn DnsResolver>,
+    ttl: Duration,
+    cache: Mutex<HashMap<(String, u16), (SocketAddr, Instant)>>,
+}
+
+impl CachingDnsResolver {
+    pub fn new(inner: Arc<dyn DnsResolver>) -> Self {
+        Self::with_ttl(inner, DNS_CACHE_TTL)
+    }
+
+    pub fn with_ttl(inner: Arc<dyn DnsResolver>, ttl: Duration) -> Self {
+        Self {
+            inner,
+            ttl,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl DnsResolver for CachingDnsResolver {
+    async fn resolve(&self, domain: &str, port: u16) -> Result<SocketAddr, TransportError> {
+        let key = (domain.to_owned(), port);
+        let now = Instant::now();
+        {
+            let cache = self
+                .cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some((addr, stored_at)) = cache.get(&key) {
+                if now.duration_since(*stored_at) < self.ttl {
+                    return Ok(*addr);
+                }
+            }
+        }
+
+        let addr = self.inner.resolve(domain, port).await?;
+
+        let mut cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if cache.len() >= DNS_CACHE_MAX_ENTRIES {
+            cache.retain(|_, (_, stored_at)| now.duration_since(*stored_at) < self.ttl);
+        }
+        if cache.len() >= DNS_CACHE_MAX_ENTRIES {
+            cache.clear();
+        }
+        cache.insert(key, (addr, now));
+        Ok(addr)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticHostRule {
+    pub matcher: TransportDomainMatcher,
+    pub target: StaticHostTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransportDomainMatcher {
+    Keyword(String),
+    Full(String),
+    Suffix(String),
+    Regex(TransportRegexMatcher),
+}
+
+impl TransportDomainMatcher {
+    pub fn regex(pattern: impl Into<String>) -> Result<Self, regex::Error> {
+        TransportRegexMatcher::new(pattern).map(Self::Regex)
+    }
+
+    pub fn matches(&self, domain: &str) -> bool {
+        match self {
+            Self::Keyword(keyword) => contains_ignore_ascii_case(domain, keyword),
+            Self::Full(expected) => domain.eq_ignore_ascii_case(expected),
+            Self::Suffix(suffix) => domain_matches_suffix(domain, suffix),
+            Self::Regex(matcher) => matcher.matches(domain),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransportRegexMatcher {
+    pattern: String,
+    regex: regex::Regex,
+}
+
+impl TransportRegexMatcher {
+    pub fn new(pattern: impl Into<String>) -> Result<Self, regex::Error> {
+        let pattern = pattern.into();
+        let regex = regex::Regex::new(&pattern)?;
+        Ok(Self { pattern, regex })
+    }
+
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+
+    fn matches(&self, domain: &str) -> bool {
+        self.regex.is_match(&domain.to_ascii_lowercase())
+    }
+}
+
+impl PartialEq for TransportRegexMatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+    }
+}
+
+impl Eq for TransportRegexMatcher {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaticHostTarget {
+    Ip(IpAddr),
+    Domain(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NameServer {
+    Socket(SocketAddr),
+    Domain { domain: String, port: u16 },
+}
+
+pub struct ConfiguredDnsResolver {
+    host_rules: Vec<StaticHostRule>,
+    name_servers: Vec<NameServer>,
+    fallback: Arc<dyn DnsResolver>,
+    server_timeout: Duration,
+}
+
+impl ConfiguredDnsResolver {
+    pub fn new(
+        host_rules: Vec<StaticHostRule>,
+        name_servers: Vec<NameServer>,
+        fallback: Arc<dyn DnsResolver>,
+    ) -> Self {
+        Self {
+            host_rules,
+            name_servers,
+            fallback,
+            server_timeout: Duration::from_secs(2),
+        }
+    }
+
+    pub fn with_server_timeout(mut self, timeout: Duration) -> Self {
+        self.server_timeout = timeout;
+        self
+    }
+
+    fn matching_host_rule(&self, domain: &str) -> Option<&StaticHostRule> {
+        self.host_rules
+            .iter()
+            .find(|rule| rule.matcher.matches(domain))
+    }
+
+    async fn query_configured_servers(&self, domain: &str) -> Option<ConfiguredDnsAnswer> {
+        for name_server in &self.name_servers {
+            let server_addr = match name_server {
+                NameServer::Socket(addr) => *addr,
+                NameServer::Domain {
+                    domain: server_domain,
+                    port,
+                } => {
+                    let Ok(addr) = self.fallback.resolve(server_domain, *port).await else {
+                        continue;
+                    };
+                    addr
+                }
+            };
+
+            if let Ok(Some(answer)) =
+                query_udp_dns_server(server_addr, domain, DnsRecordType::A, self.server_timeout)
+                    .await
+            {
+                return Some(answer);
+            }
+
+            if let Ok(Some(answer)) = query_udp_dns_server(
+                server_addr,
+                domain,
+                DnsRecordType::Aaaa,
+                self.server_timeout,
+            )
+            .await
+            {
+                return Some(answer);
+            }
+        }
+
+        None
+    }
+}
+
+#[async_trait]
+impl DnsResolver for ConfiguredDnsResolver {
+    async fn resolve(&self, domain: &str, port: u16) -> Result<SocketAddr, TransportError> {
+        const MAX_ALIAS_DEPTH: usize = 8;
+
+        let mut current_domain = domain.to_owned();
+        for depth in 0..MAX_ALIAS_DEPTH {
+            if let Some(rule) = self.matching_host_rule(&current_domain) {
+                match &rule.target {
+                    StaticHostTarget::Ip(ip) => return Ok(SocketAddr::new(*ip, port)),
+                    StaticHostTarget::Domain(alias) => {
+                        if alias.eq_ignore_ascii_case(&current_domain) {
+                            break;
+                        }
+                        if depth + 1 == MAX_ALIAS_DEPTH {
+                            return self.fallback.resolve(domain, port).await;
+                        }
+                        current_domain = alias.clone();
+                        continue;
+                    }
+                }
+            }
+
+            match self.query_configured_servers(&current_domain).await {
+                Some(ConfiguredDnsAnswer::Ip(ip)) => return Ok(SocketAddr::new(ip, port)),
+                Some(ConfiguredDnsAnswer::Cname(alias)) => {
+                    if alias.eq_ignore_ascii_case(&current_domain) {
+                        break;
+                    }
+                    if depth + 1 == MAX_ALIAS_DEPTH {
+                        return self.fallback.resolve(domain, port).await;
+                    }
+                    current_domain = alias;
+                }
+                None => break,
+            }
+        }
+
+        self.fallback.resolve(&current_domain, port).await
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ConfiguredDnsAnswer {
+    Ip(IpAddr),
+    Cname(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DnsRecordType {
+    A,
+    Aaaa,
+}
+
+impl DnsRecordType {
+    fn code(self) -> u16 {
+        match self {
+            Self::A => 1,
+            Self::Aaaa => 28,
+        }
+    }
+}
+
+async fn query_udp_dns_server(
+    server_addr: SocketAddr,
+    domain: &str,
+    record_type: DnsRecordType,
+    timeout: Duration,
+) -> io::Result<Option<ConfiguredDnsAnswer>> {
+    let bind_addr = if server_addr.is_ipv4() {
+        SocketAddr::from(([0, 0, 0, 0], 0))
+    } else {
+        SocketAddr::from(([0_u16; 8], 0))
+    };
+    let socket = UdpSocket::bind(bind_addr).await?;
+    let query = build_dns_query(domain, record_type)?;
+
+    time::timeout(timeout, socket.send_to(&query, server_addr))
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "dns query send timed out"))??;
+
+    let mut buffer = [0_u8; 1232];
+    let len = time::timeout(timeout, async {
+        loop {
+            let (len, peer) = socket.recv_from(&mut buffer).await?;
+            if peer == server_addr {
+                return Ok::<usize, io::Error>(len);
+            }
+        }
+    })
+    .await
+    .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "dns query timed out"))??;
+
+    parse_dns_response(&query, &buffer[..len], record_type)
+}
+
+fn build_dns_query(domain: &str, record_type: DnsRecordType) -> io::Result<Vec<u8>> {
+    let normalized_domain = domain.trim_end_matches('.');
+    if normalized_domain.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "dns query domain cannot be empty",
+        ));
+    }
+
+    let mut query = Vec::with_capacity(12 + normalized_domain.len() + 6);
+    let id = dns_query_id(normalized_domain, record_type);
+    query.extend_from_slice(&id.to_be_bytes());
+    query.extend_from_slice(&0x0100_u16.to_be_bytes());
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    query.extend_from_slice(&0_u16.to_be_bytes());
+    query.extend_from_slice(&0_u16.to_be_bytes());
+    query.extend_from_slice(&0_u16.to_be_bytes());
+
+    for label in normalized_domain.split('.') {
+        let label_bytes = label.as_bytes();
+        if label_bytes.is_empty() || label_bytes.len() > 63 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "dns query domain has invalid label",
+            ));
+        }
+        query.push(label_bytes.len() as u8);
+        query.extend_from_slice(label_bytes);
+    }
+    query.push(0);
+    query.extend_from_slice(&record_type.code().to_be_bytes());
+    query.extend_from_slice(&1_u16.to_be_bytes());
+    Ok(query)
+}
+
+fn dns_query_id(domain: &str, record_type: DnsRecordType) -> u16 {
+    domain.bytes().fold(record_type.code(), |hash, byte| {
+        hash.wrapping_mul(31).wrapping_add(u16::from(byte))
+    })
+}
+
+fn parse_dns_response(
+    query: &[u8],
+    packet: &[u8],
+    requested_type: DnsRecordType,
+) -> io::Result<Option<ConfiguredDnsAnswer>> {
+    if packet.len() < 12 || query.len() < 2 || packet[0..2] != query[0..2] {
+        return Ok(None);
+    }
+
+    let flags = read_u16(packet, 2)?;
+    let rcode = flags & 0x000F;
+    if flags & 0x8000 == 0 || rcode != 0 {
+        return Ok(None);
+    }
+
+    let (expected_question, expected_type, expected_class) = parse_dns_question(query)?;
+    if expected_type != requested_type.code() || expected_class != 1 {
+        return Ok(None);
+    }
+
+    let question_count = read_u16(packet, 4)?;
+    if question_count != 1 {
+        return Ok(None);
+    }
+    let answer_count = read_u16(packet, 6)?;
+    let mut offset = 12;
+
+    let (response_question, response_type, response_class) =
+        read_dns_question(packet, &mut offset)?;
+    if response_question != expected_question
+        || response_type != expected_type
+        || response_class != expected_class
+    {
+        return Ok(None);
+    }
+
+    let mut accepted_answer_names = vec![expected_question];
+    let mut cname = None;
+    for _ in 0..answer_count {
+        let owner_name = read_dns_name(packet, &mut offset)?;
+        let record_type = read_u16(packet, offset)?;
+        let record_class = read_u16(packet, offset + 2)?;
+        let data_len = usize::from(read_u16(packet, offset + 8)?);
+        offset = offset
+            .checked_add(10)
+            .ok_or_else(|| invalid_dns_response("dns answer overflow"))?;
+        let data_end = offset
+            .checked_add(data_len)
+            .ok_or_else(|| invalid_dns_response("dns rdata overflow"))?;
+        if data_end > packet.len() {
+            return Err(invalid_dns_response("truncated dns rdata"));
+        }
+
+        if record_class == 1
+            && record_type == requested_type.code()
+            && accepted_answer_names
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(&owner_name))
+        {
+            match requested_type {
+                DnsRecordType::A if data_len == 4 => {
+                    return Ok(Some(ConfiguredDnsAnswer::Ip(IpAddr::V4(Ipv4Addr::new(
+                        packet[offset],
+                        packet[offset + 1],
+                        packet[offset + 2],
+                        packet[offset + 3],
+                    )))));
+                }
+                DnsRecordType::Aaaa if data_len == 16 => {
+                    let segments = [
+                        read_u16(packet, offset)?,
+                        read_u16(packet, offset + 2)?,
+                        read_u16(packet, offset + 4)?,
+                        read_u16(packet, offset + 6)?,
+                        read_u16(packet, offset + 8)?,
+                        read_u16(packet, offset + 10)?,
+                        read_u16(packet, offset + 12)?,
+                        read_u16(packet, offset + 14)?,
+                    ];
+                    return Ok(Some(ConfiguredDnsAnswer::Ip(IpAddr::V6(Ipv6Addr::new(
+                        segments[0],
+                        segments[1],
+                        segments[2],
+                        segments[3],
+                        segments[4],
+                        segments[5],
+                        segments[6],
+                        segments[7],
+                    )))));
+                }
+                _ => {}
+            }
+        } else if record_class == 1
+            && record_type == 5
+            && accepted_answer_names
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(&owner_name))
+        {
+            let mut cname_offset = offset;
+            let alias = read_dns_name_limited(packet, &mut cname_offset, data_end)?;
+            if cname_offset != data_end {
+                return Err(invalid_dns_response("dns cname rdata length mismatch"));
+            }
+            accepted_answer_names.push(alias.clone());
+            cname = Some(alias);
+        }
+
+        offset = data_end;
+    }
+
+    Ok(cname.map(ConfiguredDnsAnswer::Cname))
+}
+
+fn parse_dns_question(packet: &[u8]) -> io::Result<(String, u16, u16)> {
+    let question_count = read_u16(packet, 4)?;
+    if question_count != 1 {
+        return Err(invalid_dns_response("dns query must have one question"));
+    }
+    let mut offset = 12;
+    read_dns_question(packet, &mut offset)
+}
+
+fn read_dns_question(packet: &[u8], offset: &mut usize) -> io::Result<(String, u16, u16)> {
+    let name = read_dns_name(packet, offset)?;
+    let record_type = read_u16(packet, *offset)?;
+    let record_class = read_u16(packet, *offset + 2)?;
+    *offset = (*offset)
+        .checked_add(4)
+        .ok_or_else(|| invalid_dns_response("dns question overflow"))?;
+    if *offset > packet.len() {
+        return Err(invalid_dns_response("truncated dns question"));
+    }
+    Ok((name, record_type, record_class))
+}
+
+fn read_dns_name(packet: &[u8], offset: &mut usize) -> io::Result<String> {
+    read_dns_name_limited(packet, offset, packet.len())
+}
+
+fn read_dns_name_limited(packet: &[u8], offset: &mut usize, limit: usize) -> io::Result<String> {
+    if limit > packet.len() || *offset > limit {
+        return Err(invalid_dns_response("invalid dns name limit"));
+    }
+
+    let mut labels = Vec::new();
+    let mut cursor = *offset;
+    let mut jumped = false;
+
+    for _ in 0..32 {
+        if !jumped && cursor >= limit {
+            return Err(invalid_dns_response("truncated dns name"));
+        }
+        let Some(&length) = packet.get(cursor) else {
+            return Err(invalid_dns_response("truncated dns name"));
+        };
+
+        if length & 0xC0 == 0xC0 {
+            if !jumped && cursor + 2 > limit {
+                return Err(invalid_dns_response("truncated dns name pointer"));
+            }
+            let Some(&next) = packet.get(cursor + 1) else {
+                return Err(invalid_dns_response("truncated dns name pointer"));
+            };
+            if !jumped {
+                *offset = cursor + 2;
+            }
+            cursor = ((usize::from(length & 0x3F)) << 8) | usize::from(next);
+            jumped = true;
+            continue;
+        }
+
+        if length == 0 {
+            if !jumped {
+                *offset = cursor + 1;
+            }
+            return Ok(labels.join("."));
+        }
+
+        if length & 0xC0 != 0 {
+            return Err(invalid_dns_response("unsupported dns label encoding"));
+        }
+
+        cursor += 1;
+        let label_len = usize::from(length);
+        let label_end = cursor
+            .checked_add(label_len)
+            .ok_or_else(|| invalid_dns_response("dns label overflow"))?;
+        if !jumped && label_end > limit {
+            return Err(invalid_dns_response("truncated dns label"));
+        }
+        if label_end > packet.len() {
+            return Err(invalid_dns_response("truncated dns label"));
+        }
+        let label = std::str::from_utf8(&packet[cursor..label_end])
+            .map_err(|_| invalid_dns_response("dns label is not utf-8"))?;
+        labels.push(label.to_ascii_lowercase());
+        cursor = label_end;
+    }
+
+    Err(invalid_dns_response("dns name pointer loop"))
+}
+
+fn read_u16(packet: &[u8], offset: usize) -> io::Result<u16> {
+    let bytes = packet
+        .get(offset..offset + 2)
+        .ok_or_else(|| invalid_dns_response("truncated u16"))?;
+    Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+}
+
+fn invalid_dns_response(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn contains_ignore_ascii_case(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .any(|window| window.eq_ignore_ascii_case(needle.as_bytes()))
+}
+
+fn domain_matches_suffix(domain: &str, suffix: &str) -> bool {
+    if domain.eq_ignore_ascii_case(suffix) {
+        return true;
+    }
+
+    let Some(prefix_len) = domain.len().checked_sub(suffix.len()) else {
+        return false;
+    };
+
+    domain.as_bytes().get(prefix_len.wrapping_sub(1)) == Some(&b'.')
+        && domain[prefix_len..].eq_ignore_ascii_case(suffix)
+}

--- a/third_party/xray-transport/src/lib.rs
+++ b/third_party/xray-transport/src/lib.rs
@@ -1,0 +1,376 @@
+use async_trait::async_trait;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{fmt, io, sync::Arc};
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{TcpSocket, TcpStream, UdpSocket};
+use xray_routing::{Target, TargetAddr};
+use zeroize::Zeroize;
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+
+#[cfg(windows)]
+use std::os::windows::io::AsRawSocket;
+
+mod dialer;
+mod dns;
+mod penetrating_tls;
+pub mod reality;
+pub mod reality_connector;
+pub mod reality_runtime;
+mod reality_rustls;
+mod reality_utls_profiles;
+mod tls;
+
+pub use dialer::TransportDialer;
+pub use dns::{
+    CachingDnsResolver, ConfiguredDnsResolver, DnsResolver, NameServer, StaticHostRule,
+    StaticHostTarget, SystemDnsResolver, TransportDomainMatcher, TransportRegexMatcher,
+};
+pub(crate) use penetrating_tls::{CapturedTcpStream, PenetratingTlsStream, ServerReadLog};
+pub use reality_connector::{RealityTlsSession, RealityTlsSessionProvider};
+pub use reality_runtime::{
+    RealityHandshakeContextProvider, RealityRuntimeEngine, SystemRealityHandshakeContextProvider,
+};
+pub use reality_rustls::RustlsRealityTlsSessionProvider;
+pub use tls::TlsConnector;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectorConfig {
+    Tcp,
+    Tls(TlsClientConfig),
+    Reality(RealityClientConfig),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsClientConfig {
+    pub server_name: String,
+    pub allow_insecure: bool,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RealityClientConfig {
+    pub server_name: String,
+    pub fingerprint: String,
+    pub public_key: [u8; 32],
+    pub short_id: Vec<u8>,
+    pub spider_x: String,
+    pub mldsa65_verify: Option<Vec<u8>>,
+}
+
+impl fmt::Debug for RealityClientConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityClientConfig")
+            .field("server_name", &self.server_name)
+            .field("fingerprint", &self.fingerprint)
+            .field("public_key", &self.public_key)
+            .field("short_id", &"<redacted>")
+            .field("spider_x", &self.spider_x)
+            .field(
+                "mldsa65_verify_len",
+                &self.mldsa65_verify.as_ref().map(Vec::len),
+            )
+            .finish()
+    }
+}
+
+impl Drop for RealityClientConfig {
+    fn drop(&mut self) {
+        self.short_id.zeroize();
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum TransportError {
+    #[error("domain resolution is required for {0}")]
+    NeedsDns(String),
+    #[error("dns lookup failed for {domain}:{port}: {source}")]
+    Dns {
+        domain: String,
+        port: u16,
+        source: std::io::Error,
+    },
+    #[error("dns lookup returned no addresses for {0}:{1}")]
+    NoResolvedAddress(String, u16),
+    #[error("tcp connect failed: {0}")]
+    Tcp(std::io::Error),
+    #[error("socket protection failed: {0}")]
+    SocketProtection(std::io::Error),
+    #[error("tls connect failed: {0}")]
+    Tls(std::io::Error),
+    #[error("tls configuration failed: {0}")]
+    TlsConfig(String),
+    #[error("invalid tls server name `{0}`")]
+    InvalidTlsServerName(String),
+    #[error("{0} connector config is not supported by TcpConnector")]
+    UnsupportedConnectorConfig(&'static str),
+    #[error("unsupported REALITY fingerprint {0}")]
+    UnsupportedRealityFingerprint(String),
+    #[error("reality handshake failed: {0}")]
+    Reality(#[from] reality::RealityError),
+    #[error("REALITY live TLS completion is not implemented")]
+    RealityTlsCompletionUnsupported,
+    #[error("REALITY peer presented a real certificate instead of a REALITY binding")]
+    RealityNotVerified,
+}
+
+pub trait TransportStream: AsyncRead + AsyncWrite + Send + Unpin {
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>>;
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>>;
+
+    fn poll_flush_direct(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_flush(self, cx)
+    }
+
+    fn poll_shutdown_direct(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        AsyncWrite::poll_shutdown(self, cx)
+    }
+}
+
+impl TransportStream for TcpStream {
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        AsyncRead::poll_read(self, cx, output)
+    }
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(self, cx, input)
+    }
+}
+
+impl TransportStream for tokio::io::DuplexStream {
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        AsyncRead::poll_read(self, cx, output)
+    }
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(self, cx, input)
+    }
+}
+
+impl TransportStream for tokio_rustls::client::TlsStream<TcpStream> {
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        AsyncRead::poll_read(self, cx, output)
+    }
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(self, cx, input)
+    }
+}
+
+pub type BoxedTransportStream = Box<dyn TransportStream>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SocketHandle {
+    raw: i64,
+}
+
+impl SocketHandle {
+    pub fn raw(self) -> i64 {
+        self.raw
+    }
+
+    #[cfg(unix)]
+    fn from_tcp_socket(socket: &TcpSocket) -> Self {
+        Self {
+            raw: socket.as_raw_fd() as i64,
+        }
+    }
+
+    #[cfg(unix)]
+    fn from_udp_socket(socket: &UdpSocket) -> Self {
+        Self {
+            raw: socket.as_raw_fd() as i64,
+        }
+    }
+
+    #[cfg(windows)]
+    fn from_tcp_socket(socket: &TcpSocket) -> Self {
+        Self {
+            raw: socket.as_raw_socket() as i64,
+        }
+    }
+
+    #[cfg(windows)]
+    fn from_udp_socket(socket: &UdpSocket) -> Self {
+        Self {
+            raw: socket.as_raw_socket() as i64,
+        }
+    }
+}
+
+pub trait SocketProtector: Send + Sync {
+    fn protect(&self, socket: SocketHandle) -> io::Result<()>;
+}
+
+#[async_trait]
+pub trait RealityTlsEngine: Send + Sync {
+    async fn connect(
+        &self,
+        config: &RealityClientConfig,
+        target: &Target,
+    ) -> Result<BoxedTransportStream, TransportError>;
+}
+
+#[async_trait]
+pub trait TransportConnector: Send + Sync {
+    async fn connect(&self, target: &Target) -> Result<BoxedTransportStream, TransportError>;
+
+    fn describe_target(&self, target: &Target) -> String {
+        match &target.addr {
+            TargetAddr::Ip(ip) => format!("{ip}:{}", target.port),
+            TargetAddr::Domain(domain) => format!("{domain}:{}", target.port),
+        }
+    }
+}
+
+pub struct TcpConnector {
+    config: ConnectorConfig,
+    socket_protector: Option<Arc<dyn SocketProtector>>,
+}
+
+impl fmt::Debug for TcpConnector {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TcpConnector")
+            .field("config", &self.config)
+            .field("socket_protector", &self.socket_protector.is_some())
+            .finish()
+    }
+}
+
+impl Clone for TcpConnector {
+    fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            socket_protector: self.socket_protector.clone(),
+        }
+    }
+}
+
+impl TcpConnector {
+    pub fn new(config: ConnectorConfig) -> Self {
+        Self {
+            config,
+            socket_protector: None,
+        }
+    }
+
+    pub fn with_socket_protector(mut self, protector: Arc<dyn SocketProtector>) -> Self {
+        self.socket_protector = Some(protector);
+        self
+    }
+}
+
+#[async_trait]
+impl TransportConnector for TcpConnector {
+    async fn connect(&self, target: &Target) -> Result<BoxedTransportStream, TransportError> {
+        match &self.config {
+            ConnectorConfig::Tcp => {}
+            ConnectorConfig::Tls(_) => {
+                return Err(TransportError::UnsupportedConnectorConfig("tls"));
+            }
+            ConnectorConfig::Reality(_) => {
+                return Err(TransportError::UnsupportedConnectorConfig("reality"));
+            }
+        }
+
+        let stream = connect_tcp_target(target, self.socket_protector.as_deref()).await?;
+        Ok(Box::new(stream))
+    }
+}
+
+pub async fn connect_tcp_target(
+    target: &Target,
+    socket_protector: Option<&dyn SocketProtector>,
+) -> Result<TcpStream, TransportError> {
+    let addr = match &target.addr {
+        TargetAddr::Ip(ip) => SocketAddr::new(*ip, target.port),
+        TargetAddr::Domain(domain) => return Err(TransportError::NeedsDns(domain.clone())),
+    };
+
+    connect_tcp_stream(addr, socket_protector).await
+}
+
+pub async fn connect_tcp_stream(
+    addr: SocketAddr,
+    socket_protector: Option<&dyn SocketProtector>,
+) -> Result<TcpStream, TransportError> {
+    let stream = match socket_protector {
+        None => TcpStream::connect(addr)
+            .await
+            .map_err(TransportError::Tcp)?,
+        Some(socket_protector) => {
+            let socket = if addr.is_ipv4() {
+                TcpSocket::new_v4()
+            } else {
+                TcpSocket::new_v6()
+            }
+            .map_err(TransportError::Tcp)?;
+
+            socket_protector
+                .protect(SocketHandle::from_tcp_socket(&socket))
+                .map_err(TransportError::SocketProtection)?;
+
+            socket.connect(addr).await.map_err(TransportError::Tcp)?
+        }
+    };
+
+    // The relay carries many latency-sensitive small frames (VLESS headers,
+    // Vision blocks, TLS records); Nagle would delay them behind ACKs.
+    stream.set_nodelay(true).map_err(TransportError::Tcp)?;
+    Ok(stream)
+}
+
+pub fn protect_udp_socket(
+    socket: &UdpSocket,
+    socket_protector: Option<&dyn SocketProtector>,
+) -> Result<(), TransportError> {
+    if let Some(protector) = socket_protector {
+        protector
+            .protect(SocketHandle::from_udp_socket(socket))
+            .map_err(TransportError::SocketProtection)?;
+    }
+
+    Ok(())
+}
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}

--- a/third_party/xray-transport/src/penetrating_tls.rs
+++ b/third_party/xray-transport/src/penetrating_tls.rs
@@ -1,0 +1,554 @@
+use std::io::{self, Read};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use bytes::BytesMut;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+use tokio_rustls::client::TlsStream;
+
+use crate::TransportStream;
+
+const TLS_READ_CHUNK_LIMIT: usize = 8 * 1024;
+
+pub(crate) type ServerReadLog = Arc<Mutex<Option<Vec<u8>>>>;
+
+pub(crate) struct CapturedTcpStream {
+    stream: TcpStream,
+    server_read_log: Option<ServerReadLog>,
+    tls_read_limiter: TlsRecordReadLimiter,
+}
+
+impl CapturedTcpStream {
+    pub(crate) fn new(stream: TcpStream, server_read_log: Option<ServerReadLog>) -> Self {
+        Self {
+            stream,
+            server_read_log,
+            tls_read_limiter: TlsRecordReadLimiter::new(),
+        }
+    }
+
+    fn into_inner(self) -> TcpStream {
+        self.stream
+    }
+}
+
+struct TlsRecordReadLimiter {
+    header: [u8; 5],
+    header_len: usize,
+    payload_remaining: usize,
+}
+
+impl TlsRecordReadLimiter {
+    fn new() -> Self {
+        Self {
+            header: [0; 5],
+            header_len: 0,
+            payload_remaining: 0,
+        }
+    }
+
+    fn next_limit(&self, requested: usize) -> usize {
+        if self.header_len < self.header.len() {
+            requested.min(self.header.len() - self.header_len)
+        } else {
+            requested.min(self.payload_remaining)
+        }
+    }
+
+    fn observe(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+
+        if self.header_len < self.header.len() {
+            let len = (self.header.len() - self.header_len).min(bytes.len());
+            self.header[self.header_len..self.header_len + len].copy_from_slice(&bytes[..len]);
+            self.header_len += len;
+            if self.header_len == self.header.len() {
+                self.payload_remaining =
+                    u16::from_be_bytes([self.header[3], self.header[4]]) as usize;
+                if self.payload_remaining == 0 {
+                    self.header_len = 0;
+                }
+            }
+            return;
+        }
+
+        self.payload_remaining = self.payload_remaining.saturating_sub(bytes.len());
+        if self.payload_remaining == 0 {
+            self.header_len = 0;
+        }
+    }
+}
+
+impl AsyncRead for CapturedTcpStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let limit = this
+            .tls_read_limiter
+            .next_limit(output.remaining())
+            .min(TLS_READ_CHUNK_LIMIT);
+        let mut scratch = [0; TLS_READ_CHUNK_LIMIT];
+        let mut limited = ReadBuf::new(&mut scratch[..limit]);
+        match Pin::new(&mut this.stream).poll_read(cx, &mut limited) {
+            Poll::Ready(Ok(())) => {
+                let filled = limited.filled();
+                this.tls_read_limiter.observe(filled);
+                output.put_slice(filled);
+                if let Some(server_read_log) = &this.server_read_log {
+                    if !filled.is_empty() {
+                        let mut log = server_read_log
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        if let Some(log) = log.as_mut() {
+                            log.extend_from_slice(filled);
+                        }
+                    }
+                }
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+impl AsyncWrite for CapturedTcpStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().stream).poll_write(cx, input)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().stream).poll_shutdown(cx)
+    }
+}
+
+enum PenetratingTlsState {
+    Tls(Option<Box<TlsStream<CapturedTcpStream>>>),
+    Direct {
+        stream: TcpStream,
+        pending_plaintext: BytesMut,
+    },
+}
+
+pub(crate) struct PenetratingTlsStream {
+    state: PenetratingTlsState,
+}
+
+impl PenetratingTlsStream {
+    pub(crate) fn new(stream: TlsStream<CapturedTcpStream>) -> Self {
+        Self {
+            state: PenetratingTlsState::Tls(Some(Box::new(stream))),
+        }
+    }
+
+    fn ensure_read_direct(&mut self) -> io::Result<()> {
+        let PenetratingTlsState::Tls(tls) = &mut self.state else {
+            return Ok(());
+        };
+        let tls = tls
+            .take()
+            .ok_or_else(|| io::Error::other("TLS stream was already taken"))?;
+        let (stream, mut session) = (*tls).into_inner();
+        let stream = stream.into_inner();
+        let mut pending_plaintext = BytesMut::new();
+        let mut scratch = [0; 8192];
+
+        loop {
+            match session.reader().read(&mut scratch) {
+                Ok(0) => break,
+                Ok(len) => pending_plaintext.extend_from_slice(&scratch[..len]),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                Err(error) => return Err(error),
+            }
+        }
+
+        self.state = PenetratingTlsState::Direct {
+            stream,
+            pending_plaintext,
+        };
+        Ok(())
+    }
+
+    fn poll_read_direct_mode(
+        &mut self,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.ensure_read_direct()?;
+        let PenetratingTlsState::Direct {
+            stream,
+            pending_plaintext,
+        } = &mut self.state
+        else {
+            unreachable!("ensure_direct transitions TLS state to direct");
+        };
+
+        if !pending_plaintext.is_empty() {
+            let len = output.remaining().min(pending_plaintext.len());
+            output.put_slice(&pending_plaintext.split_to(len));
+            return Poll::Ready(Ok(()));
+        }
+
+        Pin::new(stream).poll_read(cx, output)
+    }
+
+    fn poll_write_direct_mode(
+        &mut self,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut self.state {
+            PenetratingTlsState::Tls(Some(stream)) => {
+                let (raw_stream, _) = stream.as_mut().get_mut();
+                Pin::new(raw_stream).poll_write(cx, input)
+            }
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_write(cx, input),
+        }
+    }
+}
+
+impl AsyncRead for PenetratingTlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match &mut this.state {
+            PenetratingTlsState::Tls(Some(stream)) => Pin::new(stream).poll_read(cx, output),
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { .. } => this.poll_read_direct_mode(cx, output),
+        }
+    }
+}
+
+impl AsyncWrite for PenetratingTlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        match &mut this.state {
+            PenetratingTlsState::Tls(Some(stream)) => Pin::new(stream).poll_write(cx, input),
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { .. } => this.poll_write_direct_mode(cx, input),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match &mut this.state {
+            PenetratingTlsState::Tls(Some(stream)) => Pin::new(stream).poll_flush(cx),
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match &mut this.state {
+            PenetratingTlsState::Tls(Some(stream)) => Pin::new(stream).poll_shutdown(cx),
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+impl TransportStream for PenetratingTlsStream {
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.get_mut().poll_read_direct_mode(cx, output)
+    }
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.get_mut().poll_write_direct_mode(cx, input)
+    }
+
+    fn poll_flush_direct(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match &mut this.state {
+            PenetratingTlsState::Tls(Some(stream)) => {
+                let (raw_stream, _) = stream.as_mut().get_mut();
+                Pin::new(raw_stream).poll_flush(cx)
+            }
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown_direct(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match &mut this.state {
+            PenetratingTlsState::Tls(Some(stream)) => {
+                let (raw_stream, _) = stream.as_mut().get_mut();
+                Pin::new(raw_stream).poll_shutdown(cx)
+            }
+            PenetratingTlsState::Tls(None) => {
+                Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
+            }
+            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::poll_fn;
+    use std::sync::Arc;
+
+    use rcgen::{generate_simple_self_signed, CertifiedKey};
+    use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+    use super::*;
+
+    async fn connect_test_stream() -> (
+        PenetratingTlsStream,
+        tokio_rustls::server::TlsStream<TcpStream>,
+    ) {
+        let CertifiedKey { cert, signing_key } =
+            generate_simple_self_signed(vec!["server.test".to_owned()])
+                .expect("generate self-signed certificate");
+        let cert_der = cert.der().clone();
+        let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert_der.clone()).expect("add test root");
+        let client_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("ring provider should support default TLS versions")
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+        let server_config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("ring provider should support default TLS versions")
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .expect("server certificate config");
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind TLS listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept TLS client");
+            acceptor.accept(stream).await.expect("accept TLS")
+        });
+
+        let client = CapturedTcpStream::new(
+            TcpStream::connect(addr).await.expect("connect TLS client"),
+            None,
+        );
+        let server_name = ServerName::try_from("server.test").expect("server name");
+        let client = TlsConnector::from(Arc::new(client_config))
+            .connect(server_name, client)
+            .await
+            .expect("client TLS connect");
+        let server = server.await.expect("server task");
+
+        (PenetratingTlsStream::new(client), server)
+    }
+
+    async fn write_direct(stream: &mut PenetratingTlsStream, bytes: &[u8]) -> io::Result<()> {
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let written =
+                poll_fn(|cx| Pin::new(&mut *stream).poll_write_direct(cx, &bytes[offset..]))
+                    .await?;
+            if written == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "direct write returned zero",
+                ));
+            }
+            offset += written;
+        }
+        poll_fn(|cx| Pin::new(&mut *stream).poll_flush_direct(cx)).await
+    }
+
+    async fn read_direct_exact(
+        stream: &mut PenetratingTlsStream,
+        output: &mut [u8],
+    ) -> io::Result<()> {
+        let mut offset = 0;
+        while offset < output.len() {
+            let mut read_buf = ReadBuf::new(&mut output[offset..]);
+            poll_fn(|cx| Pin::new(&mut *stream).poll_read_direct(cx, &mut read_buf)).await?;
+            let read = read_buf.filled().len();
+            if read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "direct read ended early",
+                ));
+            }
+            offset += read;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn direct_write_bypasses_tls_after_switch() {
+        let (mut client, mut server) = connect_test_stream().await;
+
+        client.write_all(b"tls").await.expect("write TLS plaintext");
+        client.flush().await.expect("flush TLS plaintext");
+        let mut tls_plaintext = [0; 3];
+        server
+            .read_exact(&mut tls_plaintext)
+            .await
+            .expect("read TLS plaintext");
+        assert_eq!(&tls_plaintext, b"tls");
+
+        write_direct(&mut client, b"raw")
+            .await
+            .expect("write direct bytes");
+        let (mut raw_server, _) = server.into_inner();
+        let mut raw = [0; 3];
+        raw_server
+            .read_exact(&mut raw)
+            .await
+            .expect("read raw bytes");
+
+        assert_eq!(&raw, b"raw");
+    }
+
+    #[tokio::test]
+    async fn direct_write_keeps_tls_read_available_until_direct_read() {
+        let (mut client, mut server) = connect_test_stream().await;
+
+        write_direct(&mut client, b"raw")
+            .await
+            .expect("write direct bytes");
+
+        server
+            .write_all(b"tls reply")
+            .await
+            .expect("write TLS reply");
+        server.flush().await.expect("flush TLS reply");
+
+        let mut reply = [0; 9];
+        client
+            .read_exact(&mut reply)
+            .await
+            .expect("read TLS reply after direct write");
+        assert_eq!(&reply, b"tls reply");
+
+        let (mut raw_server, _) = server.into_inner();
+        let mut raw = [0; 3];
+        raw_server
+            .read_exact(&mut raw)
+            .await
+            .expect("read raw bytes");
+        assert_eq!(&raw, b"raw");
+    }
+
+    #[tokio::test]
+    async fn direct_read_drains_buffered_tls_plaintext_before_raw_socket() {
+        let (mut client, mut server) = connect_test_stream().await;
+
+        server
+            .write_all(b"tlsbuffered")
+            .await
+            .expect("write TLS plaintext");
+        server.flush().await.expect("flush TLS plaintext");
+        let mut tls_prefix = [0; 3];
+        client
+            .read_exact(&mut tls_prefix)
+            .await
+            .expect("read TLS prefix");
+        assert_eq!(&tls_prefix, b"tls");
+
+        let (mut raw_server, _) = server.into_inner();
+        raw_server
+            .write_all(b"raw")
+            .await
+            .expect("write raw response");
+        raw_server.flush().await.expect("flush raw response");
+
+        let mut direct = [0; 11];
+        read_direct_exact(&mut client, &mut direct)
+            .await
+            .expect("read buffered plaintext and raw bytes");
+
+        assert_eq!(&direct, b"bufferedraw");
+    }
+
+    #[tokio::test]
+    async fn direct_read_preserves_raw_bytes_after_tls_record() {
+        let (mut client, mut server) = connect_test_stream().await;
+
+        server
+            .write_all(b"tls frame")
+            .await
+            .expect("write TLS plaintext");
+        server.flush().await.expect("flush TLS plaintext");
+
+        let (mut raw_server, _) = server.into_inner();
+        raw_server
+            .write_all(b"raw")
+            .await
+            .expect("write raw response");
+        raw_server.flush().await.expect("flush raw response");
+
+        let mut tls_frame = [0; 8192];
+        let read = client
+            .read(&mut tls_frame)
+            .await
+            .expect("read TLS plaintext before switching direct");
+        assert_eq!(&tls_frame[..read], b"tls frame");
+
+        let mut raw = [0; 3];
+        read_direct_exact(&mut client, &mut raw)
+            .await
+            .expect("read raw bytes after TLS record");
+
+        assert_eq!(&raw, b"raw");
+    }
+}

--- a/third_party/xray-transport/src/reality.rs
+++ b/third_party/xray-transport/src/reality.rs
@@ -1,0 +1,796 @@
+use std::fmt;
+
+use aes_gcm::{
+    aead::{AeadInPlace, KeyInit},
+    Aes256Gcm, Nonce,
+};
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use ml_dsa::{EncodedVerifyingKey, MlDsa65, Signature, Verifier, VerifyingKey};
+use sha2::{Sha256, Sha512};
+use thiserror::Error;
+use x25519_dalek::{PublicKey, StaticSecret};
+use x509_parser::{
+    oid_registry::OID_SIG_ED25519,
+    prelude::{FromDer, X509Certificate},
+};
+use zeroize::{Zeroize, Zeroizing};
+
+type HmacSha512 = Hmac<Sha512>;
+
+const REALITY_SESSION_ID_LEN: usize = 32;
+const REALITY_MAX_SHORT_ID_LEN: usize = 8;
+const TLS_HANDSHAKE_CLIENT_HELLO: u8 = 0x01;
+const TLS_EXTENSION_KEY_SHARE: u16 = 0x0033;
+const TLS_GROUP_X25519: u16 = 0x001d;
+const TLS_GROUP_X25519_MLKEM768: u16 = 0x11ec;
+const TLS_GROUP_X25519_MLKEM768_DRAFT: u16 = 0x6399;
+const TLS_GROUP_X25519_MLKEM768_KEY_EXCHANGE_LEN: usize = 1216;
+
+pub struct RealitySessionIdInput {
+    pub version: [u8; 3],
+    pub unix_time: u32,
+    pub short_id: Vec<u8>,
+    pub shared_secret: [u8; 32],
+    pub hello_random: [u8; 32],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealityClientHelloPatch {
+    pub session_id_offset: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealityClientHelloKeyShare {
+    pub group: RealityClientHelloKeyShareGroup,
+    pub offset: usize,
+    pub public_key: [u8; 32],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RealityClientHelloKeyShareGroup {
+    X25519,
+    X25519MlKem768,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealityClientHelloValidation {
+    pub session_id_offset: usize,
+    pub key_share: RealityClientHelloKeyShare,
+}
+
+pub struct RealityPreparedClientHello {
+    pub fingerprint: String,
+    pub raw_client_hello: Vec<u8>,
+    pub hello_random: [u8; 32],
+    pub session_id_offset: usize,
+    pub local_x25519_private_key: [u8; 32],
+}
+
+impl fmt::Debug for RealityPreparedClientHello {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityPreparedClientHello")
+            .field("fingerprint", &self.fingerprint)
+            .field("raw_client_hello_len", &self.raw_client_hello.len())
+            .field("hello_random", &"<redacted>")
+            .field("session_id_offset", &self.session_id_offset)
+            .field("local_x25519_private_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Drop for RealityPreparedClientHello {
+    fn drop(&mut self) {
+        self.local_x25519_private_key.zeroize();
+    }
+}
+
+pub struct RealityHandshakeInput {
+    pub version: [u8; 3],
+    pub unix_time: u32,
+    pub short_id: Vec<u8>,
+    pub server_public_key: [u8; 32],
+    pub prepared_client_hello: RealityPreparedClientHello,
+}
+
+impl fmt::Debug for RealityHandshakeInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityHandshakeInput")
+            .field("version", &self.version)
+            .field("unix_time", &self.unix_time)
+            .field("short_id", &"<redacted>")
+            .field("server_public_key", &self.server_public_key)
+            .field("prepared_client_hello", &self.prepared_client_hello)
+            .finish()
+    }
+}
+
+impl Drop for RealityHandshakeInput {
+    fn drop(&mut self) {
+        self.short_id.zeroize();
+    }
+}
+
+pub struct RealityPreparedHandshake {
+    pub patched_client_hello: Vec<u8>,
+    pub auth_key: [u8; 32],
+    pub session_id: [u8; 32],
+    pub version: [u8; 3],
+    pub unix_time: u32,
+    pub short_id: Vec<u8>,
+    pub server_public_key: [u8; 32],
+}
+
+impl fmt::Debug for RealityPreparedHandshake {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityPreparedHandshake")
+            .field("patched_client_hello_len", &self.patched_client_hello.len())
+            .field("auth_key", &"<redacted>")
+            .field("session_id", &"<redacted>")
+            .field("version", &self.version)
+            .field("unix_time", &self.unix_time)
+            .field("short_id", &"<redacted>")
+            .field("server_public_key", &self.server_public_key)
+            .finish()
+    }
+}
+
+impl Drop for RealityPreparedHandshake {
+    fn drop(&mut self) {
+        self.patched_client_hello.zeroize();
+        self.auth_key.zeroize();
+        self.session_id.zeroize();
+        self.short_id.zeroize();
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RealityCertificateInput<'a> {
+    pub auth_key: &'a [u8; 32],
+    pub ed25519_public_key: &'a [u8; 32],
+    pub certificate_signature: &'a [u8],
+}
+
+impl fmt::Debug for RealityCertificateInput<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityCertificateInput")
+            .field("auth_key", &"<redacted>")
+            .field("ed25519_public_key", &"<redacted>")
+            .field("certificate_signature", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct RealityMldsa65CertificateInput<'a> {
+    pub verifying_key: &'a [u8],
+    pub client_hello: &'a [u8],
+    pub server_hello: &'a [u8],
+}
+
+impl fmt::Debug for RealityMldsa65CertificateInput<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityMldsa65CertificateInput")
+            .field("verifying_key_len", &self.verifying_key.len())
+            .field("client_hello_len", &self.client_hello.len())
+            .field("server_hello_len", &self.server_hello.len())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RealityCertificateVerification {
+    Verified,
+    NotReality,
+}
+
+impl fmt::Debug for RealitySessionIdInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealitySessionIdInput")
+            .field("version", &self.version)
+            .field("unix_time", &self.unix_time)
+            .field("short_id", &"<redacted>")
+            .field("shared_secret", &"<redacted>")
+            .field("hello_random", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Drop for RealitySessionIdInput {
+    fn drop(&mut self) {
+        self.short_id.zeroize();
+        self.shared_secret.zeroize();
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RealityError {
+    #[error("reality short id cannot exceed 8 bytes")]
+    ShortIdTooLong,
+    #[error("client hello session id range {offset}..{end} is out of bounds for {len} bytes")]
+    InvalidSessionIdRange {
+        offset: usize,
+        end: usize,
+        len: usize,
+    },
+    #[error("unsupported REALITY fingerprint {0}")]
+    UnsupportedRealityFingerprint(String),
+    #[error(
+        "REALITY fingerprint {0} does not support REALITY because it has no X25519-compatible key share"
+    )]
+    RealityFingerprintNotRealityCapable(String),
+    #[error("failed to generate REALITY ClientHello: {0}")]
+    ClientHelloGenerationFailed(String),
+    #[error("invalid ClientHello: {reason}")]
+    InvalidClientHello { reason: &'static str },
+    #[error("ClientHello random does not match prepared metadata")]
+    ClientHelloRandomMismatch,
+    #[error("ClientHello does not contain a 32-byte session id")]
+    MissingClientHelloSessionId,
+    #[error(
+        "prepared ClientHello session-id offset {actual} does not match parsed offset {expected}"
+    )]
+    ClientHelloSessionIdOffsetMismatch { expected: usize, actual: usize },
+    #[error("ClientHello does not contain an X25519-compatible key share")]
+    MissingClientHelloX25519KeyShare,
+    #[error("ClientHello key-share public key does not match local private key")]
+    ClientHelloKeyShareMismatch,
+    #[error("reality X25519 shared secret was all zero")]
+    AllZeroSharedSecret,
+    #[error("hkdf expand failed")]
+    Hkdf,
+    #[error("aead seal failed")]
+    Aead,
+    #[error("invalid reality certificate DER")]
+    InvalidRealityCertificateDer,
+    #[error("invalid reality certificate bit string")]
+    InvalidRealityCertificateBitString,
+    #[error("invalid reality Ed25519 public key length {len}")]
+    InvalidRealityCertificatePublicKey { len: usize },
+    #[error("invalid reality ML-DSA-65 verify key length {len}")]
+    InvalidRealityMldsa65VerifyKey { len: usize },
+}
+
+pub fn validate_reality_fingerprint(fingerprint: &str) -> Result<&'static str, RealityError> {
+    let Some(fingerprint) = xray_utls::normalize_reality_fingerprint(fingerprint) else {
+        return Err(RealityError::UnsupportedRealityFingerprint(
+            fingerprint.to_owned(),
+        ));
+    };
+
+    if xray_utls::normalize_reality_supported_fingerprint(fingerprint).is_none() {
+        return Err(RealityError::RealityFingerprintNotRealityCapable(
+            fingerprint.to_owned(),
+        ));
+    }
+
+    Ok(fingerprint)
+}
+
+struct ParsedClientHello {
+    random: [u8; 32],
+    session_id_offset: usize,
+    key_share: Option<RealityClientHelloKeyShare>,
+}
+
+struct ClientHelloCursor<'a> {
+    raw: &'a [u8],
+    offset: usize,
+    base: usize,
+}
+
+impl<'a> ClientHelloCursor<'a> {
+    fn new(raw: &'a [u8]) -> Self {
+        Self {
+            raw,
+            offset: 0,
+            base: 0,
+        }
+    }
+
+    fn with_base(raw: &'a [u8], base: usize) -> Self {
+        Self {
+            raw,
+            offset: 0,
+            base,
+        }
+    }
+
+    fn absolute_offset(&self) -> usize {
+        self.base + self.offset
+    }
+
+    fn checked_end(&self, len: usize, reason: &'static str) -> Result<usize, RealityError> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .ok_or(RealityError::InvalidClientHello { reason })?;
+        if end > self.raw.len() {
+            return Err(RealityError::InvalidClientHello { reason });
+        }
+
+        Ok(end)
+    }
+
+    fn take(&mut self, len: usize, reason: &'static str) -> Result<&'a [u8], RealityError> {
+        let end = self.checked_end(len, reason)?;
+        let value = &self.raw[self.offset..end];
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn read_u8(&mut self, reason: &'static str) -> Result<u8, RealityError> {
+        Ok(self.take(1, reason)?[0])
+    }
+
+    fn read_u16(&mut self, reason: &'static str) -> Result<u16, RealityError> {
+        let bytes = self.take(2, reason)?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn read_u24(&mut self, reason: &'static str) -> Result<usize, RealityError> {
+        let bytes = self.take(3, reason)?;
+        Ok(((bytes[0] as usize) << 16) | ((bytes[1] as usize) << 8) | bytes[2] as usize)
+    }
+}
+
+impl ParsedClientHello {
+    fn parse(raw: &[u8]) -> Result<Self, RealityError> {
+        let mut cursor = ClientHelloCursor::new(raw);
+
+        let handshake_type = cursor.read_u8("missing handshake type")?;
+        if handshake_type != TLS_HANDSHAKE_CLIENT_HELLO {
+            return Err(RealityError::InvalidClientHello {
+                reason: "unexpected handshake type",
+            });
+        }
+
+        let handshake_len = cursor.read_u24("missing handshake length")?;
+        let expected_handshake_len =
+            raw.len()
+                .checked_sub(4)
+                .ok_or(RealityError::InvalidClientHello {
+                    reason: "missing handshake header",
+                })?;
+        if handshake_len != expected_handshake_len {
+            return Err(RealityError::InvalidClientHello {
+                reason: "handshake length mismatch",
+            });
+        }
+
+        cursor.take(2, "missing legacy version")?;
+        let mut random = [0u8; 32];
+        random.copy_from_slice(cursor.take(32, "missing random")?);
+
+        let session_id_len = usize::from(cursor.read_u8("missing session id length")?);
+        if session_id_len != REALITY_SESSION_ID_LEN {
+            return Err(RealityError::MissingClientHelloSessionId);
+        }
+        let session_id_offset = cursor.absolute_offset();
+        cursor.take(REALITY_SESSION_ID_LEN, "truncated session id")?;
+
+        let cipher_suites_len = usize::from(cursor.read_u16("missing cipher suites length")?);
+        if cipher_suites_len % 2 != 0 {
+            return Err(RealityError::InvalidClientHello {
+                reason: "cipher suites length is not even",
+            });
+        }
+        cursor.take(cipher_suites_len, "truncated cipher suites")?;
+
+        let compression_methods_len =
+            usize::from(cursor.read_u8("missing compression methods length")?);
+        cursor.take(compression_methods_len, "truncated compression methods")?;
+
+        let extensions_len = usize::from(cursor.read_u16("missing extensions length")?);
+        let extensions_start = cursor.absolute_offset();
+        if cursor.checked_end(extensions_len, "truncated extensions")? != raw.len() {
+            return Err(RealityError::InvalidClientHello {
+                reason: "extensions length mismatch",
+            });
+        }
+        let extensions = cursor.take(extensions_len, "truncated extensions")?;
+
+        let mut extensions_cursor = ClientHelloCursor::with_base(extensions, extensions_start);
+        let mut key_share = None;
+        while extensions_cursor.offset < extensions.len() {
+            let extension_type = extensions_cursor.read_u16("missing extension type")?;
+            let extension_len =
+                usize::from(extensions_cursor.read_u16("missing extension length")?);
+            let extension_offset = extensions_cursor.absolute_offset();
+            let extension_data =
+                extensions_cursor.take(extension_len, "truncated extension data")?;
+            if extension_type == TLS_EXTENSION_KEY_SHARE {
+                key_share = parse_key_share_extension(extension_data, extension_offset)?;
+                if key_share.is_some() {
+                    break;
+                }
+            }
+        }
+
+        Ok(Self {
+            random,
+            session_id_offset,
+            key_share,
+        })
+    }
+}
+
+fn parse_key_share_extension(
+    extension_data: &[u8],
+    extension_offset: usize,
+) -> Result<Option<RealityClientHelloKeyShare>, RealityError> {
+    let mut cursor = ClientHelloCursor::with_base(extension_data, extension_offset);
+    let client_shares_len = usize::from(cursor.read_u16("missing key-share vector length")?);
+    if cursor.checked_end(client_shares_len, "truncated key-share vector")? != extension_data.len()
+    {
+        return Err(RealityError::InvalidClientHello {
+            reason: "key-share vector length mismatch",
+        });
+    }
+
+    let mut hybrid_key_share = None;
+
+    while cursor.offset < extension_data.len() {
+        let group = cursor.read_u16("missing key-share group")?;
+        let key_exchange_len = usize::from(cursor.read_u16("missing key-share length")?);
+        let key_exchange_offset = cursor.absolute_offset();
+        let key_exchange = cursor.take(key_exchange_len, "truncated key-share bytes")?;
+
+        if is_tls_grease_value(group) {
+            continue;
+        }
+
+        match group {
+            TLS_GROUP_X25519 => {
+                if key_exchange.len() != 32 {
+                    return Err(RealityError::InvalidClientHello {
+                        reason: "invalid X25519 key-share length",
+                    });
+                }
+
+                let mut public_key = [0u8; 32];
+                public_key.copy_from_slice(key_exchange);
+                return Ok(Some(RealityClientHelloKeyShare {
+                    group: RealityClientHelloKeyShareGroup::X25519,
+                    offset: key_exchange_offset,
+                    public_key,
+                }));
+            }
+            TLS_GROUP_X25519_MLKEM768 | TLS_GROUP_X25519_MLKEM768_DRAFT => {
+                if key_exchange.len() != TLS_GROUP_X25519_MLKEM768_KEY_EXCHANGE_LEN {
+                    return Err(RealityError::InvalidClientHello {
+                        reason: "invalid X25519MLKEM768 key-share length",
+                    });
+                }
+
+                let public_key_offset = if group == TLS_GROUP_X25519_MLKEM768_DRAFT {
+                    key_exchange_offset
+                } else {
+                    key_exchange_offset + key_exchange.len() - 32
+                };
+                let mut public_key = [0u8; 32];
+                if group == TLS_GROUP_X25519_MLKEM768_DRAFT {
+                    public_key.copy_from_slice(&key_exchange[..32]);
+                } else {
+                    public_key.copy_from_slice(&key_exchange[key_exchange.len() - 32..]);
+                }
+                hybrid_key_share.get_or_insert(RealityClientHelloKeyShare {
+                    group: RealityClientHelloKeyShareGroup::X25519MlKem768,
+                    offset: public_key_offset,
+                    public_key,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(hybrid_key_share)
+}
+
+fn is_tls_grease_value(value: u16) -> bool {
+    let [high, low] = value.to_be_bytes();
+    high == low && high & 0x0f == 0x0a
+}
+
+/// Validates uTLS `hello.Raw` ClientHello metadata for REALITY preparation.
+///
+/// The input must be TLS handshake ClientHello bytes, not a TLS record. This
+/// boundary is intentionally separate from `prepare_reality_handshake` so the
+/// current synthetic preparation tests can remain narrow while the future live
+/// provider can validate real Chrome/uTLS output before sealing.
+pub fn validate_reality_client_hello_metadata(
+    prepared: &RealityPreparedClientHello,
+) -> Result<RealityClientHelloValidation, RealityError> {
+    validate_reality_fingerprint(&prepared.fingerprint)?;
+
+    let parsed = ParsedClientHello::parse(&prepared.raw_client_hello)?;
+    if parsed.random != prepared.hello_random {
+        return Err(RealityError::ClientHelloRandomMismatch);
+    }
+    if parsed.session_id_offset != prepared.session_id_offset {
+        return Err(RealityError::ClientHelloSessionIdOffsetMismatch {
+            expected: parsed.session_id_offset,
+            actual: prepared.session_id_offset,
+        });
+    }
+
+    let key_share = parsed
+        .key_share
+        .ok_or(RealityError::MissingClientHelloX25519KeyShare)?;
+    let local_x25519_private_key = Zeroizing::new(prepared.local_x25519_private_key);
+    let local_secret = StaticSecret::from(*local_x25519_private_key);
+    let local_public_key = PublicKey::from(&local_secret).to_bytes();
+    if local_public_key != key_share.public_key {
+        return Err(RealityError::ClientHelloKeyShareMismatch);
+    }
+
+    Ok(RealityClientHelloValidation {
+        session_id_offset: parsed.session_id_offset,
+        key_share,
+    })
+}
+
+/// Derives Xray-core's REALITY auth key from the X25519 shared secret.
+///
+/// Xray-core uses HKDF-SHA256 with `hello.Random[..20]` as salt and
+/// `REALITY` as info. The resulting key is used both for ClientHello
+/// session-id sealing and REALITY certificate binding.
+pub fn derive_reality_auth_key(
+    shared_secret: &[u8; 32],
+    hello_random: &[u8; 32],
+) -> Result<[u8; 32], RealityError> {
+    let hkdf = Hkdf::<Sha256>::new(Some(&hello_random[..20]), shared_secret);
+    let mut auth_key = [0u8; 32];
+    hkdf.expand(b"REALITY", &mut auth_key[..])
+        .map_err(|_| RealityError::Hkdf)?;
+    Ok(auth_key)
+}
+
+/// Prepares a REALITY ClientHello for the future live connector.
+///
+/// This function does not perform network I/O. The caller supplies raw
+/// ClientHello metadata produced by a Chrome/uTLS-compatible provider.
+pub fn prepare_reality_handshake(
+    mut input: RealityHandshakeInput,
+) -> Result<RealityPreparedHandshake, RealityError> {
+    validate_reality_fingerprint(&input.prepared_client_hello.fingerprint)?;
+    let mut output_short_id = Zeroizing::new(input.short_id.clone());
+    let output_server_public_key = input.server_public_key;
+
+    let local_x25519_private_key =
+        Zeroizing::new(input.prepared_client_hello.local_x25519_private_key);
+    input
+        .prepared_client_hello
+        .local_x25519_private_key
+        .zeroize();
+
+    let local_secret = StaticSecret::from(*local_x25519_private_key);
+    let server_public_key = PublicKey::from(input.server_public_key);
+    let shared_secret = local_secret.diffie_hellman(&server_public_key);
+    if !shared_secret.was_contributory() {
+        return Err(RealityError::AllZeroSharedSecret);
+    }
+
+    let shared_secret = Zeroizing::new(shared_secret.to_bytes());
+    let auth_key = Zeroizing::new(derive_reality_auth_key(
+        &shared_secret,
+        &input.prepared_client_hello.hello_random,
+    )?);
+
+    let session_input = RealitySessionIdInput {
+        version: input.version,
+        unix_time: input.unix_time,
+        short_id: std::mem::take(&mut input.short_id),
+        shared_secret: *shared_secret,
+        hello_random: input.prepared_client_hello.hello_random,
+    };
+    let mut raw_client_hello = std::mem::take(&mut input.prepared_client_hello.raw_client_hello);
+    let session_id = seal_reality_client_hello(
+        &session_input,
+        RealityClientHelloPatch {
+            session_id_offset: input.prepared_client_hello.session_id_offset,
+        },
+        &mut raw_client_hello,
+    )?;
+
+    Ok(RealityPreparedHandshake {
+        patched_client_hello: raw_client_hello,
+        auth_key: *auth_key,
+        session_id,
+        version: input.version,
+        unix_time: input.unix_time,
+        short_id: std::mem::take(&mut *output_short_id),
+        server_public_key: output_server_public_key,
+    })
+}
+
+/// Builds the sealed 32-byte REALITY session id.
+///
+/// `raw_client_hello_before_seal` must be the pre-seal raw ClientHello bytes
+/// with the target session-id range already zeroed. Xray-core uses those bytes
+/// as AEAD associated data before copying the sealed session id back.
+pub fn build_reality_session_id(
+    input: &RealitySessionIdInput,
+    raw_client_hello_before_seal: &[u8],
+) -> Result<[u8; 32], RealityError> {
+    validate_reality_short_id(input)?;
+
+    let mut session_id_prefix = Zeroizing::new([0u8; 16]);
+    session_id_prefix[..3].copy_from_slice(&input.version);
+    session_id_prefix[4..8].copy_from_slice(&input.unix_time.to_be_bytes());
+    session_id_prefix[8..8 + input.short_id.len()].copy_from_slice(&input.short_id);
+
+    let auth_key = Zeroizing::new(derive_reality_auth_key(
+        &input.shared_secret,
+        &input.hello_random,
+    )?);
+
+    let cipher = Aes256Gcm::new_from_slice(&auth_key[..]).map_err(|_| RealityError::Aead)?;
+    let nonce = Nonce::from_slice(&input.hello_random[20..]);
+    let tag = cipher
+        .encrypt_in_place_detached(
+            nonce,
+            raw_client_hello_before_seal,
+            session_id_prefix.as_mut(),
+        )
+        .map_err(|_| RealityError::Aead)?;
+
+    let mut session_id = [0u8; 32];
+    session_id[..16].copy_from_slice(session_id_prefix.as_ref());
+    session_id[16..].copy_from_slice(&tag);
+    Ok(session_id)
+}
+
+/// Verifies Xray-core's non-ML-DSA REALITY certificate binding.
+///
+/// Xray-core recognizes a REALITY peer certificate when
+/// `HMAC-SHA512(auth_key, ed25519_public_key)` equals the leaf certificate
+/// signature bytes. The auth key is the derived REALITY auth key, not the raw
+/// X25519 shared secret.
+pub fn verify_reality_certificate_binding(
+    input: RealityCertificateInput<'_>,
+) -> RealityCertificateVerification {
+    let mut mac = <HmacSha512 as Mac>::new_from_slice(input.auth_key)
+        .expect("HMAC-SHA512 accepts any key length");
+    mac.update(input.ed25519_public_key);
+
+    if mac.verify_slice(input.certificate_signature).is_ok() {
+        RealityCertificateVerification::Verified
+    } else {
+        RealityCertificateVerification::NotReality
+    }
+}
+
+/// Parses a leaf certificate DER and verifies Xray-core's REALITY HMAC binding.
+///
+/// This is only the REALITY recognition step. Normal x509 fallback validation
+/// stays outside this primitive.
+pub fn verify_reality_certificate_der(
+    auth_key: &[u8; 32],
+    leaf_der: &[u8],
+) -> Result<RealityCertificateVerification, RealityError> {
+    verify_reality_certificate_der_with_mldsa65(auth_key, leaf_der, None)
+}
+
+pub fn verify_reality_certificate_der_with_mldsa65(
+    auth_key: &[u8; 32],
+    leaf_der: &[u8],
+    mldsa65: Option<RealityMldsa65CertificateInput<'_>>,
+) -> Result<RealityCertificateVerification, RealityError> {
+    let (remaining, certificate) = X509Certificate::from_der(leaf_der)
+        .map_err(|_| RealityError::InvalidRealityCertificateDer)?;
+    if !remaining.is_empty() {
+        return Err(RealityError::InvalidRealityCertificateDer);
+    }
+
+    let public_key_info = certificate.public_key();
+    if public_key_info.algorithm.algorithm != OID_SIG_ED25519 {
+        return Ok(RealityCertificateVerification::NotReality);
+    }
+    if public_key_info.algorithm.parameters.is_some()
+        || (certificate.signature_algorithm.algorithm == OID_SIG_ED25519
+            && certificate.signature_algorithm.parameters.is_some())
+    {
+        return Err(RealityError::InvalidRealityCertificateDer);
+    }
+    if public_key_info.subject_public_key.unused_bits != 0
+        || certificate.signature_value.unused_bits != 0
+    {
+        return Err(RealityError::InvalidRealityCertificateBitString);
+    }
+
+    let public_key = public_key_info.subject_public_key.data.as_ref();
+    let public_key: &[u8; 32] =
+        public_key
+            .try_into()
+            .map_err(|_| RealityError::InvalidRealityCertificatePublicKey {
+                len: public_key.len(),
+            })?;
+
+    let mut mac =
+        <HmacSha512 as Mac>::new_from_slice(auth_key).expect("HMAC-SHA512 accepts any key length");
+    mac.update(public_key);
+
+    if mac
+        .clone()
+        .verify_slice(certificate.signature_value.data.as_ref())
+        .is_err()
+    {
+        return Ok(RealityCertificateVerification::NotReality);
+    }
+
+    let Some(mldsa65) = mldsa65 else {
+        return Ok(RealityCertificateVerification::Verified);
+    };
+
+    let Some(extension) = certificate.extensions().first() else {
+        return Ok(RealityCertificateVerification::NotReality);
+    };
+    let verifying_key_bytes: EncodedVerifyingKey<MlDsa65> = mldsa65
+        .verifying_key
+        .try_into()
+        .map_err(|_| RealityError::InvalidRealityMldsa65VerifyKey {
+            len: mldsa65.verifying_key.len(),
+        })?;
+    let verifying_key = VerifyingKey::<MlDsa65>::decode(&verifying_key_bytes);
+    let Ok(signature) = Signature::<MlDsa65>::try_from(extension.value) else {
+        return Ok(RealityCertificateVerification::NotReality);
+    };
+    mac.update(mldsa65.client_hello);
+    mac.update(mldsa65.server_hello);
+    let message = mac.finalize().into_bytes();
+
+    if verifying_key.verify(message.as_slice(), &signature).is_ok() {
+        Ok(RealityCertificateVerification::Verified)
+    } else {
+        Ok(RealityCertificateVerification::NotReality)
+    }
+}
+
+/// Seals and patches the REALITY session id bytes into a raw ClientHello.
+///
+/// Invalid session-id ranges and overlong `short_id` values return before mutating
+/// `raw_client_hello`. On success, the configured session-id range is first zeroed
+/// for associated-data construction and then rewritten with the sealed bytes.
+pub fn seal_reality_client_hello(
+    input: &RealitySessionIdInput,
+    patch: RealityClientHelloPatch,
+    raw_client_hello: &mut [u8],
+) -> Result<[u8; REALITY_SESSION_ID_LEN], RealityError> {
+    validate_reality_short_id(input)?;
+
+    let offset = patch.session_id_offset;
+    let len = raw_client_hello.len();
+    let end =
+        offset
+            .checked_add(REALITY_SESSION_ID_LEN)
+            .ok_or(RealityError::InvalidSessionIdRange {
+                offset,
+                end: usize::MAX,
+                len,
+            })?;
+
+    if end > len {
+        return Err(RealityError::InvalidSessionIdRange { offset, end, len });
+    }
+
+    raw_client_hello[offset..end].fill(0);
+    let session_id = build_reality_session_id(input, raw_client_hello)?;
+    raw_client_hello[offset..end].copy_from_slice(&session_id);
+
+    Ok(session_id)
+}
+
+fn validate_reality_short_id(input: &RealitySessionIdInput) -> Result<(), RealityError> {
+    if input.short_id.len() > REALITY_MAX_SHORT_ID_LEN {
+        return Err(RealityError::ShortIdTooLong);
+    }
+
+    Ok(())
+}

--- a/third_party/xray-transport/src/reality_connector.rs
+++ b/third_party/xray-transport/src/reality_connector.rs
@@ -1,0 +1,210 @@
+//! REALITY connector boundary.
+//!
+//! Oracle/source: `Xray-core/transport/internet/reality/reality.go::UClient`.
+//! Pure session-id sealing, ClientHello patching, and certificate HMAC
+//! verification live in `crate::reality`.
+//!
+//! This connector remains non-networked until Chrome/uTLS-compatible ClientHello generation
+//! and a complete REALITY TLS handshake exist.
+//!
+//! Future `RealityConnector::connect` implementation notes:
+//!
+//! 1. Build or integrate a Chrome-compatible TLS 1.3 ClientHello provider that
+//!    exposes raw bytes, random, session-id offset, and local ECDHE private key.
+//! 2. Feed that provider output into `prepare_reality_handshake`.
+//! 3. Write the patched ClientHello to the network stream and complete TLS.
+//! 4. Call `verify_reality_certificate_der` on the leaf certificate with the
+//!    derived auth key from `RealityPreparedHandshake`.
+//! 5. Expose the protected stream to VLESS only after REALITY verification.
+//!
+//! VLESS should only see an async byte stream once live REALITY is implemented.
+
+use std::fmt;
+
+use crate::{
+    reality::{
+        prepare_reality_handshake, validate_reality_client_hello_metadata,
+        validate_reality_fingerprint, RealityError, RealityHandshakeInput,
+        RealityPreparedClientHello, RealityPreparedHandshake,
+    },
+    BoxedTransportStream, RealityClientConfig, TransportError,
+};
+use async_trait::async_trait;
+use tokio::net::TcpStream;
+use zeroize::Zeroize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealityClientHelloRequest<'a> {
+    pub server_name: &'a str,
+    pub fingerprint: &'a str,
+}
+
+pub trait RealityClientHelloProvider: Send + Sync {
+    fn prepare_client_hello(
+        &self,
+        request: RealityClientHelloRequest<'_>,
+    ) -> Result<RealityPreparedClientHello, RealityError>;
+}
+
+/// Creates one-shot REALITY TLS sessions for runtime connections.
+///
+/// The provider is shared by the runtime engine, but each call must return a
+/// fresh session whose ClientHello state can later be consumed by
+/// `RealityTlsSession::complete`.
+pub trait RealityTlsSessionProvider: Send + Sync {
+    fn create_session(
+        &self,
+        request: RealityClientHelloRequest<'_>,
+    ) -> Result<Box<dyn RealityTlsSession>, RealityError>;
+}
+
+/// Result of a completed TLS handshake. Xray keeps the already-negotiated TLS
+/// connection when the leaf certificate is real (not REALITY-bound) so its
+/// spiderX HTTP/2 cover flow can reuse the exact same socket.
+pub enum RealityTlsSessionOutcome {
+    Verified(BoxedTransportStream),
+    NotReality(BoxedTransportStream),
+}
+
+/// A single REALITY TLS handshake session.
+///
+/// Implementations expose the ClientHello metadata needed for REALITY
+/// session-id sealing, then consume themselves to complete TLS over the TCP
+/// stream with the patched `RealityPreparedHandshake`.
+#[async_trait]
+pub trait RealityTlsSession: Send {
+    fn prepared_client_hello(&self) -> Result<RealityPreparedClientHello, RealityError>;
+
+    async fn complete(
+        self: Box<Self>,
+        tcp_stream: TcpStream,
+        prepared: RealityPreparedHandshake,
+        mldsa65_verify: Option<Vec<u8>>,
+    ) -> Result<BoxedTransportStream, TransportError> {
+        match self
+            .complete_with_outcome(tcp_stream, prepared, mldsa65_verify)
+            .await?
+        {
+            RealityTlsSessionOutcome::Verified(stream) => Ok(stream),
+            RealityTlsSessionOutcome::NotReality(_) => Err(TransportError::RealityNotVerified),
+        }
+    }
+
+    async fn complete_with_outcome(
+        self: Box<Self>,
+        tcp_stream: TcpStream,
+        prepared: RealityPreparedHandshake,
+        mldsa65_verify: Option<Vec<u8>>,
+    ) -> Result<RealityTlsSessionOutcome, TransportError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RealityHandshakeContext {
+    pub version: [u8; 3],
+    pub unix_time: u32,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct RealityHandshakePlan {
+    pub server_name: String,
+    pub fingerprint: String,
+    pub public_key: [u8; 32],
+    pub short_id: Vec<u8>,
+    pub spider_x: String,
+    pub mldsa65_verify: Option<Vec<u8>>,
+}
+
+impl fmt::Debug for RealityHandshakePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityHandshakePlan")
+            .field("server_name", &self.server_name)
+            .field("fingerprint", &self.fingerprint)
+            .field("public_key", &self.public_key)
+            .field("short_id", &"<redacted>")
+            .field("spider_x", &self.spider_x)
+            .field(
+                "mldsa65_verify_len",
+                &self.mldsa65_verify.as_ref().map(Vec::len),
+            )
+            .finish()
+    }
+}
+
+impl Drop for RealityHandshakePlan {
+    fn drop(&mut self) {
+        self.short_id.zeroize();
+    }
+}
+
+#[derive(Clone)]
+pub struct RealityConnector {
+    config: RealityClientConfig,
+}
+
+impl fmt::Debug for RealityConnector {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityConnector")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+impl RealityConnector {
+    pub fn new(config: RealityClientConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn is_fingerprint_supported(&self) -> bool {
+        self.validate_fingerprint().is_ok()
+    }
+
+    pub fn validate_fingerprint(&self) -> Result<(), RealityError> {
+        validate_reality_fingerprint(&self.config.fingerprint).map(|_| ())
+    }
+
+    pub fn handshake_plan(&self) -> RealityHandshakePlan {
+        RealityHandshakePlan {
+            server_name: self.config.server_name.clone(),
+            fingerprint: self.config.fingerprint.clone(),
+            public_key: self.config.public_key,
+            short_id: self.config.short_id.clone(),
+            spider_x: self.config.spider_x.clone(),
+            mldsa65_verify: self.config.mldsa65_verify.clone(),
+        }
+    }
+
+    pub fn prepare_handshake(
+        &self,
+        provider: &dyn RealityClientHelloProvider,
+        context: RealityHandshakeContext,
+    ) -> Result<RealityPreparedHandshake, RealityError> {
+        self.validate_fingerprint()?;
+
+        let prepared_client_hello = provider.prepare_client_hello(RealityClientHelloRequest {
+            server_name: &self.config.server_name,
+            fingerprint: &self.config.fingerprint,
+        })?;
+
+        self.prepare_handshake_with_client_hello(prepared_client_hello, context)
+    }
+
+    pub fn prepare_handshake_with_client_hello(
+        &self,
+        prepared_client_hello: RealityPreparedClientHello,
+        context: RealityHandshakeContext,
+    ) -> Result<RealityPreparedHandshake, RealityError> {
+        self.validate_fingerprint()?;
+
+        validate_reality_client_hello_metadata(&prepared_client_hello)?;
+
+        prepare_reality_handshake(RealityHandshakeInput {
+            version: context.version,
+            unix_time: context.unix_time,
+            short_id: self.config.short_id.clone(),
+            server_public_key: self.config.public_key,
+            prepared_client_hello,
+        })
+    }
+}

--- a/third_party/xray-transport/src/reality_runtime.rs
+++ b/third_party/xray-transport/src/reality_runtime.rs
@@ -1,0 +1,126 @@
+use std::{
+    fmt,
+    net::SocketAddr,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use xray_routing::{Target, TargetAddr};
+
+use crate::{
+    connect_tcp_stream,
+    reality_connector::{
+        RealityClientHelloRequest, RealityConnector, RealityHandshakeContext,
+        RealityTlsSessionProvider,
+    },
+    BoxedTransportStream, DnsResolver, RealityClientConfig, RealityTlsEngine, SocketProtector,
+    SystemDnsResolver, TransportError,
+};
+
+const REALITY_HANDSHAKE_VERSION: [u8; 3] = [1, 8, 0];
+
+pub trait RealityHandshakeContextProvider: Send + Sync {
+    fn context(&self) -> RealityHandshakeContext;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SystemRealityHandshakeContextProvider;
+
+impl RealityHandshakeContextProvider for SystemRealityHandshakeContextProvider {
+    fn context(&self) -> RealityHandshakeContext {
+        let unix_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |duration| duration.as_secs().min(u32::MAX as u64) as u32);
+
+        RealityHandshakeContext {
+            version: REALITY_HANDSHAKE_VERSION,
+            unix_time,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RealityRuntimeEngine {
+    session_provider: Arc<dyn RealityTlsSessionProvider>,
+    dns_resolver: Arc<dyn DnsResolver>,
+    context_provider: Arc<dyn RealityHandshakeContextProvider>,
+    socket_protector: Option<Arc<dyn SocketProtector>>,
+}
+
+impl fmt::Debug for RealityRuntimeEngine {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityRuntimeEngine")
+            .field("session_provider", &"<dyn RealityTlsSessionProvider>")
+            .field("dns_resolver", &"<dyn DnsResolver>")
+            .field("context_provider", &"<dyn RealityHandshakeContextProvider>")
+            .field("socket_protector", &self.socket_protector.is_some())
+            .finish()
+    }
+}
+
+impl RealityRuntimeEngine {
+    pub fn new(session_provider: Arc<dyn RealityTlsSessionProvider>) -> Self {
+        Self {
+            session_provider,
+            dns_resolver: Arc::new(SystemDnsResolver),
+            context_provider: Arc::new(SystemRealityHandshakeContextProvider),
+            socket_protector: None,
+        }
+    }
+
+    pub fn with_dns_resolver(mut self, dns_resolver: Arc<dyn DnsResolver>) -> Self {
+        self.dns_resolver = dns_resolver;
+        self
+    }
+
+    pub fn with_context_provider(
+        mut self,
+        context_provider: Arc<dyn RealityHandshakeContextProvider>,
+    ) -> Self {
+        self.context_provider = context_provider;
+        self
+    }
+
+    pub fn with_socket_protector(mut self, protector: Arc<dyn SocketProtector>) -> Self {
+        self.socket_protector = Some(protector);
+        self
+    }
+
+    async fn resolve_socket_addr(&self, target: &Target) -> Result<SocketAddr, TransportError> {
+        match &target.addr {
+            TargetAddr::Ip(ip) => Ok(SocketAddr::new(*ip, target.port)),
+            TargetAddr::Domain(domain) => self.dns_resolver.resolve(domain, target.port).await,
+        }
+    }
+}
+
+#[async_trait]
+impl RealityTlsEngine for RealityRuntimeEngine {
+    async fn connect(
+        &self,
+        config: &RealityClientConfig,
+        target: &Target,
+    ) -> Result<BoxedTransportStream, TransportError> {
+        let connector = RealityConnector::new(config.clone());
+        connector.validate_fingerprint()?;
+
+        let session = self
+            .session_provider
+            .create_session(RealityClientHelloRequest {
+                server_name: &config.server_name,
+                fingerprint: &config.fingerprint,
+            })?;
+        let prepared_client_hello = session.prepared_client_hello()?;
+        let context = self.context_provider.context();
+        let prepared =
+            connector.prepare_handshake_with_client_hello(prepared_client_hello, context)?;
+        let addr = self.resolve_socket_addr(target).await?;
+        let stream = connect_tcp_stream(addr, self.socket_protector.as_deref()).await?;
+
+        session
+            .complete(stream, prepared, config.mldsa65_verify.clone())
+            .await
+    }
+}

--- a/third_party/xray-transport/src/reality_rustls.rs
+++ b/third_party/xray-transport/src/reality_rustls.rs
@@ -1,0 +1,1484 @@
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use async_trait::async_trait;
+use rustls::{
+    client::{
+        danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+        CapturesClientHello, ClientHelloAdvertisedCipherSuites,
+        ClientHelloAdvertisedSupportedGroups, ClientHelloAdvertisedSupportedVersions,
+        ClientHelloAlpnProtocols, ClientHelloCertificateCompressionAlgorithms, ClientHelloContext,
+        ClientHelloCustomizer, ClientHelloExactExtension, ClientHelloExactExtensions,
+        ClientHelloExtensionOrder, ClientHelloExtensionPlan, ClientHelloForcedExtensions,
+        ClientHelloGreaseExtension, ClientHelloGreasePlan, ClientHelloKeySharePlan,
+        ClientHelloPaddingPlan, ClientHelloPlan, ClientHelloRawExtension, ClientHelloRawExtensions,
+        ClientHelloRawKeyShare, ClientHelloRawKeyShares, ClientHelloSessionId,
+        ClientHelloSupportedGroups, ClientHelloSupportedVersions, FinalizesClientHello,
+        FixedX25519KeyShare,
+    },
+    crypto::{self, CryptoProvider, GetRandomFailed},
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    CertificateCompressionAlgorithm, CertificateError, CipherSuite, ClientConfig, ClientConnection,
+    DigitallySignedStruct, Error as RustlsError, NamedGroup, ProtocolVersion, SignatureScheme,
+};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector as TokioTlsConnector;
+use zeroize::Zeroize;
+
+use crate::{
+    reality::{
+        prepare_reality_handshake, validate_reality_client_hello_metadata,
+        validate_reality_fingerprint, verify_reality_certificate_der_with_mldsa65, RealityError,
+        RealityHandshakeInput, RealityMldsa65CertificateInput, RealityPreparedClientHello,
+    },
+    reality_connector::{
+        RealityClientHelloRequest, RealityTlsSession, RealityTlsSessionOutcome,
+        RealityTlsSessionProvider,
+    },
+    reality_utls_profiles::{profile_for_fingerprint, UtlsClientHelloProfile},
+    BoxedTransportStream, CapturedTcpStream, PenetratingTlsStream, ServerReadLog, TransportError,
+};
+
+const TLS_RECORD_HANDSHAKE: u8 = 0x16;
+const TLS_HANDSHAKE_SERVER_HELLO: u8 = 0x02;
+const TLS_RECORD_HEADER_LEN: usize = 5;
+const TLS_HANDSHAKE_HEADER_LEN: usize = 4;
+const REALITY_SESSION_ID_LEN: usize = 32;
+const REALITY_VERIFICATION_UNKNOWN: u8 = 0;
+const REALITY_VERIFICATION_VERIFIED: u8 = 1;
+const REALITY_VERIFICATION_NOT_REALITY: u8 = 2;
+const TLS_CLIENT_HELLO_SESSION_ID_OFFSET: usize = 39;
+const EXT_SERVER_NAME: u16 = 0x0000;
+const EXT_STATUS_REQUEST: u16 = 0x0005;
+const EXT_SUPPORTED_GROUPS: u16 = 0x000a;
+const EXT_EC_POINT_FORMATS: u16 = 0x000b;
+const EXT_SIGNATURE_ALGORITHMS: u16 = 0x000d;
+const EXT_ALPN: u16 = 0x0010;
+const EXT_SIGNED_CERTIFICATE_TIMESTAMP: u16 = 0x0012;
+const EXT_PADDING: u16 = 0x0015;
+const EXT_EXTENDED_MASTER_SECRET: u16 = 0x0017;
+const EXT_CERTIFICATE_COMPRESSION: u16 = 0x001b;
+const EXT_RECORD_SIZE_LIMIT: u16 = 0x001c;
+const EXT_DELEGATED_CREDENTIALS: u16 = 0x0022;
+const EXT_SESSION_TICKET: u16 = 0x0023;
+const EXT_SUPPORTED_VERSIONS: u16 = 0x002b;
+const EXT_PSK_KEY_EXCHANGE_MODES: u16 = 0x002d;
+const EXT_KEY_SHARE: u16 = 0x0033;
+const EXT_ENCRYPTED_CLIENT_HELLO: u16 = 0xfe0d;
+const EXT_RENEGOTIATION_INFO: u16 = 0xff01;
+const GROUP_X25519: u16 = 0x001d;
+const GROUP_SECP256R1: u16 = 0x0017;
+const GROUP_SECP384R1: u16 = 0x0018;
+const GROUP_X25519_MLKEM768: u16 = 0x11ec;
+const GROUP_X25519_MLKEM768_DRAFT: u16 = 0x6399;
+const TLS_VERSION_1_3: u16 = 0x0304;
+const BROTLI_CERTIFICATE_COMPRESSION: u16 = 0x0002;
+const BORINGSSL_PADDING_TARGET_HANDSHAKE_SIZE: usize = 512;
+const STRUCTURED_OPTIONAL_EXTENSIONS: &[u16] = &[
+    EXT_SERVER_NAME,
+    EXT_STATUS_REQUEST,
+    EXT_SUPPORTED_GROUPS,
+    EXT_EC_POINT_FORMATS,
+    EXT_ALPN,
+    EXT_EXTENDED_MASTER_SECRET,
+    EXT_CERTIFICATE_COMPRESSION,
+    EXT_SESSION_TICKET,
+    EXT_PSK_KEY_EXCHANGE_MODES,
+    EXT_RENEGOTIATION_INFO,
+];
+
+#[derive(Debug, Clone, Default)]
+pub struct RustlsRealityTlsSessionProvider;
+
+impl RustlsRealityTlsSessionProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl RealityTlsSessionProvider for RustlsRealityTlsSessionProvider {
+    fn create_session(
+        &self,
+        request: RealityClientHelloRequest<'_>,
+    ) -> Result<Box<dyn RealityTlsSession>, RealityError> {
+        validate_reality_fingerprint(request.fingerprint)?;
+
+        let plan = RustlsRealityPlan::random().map_err(|_| {
+            RealityError::ClientHelloGenerationFailed(
+                "failed to fill REALITY handshake entropy".to_owned(),
+            )
+        })?;
+        let prepared = plan.prepare_client_hello(request)?;
+
+        Ok(Box::new(RustlsRealityTlsSession {
+            server_name: request.server_name.to_owned(),
+            fingerprint: request.fingerprint.to_owned(),
+            plan,
+            prepared_client_hello: prepared,
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct RustlsRealityPlan {
+    hello_random: [u8; 32],
+    local_x25519_private_key: [u8; 32],
+}
+
+impl fmt::Debug for RustlsRealityPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RustlsRealityPlan")
+            .field("hello_random", &"<redacted>")
+            .field("local_x25519_private_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Drop for RustlsRealityPlan {
+    fn drop(&mut self) {
+        self.local_x25519_private_key.zeroize();
+    }
+}
+
+impl RustlsRealityPlan {
+    fn random() -> Result<Self, GetRandomFailed> {
+        let mut hello_random = [0; 32];
+        let mut local_x25519_private_key = [0; 32];
+        let secure_random = crypto::ring::default_provider().secure_random;
+
+        secure_random.fill(&mut hello_random)?;
+        secure_random.fill(&mut local_x25519_private_key)?;
+
+        let plan = Self {
+            hello_random,
+            local_x25519_private_key,
+        };
+        local_x25519_private_key.zeroize();
+
+        Ok(plan)
+    }
+
+    fn prepare_client_hello(
+        &self,
+        request: RealityClientHelloRequest<'_>,
+    ) -> Result<RealityPreparedClientHello, RealityError> {
+        let raw_client_hello = self
+            .client_hello_message(
+                request.server_name,
+                request.fingerprint,
+                [0; REALITY_SESSION_ID_LEN],
+                [0; 32],
+            )
+            .map_err(|error| RealityError::ClientHelloGenerationFailed(error.to_string()))?;
+        let prepared = RealityPreparedClientHello {
+            fingerprint: request.fingerprint.to_owned(),
+            raw_client_hello,
+            hello_random: self.hello_random,
+            session_id_offset: TLS_CLIENT_HELLO_SESSION_ID_OFFSET,
+            local_x25519_private_key: self.local_x25519_private_key,
+        };
+        let validation = validate_reality_client_hello_metadata(&prepared)?;
+
+        debug_assert_eq!(
+            validation.session_id_offset,
+            TLS_CLIENT_HELLO_SESSION_ID_OFFSET
+        );
+
+        Ok(prepared)
+    }
+
+    fn client_hello_message(
+        &self,
+        server_name: &str,
+        fingerprint: &str,
+        session_id: [u8; REALITY_SESSION_ID_LEN],
+        auth_key: [u8; 32],
+    ) -> Result<Vec<u8>, TransportError> {
+        self.client_hello_message_inner(server_name, fingerprint, session_id, auth_key, None)
+    }
+
+    #[cfg(test)]
+    fn client_hello_message_with_finalizer(
+        &self,
+        server_name: &str,
+        fingerprint: &str,
+        finalizer: Arc<dyn FinalizesClientHello>,
+    ) -> Result<Vec<u8>, TransportError> {
+        self.client_hello_message_inner(
+            server_name,
+            fingerprint,
+            [0; REALITY_SESSION_ID_LEN],
+            [0; 32],
+            Some(finalizer),
+        )
+    }
+
+    fn client_hello_message_inner(
+        &self,
+        server_name: &str,
+        fingerprint: &str,
+        session_id: [u8; REALITY_SESSION_ID_LEN],
+        auth_key: [u8; 32],
+        finalizer: Option<Arc<dyn FinalizesClientHello>>,
+    ) -> Result<Vec<u8>, TransportError> {
+        let profile = profile_for_fingerprint(fingerprint).ok_or_else(|| {
+            TransportError::TlsConfig(format!(
+                "unsupported REALITY uTLS fingerprint profile: {fingerprint}"
+            ))
+        })?;
+        let capture = Arc::new(RealityClientHelloCapture::default());
+        let customizer = Arc::new(RustlsRealityClientHelloCustomizer::new(
+            self,
+            profile,
+            session_id,
+            Some(capture.clone()),
+            finalizer,
+        ));
+        let config = reality_client_config(
+            RealityVerificationMaterial::Static {
+                auth_key,
+                client_hello: None,
+            },
+            None,
+            None,
+            Some(customizer),
+            profile_uses_structured_certificate_compression(profile),
+        )?;
+        let server_name = ServerName::try_from(server_name.to_owned())
+            .map_err(|_| TransportError::InvalidTlsServerName(server_name.to_owned()))?;
+        let mut connection =
+            ClientConnection::new(Arc::new(config), server_name).map_err(rustls_config_error)?;
+        let mut record = Vec::new();
+        connection
+            .write_tls(&mut record)
+            .map_err(TransportError::Tcp)?;
+
+        capture.take()
+    }
+}
+
+#[derive(Debug, Default)]
+struct RealityClientHelloCapture {
+    bytes: Mutex<Option<Vec<u8>>>,
+}
+
+impl RealityClientHelloCapture {
+    fn take(&self) -> Result<Vec<u8>, TransportError> {
+        let mut bytes = self.bytes.lock().map_err(|_| {
+            TransportError::TlsConfig("REALITY ClientHello capture lock was poisoned".to_owned())
+        })?;
+        bytes.take().ok_or_else(|| {
+            TransportError::TlsConfig("rustls did not capture a REALITY ClientHello".to_owned())
+        })
+    }
+}
+
+impl CapturesClientHello for RealityClientHelloCapture {
+    fn capture_client_hello(&self, bytes: &[u8]) -> Result<(), RustlsError> {
+        let mut captured = self.bytes.lock().map_err(|_| {
+            RustlsError::General("REALITY ClientHello capture lock was poisoned".to_owned())
+        })?;
+        *captured = Some(bytes.to_vec());
+        Ok(())
+    }
+}
+
+struct RustlsRealityClientHelloCustomizer {
+    profile: &'static UtlsClientHelloProfile,
+    hello_random: [u8; 32],
+    session_id: [u8; REALITY_SESSION_ID_LEN],
+    local_x25519_private_key: [u8; 32],
+    capture: Option<Arc<RealityClientHelloCapture>>,
+    finalizer: Option<Arc<dyn FinalizesClientHello>>,
+}
+
+impl RustlsRealityClientHelloCustomizer {
+    fn new(
+        plan: &RustlsRealityPlan,
+        profile: &'static UtlsClientHelloProfile,
+        session_id: [u8; REALITY_SESSION_ID_LEN],
+        capture: Option<Arc<RealityClientHelloCapture>>,
+        finalizer: Option<Arc<dyn FinalizesClientHello>>,
+    ) -> Self {
+        Self {
+            profile,
+            hello_random: plan.hello_random,
+            session_id,
+            local_x25519_private_key: plan.local_x25519_private_key,
+            capture,
+            finalizer,
+        }
+    }
+}
+
+impl fmt::Debug for RustlsRealityClientHelloCustomizer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RustlsRealityClientHelloCustomizer")
+            .field("profile", &self.profile)
+            .field("hello_random", &"<redacted>")
+            .field("session_id", &"<redacted>")
+            .field("local_x25519_private_key", &"<redacted>")
+            .field("capture", &self.capture.is_some())
+            .field("finalizer", &self.finalizer.is_some())
+            .finish()
+    }
+}
+
+impl Drop for RustlsRealityClientHelloCustomizer {
+    fn drop(&mut self) {
+        self.hello_random.zeroize();
+        self.session_id.zeroize();
+        self.local_x25519_private_key.zeroize();
+    }
+}
+
+impl ClientHelloCustomizer for RustlsRealityClientHelloCustomizer {
+    fn build_client_hello_plan(
+        &self,
+        _context: ClientHelloContext<'_>,
+    ) -> Result<Option<ClientHelloPlan>, RustlsError> {
+        let session_id = ClientHelloSessionId::try_from(self.session_id.to_vec())?;
+        let mut plan = ClientHelloPlan::new()
+            .with_random(self.hello_random)
+            .with_session_id(session_id)
+            .with_fixed_x25519(FixedX25519KeyShare::new(self.local_x25519_private_key));
+
+        plan = apply_utls_profile(plan, self.profile)?;
+
+        if let Some(capture) = &self.capture {
+            plan = plan.with_capture(capture.clone());
+        }
+        if let Some(finalizer) = &self.finalizer {
+            plan = plan.with_finalizer(finalizer.clone());
+        }
+
+        Ok(Some(plan))
+    }
+}
+
+#[derive(Clone)]
+struct RealityFinalizedClientHello {
+    auth_key: [u8; 32],
+    session_id: [u8; REALITY_SESSION_ID_LEN],
+    client_hello: Vec<u8>,
+}
+
+impl fmt::Debug for RealityFinalizedClientHello {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityFinalizedClientHello")
+            .field("auth_key", &"<redacted>")
+            .field("session_id", &"<redacted>")
+            .field("client_hello_len", &self.client_hello.len())
+            .finish()
+    }
+}
+
+impl Drop for RealityFinalizedClientHello {
+    fn drop(&mut self) {
+        self.auth_key.zeroize();
+        self.session_id.zeroize();
+        self.client_hello.zeroize();
+    }
+}
+
+#[derive(Default)]
+struct RealityFinalizedClientHelloState {
+    finalized: Mutex<Option<RealityFinalizedClientHello>>,
+}
+
+impl fmt::Debug for RealityFinalizedClientHelloState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityFinalizedClientHelloState")
+            .finish_non_exhaustive()
+    }
+}
+
+impl RealityFinalizedClientHelloState {
+    fn store(&self, finalized: RealityFinalizedClientHello) -> Result<(), RustlsError> {
+        let mut stored = self.finalized.lock().map_err(|_| {
+            RustlsError::General("REALITY ClientHello finalizer state lock was poisoned".to_owned())
+        })?;
+        if stored.is_some() {
+            return Err(RustlsError::General(
+                "REALITY ClientHello finalizer ran more than once".to_owned(),
+            ));
+        }
+        *stored = Some(finalized);
+        Ok(())
+    }
+
+    fn snapshot(&self) -> Result<RealityFinalizedClientHello, RustlsError> {
+        let stored = self.finalized.lock().map_err(|_| {
+            RustlsError::General("REALITY ClientHello finalizer state lock was poisoned".to_owned())
+        })?;
+        stored.as_ref().cloned().ok_or_else(|| {
+            RustlsError::General("REALITY ClientHello finalizer did not run".to_owned())
+        })
+    }
+}
+
+struct RustlsRealityClientHelloFinalizer {
+    fingerprint: String,
+    hello_random: [u8; 32],
+    local_x25519_private_key: [u8; 32],
+    version: [u8; 3],
+    unix_time: u32,
+    short_id: Vec<u8>,
+    server_public_key: [u8; 32],
+    finalized_state: Arc<RealityFinalizedClientHelloState>,
+}
+
+impl RustlsRealityClientHelloFinalizer {
+    fn new(
+        plan: &RustlsRealityPlan,
+        fingerprint: &str,
+        prepared: &crate::reality::RealityPreparedHandshake,
+        finalized_state: Arc<RealityFinalizedClientHelloState>,
+    ) -> Self {
+        Self {
+            fingerprint: fingerprint.to_owned(),
+            hello_random: plan.hello_random,
+            local_x25519_private_key: plan.local_x25519_private_key,
+            version: prepared.version,
+            unix_time: prepared.unix_time,
+            short_id: prepared.short_id.clone(),
+            server_public_key: prepared.server_public_key,
+            finalized_state,
+        }
+    }
+}
+
+impl fmt::Debug for RustlsRealityClientHelloFinalizer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RustlsRealityClientHelloFinalizer")
+            .field("fingerprint", &self.fingerprint)
+            .field("hello_random", &"<redacted>")
+            .field("local_x25519_private_key", &"<redacted>")
+            .field("version", &self.version)
+            .field("unix_time", &self.unix_time)
+            .field("short_id", &"<redacted>")
+            .field("server_public_key", &self.server_public_key)
+            .finish()
+    }
+}
+
+impl Drop for RustlsRealityClientHelloFinalizer {
+    fn drop(&mut self) {
+        self.local_x25519_private_key.zeroize();
+        self.short_id.zeroize();
+    }
+}
+
+impl FinalizesClientHello for RustlsRealityClientHelloFinalizer {
+    fn finalize_client_hello(&self, bytes: &mut Vec<u8>) -> Result<(), RustlsError> {
+        let prepared = prepare_reality_handshake(RealityHandshakeInput {
+            version: self.version,
+            unix_time: self.unix_time,
+            short_id: self.short_id.clone(),
+            server_public_key: self.server_public_key,
+            prepared_client_hello: RealityPreparedClientHello {
+                fingerprint: self.fingerprint.clone(),
+                raw_client_hello: bytes.clone(),
+                hello_random: self.hello_random,
+                session_id_offset: TLS_CLIENT_HELLO_SESSION_ID_OFFSET,
+                local_x25519_private_key: self.local_x25519_private_key,
+            },
+        })
+        .map_err(|error| {
+            RustlsError::General(format!("REALITY ClientHello finalization failed: {error}"))
+        })?;
+
+        if prepared.patched_client_hello.len() != bytes.len() {
+            return Err(RustlsError::General(
+                "REALITY ClientHello finalizer changed ClientHello length".to_owned(),
+            ));
+        }
+
+        let finalized_client_hello = prepared.patched_client_hello.clone();
+        bytes.copy_from_slice(&finalized_client_hello);
+        self.finalized_state.store(RealityFinalizedClientHello {
+            auth_key: prepared.auth_key,
+            session_id: prepared.session_id,
+            client_hello: finalized_client_hello,
+        })
+    }
+}
+
+fn apply_utls_profile(
+    mut plan: ClientHelloPlan,
+    profile: &'static UtlsClientHelloProfile,
+) -> Result<ClientHelloPlan, RustlsError> {
+    plan = plan
+        .with_advertised_cipher_suites(advertised_cipher_suites(profile)?)
+        .with_supported_versions(supported_versions(profile)?);
+
+    if !profile.supported_versions.is_empty() {
+        plan = plan.with_advertised_supported_versions(advertised_supported_versions(profile)?);
+    }
+    if !profile.supported_groups.is_empty() {
+        plan = plan.with_supported_groups(supported_groups(profile)?);
+        plan = plan.with_advertised_supported_groups(advertised_supported_groups(profile)?);
+    }
+    if !profile.key_shares.is_empty() {
+        plan = plan.with_key_share_plan(key_share_plan(profile)?);
+    }
+    if let Some(raw_key_shares) = raw_key_shares(profile)? {
+        plan = plan.with_raw_key_shares(raw_key_shares);
+    }
+    if !profile.alpn_protocols.is_empty() {
+        plan = plan.with_alpn_protocols(alpn_protocols(profile)?);
+    }
+    if profile_uses_structured_certificate_compression(profile) {
+        plan = plan.with_certificate_compression_algorithms(certificate_compression(profile)?);
+    }
+
+    let forced_extensions = forced_extensions(profile);
+    let extension_plan = extension_plan(profile)?;
+    let (exact_extensions, raw_extensions) = extension_payloads(profile)?;
+
+    plan = plan
+        .with_forced_extensions(forced_extensions)
+        .with_extensions(extension_plan);
+    if !profile.supported_versions.is_empty() {
+        plan = plan.with_extension_order(extension_order(profile)?);
+    }
+
+    if let Some(exact_extensions) = exact_extensions {
+        plan = plan.with_exact_extensions(exact_extensions);
+    }
+    if let Some(raw_extensions) = raw_extensions {
+        plan = plan.with_raw_extensions(raw_extensions);
+    }
+    if let Some(grease) = grease_plan(profile)? {
+        plan = plan.with_grease(grease);
+    }
+    if profile.padding_length.is_some() {
+        plan = plan.with_padding(ClientHelloPaddingPlan::pad_to_handshake_size(
+            BORINGSSL_PADDING_TARGET_HANDSHAKE_SIZE,
+        )?);
+    }
+
+    Ok(plan)
+}
+
+fn advertised_cipher_suites(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloAdvertisedCipherSuites, RustlsError> {
+    ClientHelloAdvertisedCipherSuites::try_from(
+        profile
+            .cipher_suites
+            .iter()
+            .copied()
+            .filter(|suite| !is_grease_value(*suite))
+            .map(CipherSuite::from)
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn supported_versions(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloSupportedVersions, RustlsError> {
+    let versions = if profile.supported_versions.contains(&TLS_VERSION_1_3) {
+        vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2]
+    } else {
+        vec![ProtocolVersion::TLSv1_2]
+    };
+    ClientHelloSupportedVersions::try_from(versions)
+}
+
+fn advertised_supported_versions(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloAdvertisedSupportedVersions, RustlsError> {
+    ClientHelloAdvertisedSupportedVersions::try_from(
+        profile
+            .supported_versions
+            .iter()
+            .copied()
+            .map(ProtocolVersion::from)
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn supported_groups(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloSupportedGroups, RustlsError> {
+    let mut groups = Vec::new();
+    for group in profile.supported_groups {
+        if let Some(group) = real_supported_group(*group) {
+            if !groups.contains(&group) {
+                groups.push(group);
+            }
+        }
+    }
+    if groups.is_empty() {
+        groups.push(NamedGroup::X25519);
+    }
+    ClientHelloSupportedGroups::try_from(groups)
+}
+
+fn advertised_supported_groups(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloAdvertisedSupportedGroups, RustlsError> {
+    ClientHelloAdvertisedSupportedGroups::try_from(
+        profile
+            .supported_groups
+            .iter()
+            .copied()
+            .map(NamedGroup::from)
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn key_share_plan(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloKeySharePlan, RustlsError> {
+    let mut groups = Vec::new();
+    for key_share in profile.key_shares {
+        if let Some(group) = real_key_share_group(key_share.group) {
+            groups.push(group);
+        }
+    }
+    if groups.is_empty() {
+        groups.push(NamedGroup::X25519);
+    }
+    ClientHelloKeySharePlan::try_from(groups)
+}
+
+fn raw_key_shares(
+    profile: &UtlsClientHelloProfile,
+) -> Result<Option<ClientHelloRawKeyShares>, RustlsError> {
+    let mut raw_key_shares = Vec::new();
+    let mut non_grease_position = 0;
+
+    for key_share in profile.key_shares {
+        if is_grease_value(key_share.group) {
+            continue;
+        }
+
+        if real_key_share_group(key_share.group).is_some() {
+            non_grease_position += 1;
+            continue;
+        }
+
+        raw_key_shares.push(ClientHelloRawKeyShare::new_at(
+            non_grease_position,
+            NamedGroup::from(key_share.group),
+            vec![0; key_share.key_exchange_len],
+        )?);
+        non_grease_position += 1;
+    }
+
+    if raw_key_shares.is_empty() {
+        Ok(None)
+    } else {
+        ClientHelloRawKeyShares::try_from(raw_key_shares).map(Some)
+    }
+}
+
+fn alpn_protocols(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloAlpnProtocols, RustlsError> {
+    ClientHelloAlpnProtocols::try_from(
+        profile
+            .alpn_protocols
+            .iter()
+            .map(|protocol| protocol.to_vec())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn certificate_compression(
+    _profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloCertificateCompressionAlgorithms, RustlsError> {
+    ClientHelloCertificateCompressionAlgorithms::try_from(vec![
+        CertificateCompressionAlgorithm::Brotli,
+    ])
+}
+
+fn extension_order(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloExtensionOrder, RustlsError> {
+    ClientHelloExtensionOrder::try_from(
+        profile
+            .extensions
+            .iter()
+            .map(|extension| extension.extension_type)
+            .filter(|extension_type| !is_grease_value(*extension_type))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn extension_plan(
+    profile: &UtlsClientHelloProfile,
+) -> Result<ClientHelloExtensionPlan, RustlsError> {
+    let disabled = STRUCTURED_OPTIONAL_EXTENSIONS
+        .iter()
+        .copied()
+        .filter(|extension_type| !profile_has_extension(profile, *extension_type))
+        .filter(|extension_type| {
+            *extension_type != EXT_CERTIFICATE_COMPRESSION
+                || !profile_uses_structured_certificate_compression(profile)
+        })
+        .collect::<Vec<_>>();
+
+    ClientHelloExtensionPlan::try_from(disabled)
+}
+
+fn forced_extensions(profile: &UtlsClientHelloProfile) -> ClientHelloForcedExtensions {
+    let mut forced = ClientHelloForcedExtensions::new();
+    if profile_has_extension(profile, EXT_RENEGOTIATION_INFO) {
+        forced = forced.with_renegotiation_info_empty();
+    }
+    if profile_has_extension(profile, EXT_SESSION_TICKET) {
+        forced = forced.with_session_ticket_request();
+    }
+    if profile_has_extension(profile, EXT_SIGNED_CERTIFICATE_TIMESTAMP) {
+        forced = forced.with_signed_certificate_timestamp_empty();
+    }
+    forced
+}
+
+fn extension_payloads(
+    profile: &UtlsClientHelloProfile,
+) -> Result<
+    (
+        Option<ClientHelloExactExtensions>,
+        Option<ClientHelloRawExtensions>,
+    ),
+    RustlsError,
+> {
+    let mut exact_extensions = Vec::new();
+    let mut raw_extensions = Vec::new();
+
+    if profile_has_extension(profile, EXT_SIGNATURE_ALGORITHMS) {
+        exact_extensions.push(ClientHelloExactExtension::new(
+            EXT_SIGNATURE_ALGORITHMS,
+            signature_algorithms_payload(profile.signature_algorithms)?,
+        )?);
+    }
+    if profile_has_extension(profile, EXT_DELEGATED_CREDENTIALS) {
+        push_exact_or_raw_extension(
+            &mut exact_extensions,
+            &mut raw_extensions,
+            EXT_DELEGATED_CREDENTIALS,
+            signature_algorithms_payload(profile.delegated_credentials_algorithms)?,
+        )?;
+    }
+    if !profile_uses_structured_certificate_compression(profile)
+        && profile_has_extension(profile, EXT_CERTIFICATE_COMPRESSION)
+    {
+        exact_extensions.push(ClientHelloExactExtension::new(
+            EXT_CERTIFICATE_COMPRESSION,
+            certificate_compression_payload(profile.certificate_compression_algorithms)?,
+        )?);
+    }
+    if let Some(record_size_limit) = profile.record_size_limit {
+        push_exact_or_raw_extension(
+            &mut exact_extensions,
+            &mut raw_extensions,
+            EXT_RECORD_SIZE_LIMIT,
+            record_size_limit.to_be_bytes().to_vec(),
+        )?;
+    }
+    if let Some(length) = profile.encrypted_client_hello_length {
+        exact_extensions.push(ClientHelloExactExtension::new(
+            EXT_ENCRYPTED_CLIENT_HELLO,
+            encrypted_client_hello_payload(length)?,
+        )?);
+    }
+    for application_settings in profile.application_settings {
+        push_exact_or_raw_extension(
+            &mut exact_extensions,
+            &mut raw_extensions,
+            application_settings.extension_type,
+            application_settings_payload(application_settings.protocols)?,
+        )?;
+    }
+    for extension in profile.extensions {
+        if is_grease_value(extension.extension_type)
+            || is_structured_extension(profile, extension.extension_type)
+            || extension.extension_type == EXT_SIGNATURE_ALGORITHMS
+            || extension.extension_type == EXT_DELEGATED_CREDENTIALS
+            || extension.extension_type == EXT_CERTIFICATE_COMPRESSION
+            || extension.extension_type == EXT_RECORD_SIZE_LIMIT
+            || extension.extension_type == EXT_ENCRYPTED_CLIENT_HELLO
+            || profile
+                .application_settings
+                .iter()
+                .any(|settings| settings.extension_type == extension.extension_type)
+        {
+            continue;
+        }
+
+        push_exact_or_raw_extension(
+            &mut exact_extensions,
+            &mut raw_extensions,
+            extension.extension_type,
+            vec![0; extension.payload_len],
+        )?;
+    }
+
+    let exact_extensions = if exact_extensions.is_empty() {
+        None
+    } else {
+        Some(ClientHelloExactExtensions::try_from(exact_extensions)?)
+    };
+    let raw_extensions = if raw_extensions.is_empty() {
+        None
+    } else {
+        Some(ClientHelloRawExtensions::try_from(raw_extensions)?)
+    };
+
+    Ok((exact_extensions, raw_extensions))
+}
+
+fn encrypted_client_hello_payload(length: usize) -> Result<Vec<u8>, RustlsError> {
+    // The finalizer path reparses ClientHello, so the ECH GREASE placeholder
+    // must be syntactically valid even though it remains opaque filler.
+    const OUTER_TYPE: u8 = 0;
+    const HPKE_KDF_HKDF_SHA256: u16 = 0x0001;
+    const HPKE_AEAD_AES_128_GCM: u16 = 0x0001;
+    const CONFIG_ID: u8 = 0;
+    const MIN_OUTER_LEN: usize = 11;
+
+    if length < MIN_OUTER_LEN {
+        return Err(RustlsError::General(
+            "encrypted_client_hello payload is too short".into(),
+        ));
+    }
+
+    let encrypted_payload_len = length - 10;
+    let encrypted_payload_len = u16::try_from(encrypted_payload_len).map_err(|_| {
+        RustlsError::General("encrypted_client_hello payload cannot exceed 65535 bytes".into())
+    })?;
+    let mut payload = Vec::with_capacity(length);
+    payload.push(OUTER_TYPE);
+    payload.extend_from_slice(&HPKE_KDF_HKDF_SHA256.to_be_bytes());
+    payload.extend_from_slice(&HPKE_AEAD_AES_128_GCM.to_be_bytes());
+    payload.push(CONFIG_ID);
+    payload.extend_from_slice(&0u16.to_be_bytes());
+    payload.extend_from_slice(&encrypted_payload_len.to_be_bytes());
+    payload.resize(length, 0);
+    Ok(payload)
+}
+
+fn grease_plan(
+    profile: &UtlsClientHelloProfile,
+) -> Result<Option<ClientHelloGreasePlan>, RustlsError> {
+    let grease_value = profile
+        .cipher_suites
+        .iter()
+        .chain(profile.key_shares.iter().map(|key_share| &key_share.group))
+        .chain(
+            profile
+                .extensions
+                .iter()
+                .map(|extension| &extension.extension_type),
+        )
+        .copied()
+        .find(|value| is_grease_value(*value));
+    let Some(grease_value) = grease_value else {
+        return Ok(None);
+    };
+
+    let mut grease = ClientHelloGreasePlan::new(grease_value)?;
+    if let Some(position) = profile
+        .cipher_suites
+        .iter()
+        .position(|suite| is_grease_value(*suite))
+    {
+        grease = grease.with_cipher_suite_position(position);
+    }
+    if let Some(position) = profile
+        .key_shares
+        .iter()
+        .position(|key_share| is_grease_value(key_share.group))
+    {
+        grease = grease.with_key_share_position(position);
+    }
+    let mut non_grease_position = 0;
+    for extension in profile.extensions {
+        if is_grease_value(extension.extension_type) {
+            grease = grease.with_extension(ClientHelloGreaseExtension::new(
+                extension.extension_type,
+                non_grease_position,
+                vec![0; extension.payload_len],
+            )?)?;
+        } else {
+            non_grease_position += 1;
+        }
+    }
+
+    Ok(Some(grease))
+}
+
+fn signature_algorithms_payload(algorithms: &[u16]) -> Result<Vec<u8>, RustlsError> {
+    let byte_len = algorithms
+        .len()
+        .checked_mul(2)
+        .ok_or_else(|| RustlsError::General("signature_algorithms payload is too large".into()))?;
+    let byte_len = u16::try_from(byte_len).map_err(|_| {
+        RustlsError::General("signature_algorithms payload cannot exceed 65535 bytes".into())
+    })?;
+    let mut payload = Vec::with_capacity(2 + usize::from(byte_len));
+    payload.extend_from_slice(&byte_len.to_be_bytes());
+    for algorithm in algorithms {
+        payload.extend_from_slice(&algorithm.to_be_bytes());
+    }
+    Ok(payload)
+}
+
+fn certificate_compression_payload(algorithms: &[u16]) -> Result<Vec<u8>, RustlsError> {
+    let byte_len = algorithms
+        .len()
+        .checked_mul(2)
+        .ok_or_else(|| RustlsError::General("compress_certificate payload is too large".into()))?;
+    let byte_len = u8::try_from(byte_len).map_err(|_| {
+        RustlsError::General("compress_certificate payload cannot exceed 255 bytes".into())
+    })?;
+    let mut payload = Vec::with_capacity(1 + usize::from(byte_len));
+    payload.push(byte_len);
+    for algorithm in algorithms {
+        payload.extend_from_slice(&algorithm.to_be_bytes());
+    }
+    Ok(payload)
+}
+
+fn application_settings_payload(protocols: &[&[u8]]) -> Result<Vec<u8>, RustlsError> {
+    let protocols_len = protocols.iter().try_fold(0usize, |total, protocol| {
+        if protocol.len() > usize::from(u8::MAX) {
+            return Err(RustlsError::General(
+                "application_settings protocol name cannot exceed 255 bytes".into(),
+            ));
+        }
+        total
+            .checked_add(1 + protocol.len())
+            .ok_or_else(|| RustlsError::General("application_settings payload is too large".into()))
+    })?;
+    let protocols_len = u16::try_from(protocols_len).map_err(|_| {
+        RustlsError::General("application_settings payload cannot exceed 65535 bytes".into())
+    })?;
+    let mut payload = Vec::with_capacity(2 + usize::from(protocols_len));
+    payload.extend_from_slice(&protocols_len.to_be_bytes());
+    for protocol in protocols {
+        payload.push(protocol.len() as u8);
+        payload.extend_from_slice(protocol);
+    }
+    Ok(payload)
+}
+
+fn push_exact_or_raw_extension(
+    exact_extensions: &mut Vec<ClientHelloExactExtension>,
+    raw_extensions: &mut Vec<ClientHelloRawExtension>,
+    extension_type: u16,
+    payload: Vec<u8>,
+) -> Result<(), RustlsError> {
+    match ClientHelloRawExtension::new(extension_type, payload.clone()) {
+        Ok(extension) => {
+            raw_extensions.push(extension);
+            Ok(())
+        }
+        Err(_) => {
+            exact_extensions.push(ClientHelloExactExtension::new(extension_type, payload)?);
+            Ok(())
+        }
+    }
+}
+
+fn is_structured_extension(profile: &UtlsClientHelloProfile, extension_type: u16) -> bool {
+    matches!(
+        extension_type,
+        EXT_SERVER_NAME
+            | EXT_STATUS_REQUEST
+            | EXT_SUPPORTED_GROUPS
+            | EXT_EC_POINT_FORMATS
+            | EXT_ALPN
+            | EXT_SIGNED_CERTIFICATE_TIMESTAMP
+            | EXT_PADDING
+            | EXT_EXTENDED_MASTER_SECRET
+            | EXT_SESSION_TICKET
+            | EXT_SUPPORTED_VERSIONS
+            | EXT_PSK_KEY_EXCHANGE_MODES
+            | EXT_KEY_SHARE
+            | EXT_RENEGOTIATION_INFO
+    ) || extension_type == EXT_CERTIFICATE_COMPRESSION
+        && profile_uses_structured_certificate_compression(profile)
+}
+
+fn profile_has_extension(profile: &UtlsClientHelloProfile, extension_type: u16) -> bool {
+    profile
+        .extensions
+        .iter()
+        .any(|extension| extension.extension_type == extension_type)
+}
+
+fn profile_uses_structured_certificate_compression(profile: &UtlsClientHelloProfile) -> bool {
+    profile.certificate_compression_algorithms == [BROTLI_CERTIFICATE_COMPRESSION]
+}
+
+fn real_supported_group(group: u16) -> Option<NamedGroup> {
+    match group {
+        GROUP_X25519 => Some(NamedGroup::X25519),
+        GROUP_X25519_MLKEM768 => Some(NamedGroup::X25519MLKEM768),
+        GROUP_X25519_MLKEM768_DRAFT => Some(NamedGroup::Unknown(GROUP_X25519_MLKEM768_DRAFT)),
+        GROUP_SECP256R1 => Some(NamedGroup::secp256r1),
+        GROUP_SECP384R1 => Some(NamedGroup::secp384r1),
+        _ => None,
+    }
+}
+
+fn real_key_share_group(group: u16) -> Option<NamedGroup> {
+    match group {
+        GROUP_X25519 => Some(NamedGroup::X25519),
+        GROUP_X25519_MLKEM768 => Some(NamedGroup::X25519MLKEM768),
+        GROUP_X25519_MLKEM768_DRAFT => Some(NamedGroup::Unknown(GROUP_X25519_MLKEM768_DRAFT)),
+        _ => None,
+    }
+}
+
+fn is_grease_value(value: u16) -> bool {
+    let [high, low] = value.to_be_bytes();
+    high == low && high & 0x0f == 0x0a
+}
+
+struct RustlsRealityTlsSession {
+    server_name: String,
+    fingerprint: String,
+    plan: RustlsRealityPlan,
+    prepared_client_hello: RealityPreparedClientHello,
+}
+
+impl fmt::Debug for RustlsRealityTlsSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RustlsRealityTlsSession")
+            .field("server_name", &self.server_name)
+            .field("fingerprint", &self.fingerprint)
+            .field("plan", &self.plan)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl RealityTlsSession for RustlsRealityTlsSession {
+    fn prepared_client_hello(&self) -> Result<RealityPreparedClientHello, RealityError> {
+        Ok(RealityPreparedClientHello {
+            fingerprint: self.prepared_client_hello.fingerprint.clone(),
+            raw_client_hello: self.prepared_client_hello.raw_client_hello.clone(),
+            hello_random: self.prepared_client_hello.hello_random,
+            session_id_offset: self.prepared_client_hello.session_id_offset,
+            local_x25519_private_key: self.plan.local_x25519_private_key,
+        })
+    }
+
+    async fn complete_with_outcome(
+        self: Box<Self>,
+        tcp_stream: TcpStream,
+        prepared: crate::reality::RealityPreparedHandshake,
+        mldsa65_verify: Option<Vec<u8>>,
+    ) -> Result<RealityTlsSessionOutcome, TransportError> {
+        let profile = profile_for_fingerprint(&self.fingerprint).ok_or_else(|| {
+            TransportError::TlsConfig(format!(
+                "unsupported REALITY uTLS fingerprint profile: {}",
+                self.fingerprint
+            ))
+        })?;
+        let finalized_state = Arc::new(RealityFinalizedClientHelloState::default());
+        let finalizer = Arc::new(RustlsRealityClientHelloFinalizer::new(
+            &self.plan,
+            &self.fingerprint,
+            &prepared,
+            finalized_state.clone(),
+        ));
+
+        let server_read_log = mldsa65_verify
+            .as_ref()
+            .map(|_| Arc::new(Mutex::new(Some(Vec::new()))));
+        let mldsa65 = mldsa65_verify.map(|verifying_key| RealityMldsa65VerifierContext {
+            verifying_key,
+            server_read_log: server_read_log
+                .as_ref()
+                .expect("ML-DSA verifier has a server read log")
+                .clone(),
+        });
+        let customizer = Arc::new(RustlsRealityClientHelloCustomizer::new(
+            &self.plan,
+            profile,
+            [0; REALITY_SESSION_ID_LEN],
+            None,
+            Some(finalizer),
+        ));
+        let verification_outcome = Arc::new(AtomicU8::new(REALITY_VERIFICATION_UNKNOWN));
+        let config = Arc::new(reality_client_config(
+            RealityVerificationMaterial::Finalized(finalized_state),
+            mldsa65,
+            Some(verification_outcome.clone()),
+            Some(customizer),
+            profile_uses_structured_certificate_compression(profile),
+        )?);
+        let server_name = ServerName::try_from(self.server_name.clone())
+            .map_err(|_| TransportError::InvalidTlsServerName(self.server_name.clone()))?;
+        let connector = TokioTlsConnector::from(config);
+        let tcp_stream = CapturedTcpStream::new(tcp_stream, server_read_log);
+        let connect = connector.connect(server_name, tcp_stream);
+        let stream = connect.await.map_err(TransportError::Tls)?;
+        let stream: BoxedTransportStream = Box::new(PenetratingTlsStream::new(stream));
+
+        match verification_outcome.load(Ordering::Acquire) {
+            REALITY_VERIFICATION_VERIFIED => Ok(RealityTlsSessionOutcome::Verified(stream)),
+            REALITY_VERIFICATION_NOT_REALITY => Ok(RealityTlsSessionOutcome::NotReality(stream)),
+            _ => Err(TransportError::TlsConfig(
+                "REALITY certificate verifier did not record an outcome".to_owned(),
+            )),
+        }
+    }
+}
+
+fn reality_client_config(
+    material: RealityVerificationMaterial,
+    mldsa65: Option<RealityMldsa65VerifierContext>,
+    verification_outcome: Option<Arc<AtomicU8>>,
+    client_hello_customizer: Option<Arc<dyn ClientHelloCustomizer>>,
+    certificate_compression: bool,
+) -> Result<ClientConfig, TransportError> {
+    let provider = Arc::new(reality_crypto_provider());
+    let builder = ClientConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13, &rustls::version::TLS12])
+        .map_err(|error| TransportError::TlsConfig(error.to_string()))?;
+    let verifier = RealityServerVerifier {
+        material,
+        mldsa65,
+        verification_outcome,
+    };
+    let mut config = builder
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(verifier))
+        .with_no_client_auth();
+    if !certificate_compression {
+        config.cert_decompressors.clear();
+    }
+    config.resumption = rustls::client::Resumption::disabled();
+    config.client_hello_customizer = client_hello_customizer;
+
+    Ok(config)
+}
+
+fn reality_crypto_provider() -> CryptoProvider {
+    let mut provider = crypto::aws_lc_rs::default_provider();
+    provider.kx_groups = vec![
+        crypto::aws_lc_rs::kx_group::X25519KYBER768DRAFT00,
+        crypto::aws_lc_rs::kx_group::X25519MLKEM768,
+        crypto::aws_lc_rs::kx_group::X25519,
+        crypto::aws_lc_rs::kx_group::SECP256R1,
+        crypto::aws_lc_rs::kx_group::SECP384R1,
+    ];
+    provider
+}
+
+fn extract_server_hello(records: &[u8]) -> Result<Vec<u8>, TransportError> {
+    let mut record_offset = 0;
+    while record_offset + TLS_RECORD_HEADER_LEN <= records.len() {
+        let record_type = records[record_offset];
+        let record_len =
+            u16::from_be_bytes([records[record_offset + 3], records[record_offset + 4]]) as usize;
+        let record_body_start = record_offset + TLS_RECORD_HEADER_LEN;
+        let record_end = record_body_start
+            .checked_add(record_len)
+            .ok_or_else(|| TransportError::TlsConfig("TLS record length overflow".to_owned()))?;
+        if record_end > records.len() {
+            return Err(TransportError::TlsConfig(
+                "truncated TLS server record".to_owned(),
+            ));
+        }
+
+        if record_type == TLS_RECORD_HANDSHAKE {
+            let mut handshake_offset = record_body_start;
+            while handshake_offset + TLS_HANDSHAKE_HEADER_LEN <= record_end {
+                let handshake_len = ((records[handshake_offset + 1] as usize) << 16)
+                    | ((records[handshake_offset + 2] as usize) << 8)
+                    | (records[handshake_offset + 3] as usize);
+                let handshake_end = handshake_offset
+                    .checked_add(TLS_HANDSHAKE_HEADER_LEN)
+                    .and_then(|start| start.checked_add(handshake_len))
+                    .ok_or_else(|| {
+                        TransportError::TlsConfig("TLS handshake length overflow".to_owned())
+                    })?;
+                if handshake_end > record_end {
+                    return Err(TransportError::TlsConfig(
+                        "truncated TLS ServerHello handshake".to_owned(),
+                    ));
+                }
+                if records[handshake_offset] == TLS_HANDSHAKE_SERVER_HELLO {
+                    return Ok(records[handshake_offset..handshake_end].to_vec());
+                }
+                handshake_offset = handshake_end;
+            }
+        }
+
+        record_offset = record_end;
+    }
+
+    Err(TransportError::TlsConfig(
+        "TLS ServerHello record was not captured".to_owned(),
+    ))
+}
+
+fn rustls_config_error(error: RustlsError) -> TransportError {
+    TransportError::TlsConfig(error.to_string())
+}
+
+struct RealityVerificationSnapshot {
+    auth_key: [u8; 32],
+    client_hello: Vec<u8>,
+}
+
+impl Drop for RealityVerificationSnapshot {
+    fn drop(&mut self) {
+        self.auth_key.zeroize();
+        self.client_hello.zeroize();
+    }
+}
+
+enum RealityVerificationMaterial {
+    Static {
+        auth_key: [u8; 32],
+        client_hello: Option<Vec<u8>>,
+    },
+    Finalized(Arc<RealityFinalizedClientHelloState>),
+}
+
+impl fmt::Debug for RealityVerificationMaterial {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Static { client_hello, .. } => formatter
+                .debug_struct("RealityVerificationMaterial::Static")
+                .field("auth_key", &"<redacted>")
+                .field("client_hello_len", &client_hello.as_ref().map(Vec::len))
+                .finish(),
+            Self::Finalized(_) => formatter
+                .debug_struct("RealityVerificationMaterial::Finalized")
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+impl Drop for RealityVerificationMaterial {
+    fn drop(&mut self) {
+        if let Self::Static {
+            auth_key,
+            client_hello,
+        } = self
+        {
+            auth_key.zeroize();
+            if let Some(client_hello) = client_hello {
+                client_hello.zeroize();
+            }
+        }
+    }
+}
+
+impl RealityVerificationMaterial {
+    fn snapshot(&self) -> Result<RealityVerificationSnapshot, RustlsError> {
+        match self {
+            Self::Static {
+                auth_key,
+                client_hello,
+            } => Ok(RealityVerificationSnapshot {
+                auth_key: *auth_key,
+                client_hello: client_hello.clone().unwrap_or_default(),
+            }),
+            Self::Finalized(finalized_state) => {
+                let finalized = finalized_state.snapshot()?;
+                Ok(RealityVerificationSnapshot {
+                    auth_key: finalized.auth_key,
+                    client_hello: finalized.client_hello.clone(),
+                })
+            }
+        }
+    }
+}
+
+struct RealityMldsa65VerifierContext {
+    verifying_key: Vec<u8>,
+    server_read_log: ServerReadLog,
+}
+
+impl fmt::Debug for RealityMldsa65VerifierContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityMldsa65VerifierContext")
+            .field("verifying_key_len", &self.verifying_key.len())
+            .finish()
+    }
+}
+
+struct RealityServerVerifier {
+    material: RealityVerificationMaterial,
+    mldsa65: Option<RealityMldsa65VerifierContext>,
+    verification_outcome: Option<Arc<AtomicU8>>,
+}
+
+impl fmt::Debug for RealityServerVerifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RealityServerVerifier")
+            .field("material", &self.material)
+            .field("mldsa65", &self.mldsa65)
+            .field(
+                "verification_outcome",
+                &self
+                    .verification_outcome
+                    .as_ref()
+                    .map(|outcome| outcome.load(Ordering::Relaxed)),
+            )
+            .finish()
+    }
+}
+
+impl ServerCertVerifier for RealityServerVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        let material = self.material.snapshot()?;
+        let server_hello;
+        let mldsa65 = if let Some(mldsa65) = &self.mldsa65 {
+            let captured = {
+                let mut captured = mldsa65
+                    .server_read_log
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                captured.take().ok_or(RustlsError::InvalidCertificate(
+                    CertificateError::BadEncoding,
+                ))?
+            };
+            server_hello = extract_server_hello(&captured)
+                .map_err(|_| RustlsError::InvalidCertificate(CertificateError::BadEncoding))?;
+            Some(RealityMldsa65CertificateInput {
+                verifying_key: &mldsa65.verifying_key,
+                client_hello: &material.client_hello,
+                server_hello: &server_hello,
+            })
+        } else {
+            None
+        };
+
+        match verify_reality_certificate_der_with_mldsa65(
+            &material.auth_key,
+            end_entity.as_ref(),
+            mldsa65,
+        ) {
+            Ok(crate::reality::RealityCertificateVerification::Verified) => {
+                if let Some(outcome) = &self.verification_outcome {
+                    outcome.store(REALITY_VERIFICATION_VERIFIED, Ordering::Release);
+                }
+                Ok(ServerCertVerified::assertion())
+            }
+            Ok(crate::reality::RealityCertificateVerification::NotReality) => {
+                if let Some(outcome) = &self.verification_outcome {
+                    outcome.store(REALITY_VERIFICATION_NOT_REALITY, Ordering::Release);
+                    Ok(ServerCertVerified::assertion())
+                } else {
+                    Err(RustlsError::InvalidCertificate(
+                        CertificateError::ApplicationVerificationFailure,
+                    ))
+                }
+            }
+            Err(_) => Err(RustlsError::InvalidCertificate(
+                CertificateError::BadEncoding,
+            )),
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        Err(RustlsError::InvalidCertificate(
+            CertificateError::ApplicationVerificationFailure,
+        ))
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        let provider = crypto::ring::default_provider();
+        crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSecret};
+
+    #[test]
+    fn reality_client_hello_finalizer_seals_actual_chrome_client_hello() {
+        let plan = RustlsRealityPlan::random()
+            .expect("REALITY ClientHello plan should get random material");
+        let server_secret = X25519StaticSecret::from([7u8; 32]);
+        let server_public_key = X25519PublicKey::from(&server_secret).to_bytes();
+        let prepared = crate::reality::RealityPreparedHandshake {
+            patched_client_hello: Vec::new(),
+            auth_key: [0; 32],
+            session_id: [0; REALITY_SESSION_ID_LEN],
+            version: [0, 0, 1],
+            unix_time: 1_700_000_000,
+            short_id: vec![0xaa, 0xbb, 0xcc],
+            server_public_key,
+        };
+        let finalized_state = Arc::new(RealityFinalizedClientHelloState::default());
+        let finalizer = Arc::new(RustlsRealityClientHelloFinalizer::new(
+            &plan,
+            "chrome",
+            &prepared,
+            finalized_state.clone(),
+        ));
+
+        let captured = plan
+            .client_hello_message_with_finalizer("www.example.com", "chrome", finalizer)
+            .expect("finalized ClientHello should be generated");
+        let finalized = finalized_state
+            .snapshot()
+            .expect("finalizer should store verification material");
+
+        assert_eq!(captured, finalized.client_hello);
+        assert_eq!(
+            &captured[TLS_CLIENT_HELLO_SESSION_ID_OFFSET
+                ..TLS_CLIENT_HELLO_SESSION_ID_OFFSET + REALITY_SESSION_ID_LEN],
+            finalized.session_id
+        );
+        assert_ne!(finalized.session_id, [0; REALITY_SESSION_ID_LEN]);
+        assert_ne!(finalized.auth_key, [0; 32]);
+    }
+}

--- a/third_party/xray-transport/src/reality_utls_profiles.rs
+++ b/third_party/xray-transport/src/reality_utls_profiles.rs
@@ -1,0 +1,4446 @@
+#[derive(Clone, Copy, Debug)]
+pub(super) struct UtlsClientHelloProfile {
+    pub cipher_suites: &'static [u16],
+    pub supported_versions: &'static [u16],
+    pub supported_groups: &'static [u16],
+    pub key_shares: &'static [UtlsKeyShare],
+    pub signature_algorithms: &'static [u16],
+    pub delegated_credentials_algorithms: &'static [u16],
+    pub alpn_protocols: &'static [&'static [u8]],
+    pub certificate_compression_algorithms: &'static [u16],
+    pub record_size_limit: Option<u16>,
+    pub application_settings: &'static [UtlsApplicationSettings],
+    pub extensions: &'static [UtlsExtension],
+    pub padding_length: Option<usize>,
+    pub encrypted_client_hello_length: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct UtlsKeyShare {
+    pub group: u16,
+    pub key_exchange_len: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct UtlsApplicationSettings {
+    pub extension_type: u16,
+    pub protocols: &'static [&'static [u8]],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct UtlsExtension {
+    pub extension_type: u16,
+    pub payload_len: usize,
+}
+
+const GREASE: u16 = 0x0a0a;
+const GREASE_SECOND: u16 = 0x1a1a;
+
+const PROFILE_0_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_0_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_0_GROUPS: &[u16] = &[0x0a0a, 0x11ec, 0x001d, 0x0017, 0x0018];
+const PROFILE_0_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x11ec,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_0_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_0_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_0_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_0_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_0_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_0_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x44cd,
+    protocols: PROFILE_0_APP_0_PROTOCOLS,
+}];
+const PROFILE_0_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xfe0d,
+        payload_len: 186,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x44cd,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1263,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_0: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_0_CIPHERS,
+    supported_versions: PROFILE_0_VERSIONS,
+    supported_groups: PROFILE_0_GROUPS,
+    key_shares: PROFILE_0_KEY_SHARES,
+    signature_algorithms: PROFILE_0_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_0_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_0_ALPN,
+    certificate_compression_algorithms: PROFILE_0_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_0_APPS,
+    extensions: PROFILE_0_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: Some(186),
+};
+
+const PROFILE_1_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_1_VERSIONS: &[u16] = &[0x0304, 0x0303];
+const PROFILE_1_GROUPS: &[u16] = &[0x11ec, 0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_1_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x11ec,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_1_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_1_DELEGATED_CREDENTIALS: &[u16] = &[0x0403, 0x0503, 0x0603, 0x0203];
+const PROFILE_1_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_1_CERT_COMP: &[u16] = &[0x0001, 0x0002, 0x0003];
+const PROFILE_1_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_1_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0022,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1327,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0xfe0d,
+        payload_len: 281,
+    },
+];
+const PROFILE_1: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_1_CIPHERS,
+    supported_versions: PROFILE_1_VERSIONS,
+    supported_groups: PROFILE_1_GROUPS,
+    key_shares: PROFILE_1_KEY_SHARES,
+    signature_algorithms: PROFILE_1_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_1_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_1_ALPN,
+    certificate_compression_algorithms: PROFILE_1_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_1_APPS,
+    extensions: PROFILE_1_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: Some(281),
+};
+
+const PROFILE_2_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1302, 0x1303, 0x1301, 0xc02c, 0xc02b, 0xcca9, 0xc030, 0xc02f, 0xcca8, 0xc00a, 0xc009,
+    0xc014, 0xc013, 0x009d, 0x009c, 0x0035, 0x002f, 0xc008, 0xc012, 0x000a,
+];
+const PROFILE_2_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_2_GROUPS: &[u16] = &[0x0a0a, 0x11ec, 0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_2_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x11ec,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_2_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_2_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_2_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_2_CERT_COMP: &[u16] = &[0x0001];
+const PROFILE_2_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_2_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 22,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1263,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_2: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_2_CIPHERS,
+    supported_versions: PROFILE_2_VERSIONS,
+    supported_groups: PROFILE_2_GROUPS,
+    key_shares: PROFILE_2_KEY_SHARES,
+    signature_algorithms: PROFILE_2_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_2_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_2_ALPN,
+    certificate_compression_algorithms: PROFILE_2_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_2_APPS,
+    extensions: PROFILE_2_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_3_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02c, 0xc02b, 0xcca9, 0xc030, 0xc02f, 0xcca8, 0xc024, 0xc023,
+    0xc00a, 0xc009, 0xc028, 0xc027, 0xc014, 0xc013, 0x009d, 0x009c, 0x003d, 0x003c, 0x0035, 0x002f,
+    0xc008, 0xc012, 0x000a,
+];
+const PROFILE_3_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_3_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_3_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_3_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0203, 0x0805, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_3_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_3_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_3_CERT_COMP: &[u16] = &[];
+const PROFILE_3_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_3_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 190,
+    },
+];
+const PROFILE_3: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_3_CIPHERS,
+    supported_versions: PROFILE_3_VERSIONS,
+    supported_groups: PROFILE_3_GROUPS,
+    key_shares: PROFILE_3_KEY_SHARES,
+    signature_algorithms: PROFILE_3_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_3_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_3_ALPN,
+    certificate_compression_algorithms: PROFILE_3_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_3_APPS,
+    extensions: PROFILE_3_EXTENSIONS,
+    padding_length: Some(190),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_4_CIPHERS: &[u16] = &[
+    0xc02b, 0xc02c, 0xcca9, 0xc02f, 0xc030, 0xcca8, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_4_VERSIONS: &[u16] = &[];
+const PROFILE_4_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018];
+const PROFILE_4_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_4_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_4_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_4_ALPN: &[&[u8]] = &[];
+const PROFILE_4_CERT_COMP: &[u16] = &[];
+const PROFILE_4_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_4_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 8,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+];
+const PROFILE_4: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_4_CIPHERS,
+    supported_versions: PROFILE_4_VERSIONS,
+    supported_groups: PROFILE_4_GROUPS,
+    key_shares: PROFILE_4_KEY_SHARES,
+    signature_algorithms: PROFILE_4_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_4_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_4_ALPN,
+    certificate_compression_algorithms: PROFILE_4_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_4_APPS,
+    extensions: PROFILE_4_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_5_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_5_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_5_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_5_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_5_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_5_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_5_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_5_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_5_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_5_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 209,
+    },
+];
+const PROFILE_5: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_5_CIPHERS,
+    supported_versions: PROFILE_5_VERSIONS,
+    supported_groups: PROFILE_5_GROUPS,
+    key_shares: PROFILE_5_KEY_SHARES,
+    signature_algorithms: PROFILE_5_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_5_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_5_ALPN,
+    certificate_compression_algorithms: PROFILE_5_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_5_APPS,
+    extensions: PROFILE_5_EXTENSIONS,
+    padding_length: Some(209),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_6_CIPHERS: &[u16] = &[
+    0xc00a, 0xc014, 0x0039, 0x006b, 0x0035, 0x003d, 0xc007, 0xc009, 0xc023, 0xc011, 0xc013, 0xc027,
+    0x0033, 0x0067, 0x0032, 0x0005, 0x0004, 0x002f, 0x003c, 0x000a,
+];
+const PROFILE_6_VERSIONS: &[u16] = &[];
+const PROFILE_6_GROUPS: &[u16] = &[0x0017, 0x0018, 0x0019];
+const PROFILE_6_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_6_SIGALGS: &[u16] = &[
+    0x0401, 0x0501, 0x0201, 0x0403, 0x0503, 0x0203, 0x0402, 0x0202,
+];
+const PROFILE_6_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_6_ALPN: &[&[u8]] = &[b"spdy/2", b"spdy/3", b"spdy/3.1", b"http/1.1"];
+const PROFILE_6_CERT_COMP: &[u16] = &[];
+const PROFILE_6_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_6_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 8,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x3374,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 34,
+    },
+    UtlsExtension {
+        extension_type: 0x754f,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+];
+const PROFILE_6: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_6_CIPHERS,
+    supported_versions: PROFILE_6_VERSIONS,
+    supported_groups: PROFILE_6_GROUPS,
+    key_shares: PROFILE_6_KEY_SHARES,
+    signature_algorithms: PROFILE_6_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_6_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_6_ALPN,
+    certificate_compression_algorithms: PROFILE_6_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_6_APPS,
+    extensions: PROFILE_6_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_7_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_7_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_7_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_7_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_7_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_7_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_7_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_7_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_7_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_7_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_7_APP_0_PROTOCOLS,
+}];
+const PROFILE_7_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 200,
+    },
+];
+const PROFILE_7: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_7_CIPHERS,
+    supported_versions: PROFILE_7_VERSIONS,
+    supported_groups: PROFILE_7_GROUPS,
+    key_shares: PROFILE_7_KEY_SHARES,
+    signature_algorithms: PROFILE_7_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_7_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_7_ALPN,
+    certificate_compression_algorithms: PROFILE_7_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_7_APPS,
+    extensions: PROFILE_7_EXTENSIONS,
+    padding_length: Some(200),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_8_CIPHERS: &[u16] = &[
+    0x1302, 0x1301, 0x1303, 0xcca9, 0x009d, 0x003c, 0x009c, 0xc02f, 0xc02c, 0xcca8, 0xc027, 0xc023,
+    0xc030, 0xc02b, 0xc014, 0x002f, 0xc00a, 0xc013, 0xc009, 0xc012, 0x000a,
+];
+const PROFILE_8_VERSIONS: &[u16] = &[0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_8_GROUPS: &[u16] = &[0x11ec, 0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_8_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x11ec,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_8_SIGALGS: &[u16] = &[
+    0x0503, 0x0804, 0x0201, 0x0501, 0x0401, 0x0601, 0x0806, 0x0403, 0x0805,
+];
+const PROFILE_8_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_8_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_8_CERT_COMP: &[u16] = &[];
+const PROFILE_8_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_8_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1327,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 9,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+];
+const PROFILE_8: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_8_CIPHERS,
+    supported_versions: PROFILE_8_VERSIONS,
+    supported_groups: PROFILE_8_GROUPS,
+    key_shares: PROFILE_8_KEY_SHARES,
+    signature_algorithms: PROFILE_8_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_8_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_8_ALPN,
+    certificate_compression_algorithms: PROFILE_8_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_8_APPS,
+    extensions: PROFILE_8_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_9_CIPHERS: &[u16] = &[
+    0xc023, 0x003c, 0xc02f, 0x009d, 0xc02c, 0xcca8, 0xc02b, 0x009c, 0xc030, 0xc027, 0xc013, 0x000a,
+    0x0005, 0x0035, 0x002f, 0xc00a, 0xc011, 0xc014, 0xc009, 0xc007, 0xc012,
+];
+const PROFILE_9_VERSIONS: &[u16] = &[];
+const PROFILE_9_GROUPS: &[u16] = &[0x0017, 0x0018, 0x0019];
+const PROFILE_9_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_9_SIGALGS: &[u16] = &[0x0501, 0x0503, 0x0201, 0x0601, 0x0401, 0x0603, 0x0403];
+const PROFILE_9_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_9_ALPN: &[&[u8]] = &[];
+const PROFILE_9_CERT_COMP: &[u16] = &[];
+const PROFILE_9_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_9_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 8,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+];
+const PROFILE_9: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_9_CIPHERS,
+    supported_versions: PROFILE_9_VERSIONS,
+    supported_groups: PROFILE_9_GROUPS,
+    key_shares: PROFILE_9_KEY_SHARES,
+    signature_algorithms: PROFILE_9_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_9_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_9_ALPN,
+    certificate_compression_algorithms: PROFILE_9_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_9_APPS,
+    extensions: PROFILE_9_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_10_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_10_VERSIONS: &[u16] = &[0x0304, 0x0303];
+const PROFILE_10_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_10_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_10_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_10_DELEGATED_CREDENTIALS: &[u16] = &[0x0403, 0x0503, 0x0603, 0x0203];
+const PROFILE_10_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_10_CERT_COMP: &[u16] = &[];
+const PROFILE_10_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_10_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0022,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 107,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0xfe0d,
+        payload_len: 281,
+    },
+];
+const PROFILE_10: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_10_CIPHERS,
+    supported_versions: PROFILE_10_VERSIONS,
+    supported_groups: PROFILE_10_GROUPS,
+    key_shares: PROFILE_10_KEY_SHARES,
+    signature_algorithms: PROFILE_10_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_10_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_10_ALPN,
+    certificate_compression_algorithms: PROFILE_10_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_10_APPS,
+    extensions: PROFILE_10_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: Some(281),
+};
+
+const PROFILE_11_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_11_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_11_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_11_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_11_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_11_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_11_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_11_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_11_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_11_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_11_APP_0_PROTOCOLS,
+}];
+const PROFILE_11_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0xfe0d,
+        payload_len: 186,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 14,
+    },
+];
+const PROFILE_11: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_11_CIPHERS,
+    supported_versions: PROFILE_11_VERSIONS,
+    supported_groups: PROFILE_11_GROUPS,
+    key_shares: PROFILE_11_KEY_SHARES,
+    signature_algorithms: PROFILE_11_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_11_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_11_ALPN,
+    certificate_compression_algorithms: PROFILE_11_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_11_APPS,
+    extensions: PROFILE_11_EXTENSIONS,
+    padding_length: Some(14),
+    encrypted_client_hello_length: Some(186),
+};
+
+const PROFILE_12_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_12_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_12_GROUPS: &[u16] = &[0x0a0a, 0x11ec, 0x001d, 0x0017, 0x0018];
+const PROFILE_12_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x11ec,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_12_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_12_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_12_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_12_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_12_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_12_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_12_APP_0_PROTOCOLS,
+}];
+const PROFILE_12_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xfe0d,
+        payload_len: 186,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1263,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_12: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_12_CIPHERS,
+    supported_versions: PROFILE_12_VERSIONS,
+    supported_groups: PROFILE_12_GROUPS,
+    key_shares: PROFILE_12_KEY_SHARES,
+    signature_algorithms: PROFILE_12_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_12_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_12_ALPN,
+    certificate_compression_algorithms: PROFILE_12_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_12_APPS,
+    extensions: PROFILE_12_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: Some(186),
+};
+
+const PROFILE_13_CIPHERS: &[u16] = &[
+    0x1301, 0x1302, 0x1303, 0xc02c, 0xc02b, 0xc024, 0xc023, 0xc00a, 0xc009, 0xcca9, 0xc030, 0xc02f,
+    0xc028, 0xc027, 0xc014, 0xc013, 0xcca8, 0x009d, 0x009c, 0x003d, 0x003c, 0x0035, 0x002f, 0xc008,
+    0xc012, 0x000a,
+];
+const PROFILE_13_VERSIONS: &[u16] = &[0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_13_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_13_KEY_SHARES: &[UtlsKeyShare] = &[UtlsKeyShare {
+    group: 0x001d,
+    key_exchange_len: 32,
+}];
+const PROFILE_13_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0203, 0x0805, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_13_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_13_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_13_CERT_COMP: &[u16] = &[];
+const PROFILE_13_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_13_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 38,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 9,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 210,
+    },
+];
+const PROFILE_13: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_13_CIPHERS,
+    supported_versions: PROFILE_13_VERSIONS,
+    supported_groups: PROFILE_13_GROUPS,
+    key_shares: PROFILE_13_KEY_SHARES,
+    signature_algorithms: PROFILE_13_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_13_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_13_ALPN,
+    certificate_compression_algorithms: PROFILE_13_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_13_APPS,
+    extensions: PROFILE_13_EXTENSIONS,
+    padding_length: Some(210),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_14_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_14_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_14_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_14_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_14_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_14_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_14_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_14_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_14_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_14_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_14_APP_0_PROTOCOLS,
+}];
+const PROFILE_14_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 204,
+    },
+];
+const PROFILE_14: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_14_CIPHERS,
+    supported_versions: PROFILE_14_VERSIONS,
+    supported_groups: PROFILE_14_GROUPS,
+    key_shares: PROFILE_14_KEY_SHARES,
+    signature_algorithms: PROFILE_14_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_14_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_14_ALPN,
+    certificate_compression_algorithms: PROFILE_14_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_14_APPS,
+    extensions: PROFILE_14_EXTENSIONS,
+    padding_length: Some(204),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_15_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035, 0x000a,
+];
+const PROFILE_15_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_15_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_15_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_15_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_15_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_15_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_15_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_15_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_15_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x7550,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 201,
+    },
+];
+const PROFILE_15: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_15_CIPHERS,
+    supported_versions: PROFILE_15_VERSIONS,
+    supported_groups: PROFILE_15_GROUPS,
+    key_shares: PROFILE_15_KEY_SHARES,
+    signature_algorithms: PROFILE_15_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_15_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_15_ALPN,
+    certificate_compression_algorithms: PROFILE_15_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_15_APPS,
+    extensions: PROFILE_15_EXTENSIONS,
+    padding_length: Some(201),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_16_CIPHERS: &[u16] = &[
+    0xc023, 0x003c, 0xc02f, 0x009d, 0xc02c, 0xcca8, 0xc02b, 0x009c, 0xc030, 0xc027, 0xc013, 0x000a,
+    0x0005, 0x0035, 0x002f, 0xc00a, 0xc011, 0xc014, 0xc009, 0xc007, 0xc012,
+];
+const PROFILE_16_VERSIONS: &[u16] = &[];
+const PROFILE_16_GROUPS: &[u16] = &[0x0017, 0x0018, 0x0019];
+const PROFILE_16_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_16_SIGALGS: &[u16] = &[0x0501, 0x0503, 0x0201, 0x0601, 0x0401, 0x0603, 0x0403];
+const PROFILE_16_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_16_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_16_CERT_COMP: &[u16] = &[];
+const PROFILE_16_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_16_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 8,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+];
+const PROFILE_16: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_16_CIPHERS,
+    supported_versions: PROFILE_16_VERSIONS,
+    supported_groups: PROFILE_16_GROUPS,
+    key_shares: PROFILE_16_KEY_SHARES,
+    signature_algorithms: PROFILE_16_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_16_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_16_ALPN,
+    certificate_compression_algorithms: PROFILE_16_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_16_APPS,
+    extensions: PROFILE_16_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_17_CIPHERS: &[u16] = &[
+    0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013, 0xc014, 0x0033, 0x0039,
+    0x002f, 0x0035, 0x000a,
+];
+const PROFILE_17_VERSIONS: &[u16] = &[];
+const PROFILE_17_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_17_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_17_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_17_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_17_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_17_CERT_COMP: &[u16] = &[];
+const PROFILE_17_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_17_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+];
+const PROFILE_17: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_17_CIPHERS,
+    supported_versions: PROFILE_17_VERSIONS,
+    supported_groups: PROFILE_17_GROUPS,
+    key_shares: PROFILE_17_KEY_SHARES,
+    signature_algorithms: PROFILE_17_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_17_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_17_ALPN,
+    certificate_compression_algorithms: PROFILE_17_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_17_APPS,
+    extensions: PROFILE_17_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_18_CIPHERS: &[u16] = &[
+    0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013, 0xc014, 0x0033, 0x0039,
+    0x002f, 0x0035, 0x000a,
+];
+const PROFILE_18_VERSIONS: &[u16] = &[];
+const PROFILE_18_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_18_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_18_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_18_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_18_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_18_CERT_COMP: &[u16] = &[];
+const PROFILE_18_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_18_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+];
+const PROFILE_18: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_18_CIPHERS,
+    supported_versions: PROFILE_18_VERSIONS,
+    supported_groups: PROFILE_18_GROUPS,
+    key_shares: PROFILE_18_KEY_SHARES,
+    signature_algorithms: PROFILE_18_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_18_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_18_ALPN,
+    certificate_compression_algorithms: PROFILE_18_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_18_APPS,
+    extensions: PROFILE_18_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_19_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x0033, 0x0039, 0x002f, 0x0035, 0x000a,
+];
+const PROFILE_19_VERSIONS: &[u16] = &[0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_19_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_19_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_19_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_19_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_19_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_19_CERT_COMP: &[u16] = &[];
+const PROFILE_19_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_19_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 107,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 9,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 147,
+    },
+];
+const PROFILE_19: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_19_CIPHERS,
+    supported_versions: PROFILE_19_VERSIONS,
+    supported_groups: PROFILE_19_GROUPS,
+    key_shares: PROFILE_19_KEY_SHARES,
+    signature_algorithms: PROFILE_19_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_19_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_19_ALPN,
+    certificate_compression_algorithms: PROFILE_19_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_19_APPS,
+    extensions: PROFILE_19_EXTENSIONS,
+    padding_length: Some(147),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_20_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x0033, 0x0039, 0x002f, 0x0035, 0x000a,
+];
+const PROFILE_20_VERSIONS: &[u16] = &[0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_20_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_20_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_20_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_20_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_20_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_20_CERT_COMP: &[u16] = &[];
+const PROFILE_20_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_20_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 107,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 9,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 147,
+    },
+];
+const PROFILE_20: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_20_CIPHERS,
+    supported_versions: PROFILE_20_VERSIONS,
+    supported_groups: PROFILE_20_GROUPS,
+    key_shares: PROFILE_20_KEY_SHARES,
+    signature_algorithms: PROFILE_20_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_20_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_20_ALPN,
+    certificate_compression_algorithms: PROFILE_20_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_20_APPS,
+    extensions: PROFILE_20_EXTENSIONS,
+    padding_length: Some(147),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_21_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x009c, 0x009d, 0x002f, 0x0035, 0x000a,
+];
+const PROFILE_21_VERSIONS: &[u16] = &[0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_21_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_21_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_21_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_21_DELEGATED_CREDENTIALS: &[u16] = &[0x0403, 0x0503, 0x0603, 0x0203];
+const PROFILE_21_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_21_CERT_COMP: &[u16] = &[];
+const PROFILE_21_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_21_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0022,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 107,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 9,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 133,
+    },
+];
+const PROFILE_21: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_21_CIPHERS,
+    supported_versions: PROFILE_21_VERSIONS,
+    supported_groups: PROFILE_21_GROUPS,
+    key_shares: PROFILE_21_KEY_SHARES,
+    signature_algorithms: PROFILE_21_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_21_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_21_ALPN,
+    certificate_compression_algorithms: PROFILE_21_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_21_APPS,
+    extensions: PROFILE_21_EXTENSIONS,
+    padding_length: Some(133),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_22_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_22_VERSIONS: &[u16] = &[0x0304, 0x0303];
+const PROFILE_22_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_22_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_22_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_22_DELEGATED_CREDENTIALS: &[u16] = &[0x0403, 0x0503, 0x0603, 0x0203];
+const PROFILE_22_ALPN: &[&[u8]] = &[b"h2"];
+const PROFILE_22_CERT_COMP: &[u16] = &[];
+const PROFILE_22_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_22_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0022,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 107,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 148,
+    },
+];
+const PROFILE_22: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_22_CIPHERS,
+    supported_versions: PROFILE_22_VERSIONS,
+    supported_groups: PROFILE_22_GROUPS,
+    key_shares: PROFILE_22_KEY_SHARES,
+    signature_algorithms: PROFILE_22_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_22_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_22_ALPN,
+    certificate_compression_algorithms: PROFILE_22_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_22_APPS,
+    extensions: PROFILE_22_EXTENSIONS,
+    padding_length: Some(148),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_23_CIPHERS: &[u16] = &[
+    0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c, 0xc030, 0xc00a, 0xc009, 0xc013,
+    0xc014, 0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_23_VERSIONS: &[u16] = &[0x0304, 0x0303];
+const PROFILE_23_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019, 0x0100, 0x0101];
+const PROFILE_23_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+    UtlsKeyShare {
+        group: 0x0017,
+        key_exchange_len: 65,
+    },
+];
+const PROFILE_23_SIGALGS: &[u16] = &[
+    0x0403, 0x0503, 0x0603, 0x0804, 0x0805, 0x0806, 0x0401, 0x0501, 0x0601, 0x0203, 0x0201,
+];
+const PROFILE_23_DELEGATED_CREDENTIALS: &[u16] = &[0x0403, 0x0503, 0x0603, 0x0203];
+const PROFILE_23_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_23_CERT_COMP: &[u16] = &[];
+const PROFILE_23_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_23_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0022,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 107,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001c,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 139,
+    },
+];
+const PROFILE_23: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_23_CIPHERS,
+    supported_versions: PROFILE_23_VERSIONS,
+    supported_groups: PROFILE_23_GROUPS,
+    key_shares: PROFILE_23_KEY_SHARES,
+    signature_algorithms: PROFILE_23_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_23_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_23_ALPN,
+    certificate_compression_algorithms: PROFILE_23_CERT_COMP,
+    record_size_limit: Some(0x4001),
+    application_settings: PROFILE_23_APPS,
+    extensions: PROFILE_23_EXTENSIONS,
+    padding_length: Some(139),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_24_CIPHERS: &[u16] = &[
+    0x0a0a, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f,
+    0x0035, 0x000a,
+];
+const PROFILE_24_VERSIONS: &[u16] = &[];
+const PROFILE_24_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_24_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_24_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_24_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_24_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_24_CERT_COMP: &[u16] = &[];
+const PROFILE_24_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_24_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x7550,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_24: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_24_CIPHERS,
+    supported_versions: PROFILE_24_VERSIONS,
+    supported_groups: PROFILE_24_GROUPS,
+    key_shares: PROFILE_24_KEY_SHARES,
+    signature_algorithms: PROFILE_24_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_24_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_24_ALPN,
+    certificate_compression_algorithms: PROFILE_24_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_24_APPS,
+    extensions: PROFILE_24_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_25_CIPHERS: &[u16] = &[
+    0x0a0a, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f,
+    0x0035, 0x000a,
+];
+const PROFILE_25_VERSIONS: &[u16] = &[];
+const PROFILE_25_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_25_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_25_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_25_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_25_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_25_CERT_COMP: &[u16] = &[];
+const PROFILE_25_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_25_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x7550,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_25: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_25_CIPHERS,
+    supported_versions: PROFILE_25_VERSIONS,
+    supported_groups: PROFILE_25_GROUPS,
+    key_shares: PROFILE_25_KEY_SHARES,
+    signature_algorithms: PROFILE_25_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_25_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_25_ALPN,
+    certificate_compression_algorithms: PROFILE_25_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_25_APPS,
+    extensions: PROFILE_25_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_26_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035, 0x000a,
+];
+const PROFILE_26_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_26_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_26_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_26_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_26_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_26_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_26_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_26_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_26_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x7550,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 201,
+    },
+];
+const PROFILE_26: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_26_CIPHERS,
+    supported_versions: PROFILE_26_VERSIONS,
+    supported_groups: PROFILE_26_GROUPS,
+    key_shares: PROFILE_26_KEY_SHARES,
+    signature_algorithms: PROFILE_26_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_26_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_26_ALPN,
+    certificate_compression_algorithms: PROFILE_26_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_26_APPS,
+    extensions: PROFILE_26_EXTENSIONS,
+    padding_length: Some(201),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_27_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035, 0x000a,
+];
+const PROFILE_27_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_27_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_27_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_27_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_27_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_27_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_27_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_27_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_27_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 205,
+    },
+];
+const PROFILE_27: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_27_CIPHERS,
+    supported_versions: PROFILE_27_VERSIONS,
+    supported_groups: PROFILE_27_GROUPS,
+    key_shares: PROFILE_27_KEY_SHARES,
+    signature_algorithms: PROFILE_27_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_27_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_27_ALPN,
+    certificate_compression_algorithms: PROFILE_27_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_27_APPS,
+    extensions: PROFILE_27_EXTENSIONS,
+    padding_length: Some(205),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_28_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_28_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_28_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_28_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_28_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_28_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_28_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_28_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_28_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_28_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 209,
+    },
+];
+const PROFILE_28: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_28_CIPHERS,
+    supported_versions: PROFILE_28_VERSIONS,
+    supported_groups: PROFILE_28_GROUPS,
+    key_shares: PROFILE_28_KEY_SHARES,
+    signature_algorithms: PROFILE_28_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_28_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_28_ALPN,
+    certificate_compression_algorithms: PROFILE_28_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_28_APPS,
+    extensions: PROFILE_28_EXTENSIONS,
+    padding_length: Some(209),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_29_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_29_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_29_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_29_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_29_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_29_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_29_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_29_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_29_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_29_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 209,
+    },
+];
+const PROFILE_29: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_29_CIPHERS,
+    supported_versions: PROFILE_29_VERSIONS,
+    supported_groups: PROFILE_29_GROUPS,
+    key_shares: PROFILE_29_KEY_SHARES,
+    signature_algorithms: PROFILE_29_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_29_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_29_ALPN,
+    certificate_compression_algorithms: PROFILE_29_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_29_APPS,
+    extensions: PROFILE_29_EXTENSIONS,
+    padding_length: Some(209),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_30_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_30_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_30_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_30_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_30_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_30_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_30_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_30_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_30_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_30_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_30_APP_0_PROTOCOLS,
+}];
+const PROFILE_30_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 200,
+    },
+];
+const PROFILE_30: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_30_CIPHERS,
+    supported_versions: PROFILE_30_VERSIONS,
+    supported_groups: PROFILE_30_GROUPS,
+    key_shares: PROFILE_30_KEY_SHARES,
+    signature_algorithms: PROFILE_30_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_30_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_30_ALPN,
+    certificate_compression_algorithms: PROFILE_30_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_30_APPS,
+    extensions: PROFILE_30_EXTENSIONS,
+    padding_length: Some(200),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_31_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_31_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_31_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_31_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_31_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_31_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_31_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_31_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_31_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_31_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_31_APP_0_PROTOCOLS,
+}];
+const PROFILE_31_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 204,
+    },
+];
+const PROFILE_31: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_31_CIPHERS,
+    supported_versions: PROFILE_31_VERSIONS,
+    supported_groups: PROFILE_31_GROUPS,
+    key_shares: PROFILE_31_KEY_SHARES,
+    signature_algorithms: PROFILE_31_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_31_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_31_ALPN,
+    certificate_compression_algorithms: PROFILE_31_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_31_APPS,
+    extensions: PROFILE_31_EXTENSIONS,
+    padding_length: Some(204),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_32_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_32_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_32_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_32_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_32_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_32_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_32_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_32_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_32_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_32_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_32_APP_0_PROTOCOLS,
+}];
+const PROFILE_32_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 204,
+    },
+];
+const PROFILE_32: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_32_CIPHERS,
+    supported_versions: PROFILE_32_VERSIONS,
+    supported_groups: PROFILE_32_GROUPS,
+    key_shares: PROFILE_32_KEY_SHARES,
+    signature_algorithms: PROFILE_32_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_32_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_32_ALPN,
+    certificate_compression_algorithms: PROFILE_32_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_32_APPS,
+    extensions: PROFILE_32_EXTENSIONS,
+    padding_length: Some(204),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_33_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_33_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_33_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_33_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_33_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_33_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_33_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_33_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_33_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_33_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_33_APP_0_PROTOCOLS,
+}];
+const PROFILE_33_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 204,
+    },
+];
+const PROFILE_33: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_33_CIPHERS,
+    supported_versions: PROFILE_33_VERSIONS,
+    supported_groups: PROFILE_33_GROUPS,
+    key_shares: PROFILE_33_KEY_SHARES,
+    signature_algorithms: PROFILE_33_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_33_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_33_ALPN,
+    certificate_compression_algorithms: PROFILE_33_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_33_APPS,
+    extensions: PROFILE_33_EXTENSIONS,
+    padding_length: Some(204),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_34_CIPHERS: &[u16] = &[
+    0xc02c, 0xc02b, 0xc024, 0xc023, 0xc00a, 0xc009, 0xcca9, 0xc030, 0xc02f, 0xc028, 0xc027, 0xc014,
+    0xc013, 0xcca8, 0x009d, 0x009c, 0x003d, 0x003c, 0x0035, 0x002f,
+];
+const PROFILE_34_VERSIONS: &[u16] = &[];
+const PROFILE_34_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_34_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_34_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_34_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_34_ALPN: &[&[u8]] = &[
+    b"h2",
+    b"h2-16",
+    b"h2-15",
+    b"h2-14",
+    b"spdy/3.1",
+    b"spdy/3",
+    b"http/1.1",
+];
+const PROFILE_34_CERT_COMP: &[u16] = &[];
+const PROFILE_34_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_34_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 20,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x3374,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 48,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+];
+const PROFILE_34: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_34_CIPHERS,
+    supported_versions: PROFILE_34_VERSIONS,
+    supported_groups: PROFILE_34_GROUPS,
+    key_shares: PROFILE_34_KEY_SHARES,
+    signature_algorithms: PROFILE_34_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_34_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_34_ALPN,
+    certificate_compression_algorithms: PROFILE_34_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_34_APPS,
+    extensions: PROFILE_34_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_35_CIPHERS: &[u16] = &[
+    0xc02c, 0xc02b, 0xc024, 0xc023, 0xc00a, 0xc009, 0xcca9, 0xc030, 0xc02f, 0xc028, 0xc027, 0xc014,
+    0xc013, 0xcca8, 0x009d, 0x009c, 0x003d, 0x003c, 0x0035, 0x002f, 0xc008, 0xc012, 0x000a,
+];
+const PROFILE_35_VERSIONS: &[u16] = &[];
+const PROFILE_35_GROUPS: &[u16] = &[0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_35_KEY_SHARES: &[UtlsKeyShare] = &[];
+const PROFILE_35_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0203, 0x0805, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_35_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_35_ALPN: &[&[u8]] = &[
+    b"h2",
+    b"h2-16",
+    b"h2-15",
+    b"h2-14",
+    b"spdy/3.1",
+    b"spdy/3",
+    b"http/1.1",
+];
+const PROFILE_35_CERT_COMP: &[u16] = &[];
+const PROFILE_35_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_35_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x3374,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 48,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+];
+const PROFILE_35: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_35_CIPHERS,
+    supported_versions: PROFILE_35_VERSIONS,
+    supported_groups: PROFILE_35_GROUPS,
+    key_shares: PROFILE_35_KEY_SHARES,
+    signature_algorithms: PROFILE_35_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_35_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_35_ALPN,
+    certificate_compression_algorithms: PROFILE_35_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_35_APPS,
+    extensions: PROFILE_35_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_36_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02c, 0xc02b, 0xcca9, 0xc030, 0xc02f, 0xcca8, 0xc00a, 0xc009,
+    0xc014, 0xc013, 0x009d, 0x009c, 0x0035, 0x002f, 0xc008, 0xc012, 0x000a,
+];
+const PROFILE_36_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303, 0x0302, 0x0301];
+const PROFILE_36_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018, 0x0019];
+const PROFILE_36_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_36_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0203, 0x0805, 0x0805, 0x0501, 0x0806, 0x0601, 0x0201,
+];
+const PROFILE_36_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_36_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_36_CERT_COMP: &[u16] = &[0x0001];
+const PROFILE_36_APPS: &[UtlsApplicationSettings] = &[];
+const PROFILE_36_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 24,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 11,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 195,
+    },
+];
+const PROFILE_36: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_36_CIPHERS,
+    supported_versions: PROFILE_36_VERSIONS,
+    supported_groups: PROFILE_36_GROUPS,
+    key_shares: PROFILE_36_KEY_SHARES,
+    signature_algorithms: PROFILE_36_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_36_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_36_ALPN,
+    certificate_compression_algorithms: PROFILE_36_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_36_APPS,
+    extensions: PROFILE_36_EXTENSIONS,
+    padding_length: Some(195),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_37_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_37_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_37_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_37_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_37_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_37_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_37_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_37_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_37_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_37_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_37_APP_0_PROTOCOLS,
+}];
+const PROFILE_37_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_37: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_37_CIPHERS,
+    supported_versions: PROFILE_37_VERSIONS,
+    supported_groups: PROFILE_37_GROUPS,
+    key_shares: PROFILE_37_KEY_SHARES,
+    signature_algorithms: PROFILE_37_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_37_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_37_ALPN,
+    certificate_compression_algorithms: PROFILE_37_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_37_APPS,
+    extensions: PROFILE_37_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_38_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_38_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_38_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_38_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_38_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_38_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_38_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_38_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_38_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_38_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_38_APP_0_PROTOCOLS,
+}];
+const PROFILE_38_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_38: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_38_CIPHERS,
+    supported_versions: PROFILE_38_VERSIONS,
+    supported_groups: PROFILE_38_GROUPS,
+    key_shares: PROFILE_38_KEY_SHARES,
+    signature_algorithms: PROFILE_38_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_38_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_38_ALPN,
+    certificate_compression_algorithms: PROFILE_38_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_38_APPS,
+    extensions: PROFILE_38_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_39_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_39_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_39_GROUPS: &[u16] = &[0x0a0a, 0x001d, 0x0017, 0x0018];
+const PROFILE_39_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_39_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_39_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_39_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_39_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_39_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_39_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_39_APP_0_PROTOCOLS,
+}];
+const PROFILE_39_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 43,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 10,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x0015,
+        payload_len: 204,
+    },
+];
+const PROFILE_39: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_39_CIPHERS,
+    supported_versions: PROFILE_39_VERSIONS,
+    supported_groups: PROFILE_39_GROUPS,
+    key_shares: PROFILE_39_KEY_SHARES,
+    signature_algorithms: PROFILE_39_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_39_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_39_ALPN,
+    certificate_compression_algorithms: PROFILE_39_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_39_APPS,
+    extensions: PROFILE_39_EXTENSIONS,
+    padding_length: Some(204),
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_40_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_40_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_40_GROUPS: &[u16] = &[0x0a0a, 0x6399, 0x001d, 0x0017, 0x0018];
+const PROFILE_40_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x6399,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_40_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_40_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_40_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_40_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_40_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_40_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_40_APP_0_PROTOCOLS,
+}];
+const PROFILE_40_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1263,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_40: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_40_CIPHERS,
+    supported_versions: PROFILE_40_VERSIONS,
+    supported_groups: PROFILE_40_GROUPS,
+    key_shares: PROFILE_40_KEY_SHARES,
+    signature_algorithms: PROFILE_40_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_40_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_40_ALPN,
+    certificate_compression_algorithms: PROFILE_40_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_40_APPS,
+    extensions: PROFILE_40_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_41_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_41_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_41_GROUPS: &[u16] = &[0x0a0a, 0x6399, 0x001d, 0x0017, 0x0018];
+const PROFILE_41_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x6399,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_41_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_41_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_41_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_41_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_41_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_41_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_41_APP_0_PROTOCOLS,
+}];
+const PROFILE_41_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1263,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_41: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_41_CIPHERS,
+    supported_versions: PROFILE_41_VERSIONS,
+    supported_groups: PROFILE_41_GROUPS,
+    key_shares: PROFILE_41_KEY_SHARES,
+    signature_algorithms: PROFILE_41_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_41_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_41_ALPN,
+    certificate_compression_algorithms: PROFILE_41_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_41_APPS,
+    extensions: PROFILE_41_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: None,
+};
+
+const PROFILE_42_CIPHERS: &[u16] = &[
+    0x0a0a, 0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030, 0xcca9, 0xcca8, 0xc013, 0xc014,
+    0x009c, 0x009d, 0x002f, 0x0035,
+];
+const PROFILE_42_VERSIONS: &[u16] = &[0x0a0a, 0x0304, 0x0303];
+const PROFILE_42_GROUPS: &[u16] = &[0x0a0a, 0x6399, 0x001d, 0x0017, 0x0018];
+const PROFILE_42_KEY_SHARES: &[UtlsKeyShare] = &[
+    UtlsKeyShare {
+        group: 0x0a0a,
+        key_exchange_len: 1,
+    },
+    UtlsKeyShare {
+        group: 0x6399,
+        key_exchange_len: 1216,
+    },
+    UtlsKeyShare {
+        group: 0x001d,
+        key_exchange_len: 32,
+    },
+];
+const PROFILE_42_SIGALGS: &[u16] = &[
+    0x0403, 0x0804, 0x0401, 0x0503, 0x0805, 0x0501, 0x0806, 0x0601,
+];
+const PROFILE_42_DELEGATED_CREDENTIALS: &[u16] = &[];
+const PROFILE_42_ALPN: &[&[u8]] = &[b"h2", b"http/1.1"];
+const PROFILE_42_CERT_COMP: &[u16] = &[0x0002];
+const PROFILE_42_APP_0_PROTOCOLS: &[&[u8]] = &[b"h2"];
+const PROFILE_42_APPS: &[UtlsApplicationSettings] = &[UtlsApplicationSettings {
+    extension_type: 0x4469,
+    protocols: PROFILE_42_APP_0_PROTOCOLS,
+}];
+const PROFILE_42_EXTENSIONS: &[UtlsExtension] = &[
+    UtlsExtension {
+        extension_type: GREASE,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xfe0d,
+        payload_len: 186,
+    },
+    UtlsExtension {
+        extension_type: 0x002d,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x4469,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x000d,
+        payload_len: 18,
+    },
+    UtlsExtension {
+        extension_type: 0x002b,
+        payload_len: 7,
+    },
+    UtlsExtension {
+        extension_type: 0x0023,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x0033,
+        payload_len: 1263,
+    },
+    UtlsExtension {
+        extension_type: 0x0000,
+        payload_len: 16,
+    },
+    UtlsExtension {
+        extension_type: 0x0005,
+        payload_len: 5,
+    },
+    UtlsExtension {
+        extension_type: 0x0010,
+        payload_len: 14,
+    },
+    UtlsExtension {
+        extension_type: 0x0017,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0xff01,
+        payload_len: 1,
+    },
+    UtlsExtension {
+        extension_type: 0x000b,
+        payload_len: 2,
+    },
+    UtlsExtension {
+        extension_type: 0x001b,
+        payload_len: 3,
+    },
+    UtlsExtension {
+        extension_type: 0x0012,
+        payload_len: 0,
+    },
+    UtlsExtension {
+        extension_type: 0x000a,
+        payload_len: 12,
+    },
+    UtlsExtension {
+        extension_type: GREASE_SECOND,
+        payload_len: 1,
+    },
+];
+const PROFILE_42: UtlsClientHelloProfile = UtlsClientHelloProfile {
+    cipher_suites: PROFILE_42_CIPHERS,
+    supported_versions: PROFILE_42_VERSIONS,
+    supported_groups: PROFILE_42_GROUPS,
+    key_shares: PROFILE_42_KEY_SHARES,
+    signature_algorithms: PROFILE_42_SIGALGS,
+    delegated_credentials_algorithms: PROFILE_42_DELEGATED_CREDENTIALS,
+    alpn_protocols: PROFILE_42_ALPN,
+    certificate_compression_algorithms: PROFILE_42_CERT_COMP,
+    record_size_limit: None,
+    application_settings: PROFILE_42_APPS,
+    extensions: PROFILE_42_EXTENSIONS,
+    padding_length: None,
+    encrypted_client_hello_length: Some(186),
+};
+
+pub(super) fn profile_for_fingerprint(
+    fingerprint: &str,
+) -> Option<&'static UtlsClientHelloProfile> {
+    match fingerprint {
+        "chrome" => Some(&PROFILE_0),
+        "hellochrome_133" => Some(&PROFILE_0),
+        "hellochrome_auto" => Some(&PROFILE_0),
+        "firefox" => Some(&PROFILE_1),
+        "hellofirefox_148" => Some(&PROFILE_1),
+        "hellofirefox_auto" => Some(&PROFILE_1),
+        "safari" => Some(&PROFILE_2),
+        "hellosafari_26_3" => Some(&PROFILE_2),
+        "hellosafari_auto" => Some(&PROFILE_2),
+        "ios" => Some(&PROFILE_3),
+        "helloios_14" => Some(&PROFILE_3),
+        "helloios_auto" => Some(&PROFILE_3),
+        "android" => Some(&PROFILE_4),
+        "helloandroid_11_okhttp" => Some(&PROFILE_4),
+        "edge" => Some(&PROFILE_5),
+        "helloedge_85" => Some(&PROFILE_5),
+        "helloedge_auto" => Some(&PROFILE_5),
+        "360" => Some(&PROFILE_6),
+        "hello360_auto" => Some(&PROFILE_6),
+        "hello360_7_5" => Some(&PROFILE_6),
+        "qq" => Some(&PROFILE_7),
+        "helloqq_11_1" => Some(&PROFILE_7),
+        "helloqq_auto" => Some(&PROFILE_7),
+        "random" => Some(&PROFILE_8),
+        "randomized" => Some(&PROFILE_8),
+        "hellorandomized" => Some(&PROFILE_8),
+        "randomizednoalpn" => Some(&PROFILE_9),
+        "hellorandomizednoalpn" => Some(&PROFILE_9),
+        "hellofirefox_120" => Some(&PROFILE_10),
+        "hellochrome_120" => Some(&PROFILE_11),
+        "hellochrome_131" => Some(&PROFILE_12),
+        "helloios_13" => Some(&PROFILE_13),
+        "helloedge_106" => Some(&PROFILE_14),
+        "hello360_11_0" => Some(&PROFILE_15),
+        "hellorandomizedalpn" => Some(&PROFILE_16),
+        "hellofirefox_55" => Some(&PROFILE_17),
+        "hellofirefox_56" => Some(&PROFILE_18),
+        "hellofirefox_63" => Some(&PROFILE_19),
+        "hellofirefox_65" => Some(&PROFILE_20),
+        "hellofirefox_99" => Some(&PROFILE_21),
+        "hellofirefox_102" => Some(&PROFILE_22),
+        "hellofirefox_105" => Some(&PROFILE_23),
+        "hellochrome_58" => Some(&PROFILE_24),
+        "hellochrome_62" => Some(&PROFILE_25),
+        "hellochrome_70" => Some(&PROFILE_26),
+        "hellochrome_72" => Some(&PROFILE_27),
+        "hellochrome_83" => Some(&PROFILE_28),
+        "hellochrome_87" => Some(&PROFILE_29),
+        "hellochrome_96" => Some(&PROFILE_30),
+        "hellochrome_100" => Some(&PROFILE_31),
+        "hellochrome_102" => Some(&PROFILE_32),
+        "hellochrome_106_shuffle" => Some(&PROFILE_33),
+        "helloios_11_1" => Some(&PROFILE_34),
+        "helloios_12_1" => Some(&PROFILE_35),
+        "hellosafari_16_0" => Some(&PROFILE_36),
+        "hellochrome_100_psk" => Some(&PROFILE_37),
+        "hellochrome_112_psk_shuf" => Some(&PROFILE_38),
+        "hellochrome_114_padding_psk_shuf" => Some(&PROFILE_39),
+        "hellochrome_115_pq" => Some(&PROFILE_40),
+        "hellochrome_115_pq_psk" => Some(&PROFILE_41),
+        "hellochrome_120_pq" => Some(&PROFILE_42),
+        _ => None,
+    }
+}

--- a/third_party/xray-transport/src/tls.rs
+++ b/third_party/xray-transport/src/tls.rs
@@ -1,0 +1,209 @@
+use std::{
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{crypto, DigitallySignedStruct, Error as RustlsError, SignatureScheme};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_rustls::TlsConnector as TokioTlsConnector;
+use xray_routing::{Target, TargetAddr};
+
+use crate::{
+    connect_tcp_stream, BoxedTransportStream, SocketProtector, TlsClientConfig, TransportError,
+    TransportStream,
+};
+
+#[derive(Clone)]
+pub struct TlsConnector {
+    client_config: Arc<rustls::ClientConfig>,
+    insecure_client_config: Arc<rustls::ClientConfig>,
+    socket_protector: Option<Arc<dyn SocketProtector>>,
+}
+
+impl std::fmt::Debug for TlsConnector {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TlsConnector")
+            .field("socket_protector", &self.socket_protector.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TlsConnector {
+    pub fn system() -> Result<Self, TransportError> {
+        let root_store = rustls::RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
+        let client_config = rustls_client_config(root_store)?;
+
+        Ok(Self {
+            client_config: Arc::new(client_config),
+            insecure_client_config: Arc::new(insecure_rustls_client_config()?),
+            socket_protector: None,
+        })
+    }
+
+    pub fn with_client_config(client_config: Arc<rustls::ClientConfig>) -> Self {
+        Self {
+            insecure_client_config: Arc::clone(&client_config),
+            client_config,
+            socket_protector: None,
+        }
+    }
+
+    pub fn with_socket_protector(mut self, protector: Arc<dyn SocketProtector>) -> Self {
+        self.socket_protector = Some(protector);
+        self
+    }
+
+    pub async fn connect_stream(
+        &self,
+        stream: BoxedTransportStream,
+        config: &TlsClientConfig,
+    ) -> Result<BoxedTransportStream, TransportError> {
+        let server_name = tls_server_name(config)?;
+        self.connect_stream_with_server_name(stream, config, server_name)
+            .await
+    }
+
+    pub async fn connect(
+        &self,
+        target: &Target,
+        config: &TlsClientConfig,
+    ) -> Result<BoxedTransportStream, TransportError> {
+        let server_name = tls_server_name(config)?;
+
+        let addr = match &target.addr {
+            TargetAddr::Ip(ip) => SocketAddr::new(*ip, target.port),
+            TargetAddr::Domain(domain) => return Err(TransportError::NeedsDns(domain.clone())),
+        };
+
+        let stream = connect_tcp_stream(addr, self.socket_protector.as_deref()).await?;
+        self.connect_stream_with_server_name(Box::new(stream), config, server_name)
+            .await
+    }
+
+    async fn connect_stream_with_server_name(
+        &self,
+        stream: BoxedTransportStream,
+        config: &TlsClientConfig,
+        server_name: ServerName<'static>,
+    ) -> Result<BoxedTransportStream, TransportError> {
+        let client_config = if config.allow_insecure {
+            &self.insecure_client_config
+        } else {
+            &self.client_config
+        };
+        let stream = TokioTlsConnector::from(Arc::clone(client_config))
+            .connect(server_name, stream)
+            .await
+            .map_err(TransportError::Tls)?;
+
+        Ok(Box::new(stream))
+    }
+}
+
+fn tls_server_name(config: &TlsClientConfig) -> Result<ServerName<'static>, TransportError> {
+    ServerName::try_from(config.server_name.clone())
+        .map_err(|_| TransportError::InvalidTlsServerName(config.server_name.clone()))
+}
+
+impl TransportStream for tokio_rustls::client::TlsStream<BoxedTransportStream> {
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        AsyncRead::poll_read(self, cx, output)
+    }
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        AsyncWrite::poll_write(self, cx, input)
+    }
+}
+
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        let provider = crypto::ring::default_provider();
+        crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        let provider = crypto::ring::default_provider();
+        crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn rustls_client_config(
+    root_store: rustls::RootCertStore,
+) -> Result<rustls::ClientConfig, TransportError> {
+    rustls::ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        .with_safe_default_protocol_versions()
+        .map_err(|error| TransportError::TlsConfig(error.to_string()))
+        .map(|builder| {
+            builder
+                .with_root_certificates(root_store)
+                .with_no_client_auth()
+        })
+}
+
+fn insecure_rustls_client_config() -> Result<rustls::ClientConfig, TransportError> {
+    rustls::ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        .with_safe_default_protocol_versions()
+        .map_err(|error| TransportError::TlsConfig(error.to_string()))
+        .map(|builder| {
+            builder
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+                .with_no_client_auth()
+        })
+}


### PR DESCRIPTION
## 变更背景

当前项目虽然已能解析部分 REALITY 相关参数，但缺少可与官方 Xray 双向互操作的完整客户端、服务端和入站协议链路，部分组合还可能在配置存在时退回普通传输。此变更把 REALITY 作为独立、可验证、失败即关闭的安全传输实现，并以固定版本的官方 Xray 作为兼容基准。

## 主要实现

### REALITY 核心协议

- 新增独立的 `core-reality` crate，实现客户端与服务端完整握手、记录层和异步流接口。
- 支持 X25519 与 X25519MLKEM768 两类密钥交换组。
- 支持 ML-DSA-65 认证、短标识、版本范围、时钟差校验和抗重放约束。
- 支持分片 ClientHello、握手缓存、半关闭和透明回落。
- 认证失败时按配置转发到伪装目标；不存在普通 TLS 或明文占位回退。
- 对握手长度、并发、缓存、回落速率、上传和下载速率等资源设置严格上限。

### 客户端

- 完整注册 `publicKey`、`shortId`、`serverName`、`fingerprint`、`spiderX`、`mldsa65Verify`、版本和时钟相关字段及常用别名。
- 支持 X25519 与混合后量子组的客户端握手。
- 支持 uTLS 指纹及与官方 Xray 相同的浏览器指纹选择语义。
- `SpiderX` 使用握手后的同一条 TLS 连接执行伪装访问，不会额外创建第二条可被关联的 TCP 连接。
- 支持请求头、Cookie、并发数、访问次数、延迟、同源重定向和链接抓取，并对所有队列与抓取规模设置上限。

### 服务端与 VLESS 内层协议

- 新增结构化 REALITY 监听配置并在运行时正式启动监听器。
- 支持私钥、服务端名称、短标识、目标地址、PROXY protocol、版本范围、时钟差、ML-DSA-65 种子、回落带宽和资源限制等字段。
- 新增协议无关的 `serve_vless_stream` 公共入口，使任意已认证的异步字节流都能复用同一套 VLESS 服务端。
- VLESS 服务端支持命令 1 的 TCP、命令 2 的 UDP、命令 3 的 `mux.cool`，并覆盖普通 UDP、XUDP 多目标会话、半关闭、会话生命周期和有界队列。
- 逻辑源地址与真实对端地址分离，为后续可信代理头和其他外层传输组合提供正确语义。

### 配置与运行时

- 为 YAML、节点 URI、运行时计划和出站注册表补齐 REALITY 客户端与服务端字段。
- 对未知字段、冲突别名、非法密钥、非法短标识、无效目标、越界版本和不安全资源上限统一失败关闭。
- 日志与调试输出对私钥、种子和其他秘密进行脱敏。
- 将出站套接字标记与解析器、QUIC 及相关协议的连接路径统一，避免在 TUN 环境中产生路由回环。

## 第三方来源与可复现性

- 固定并收录 `xray-transport` 上游提交 `bb3e00da1abfc5fff70487b0dd2ba16054797584`。
- 提供上游来源、许可证、补丁清单和变更说明。
- vendored 源码已与固定上游逐文件比对，仅文档列出的三个补丁文件存在预期差异。

## 兼容性验证

- 官方 Xray 26.7.11（提交 `6e3322d219140a025285ded1114fe17a5edb74d8`）双向互操作共 4 组全部通过：
  - WutherCore 客户端到 Xray 服务端：X25519。
  - WutherCore 客户端到 Xray 服务端：X25519MLKEM768 与 ML-DSA-65。
  - Xray 客户端到 WutherCore 服务端：X25519。
  - Xray 客户端到 WutherCore 服务端：X25519MLKEM768 与 ML-DSA-65。
- `core-reality` 104 项测试通过，另含同连接 SpiderX 与透明回落集成测试。
- vendored `xray-transport` 5 项测试通过。
- `core-config` 51 项、`core-inbound` 34 项、`core-outbound` 223 项、`core-fetch` 8 项、`core-resolver` 84 项测试全部通过。
- `cargo check -p wuther-core` 与 `cargo test --workspace --no-run` 通过。
- 格式检查、暂存差异检查和 vendored 源码审计通过。

## 使用影响

用户现在可以配置真实的 VLESS-over-REALITY 客户端和服务端，并获得与官方 Xray 一致的两类密钥交换、后量子认证、透明回落、SpiderX 和资源保护行为。REALITY 与 XHTTP、gRPC 等复合 carrier 在各自独立分支完成组合接线；本分支对尚未接线的组合明确失败关闭，不会静默降级为普通 TCP 或 TLS。
