### PR TITLE
feat(capture): 完成 Linux TUN auto_redirect 混合数据面

### DIFF
--- a/crates/core-capture/src/engine.rs
+++ b/crates/core-capture/src/engine.rs
@@ -9,6 +9,7 @@ use std::{
 use async_trait::async_trait;
 use core_config::model::{
     Capture, CaptureMethod, CaptureStack, CaptureTraffic, TunHttpProxyOptions,
+    normalize_auto_redirect_mark,
 };
 use serde::Serialize;
 use thiserror::Error;
@@ -128,33 +129,36 @@ impl CapturePlan {
     /// 由 [`Capture`] 配置 + 平台决议得到的执行计划。
     pub fn from_config(c: &Capture) -> Result<Self, CaptureError> {
         let kind = decide_kind(c)?;
-        let mut excludes: Vec<ipnet::IpNet> = c
-            .exclude
-            .cidr
-            .iter()
-            .filter_map(|s| s.parse().ok())
-            .collect();
+        let mut excludes = parse_cidr_list("capture.exclude.cidr", &c.exclude.cidr, c.on)?;
         // §9.1：默认排除 Tailnet。
         for s in ["100.64.0.0/10", "fd7a:115c:a1e0::/48"] {
-            if let Ok(n) = s.parse() {
-                if !excludes.contains(&n) {
-                    excludes.push(n);
-                }
+            let n = s.parse().expect("static Tailnet CIDR must be valid");
+            if !excludes.contains(&n) {
+                excludes.push(n);
             }
         }
 
         // 解析 sing-box `address` 列表 —— 首条 v4 + 首条 v6 生效。
-        let (mut tun_v4, mut tun_v6) = (
-            "198.18.0.0/15".parse::<ipnet::Ipv4Net>().unwrap(),
-            "fc00:1::/64".parse::<ipnet::Ipv6Net>().unwrap(),
-        );
-        for s in &c.tun.address {
+        let mut tun_v4: Option<ipnet::Ipv4Net> = None;
+        let mut tun_v6: Option<ipnet::Ipv6Net> = None;
+        for (index, s) in c.tun.address.iter().enumerate() {
             if let Ok(n) = s.parse::<ipnet::Ipv4Net>() {
-                tun_v4 = n;
-            } else if let Ok(n) = s.parse::<ipnet::Ipv6Net>() {
-                tun_v6 = n;
+                tun_v4.get_or_insert(n);
+                continue;
+            }
+            if let Ok(n) = s.parse::<ipnet::Ipv6Net>() {
+                tun_v6.get_or_insert(n);
+                continue;
+            }
+            if c.on {
+                return Err(CaptureError::Route(format!(
+                    "capture.tun.address[{index}] 不是合法的 IPv4/IPv6 CIDR: {s}"
+                )));
             }
         }
+        let tun_v4 =
+            tun_v4.unwrap_or_else(|| "198.18.0.0/15".parse().expect("static IPv4 TUN CIDR"));
+        let tun_v6 = tun_v6.unwrap_or_else(|| "fc00:1::/64".parse().expect("static IPv6 TUN CIDR"));
         let tun_v6: Option<ipnet::Ipv6Net> = if c.tun.inet6 { Some(tun_v6) } else { None };
 
         let interface_name = c
@@ -163,14 +167,18 @@ impl CapturePlan {
             .clone()
             .unwrap_or_else(default_iface_name);
 
-        let route_addresses = parse_cidr_list(&c.tun.route_address);
-        let route_exclude_addresses = parse_cidr_list(&c.tun.route_exclude_address);
-        let loopback_addresses = c
-            .tun
-            .loopback_address
-            .iter()
-            .filter_map(|s| s.parse().ok())
-            .collect();
+        let route_addresses =
+            parse_cidr_list("capture.tun.route_address", &c.tun.route_address, c.on)?;
+        let route_exclude_addresses = parse_cidr_list(
+            "capture.tun.route_exclude_address",
+            &c.tun.route_exclude_address,
+            c.on,
+        )?;
+        let loopback_addresses = parse_ip_list(
+            "capture.tun.loopback_address",
+            &c.tun.loopback_address,
+            c.on,
+        )?;
 
         // 配置缺省时回填 sing-tun 默认值；与 mihomo `listener/sing_tun/server.go::202-221`
         // 一致——0 视为未设置，回退到 `tun.DefaultXxx` 常量。
@@ -181,28 +189,39 @@ impl CapturePlan {
                 _ => default_v,
             }
         }
+        fn mark_or_default(
+            field: &str,
+            value: Option<&str>,
+            default: u32,
+            strict: bool,
+        ) -> Result<u32, CaptureError> {
+            match normalize_auto_redirect_mark(value, default) {
+                Some(mark) => Ok(mark),
+                None if !strict => Ok(default),
+                None => Err(CaptureError::Nat(format!(
+                    "{field} 不是合法的 u32/十六进制 mark"
+                ))),
+            }
+        }
         let auto_redirect_marks = AutoRedirectMarks {
-            input: Some(nonzero_or(
-                c.tun
-                    .auto_redirect_input_mark
-                    .as_deref()
-                    .and_then(parse_hex_mark),
+            input: Some(mark_or_default(
+                "capture.tun.auto_redirect_input_mark",
+                c.tun.auto_redirect_input_mark.as_deref(),
                 core_config::model::DEFAULT_AUTO_REDIRECT_INPUT_MARK,
-            )),
-            output: Some(nonzero_or(
-                c.tun
-                    .auto_redirect_output_mark
-                    .as_deref()
-                    .and_then(parse_hex_mark),
+                c.on,
+            )?),
+            output: Some(mark_or_default(
+                "capture.tun.auto_redirect_output_mark",
+                c.tun.auto_redirect_output_mark.as_deref(),
                 core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK,
-            )),
-            reset: Some(nonzero_or(
-                c.tun
-                    .auto_redirect_reset_mark
-                    .as_deref()
-                    .and_then(parse_hex_mark),
+                c.on,
+            )?),
+            reset: Some(mark_or_default(
+                "capture.tun.auto_redirect_reset_mark",
+                c.tun.auto_redirect_reset_mark.as_deref(),
                 core_config::model::DEFAULT_AUTO_REDIRECT_RESET_MARK,
-            )),
+                c.on,
+            )?),
             nfqueue: Some(nonzero_or(
                 c.tun.auto_redirect_nfqueue,
                 core_config::model::DEFAULT_AUTO_REDIRECT_NFQUEUE,
@@ -217,13 +236,29 @@ impl CapturePlan {
             include_interface: c.tun.include_interface.clone(),
             exclude_interface: c.tun.exclude_interface.clone(),
             include_uid: c.tun.include_uid.clone(),
-            include_uid_range: parse_uid_ranges(&c.tun.include_uid_range),
+            include_uid_range: parse_uid_ranges(
+                "capture.tun.include_uid_range",
+                &c.tun.include_uid_range,
+                c.on,
+            )?,
             exclude_uid: c.tun.exclude_uid.clone(),
-            exclude_uid_range: parse_uid_ranges(&c.tun.exclude_uid_range),
+            exclude_uid_range: parse_uid_ranges(
+                "capture.tun.exclude_uid_range",
+                &c.tun.exclude_uid_range,
+                c.on,
+            )?,
             include_gid: c.tun.include_gid.clone(),
-            include_gid_range: parse_uid_ranges(&c.tun.include_gid_range),
+            include_gid_range: parse_uid_ranges(
+                "capture.tun.include_gid_range",
+                &c.tun.include_gid_range,
+                c.on,
+            )?,
             exclude_gid: c.tun.exclude_gid.clone(),
-            exclude_gid_range: parse_uid_ranges(&c.tun.exclude_gid_range),
+            exclude_gid_range: parse_uid_ranges(
+                "capture.tun.exclude_gid_range",
+                &c.tun.exclude_gid_range,
+                c.on,
+            )?,
             include_android_user: c.tun.include_android_user.clone(),
             include_package: c.tun.include_package.clone(),
             exclude_package: c.tun.exclude_package.clone(),
@@ -319,29 +354,61 @@ impl CapturePlan {
     }
 }
 
-fn parse_cidr_list(items: &[String]) -> Vec<ipnet::IpNet> {
-    items.iter().filter_map(|s| s.parse().ok()).collect()
-}
-
-/// `"start:end"` → `(start, end)`。
-fn parse_uid_ranges(items: &[String]) -> Vec<(u32, u32)> {
+fn parse_cidr_list(
+    field: &str,
+    items: &[String],
+    strict: bool,
+) -> Result<Vec<ipnet::IpNet>, CaptureError> {
     items
         .iter()
-        .filter_map(|s| {
-            let (a, b) = s.split_once(':')?;
-            Some((a.parse().ok()?, b.parse().ok()?))
+        .enumerate()
+        .filter_map(|(index, value)| match value.parse() {
+            Ok(network) => Some(Ok(network)),
+            Err(_) if !strict => None,
+            Err(_) => Some(Err(CaptureError::Route(format!(
+                "{field}[{index}] 不是合法的 CIDR: {value}"
+            )))),
         })
         .collect()
 }
 
-/// `"0x2023"` 或 `"8227"` → `0x2023`。
-fn parse_hex_mark(s: &str) -> Option<u32> {
-    let s = s.trim();
-    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
-        u32::from_str_radix(rest, 16).ok()
-    } else {
-        s.parse().ok()
-    }
+fn parse_ip_list(field: &str, items: &[String], strict: bool) -> Result<Vec<IpAddr>, CaptureError> {
+    items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| match value.parse() {
+            Ok(address) => Some(Ok(address)),
+            Err(_) if !strict => None,
+            Err(_) => Some(Err(CaptureError::Route(format!(
+                "{field}[{index}] 不是合法的 IP 地址: {value}"
+            )))),
+        })
+        .collect()
+}
+
+/// `"start:end"` → `(start, end)`。
+fn parse_uid_ranges(
+    field: &str,
+    items: &[String],
+    strict: bool,
+) -> Result<Vec<(u32, u32)>, CaptureError> {
+    items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| {
+            let parsed = value
+                .split_once(':')
+                .and_then(|(start, end)| Some((start.parse().ok()?, end.parse().ok()?)))
+                .filter(|(start, end)| start <= end);
+            match parsed {
+                Some(range) => Some(Ok(range)),
+                None if !strict => None,
+                None => Some(Err(CaptureError::Route(format!(
+                    "{field}[{index}] 必须是 start:end 闭区间且 start <= end: {value}"
+                )))),
+            }
+        })
+        .collect()
 }
 
 fn default_mtu(kind: EngineKind) -> u32 {
@@ -417,7 +484,28 @@ pub trait CaptureEngine: Send + Sync {
         events: mpsc::Sender<CaptureEvent>,
         runtime: Arc<core_runtime::Runtime>,
     ) -> Result<(), CaptureError>;
+    /// 第二阶段激活入口规则。
+    ///
+    /// TUN 后端必须先让 dispatcher 接管设备读写，再把系统流量导入数据面；
+    /// 默认实现为空，只有需要这种两阶段事务的后端才覆写。实现必须能处理
+    /// 任意部分启动状态：失败时保留仍归本进程所有的资源账本，允许清理后重试。
+    async fn post_start(
+        self: Arc<Self>,
+        _events: mpsc::Sender<CaptureEvent>,
+        _runtime: Arc<core_runtime::Runtime>,
+    ) -> Result<(), CaptureError> {
+        Ok(())
+    }
+    /// 在 dispatcher 停止前撤销平台入口。
+    ///
+    /// 需要内核导流规则的后端必须先停止接收新流量，才能安全拆除承载
+    /// 数据面的 dispatcher。实现必须幂等，并在部分清理失败时保留未撤销的
+    /// 所有权账本，后续调用只重试残余资源。默认实现为空。
+    async fn pre_stop(self: Arc<Self>) -> Result<(), CaptureError> {
+        Ok(())
+    }
     /// 优雅停止：撤销路由 / 清除防火墙规则 / 关 TUN。
+    /// 实现必须可重复调用，并安全处理 `start` / `post_start` 的部分成功状态。
     async fn stop(self: Arc<Self>) -> Result<(), CaptureError>;
     /// （仅 TUN engine）返回底层 `TunIo` 设备，供 user-stack / UDP forwarder 直接读写。
     /// 默认 None —— Tproxy/Redirect 等不需要直接访问 TUN。
@@ -541,6 +629,21 @@ mod tests {
     }
 
     #[test]
+    fn first_tun_address_per_family_wins() {
+        let mut c = base();
+        c.tun.address = vec![
+            "172.19.0.1/30".into(),
+            "172.20.0.1/30".into(),
+            "fdfe:dcba:9876::1/126".into(),
+            "fdfe:dcba:9877::1/126".into(),
+        ];
+        let plan = CapturePlan::from_config(&c).unwrap();
+
+        assert_eq!(plan.tun_v4_addr_cidr(), "172.19.0.1/30");
+        assert_eq!(plan.tun_v6_addr_cidr().unwrap(), "fdfe:dcba:9876::1/126");
+    }
+
+    #[test]
     fn route_allows_with_blacklist() {
         let mut c = base();
         c.tun.route_exclude_address = vec!["192.168.0.0/16".into()];
@@ -559,18 +662,24 @@ mod tests {
     }
 
     #[test]
-    fn parses_decimal_marks_too() {
-        assert_eq!(parse_hex_mark("0x2023"), Some(0x2023));
-        assert_eq!(parse_hex_mark("8227"), Some(8227));
-        assert_eq!(parse_hex_mark("garbage"), None);
+    fn parses_decimal_marks_and_normalizes_zero() {
+        assert_eq!(
+            normalize_auto_redirect_mark(Some("0x2023"), 7),
+            Some(0x2023)
+        );
+        assert_eq!(normalize_auto_redirect_mark(Some("8227"), 7), Some(8227));
+        assert_eq!(normalize_auto_redirect_mark(Some("0"), 7), Some(7));
+        assert_eq!(normalize_auto_redirect_mark(Some("garbage"), 7), None);
     }
 
     #[test]
     fn parses_uid_range() {
         assert_eq!(
-            parse_uid_ranges(&["1000:99999".into(), "bad".into(), "0:10".into()]),
+            parse_uid_ranges("test.range", &["1000:99999".into(), "0:10".into()], true).unwrap(),
             vec![(1000, 99999), (0, 10)]
         );
+        assert!(parse_uid_ranges("test.range", &["bad".into()], true).is_err());
+        assert!(parse_uid_ranges("test.range", &["10:0".into()], true).is_err());
     }
 
     #[test]
@@ -585,6 +694,42 @@ mod tests {
         assert_eq!(plan.filters.include_gid_range, vec![(10000u32, 19999u32)]);
         assert_eq!(plan.filters.exclude_gid, vec![1000u32]);
         assert_eq!(plan.filters.exclude_gid_range, vec![(2000u32, 2099u32)]);
+    }
+
+    #[test]
+    fn active_capture_literals_fail_closed_in_execution_plan() {
+        let mut invalid_route = base();
+        invalid_route.tun.route_address = vec!["not-a-cidr".into()];
+        let error = CapturePlan::from_config(&invalid_route).unwrap_err();
+        assert!(error.to_string().contains("route_address[0]"));
+
+        let mut reversed_range = base();
+        reversed_range.tun.include_uid_range = vec!["2000:1000".into()];
+        let error = CapturePlan::from_config(&reversed_range).unwrap_err();
+        assert!(error.to_string().contains("start <= end"));
+
+        let mut invalid_mark = base();
+        invalid_mark.tun.auto_redirect_output_mark = Some("not-a-mark".into());
+        let error = CapturePlan::from_config(&invalid_mark).unwrap_err();
+        assert!(error.to_string().contains("output_mark"));
+    }
+
+    #[test]
+    fn disabled_capture_ignores_dormant_invalid_literals() {
+        let mut capture = base();
+        capture.on = false;
+        capture.tun.route_address = vec!["not-a-cidr".into()];
+        capture.tun.include_uid_range = vec!["backwards".into()];
+        capture.tun.auto_redirect_output_mark = Some("not-a-mark".into());
+
+        let plan = CapturePlan::from_config(&capture).unwrap();
+
+        assert!(plan.route_addresses.is_empty());
+        assert!(plan.filters.include_uid_range.is_empty());
+        assert_eq!(
+            plan.auto_redirect_marks.output,
+            Some(core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK)
+        );
     }
 
     #[test]

--- a/crates/core-capture/src/platform/linux.rs
+++ b/crates/core-capture/src/platform/linux.rs
@@ -19,7 +19,12 @@ use tracing::{debug, info, warn};
 use crate::{
     engine::{CaptureEngine, CaptureError, CaptureEvent, CapturePlan, EngineKind},
     packet::{L4, parse_tun_frame},
-    platform::linux_tun_io,
+    platform::{
+        linux_auto_redirect::{self, AutoRedirectBackend, RedirectPorts},
+        linux_auto_redirect_route::{self, AutoRedirectRouteLease},
+        linux_tproxy::{RedirectTcpListener, bind_tcp_redirect_listener_set, run_tcp_redirect},
+        linux_tun_io,
+    },
     route_table::{ManagedRoute, RouteTable},
     tproxy_rules,
     tun_io::TunIo,
@@ -63,6 +68,123 @@ struct TunState {
     loop_handle: Option<JoinHandle<()>>,
     stop_tx: Option<oneshot::Sender<()>>,
     platform_preconfigured: bool,
+    effective_plan: Option<CapturePlan>,
+    redirect_listeners: Vec<RedirectTcpListener>,
+    redirect_backend: Option<AutoRedirectBackend>,
+    redirect_route_lease: Option<AutoRedirectRouteLease>,
+    redirect_tasks: Option<JoinSet<()>>,
+    redirect_stops: Vec<oneshot::Sender<()>>,
+}
+
+fn redirect_ports_from_addrs(
+    addresses: impl IntoIterator<Item = std::net::SocketAddr>,
+) -> Result<RedirectPorts, CaptureError> {
+    let mut ipv4 = None;
+    let mut ipv6 = None;
+    for address in addresses {
+        let slot = if address.is_ipv4() {
+            &mut ipv4
+        } else {
+            &mut ipv6
+        };
+        if slot.replace(address.port()).is_some() {
+            return Err(CaptureError::Nat(format!(
+                "duplicate TCP REDIRECT listener family: {address}"
+            )));
+        }
+    }
+    let ipv4 = ipv4
+        .ok_or_else(|| CaptureError::Nat("missing required IPv4 TCP REDIRECT listener".into()))?;
+    if ipv4 == 0 || ipv6 == Some(0) {
+        return Err(CaptureError::Nat(
+            "TCP REDIRECT listener did not receive an ephemeral port".into(),
+        ));
+    }
+    Ok(RedirectPorts::new(ipv4, ipv6))
+}
+
+fn validate_auto_redirect_activation(plan: &CapturePlan) -> Result<(), CaptureError> {
+    if !plan.auto_redirect {
+        return Ok(());
+    }
+    if cfg!(target_os = "android") {
+        return Err(CaptureError::Unsupported(
+            "auto_redirect currently supports root-managed Linux only; Android requires a dedicated iptables/VpnService contract".into(),
+        ));
+    }
+    if !plan.auto_route {
+        return Err(CaptureError::Nat(
+            "TUN auto_redirect requires auto_route".into(),
+        ));
+    }
+    if plan.traffic != core_config::model::CaptureTraffic::System {
+        return Err(CaptureError::Unsupported(
+            "auto_redirect currently supports traffic=system only".into(),
+        ));
+    }
+    if plan.strict_route {
+        return Err(CaptureError::Unsupported(
+            "auto_redirect does not yet support strict_route because it installs no policy-routing rule for ICMP/non-TCP-UDP traffic".into(),
+        ));
+    }
+    if !plan.route_address_set.is_empty() || !plan.route_exclude_address_set.is_empty() {
+        return Err(CaptureError::Unsupported(
+            "auto_redirect dynamic route-set snapshots are not installed".into(),
+        ));
+    }
+    if plan.iproute2_rule_index < 4 {
+        return Err(CaptureError::Route(
+            "auto_redirect iproute2_rule_index must be at least 4".into(),
+        ));
+    }
+    if plan.iproute2_table_index == 0 || matches!(plan.iproute2_table_index, 253..=255) {
+        return Err(CaptureError::Route(format!(
+            "auto_redirect requires a non-reserved private routing table; table {} is unsafe",
+            plan.iproute2_table_index
+        )));
+    }
+    if plan.exclude_mptcp
+        || !plan.exclude_processes.is_empty()
+        || !plan.filters.include_interface.is_empty()
+        || !plan.filters.exclude_interface.is_empty()
+        || !plan.filters.include_uid.is_empty()
+        || !plan.filters.include_uid_range.is_empty()
+        || !plan.filters.exclude_uid.is_empty()
+        || !plan.filters.exclude_uid_range.is_empty()
+        || !plan.filters.include_gid.is_empty()
+        || !plan.filters.include_gid_range.is_empty()
+        || !plan.filters.exclude_gid.is_empty()
+        || !plan.filters.exclude_gid_range.is_empty()
+        || !plan.filters.include_android_user.is_empty()
+        || !plan.filters.include_package.is_empty()
+        || !plan.filters.exclude_package.is_empty()
+        || !plan.filters.include_mac.is_empty()
+        || !plan.filters.exclude_mac.is_empty()
+    {
+        return Err(CaptureError::Unsupported(
+            "auto_redirect cannot activate filters whose full TCP/UDP policy-routing bypass is not transactional".into(),
+        ));
+    }
+    let defaults = (
+        core_config::model::DEFAULT_AUTO_REDIRECT_INPUT_MARK,
+        core_config::model::DEFAULT_AUTO_REDIRECT_RESET_MARK,
+        core_config::model::DEFAULT_AUTO_REDIRECT_NFQUEUE,
+        core_config::model::DEFAULT_IPROUTE2_AUTO_REDIRECT_FALLBACK_RULE_INDEX,
+    );
+    let actual = (
+        plan.auto_redirect_marks.input.unwrap_or(defaults.0),
+        plan.auto_redirect_marks.reset.unwrap_or(defaults.1),
+        plan.auto_redirect_marks.nfqueue.unwrap_or(defaults.2),
+        plan.auto_redirect_marks
+            .fallback_rule_index
+            .unwrap_or(defaults.3),
+    );
+    if actual != defaults {
+        return Err(CaptureError::Unsupported(
+            "auto_redirect input/reset/NFQUEUE/fallback fields belong to an unimplemented mark/NFQUEUE data plane".into(),
+        ));
+    }
+    Ok(())
 }
 
 impl LinuxTun {
@@ -108,16 +230,20 @@ impl LinuxTun {
         // 未配置（Android root linux_tun_io 路径）：手动 addr + mtu + link up
         let v4 = plan.tun_v4_addr_cidr();
         let mtu_s = plan.mtu.to_string();
-        let _ = run_logged(
+        let mtu_ok = matches!(
+            run_logged(
             "root-tun.link-mtu",
             "ip",
             &["link", "set", "dev", &plan.interface_name, "mtu", &mtu_s],
             true,
+            ),
+            Some(status) if status.success()
         );
-        let _ = configure_addr_with_ip(false, &v4, &plan.interface_name);
+        let v4_ok = configure_addr_with_ip(false, &v4, &plan.interface_name);
+        let mut v6_ok = true;
         if let Some(ref v6_cidr) = plan.tun_v6_addr_cidr() {
             if is_ipv6_available(&plan.interface_name) {
-                let _ = configure_addr_with_ip(true, v6_cidr, &plan.interface_name);
+                v6_ok = configure_addr_with_ip(true, v6_cidr, &plan.interface_name);
             } else {
                 debug!(
                     target: "capture::linux::tun",
@@ -126,16 +252,24 @@ impl LinuxTun {
                 );
             }
         }
-        let _ = run_logged(
+        let ip_link_up = matches!(
+            run_logged(
             "root-tun.link-up",
             "ip",
             &["link", "set", "dev", &plan.interface_name, "up"],
             true,
+            ),
+            Some(status) if status.success()
         );
-        if cfg!(any(target_os = "linux", target_os = "android")) {
-            let _ = linux_tun_io::set_link_up_ioctl(&plan.interface_name);
-        }
+        let ioctl_link_up = linux_tun_io::set_link_up_ioctl(&plan.interface_name).is_ok();
         let _ = log_iface_snapshot(&plan.interface_name);
+        if plan.auto_redirect && !(mtu_ok && v4_ok && v6_ok && (ip_link_up || ioctl_link_up)) {
+            return Err(CaptureError::DeviceFailed(format!(
+                "auto_redirect requires complete TUN interface configuration \
+                 (mtu={mtu_ok}, ipv4={v4_ok}, ipv6={v6_ok}, link={})",
+                ip_link_up || ioctl_link_up
+            )));
+        }
         Ok(())
     }
 }
@@ -450,6 +584,7 @@ impl CaptureEngine for LinuxTun {
         if g.started {
             return Ok(());
         }
+        validate_auto_redirect_activation(&self.plan)?;
         let summary = root_tun_summary(&self.plan);
         info!(
             target: "capture::linux::tun",
@@ -488,6 +623,15 @@ impl CaptureEngine for LinuxTun {
         let mut effective_plan = self.plan.clone();
         effective_plan.interface_name = device.name().to_string();
         let manage_linux_config = should_manage_linux_tun_config(device.as_ref());
+        // Publish every resource needed by rollback before the first
+        // fallible host-network mutation. CaptureSupervisor marks the engine
+        // started before awaiting us, so any later error calls stop() and
+        // cleans this effective (kernel-selected) interface rather than the
+        // requested name.
+        g.platform_preconfigured = !manage_linux_config;
+        g.effective_plan = Some(effective_plan.clone());
+        g.device = Some(device.clone());
+        g.started = true;
         info!(
             target: "capture::linux::tun",
             requested_iface = %self.plan.interface_name,
@@ -496,12 +640,30 @@ impl CaptureEngine for LinuxTun {
             platform_preconfigured = !manage_linux_config,
             "root tun device opened"
         );
+        if effective_plan.auto_redirect && !manage_linux_config {
+            return Err(CaptureError::Unsupported(
+                "auto_redirect requires a root-managed Linux/Android TUN; \
+                 a platform-preconfigured/VpnService device already owns capture"
+                    .into(),
+            ));
+        }
         if manage_linux_config {
             Self::configure_iface(&effective_plan, device.as_ref())?;
 
+            // Bind every required address family before routes or firewall
+            // hooks can send traffic to the data plane. The actual ports are
+            // injected into rules during post_start, after the dispatcher
+            // owns TUN packet I/O.
+            if effective_plan.auto_redirect {
+                let redirect_ipv6 = effective_plan.ipv6_enabled
+                    && effective_plan.tun_v6_cidr.is_some()
+                    && is_ipv6_available(&effective_plan.interface_name);
+                g.redirect_listeners = bind_tcp_redirect_listener_set(redirect_ipv6)?;
+            }
+
             // auto_route：将所有目标流量导入 TUN（按 sing-box 默认拆 0/1 + 128/1 双半区
             // 路由，避免覆盖系统已有的 0/0 默认路由），并写入指定 iproute2 表。
-            if effective_plan.auto_route {
+            if effective_plan.auto_route && !effective_plan.auto_redirect {
                 install_auto_route(&self.routes, &effective_plan);
                 // 内核级身份旁路：在 OUTPUT/mangle 链上为 excluded UID/GID/package
                 // 打 fwmark = tun_outbound_mark，触发 install_auto_route 注册的
@@ -524,12 +686,6 @@ impl CaptureEngine for LinuxTun {
             // strict_route：在主表里拒绝其它一切，强制流量必经 TUN。
             if effective_plan.strict_route {
                 install_strict_route(&effective_plan);
-            }
-            // auto_redirect：nftables 重定向 + fwmark；输入/输出/reset mark 全量配置。
-            if effective_plan.auto_redirect {
-                if let Err(e) = install_auto_redirect(&effective_plan) {
-                    warn!(target: "capture::linux", error = %e, "auto_redirect install failed");
-                }
             }
         } else {
             info!(
@@ -557,27 +713,159 @@ impl CaptureEngine for LinuxTun {
             let _ = events;
         }
 
-        g.platform_preconfigured = !manage_linux_config;
-        g.device = Some(device);
         g.stop_tx = Some(stop_tx);
-        g.started = true;
         info!(
             target: "capture::linux::tun",
-            iface = %self.plan.interface_name,
-            mtu = self.plan.mtu,
+            iface = %effective_plan.interface_name,
+            mtu = effective_plan.mtu,
             dispatcher_owns_tun,
-            "linux tun started"
+            auto_redirect_prebound = g.redirect_listeners.len(),
+            "linux tun prepared"
         );
         Ok(())
     }
-    async fn stop(self: Arc<Self>) -> Result<(), CaptureError> {
+
+    async fn post_start(
+        self: Arc<Self>,
+        events: mpsc::Sender<CaptureEvent>,
+        runtime: Arc<core_runtime::Runtime>,
+    ) -> Result<(), CaptureError> {
         let mut g = self.state.lock().await;
+        if !g.started {
+            return Err(CaptureError::Nat(
+                "cannot activate auto_redirect before Linux TUN is prepared".into(),
+            ));
+        }
+        let plan = g
+            .effective_plan
+            .clone()
+            .ok_or_else(|| CaptureError::Nat("Linux TUN effective plan is missing".into()))?;
+        if !plan.auto_redirect || g.platform_preconfigured {
+            return Ok(());
+        }
+        if g.redirect_backend.is_some() {
+            return Ok(());
+        }
+        validate_auto_redirect_activation(&plan)?;
+        if g.redirect_tasks.is_some() || g.redirect_route_lease.is_some() || !self.routes.is_empty()
+        {
+            return Err(CaptureError::Route(
+                "auto_redirect has a partial activation ledger; pre_stop must clean it before retry"
+                    .into(),
+            ));
+        }
+        let ports = redirect_ports_from_addrs(
+            g.redirect_listeners
+                .iter()
+                .map(RedirectTcpListener::local_addr),
+        )?;
+        let redirect_ipv6 = ports.ipv6.is_some();
+
+        let listeners = std::mem::take(&mut g.redirect_listeners);
+        let mut tasks = JoinSet::new();
+        let mut stops = Vec::with_capacity(listeners.len());
+        for listener in listeners {
+            let (listener, local_addr) = listener.into_parts();
+            let (stop_tx, stop_rx) = oneshot::channel();
+            stops.push(stop_tx);
+            let events = events.clone();
+            let runtime = runtime.clone();
+            tasks.spawn(async move {
+                if let Err(error) = run_tcp_redirect(listener, events, runtime, stop_rx).await {
+                    warn!(
+                        target: "capture::linux::auto_redirect",
+                        %local_addr,
+                        %error,
+                        "TCP REDIRECT listener stopped with error"
+                    );
+                }
+            });
+        }
+        g.redirect_tasks = Some(tasks);
+        g.redirect_stops = stops;
+
+        // Publish the exact policy-rule ledger before the first fallible route
+        // mutation. `pre_stop` can then unwind every partial post_start state.
+        g.redirect_route_lease = Some(AutoRedirectRouteLease::default());
+        linux_auto_redirect_route::prepare_routes(&self.routes, &plan, redirect_ipv6)?;
+        linux_auto_redirect_route::install(
+            &plan,
+            redirect_ipv6,
+            g.redirect_route_lease
+                .as_mut()
+                .expect("auto_redirect route lease was published"),
+        )?;
+
+        // This synchronous, bounded nft transaction contains no await and is
+        // deliberately last: no packet can enter until listeners, routes,
+        // policy rules, and the dispatcher are all ready.
+        let backend = linux_auto_redirect::install(&plan, ports)?;
+        g.redirect_backend = Some(backend);
+        info!(
+            target: "capture::linux::auto_redirect",
+            iface = %plan.interface_name,
+            ?backend,
+            ipv4_port = ports.ipv4,
+            ipv6_port = ?ports.ipv6,
+            "TUN auto_redirect activated after dispatcher"
+        );
+        Ok(())
+    }
+
+    async fn pre_stop(self: Arc<Self>) -> Result<(), CaptureError> {
+        let mut g = self.state.lock().await;
+        if let Some(backend) = g.redirect_backend {
+            // On failure retain the backend, listeners and dispatcher-facing
+            // state so CaptureSupervisor can retry without creating a
+            // black-hole window.
+            linux_auto_redirect::uninstall(backend)?;
+            g.redirect_backend = None;
+        }
+
+        // Pending listeners exist when start/post_start failed before rules
+        // were activated. Dropping them is sufficient because no hook can
+        // reference their ports.
+        g.redirect_listeners.clear();
+        let mut tasks = g.redirect_tasks.take().unwrap_or_else(JoinSet::new);
+        let mut stops = std::mem::take(&mut g.redirect_stops);
+        stop_listener_tasks(&mut stops, &mut tasks).await;
+
+        if let Some(lease) = g.redirect_route_lease.as_mut() {
+            linux_auto_redirect_route::uninstall(lease)?;
+        }
+        if self.plan.auto_redirect && !self.routes.is_empty() {
+            self.routes.revert_all_checked().map_err(|error| {
+                CaptureError::Route(format!(
+                    "auto_redirect split-default route cleanup incomplete: {error}"
+                ))
+            })?;
+        }
+        if g.redirect_route_lease
+            .as_ref()
+            .is_some_and(AutoRedirectRouteLease::is_empty)
+            && self.routes.is_empty()
+        {
+            g.redirect_route_lease = None;
+        }
+        Ok(())
+    }
+
+    async fn stop(self: Arc<Self>) -> Result<(), CaptureError> {
+        self.clone().pre_stop().await?;
+        let mut g = self.state.lock().await;
+        if !g.started && g.effective_plan.is_none() {
+            return Ok(());
+        }
+        let plan = g
+            .effective_plan
+            .clone()
+            .unwrap_or_else(|| self.plan.clone());
         info!(
             target: "capture::linux::tun",
-            iface = %self.plan.interface_name,
-            auto_route = self.plan.auto_route,
-            auto_redirect = self.plan.auto_redirect,
-            strict_route = self.plan.strict_route,
+            iface = %plan.interface_name,
+            auto_route = plan.auto_route,
+            auto_redirect = plan.auto_redirect,
+            strict_route = plan.strict_route,
             "root tun stopping"
         );
         if let Some(tx) = g.stop_tx.take() {
@@ -593,181 +881,175 @@ impl CaptureEngine for LinuxTun {
         g.platform_preconfigured = false;
         if platform_preconfigured {
             g.started = false;
+            g.effective_plan = None;
             info!(
                 target: "capture::linux::tun",
-                iface = %self.plan.interface_name,
+                iface = %plan.interface_name,
                 "tun device was platform-preconfigured; skip linux route/rule cleanup"
             );
-            info!(target: "capture", iface = %self.plan.interface_name, "linux tun stopped");
+            info!(target: "capture", iface = %plan.interface_name, "linux tun stopped");
             return Ok(());
         }
-        if self.plan.auto_redirect {
-            revert_auto_redirect(&self.plan);
-        }
-        if self.plan.strict_route {
-            revert_strict_route(&self.plan);
-        }
-        // 撤销 auto_route 安装的 main-table bypass rule
-        if self.plan.auto_route {
-            // 内核级身份旁路：与 install 对称，先于 ip rule 清理顺序由
-            // iptables -X 自身管理（与 catch-all 规则无依赖关系）。
-            crate::platform::linux_identity_bypass::revert(&self.plan);
-        }
-        if self.plan.auto_route && ip_rule_supported() {
-            let out_mark = tun_outbound_mark(&self.plan);
-            let mark_s = format!("{out_mark:#x}");
-            let bypass_prio =
-                outbound_bypass_rule_priority(self.plan.iproute2_rule_index).to_string();
-            let cleanup_tables = outbound_bypass_cleanup_tables();
-            for fam in ["", "-6"] {
-                for lookup in &cleanup_tables {
+        if !plan.auto_redirect {
+            if plan.strict_route {
+                revert_strict_route(&plan);
+            }
+            // 撤销 auto_route 安装的 main-table bypass rule
+            if plan.auto_route {
+                // 内核级身份旁路：与 install 对称，先于 ip rule 清理顺序由
+                // iptables -X 自身管理（与 catch-all 规则无依赖关系）。
+                crate::platform::linux_identity_bypass::revert(&plan);
+            }
+            if plan.auto_route && ip_rule_supported() {
+                let out_mark = tun_outbound_mark(&plan);
+                let mark_s = format!("{out_mark:#x}");
+                let bypass_prio =
+                    outbound_bypass_rule_priority(plan.iproute2_rule_index).to_string();
+                let cleanup_tables = outbound_bypass_cleanup_tables();
+                for fam in ["", "-6"] {
+                    for lookup in &cleanup_tables {
+                        let _ = run_ip_logged(
+                            "root-tun.rule-del.outbound-bypass",
+                            fam,
+                            &[
+                                "rule",
+                                "del",
+                                "priority",
+                                &bypass_prio,
+                                "fwmark",
+                                &mark_s,
+                                "lookup",
+                                lookup.as_str(),
+                            ],
+                            false,
+                        );
+                        // 兼容清理旧版本写入的无 priority 规则。
+                        let _ = run_ip_logged(
+                            "root-tun.rule-del.legacy-outbound-bypass",
+                            fam,
+                            &["rule", "del", "fwmark", &mark_s, "lookup", lookup.as_str()],
+                            false,
+                        );
+                    }
                     let _ = run_ip_logged(
-                        "root-tun.rule-del.outbound-bypass",
+                        "root-tun.rule-del.legacy-0xff-bypass",
                         fam,
-                        &[
-                            "rule",
-                            "del",
-                            "priority",
-                            &bypass_prio,
-                            "fwmark",
-                            &mark_s,
-                            "lookup",
-                            lookup.as_str(),
-                        ],
-                        false,
-                    );
-                    // 兼容清理旧版本写入的无 priority 规则。
-                    let _ = run_ip_logged(
-                        "root-tun.rule-del.legacy-outbound-bypass",
-                        fam,
-                        &["rule", "del", "fwmark", &mark_s, "lookup", lookup.as_str()],
+                        &["rule", "del", "fwmark", "0xff", "lookup", "main"],
                         false,
                     );
                 }
-                let _ = run_ip_logged(
-                    "root-tun.rule-del.legacy-0xff-bypass",
-                    fam,
-                    &["rule", "del", "fwmark", "0xff", "lookup", "main"],
-                    false,
-                );
-            }
-            // TUN 子网规则清理。
-            let tun_subnet_prio =
-                tun_subnet_rule_priority(self.plan.iproute2_rule_index).to_string();
-            let table_s_cleanup = self.plan.iproute2_table_index.to_string();
-            let v4_cidr = self.plan.tun_v4_cidr.to_string();
-            let _ = run_ip_logged(
-                "root-tun.rule-del.tun-subnet",
-                "",
-                &[
-                    "rule",
-                    "del",
-                    "priority",
-                    &tun_subnet_prio,
-                    "to",
-                    &v4_cidr,
-                    "lookup",
-                    &table_s_cleanup,
-                ],
-                false,
-            );
-            if let Some(v6_cidr) = self.plan.tun_v6_cidr {
-                let v6_cidr = v6_cidr.to_string();
+                // TUN 子网规则清理。
+                let tun_subnet_prio =
+                    tun_subnet_rule_priority(plan.iproute2_rule_index).to_string();
+                let table_s_cleanup = plan.iproute2_table_index.to_string();
+                let v4_cidr = plan.tun_v4_cidr.to_string();
                 let _ = run_ip_logged(
                     "root-tun.rule-del.tun-subnet",
-                    "-6",
+                    "",
                     &[
                         "rule",
                         "del",
                         "priority",
                         &tun_subnet_prio,
                         "to",
-                        &v6_cidr,
+                        &v4_cidr,
                         "lookup",
                         &table_s_cleanup,
                     ],
                     false,
                 );
-            }
-            // 静态 route-exclude-address 绕过 TUN 表；动态 set 在用户态强制 DIRECT。
-            // Android 的默认网络通常不在 main 表，清理时同时覆盖 main 与当前探测表。
-            let route_bypass_prio =
-                route_bypass_rule_priority(self.plan.iproute2_rule_index).to_string();
-            for net in &self.plan.route_exclude_addresses {
-                let dest = net.to_string();
-                let fam = route_rule_family(net);
-                for lookup in &cleanup_tables {
+                if let Some(v6_cidr) = plan.tun_v6_cidr {
+                    let v6_cidr = v6_cidr.to_string();
                     let _ = run_ip_logged(
-                        "root-tun.rule-del.route-exclude-bypass",
-                        fam,
+                        "root-tun.rule-del.tun-subnet",
+                        "-6",
                         &[
                             "rule",
                             "del",
                             "priority",
-                            &route_bypass_prio,
+                            &tun_subnet_prio,
                             "to",
-                            &dest,
+                            &v6_cidr,
                             "lookup",
-                            lookup.as_str(),
+                            &table_s_cleanup,
                         ],
                         false,
                     );
                 }
-            }
-            // 主 ip rule（lookup <custom>）也撤掉。
-            let prio_s = self.plan.iproute2_rule_index.to_string();
-            let table_s = self.plan.iproute2_table_index.to_string();
-            if auto_route_uses_catch_all_rule(&self.plan) {
-                for fam in ["", "-6"] {
-                    let _ = run_ip_logged(
-                        "root-tun.rule-del.catch-all",
-                        fam,
-                        &["rule", "del", "priority", &prio_s, "lookup", &table_s],
-                        false,
-                    );
-                }
-            } else {
-                for net in &self.plan.route_addresses {
+                // 静态 route-exclude-address 绕过 TUN 表；动态 set 在用户态强制 DIRECT。
+                // Android 的默认网络通常不在 main 表，清理时同时覆盖 main 与当前探测表。
+                let route_bypass_prio =
+                    route_bypass_rule_priority(plan.iproute2_rule_index).to_string();
+                for net in &plan.route_exclude_addresses {
                     let dest = net.to_string();
                     let fam = route_rule_family(net);
-                    let _ = run_ip_logged(
-                        "root-tun.rule-del.static-route-address",
-                        fam,
-                        &[
-                            "rule", "del", "priority", &prio_s, "to", &dest, "lookup", &table_s,
-                        ],
-                        false,
-                    );
+                    for lookup in &cleanup_tables {
+                        let _ = run_ip_logged(
+                            "root-tun.rule-del.route-exclude-bypass",
+                            fam,
+                            &[
+                                "rule",
+                                "del",
+                                "priority",
+                                &route_bypass_prio,
+                                "to",
+                                &dest,
+                                "lookup",
+                                lookup.as_str(),
+                            ],
+                            false,
+                        );
+                    }
+                }
+                // 主 ip rule（lookup <custom>）也撤掉。
+                let prio_s = plan.iproute2_rule_index.to_string();
+                let table_s = plan.iproute2_table_index.to_string();
+                if auto_route_uses_catch_all_rule(&plan) {
+                    for fam in ["", "-6"] {
+                        let _ = run_ip_logged(
+                            "root-tun.rule-del.catch-all",
+                            fam,
+                            &["rule", "del", "priority", &prio_s, "lookup", &table_s],
+                            false,
+                        );
+                    }
+                } else {
+                    for net in &plan.route_addresses {
+                        let dest = net.to_string();
+                        let fam = route_rule_family(net);
+                        let _ = run_ip_logged(
+                            "root-tun.rule-del.static-route-address",
+                            fam,
+                            &[
+                                "rule", "del", "priority", &prio_s, "to", &dest, "lookup", &table_s,
+                            ],
+                            false,
+                        );
+                    }
+                }
+                // 兼容清理旧版本 catch-all 规则。当前配置本身就是 catch-all 时，
+                // 上面的 `root-tun.rule-del.catch-all` 已经用完全相同的 selector
+                // 删除过；重复执行只会产生误导性的 ENOENT 日志。
+                if should_cleanup_legacy_catch_all_rule(&plan) {
+                    for fam in ["", "-6"] {
+                        let _ = run_ip_logged(
+                            "root-tun.rule-del.legacy-catch-all",
+                            fam,
+                            &["rule", "del", "priority", &prio_s, "lookup", &table_s],
+                            false,
+                        );
+                    }
                 }
             }
-            // 兼容清理旧版本 catch-all 规则。当前配置本身就是 catch-all 时，
-            // 上面的 `root-tun.rule-del.catch-all` 已经用完全相同的 selector
-            // 删除过；重复执行只会产生误导性的 ENOENT 日志。
-            if should_cleanup_legacy_catch_all_rule(&self.plan) {
-                for fam in ["", "-6"] {
-                    let _ = run_ip_logged(
-                        "root-tun.rule-del.legacy-catch-all",
-                        fam,
-                        &["rule", "del", "priority", &prio_s, "lookup", &table_s],
-                        false,
-                    );
-                }
-            }
+            self.routes.revert_all();
         }
-        self.routes.revert_all();
         let _ = run_quiet(
             "ip",
-            &[
-                "tuntap",
-                "del",
-                "dev",
-                &self.plan.interface_name,
-                "mode",
-                "tun",
-            ],
+            &["tuntap", "del", "dev", &plan.interface_name, "mode", "tun"],
         );
         g.started = false;
-        info!(target: "capture", iface = %self.plan.interface_name, "linux tun stopped");
+        g.effective_plan = None;
+        info!(target: "capture", iface = %plan.interface_name, "linux tun stopped");
         Ok(())
     }
 }
@@ -1065,6 +1347,62 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+    fn auto_redirect_plan() -> CapturePlan {
+        let mut capture = core_config::model::Capture {
+            on: true,
+            method: core_config::model::CaptureMethod::VirtualNic,
+            ..core_config::model::Capture::default()
+        };
+        capture.tun.auto_route = true;
+        capture.tun.auto_redirect = true;
+        CapturePlan::from_config(&capture).unwrap()
+    }
+
+    #[test]
+    fn redirect_listener_ports_require_one_ipv4_and_at_most_one_ipv6() {
+        let ports = redirect_ports_from_addrs([
+            "0.0.0.0:41001".parse().unwrap(),
+            "[::]:41002".parse().unwrap(),
+        ])
+        .unwrap();
+        assert_eq!(ports, RedirectPorts::new(41001, Some(41002)));
+
+        assert!(
+            redirect_ports_from_addrs(["[::]:41002".parse().unwrap()]).is_err(),
+            "IPv4 REDIRECT is mandatory"
+        );
+        assert!(
+            redirect_ports_from_addrs([
+                "0.0.0.0:41001".parse().unwrap(),
+                "127.0.0.1:41003".parse().unwrap(),
+            ])
+            .is_err(),
+            "duplicate address families must fail closed"
+        );
+    }
+
+    #[test]
+    fn auto_redirect_activation_rechecks_safe_contract() {
+        let plan = auto_redirect_plan();
+        validate_auto_redirect_activation(&plan).unwrap();
+
+        let mut lan = plan.clone();
+        lan.traffic = core_config::model::CaptureTraffic::Lan;
+        assert!(validate_auto_redirect_activation(&lan).is_err());
+
+        let mut identity = plan.clone();
+        identity.filters.exclude_uid = vec![1000];
+        assert!(validate_auto_redirect_activation(&identity).is_err());
+
+        let mut reserved = plan.clone();
+        reserved.auto_redirect_marks.reset = Some(0x5151);
+        assert!(validate_auto_redirect_activation(&reserved).is_err());
+
+        let mut reserved_table = plan;
+        reserved_table.iproute2_table_index = 254;
+        assert!(validate_auto_redirect_activation(&reserved_table).is_err());
+    }
+
     struct TunConfigProbe {
         preconfigured: bool,
     }
@@ -1300,7 +1638,7 @@ mod tests {
 
         tokio::time::timeout(
             std::time::Duration::from_secs(1),
-            stop_tproxy_listener_tasks(&mut stops, &mut tasks),
+            stop_listener_tasks(&mut stops, &mut tasks),
         )
         .await
         .expect("all listeners must stop promptly");
@@ -1333,691 +1671,6 @@ fn revert_strict_route(plan: &CapturePlan) {
     let prio_s = (plan.iproute2_rule_index + 1).to_string();
     for fam in ["", "-6"] {
         let _ = run_ip_quiet(fam, &["rule", "del", "priority", &prio_s]);
-    }
-}
-
-const NFT_REDIRECT_TABLE: &str = "wuthercore_redirect";
-
-fn install_auto_redirect(plan: &CapturePlan) -> Result<(), CaptureError> {
-    let marks = &plan.auto_redirect_marks;
-    let in_mark = marks.input.unwrap_or(0x2023);
-    let out_mark = tun_outbound_mark(plan);
-    let reset_mark = marks.reset.unwrap_or(0x2025);
-
-    let mut script = String::new();
-    use std::fmt::Write;
-    let t = NFT_REDIRECT_TABLE;
-    let iface = &plan.interface_name;
-
-    // 1. 创建独立 inet 表 + prerouting / output / mark chain
-    let _ = writeln!(script, "add table inet {t}");
-    let _ = writeln!(
-        script,
-        "add chain inet {t} prerouting {{ type filter hook prerouting priority -150; }}"
-    );
-    let _ = writeln!(
-        script,
-        "add chain inet {t} output {{ type filter hook output priority -150; }}"
-    );
-    let _ = writeln!(script, "add chain inet {t} mark_chain");
-    let _ = writeln!(
-        script,
-        "add rule inet {t} prerouting iifname != \"{iface}\" jump mark_chain"
-    );
-
-    // 2. include / exclude 接口过滤（mark_chain 入口前拒绝）
-    for excl in &plan.filters.exclude_interface {
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain iifname \"{excl}\" return"
-        );
-    }
-    if !plan.filters.include_interface.is_empty() {
-        let names: Vec<String> = plan
-            .filters
-            .include_interface
-            .iter()
-            .map(|n| format!("\"{n}\""))
-            .collect();
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain iifname != {{ {} }} return",
-            names.join(", ")
-        );
-    }
-
-    // 3. UID 过滤（exclude 优先；include 限定）
-    for u in &plan.filters.exclude_uid {
-        let _ = writeln!(script, "add rule inet {t} mark_chain meta skuid {u} return");
-    }
-    for (a, b) in &plan.filters.exclude_uid_range {
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain meta skuid {a}-{b} return"
-        );
-    }
-    if !plan.filters.include_uid.is_empty() || !plan.filters.include_uid_range.is_empty() {
-        // 把允许的 UID 集生成元素 set
-        let mut allow: Vec<String> = plan
-            .filters
-            .include_uid
-            .iter()
-            .map(|u| u.to_string())
-            .collect();
-        for (a, b) in &plan.filters.include_uid_range {
-            allow.push(format!("{a}-{b}"));
-        }
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain meta skuid != {{ {} }} return",
-            allow.join(", ")
-        );
-    }
-
-    // 3b. GID 过滤（exclude 优先；include 限定）—— mihomo `meta skgid` 等价。
-    for g in &plan.filters.exclude_gid {
-        let _ = writeln!(script, "add rule inet {t} mark_chain meta skgid {g} return");
-    }
-    for (a, b) in &plan.filters.exclude_gid_range {
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain meta skgid {a}-{b} return"
-        );
-    }
-    if !plan.filters.include_gid.is_empty() || !plan.filters.include_gid_range.is_empty() {
-        let mut allow: Vec<String> = plan
-            .filters
-            .include_gid
-            .iter()
-            .map(|g| g.to_string())
-            .collect();
-        for (a, b) in &plan.filters.include_gid_range {
-            allow.push(format!("{a}-{b}"));
-        }
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain meta skgid != {{ {} }} return",
-            allow.join(", ")
-        );
-    }
-
-    // 4. loopback_address 排除（保留地址 / lan）
-    for ip in &plan.loopback_addresses {
-        let proto = match ip {
-            std::net::IpAddr::V4(_) => "ip",
-            std::net::IpAddr::V6(_) => "ip6",
-        };
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain {proto} daddr {ip} return"
-        );
-    }
-
-    // 4b. MAC 地址过滤（路由器 / LAN 接管场景）。
-    for mac in &plan.filters.exclude_mac {
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain ether saddr {mac} return"
-        );
-    }
-    if !plan.filters.include_mac.is_empty() {
-        let macs: Vec<String> = plan.filters.include_mac.iter().map(|m| m.clone()).collect();
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain ether saddr != {{ {} }} return",
-            macs.join(", ")
-        );
-    }
-
-    // 4c. Android user → UID 偶合：Android user N 的 UID = N * 100000 + appUid。
-    // include_android_user 字段当用户没有显式指定 include_uid 时生效。
-    if plan.filters.include_uid.is_empty()
-        && plan.filters.include_uid_range.is_empty()
-        && !plan.filters.include_android_user.is_empty()
-    {
-        let mut ranges: Vec<String> = Vec::new();
-        for u in &plan.filters.include_android_user {
-            let lo = u * 100_000;
-            let hi = lo + 99_999;
-            ranges.push(format!("{lo}-{hi}"));
-        }
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain meta skuid != {{ {} }} return",
-            ranges.join(", ")
-        );
-    }
-
-    // 5. exclude_mptcp：透传 MPTCP 不接管
-    if plan.exclude_mptcp {
-        let _ = writeln!(
-            script,
-            "add rule inet {t} mark_chain tcp option mptcp exists return"
-        );
-    }
-
-    // 6. 主标记：进入 TUN 表
-    let _ = writeln!(
-        script,
-        "add rule inet {t} mark_chain meta mark set {in_mark:#x}"
-    );
-    let _ = writeln!(
-        script,
-        "add rule inet {t} mark_chain ct state new tcp flags syn meta mark set {reset_mark:#x}"
-    );
-    // 7. 出方向：output 上 outbound mark 自身流量直接 accept，避免回环
-    let _ = writeln!(
-        script,
-        "add rule inet {t} output meta mark {out_mark:#x} accept"
-    );
-
-    let create = script;
-    // —— 后端选择：nft → iptables(+ip6tables) TPROXY → iptables NAT REDIRECT 三级降级。
-    let nft_ok = has_tool("nft") && nft_load(&create);
-    if nft_ok {
-        // ip rule fwmark <in_mark> 走 TUN 自定义表
-        if ip_rule_supported() {
-            let table_s = plan.iproute2_table_index.to_string();
-            let mark_s = format!("{in_mark:#x}");
-            for fam in ["", "-6"] {
-                let _ = run_ip_quiet(fam, &["rule", "add", "fwmark", &mark_s, "lookup", &table_s]);
-            }
-            if let Some(fb) = marks.fallback_rule_index {
-                let prio_s = fb.to_string();
-                for fam in ["", "-6"] {
-                    let _ = run_ip_quiet(
-                        fam,
-                        &["rule", "add", "priority", &prio_s, "lookup", &table_s],
-                    );
-                }
-            }
-        }
-        if let Some(q) = marks.nfqueue {
-            let qs = q.to_string();
-            let _ = run_quiet(
-                "nft",
-                &[
-                    "add",
-                    "rule",
-                    "inet",
-                    NFT_REDIRECT_TABLE,
-                    "prerouting",
-                    "queue",
-                    "num",
-                    &qs,
-                ],
-            );
-        }
-        info!(
-            target: "capture::linux",
-            backend = "nftables",
-            in_mark = format_args!("{in_mark:#x}"),
-            out_mark = format_args!("{out_mark:#x}"),
-            reset_mark = format_args!("{reset_mark:#x}"),
-            "auto_redirect installed"
-        );
-        return Ok(());
-    }
-
-    // —— 回落 1：iptables + ip6tables TPROXY（双栈、Android root 通用）
-    if has_tool("iptables") && install_iptables_tproxy(plan, in_mark, out_mark) {
-        if ip_rule_supported() {
-            let table_s = plan.iproute2_table_index.to_string();
-            let mark_s = format!("{in_mark:#x}");
-            for fam in ["", "-6"] {
-                let _ = run_ip_quiet(fam, &["rule", "add", "fwmark", &mark_s, "lookup", &table_s]);
-            }
-        }
-        info!(
-            target: "capture::linux",
-            backend = "iptables-tproxy",
-            in_mark = format_args!("{in_mark:#x}"),
-            out_mark = format_args!("{out_mark:#x}"),
-            "auto_redirect installed (iptables/ip6tables TPROXY fallback; nft 不可用)"
-        );
-        return Ok(());
-    }
-
-    // —— 回落 2：iptables NAT REDIRECT（仅 TCP；UDP 走 fake-ip + TUN）
-    if has_tool("iptables") && install_iptables_redirect(plan) {
-        warn!(
-            target: "capture::linux",
-            backend = "iptables-nat-redirect",
-            "auto_redirect installed (NAT REDIRECT；仅 TCP；UDP 由 fake-ip+TUN 承担)"
-        );
-        return Ok(());
-    }
-
-    Err(CaptureError::Doctor(
-        "auto_redirect 全部后端失败：nft / iptables 都不可用。\
-         Android 设备请确认已 root 且安装 magisk 模块 iptables 或 nftables；\
-         否则请关掉 auto_redirect，使用 method=virtual_nic + stack=mixed 走纯 TUN。"
-            .into(),
-    ))
-}
-
-/// 把 nft 脚本通过 stdin 喂给 nft -f -；返回是否成功。
-fn nft_load(script: &str) -> bool {
-    use std::io::Write;
-    let child = std::process::Command::new("nft")
-        .args(["-f", "-"])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-    let Ok(mut child) = child else { return false };
-    if let Some(mut sin) = child.stdin.take() {
-        let _ = sin.write_all(script.as_bytes());
-    }
-    matches!(child.wait(), Ok(s) if s.success())
-}
-
-const IPT_CHAIN: &str = "WUTHERCORE_REDIR";
-const IPT_TPROXY_PORT: &str = "7894";
-
-/// iptables(+ip6tables) TPROXY 注入：mihomo 等价 Android `IptablesV4V6Tproxy` Tier。
-fn install_iptables_tproxy(plan: &CapturePlan, in_mark: u32, out_mark: u32) -> bool {
-    let in_mark_s = format!("{in_mark:#x}");
-    let out_mark_s = format!("{out_mark:#x}");
-    let mut all_ok = true;
-    for ipt in iptables_binaries() {
-        // 创建 / 复用 chain（已存在 → silent ok）
-        let _ = run_quiet(ipt, &["-t", "mangle", "-N", IPT_CHAIN]);
-        // 自身流量（mark 命中 out_mark）跳过
-        let r1 = run_quiet(
-            ipt,
-            &[
-                "-t",
-                "mangle",
-                "-A",
-                IPT_CHAIN,
-                "-m",
-                "mark",
-                "--mark",
-                &out_mark_s,
-                "-j",
-                "RETURN",
-            ],
-        );
-        // loopback / TUN iif 跳过
-        let _ = run_quiet(
-            ipt,
-            &["-t", "mangle", "-A", IPT_CHAIN, "-i", "lo", "-j", "RETURN"],
-        );
-        let _ = run_quiet(
-            ipt,
-            &[
-                "-t",
-                "mangle",
-                "-A",
-                IPT_CHAIN,
-                "-i",
-                &plan.interface_name,
-                "-j",
-                "RETURN",
-            ],
-        );
-
-        // UID/GID exclude
-        for u in &plan.filters.exclude_uid {
-            let val = u.to_string();
-            let _ = run_quiet(
-                ipt,
-                &[
-                    "-t",
-                    "mangle",
-                    "-A",
-                    IPT_CHAIN,
-                    "-m",
-                    "owner",
-                    "--uid-owner",
-                    &val,
-                    "-j",
-                    "RETURN",
-                ],
-            );
-        }
-        for (a, b) in &plan.filters.exclude_uid_range {
-            let val = format!("{a}-{b}");
-            let _ = run_quiet(
-                ipt,
-                &[
-                    "-t",
-                    "mangle",
-                    "-A",
-                    IPT_CHAIN,
-                    "-m",
-                    "owner",
-                    "--uid-owner",
-                    &val,
-                    "-j",
-                    "RETURN",
-                ],
-            );
-        }
-        for g in &plan.filters.exclude_gid {
-            let val = g.to_string();
-            let _ = run_quiet(
-                ipt,
-                &[
-                    "-t",
-                    "mangle",
-                    "-A",
-                    IPT_CHAIN,
-                    "-m",
-                    "owner",
-                    "--gid-owner",
-                    &val,
-                    "-j",
-                    "RETURN",
-                ],
-            );
-        }
-        for (a, b) in &plan.filters.exclude_gid_range {
-            let val = format!("{a}-{b}");
-            let _ = run_quiet(
-                ipt,
-                &[
-                    "-t",
-                    "mangle",
-                    "-A",
-                    IPT_CHAIN,
-                    "-m",
-                    "owner",
-                    "--gid-owner",
-                    &val,
-                    "-j",
-                    "RETURN",
-                ],
-            );
-        }
-        // include_uid / include_gid 用 ! 否定 RETURN 实现"只放行集合"语义。
-        if !plan.filters.include_uid.is_empty() || !plan.filters.include_uid_range.is_empty() {
-            for u in &plan.filters.include_uid {
-                let val = u.to_string();
-                let _ = run_quiet(
-                    ipt,
-                    &[
-                        "-t",
-                        "mangle",
-                        "-A",
-                        IPT_CHAIN,
-                        "-m",
-                        "owner",
-                        "!",
-                        "--uid-owner",
-                        &val,
-                        "-j",
-                        "RETURN",
-                    ],
-                );
-            }
-            for (a, b) in &plan.filters.include_uid_range {
-                let val = format!("{a}-{b}");
-                let _ = run_quiet(
-                    ipt,
-                    &[
-                        "-t",
-                        "mangle",
-                        "-A",
-                        IPT_CHAIN,
-                        "-m",
-                        "owner",
-                        "!",
-                        "--uid-owner",
-                        &val,
-                        "-j",
-                        "RETURN",
-                    ],
-                );
-            }
-        }
-        if !plan.filters.include_gid.is_empty() || !plan.filters.include_gid_range.is_empty() {
-            for g in &plan.filters.include_gid {
-                let val = g.to_string();
-                let _ = run_quiet(
-                    ipt,
-                    &[
-                        "-t",
-                        "mangle",
-                        "-A",
-                        IPT_CHAIN,
-                        "-m",
-                        "owner",
-                        "!",
-                        "--gid-owner",
-                        &val,
-                        "-j",
-                        "RETURN",
-                    ],
-                );
-            }
-            for (a, b) in &plan.filters.include_gid_range {
-                let val = format!("{a}-{b}");
-                let _ = run_quiet(
-                    ipt,
-                    &[
-                        "-t",
-                        "mangle",
-                        "-A",
-                        IPT_CHAIN,
-                        "-m",
-                        "owner",
-                        "!",
-                        "--gid-owner",
-                        &val,
-                        "-j",
-                        "RETURN",
-                    ],
-                );
-            }
-        }
-
-        // TPROXY mark + 投递到本地端口
-        let r2 = run_quiet(
-            ipt,
-            &[
-                "-t",
-                "mangle",
-                "-A",
-                IPT_CHAIN,
-                "-p",
-                "tcp",
-                "-j",
-                "TPROXY",
-                "--on-port",
-                IPT_TPROXY_PORT,
-                "--tproxy-mark",
-                &in_mark_s,
-            ],
-        );
-        let r3 = run_quiet(
-            ipt,
-            &[
-                "-t",
-                "mangle",
-                "-A",
-                IPT_CHAIN,
-                "-p",
-                "udp",
-                "-j",
-                "TPROXY",
-                "--on-port",
-                IPT_TPROXY_PORT,
-                "--tproxy-mark",
-                &in_mark_s,
-            ],
-        );
-        // PREROUTING 跳本 chain
-        let r4 = run_quiet(ipt, &["-t", "mangle", "-A", "PREROUTING", "-j", IPT_CHAIN]);
-        for r in [r1, r2, r3, r4] {
-            if !matches!(r, Some(s) if s.success()) {
-                all_ok = false;
-            }
-        }
-    }
-    all_ok
-}
-
-/// iptables NAT REDIRECT 注入（只 TCP，UDP 不支持）—— Android 旧设备 / kernel 阉割时。
-fn install_iptables_redirect(plan: &CapturePlan) -> bool {
-    let mut all_ok = true;
-    for ipt in iptables_binaries() {
-        let _ = run_quiet(ipt, &["-t", "nat", "-N", IPT_CHAIN]);
-        let _ = run_quiet(
-            ipt,
-            &["-t", "nat", "-A", IPT_CHAIN, "-i", "lo", "-j", "RETURN"],
-        );
-        let _ = run_quiet(
-            ipt,
-            &[
-                "-t",
-                "nat",
-                "-A",
-                IPT_CHAIN,
-                "-i",
-                &plan.interface_name,
-                "-j",
-                "RETURN",
-            ],
-        );
-        // UID/GID 排除：owner-match 在 nat 表只对 OUTPUT 链有效。
-        for u in &plan.filters.exclude_uid {
-            let val = u.to_string();
-            let _ = run_quiet(
-                ipt,
-                &[
-                    "-t",
-                    "nat",
-                    "-A",
-                    "OUTPUT",
-                    "-m",
-                    "owner",
-                    "--uid-owner",
-                    &val,
-                    "-j",
-                    "RETURN",
-                ],
-            );
-        }
-        for g in &plan.filters.exclude_gid {
-            let val = g.to_string();
-            let _ = run_quiet(
-                ipt,
-                &[
-                    "-t",
-                    "nat",
-                    "-A",
-                    "OUTPUT",
-                    "-m",
-                    "owner",
-                    "--gid-owner",
-                    &val,
-                    "-j",
-                    "RETURN",
-                ],
-            );
-        }
-        let r = run_quiet(
-            ipt,
-            &[
-                "-t",
-                "nat",
-                "-A",
-                IPT_CHAIN,
-                "-p",
-                "tcp",
-                "-j",
-                "REDIRECT",
-                "--to-ports",
-                IPT_TPROXY_PORT,
-            ],
-        );
-        let r2 = run_quiet(ipt, &["-t", "nat", "-A", "PREROUTING", "-j", IPT_CHAIN]);
-        for x in [r, r2] {
-            if !matches!(x, Some(s) if s.success()) {
-                all_ok = false;
-            }
-        }
-    }
-    all_ok
-}
-
-/// 返回当前可用的 iptables binaries：iptables / ip6tables（v6 可选）。
-fn iptables_binaries() -> Vec<&'static str> {
-    let mut out = Vec::new();
-    if has_tool("iptables") {
-        out.push("iptables");
-    }
-    if has_tool("ip6tables") {
-        out.push("ip6tables");
-    }
-    out
-}
-
-fn revert_auto_redirect(plan: &CapturePlan) {
-    // nft：best-effort 删表
-    let _ = run_quiet("nft", &["delete", "table", "inet", NFT_REDIRECT_TABLE]);
-
-    // iptables 后端 best-effort 卸载（chain 不存在的报错全部静默）
-    for ipt in iptables_binaries() {
-        for table in ["mangle", "nat"] {
-            let _ = run_quiet(ipt, &["-t", table, "-D", "PREROUTING", "-j", IPT_CHAIN]);
-            // NAT 模式下 owner-match 写在 OUTPUT 链 → 也撤掉
-            for u in &plan.filters.exclude_uid {
-                let val = u.to_string();
-                let _ = run_quiet(
-                    ipt,
-                    &[
-                        "-t",
-                        "nat",
-                        "-D",
-                        "OUTPUT",
-                        "-m",
-                        "owner",
-                        "--uid-owner",
-                        &val,
-                        "-j",
-                        "RETURN",
-                    ],
-                );
-            }
-            for g in &plan.filters.exclude_gid {
-                let val = g.to_string();
-                let _ = run_quiet(
-                    ipt,
-                    &[
-                        "-t",
-                        "nat",
-                        "-D",
-                        "OUTPUT",
-                        "-m",
-                        "owner",
-                        "--gid-owner",
-                        &val,
-                        "-j",
-                        "RETURN",
-                    ],
-                );
-            }
-            let _ = run_quiet(ipt, &["-t", table, "-F", IPT_CHAIN]);
-            let _ = run_quiet(ipt, &["-t", table, "-X", IPT_CHAIN]);
-        }
-    }
-
-    // ip rule 撤销
-    if ip_rule_supported() {
-        let table_s = plan.iproute2_table_index.to_string();
-        let mark_s = format!("{:#x}", plan.auto_redirect_marks.input.unwrap_or(0x2023));
-        for fam in ["", "-6"] {
-            let _ = run_ip_quiet(fam, &["rule", "del", "fwmark", &mark_s, "lookup", &table_s]);
-        }
-        if let Some(fb) = plan.auto_redirect_marks.fallback_rule_index {
-            let prio_s = fb.to_string();
-            for fam in ["", "-6"] {
-                let _ = run_ip_quiet(fam, &["rule", "del", "priority", &prio_s]);
-            }
-        }
     }
 }
 
@@ -2193,7 +1846,7 @@ fn prepare_tproxy_start<L>(
     Ok(listeners)
 }
 
-async fn stop_tproxy_listener_tasks(stops: &mut Vec<oneshot::Sender<()>>, tasks: &mut JoinSet<()>) {
+async fn stop_listener_tasks(stops: &mut Vec<oneshot::Sender<()>>, tasks: &mut JoinSet<()>) {
     // Signal every address-family/protocol listener before awaiting any one of
     // them. If this future is cancelled while joining, JoinSet::drop aborts all
     // remaining tasks and the caller's rule cleanup guard removes the routes.
@@ -2202,7 +1855,7 @@ async fn stop_tproxy_listener_tasks(stops: &mut Vec<oneshot::Sender<()>>, tasks:
     }
     while let Some(joined) = tasks.join_next().await {
         if let Err(error) = joined {
-            warn!(target: "capture::tproxy", %error, "tproxy listener task join failed");
+            warn!(target: "capture", %error, "transparent listener task join failed");
         }
     }
 }
@@ -2318,7 +1971,7 @@ impl CaptureEngine for LinuxTproxy {
         let mut listener_tasks = g.listener_tasks.take().unwrap_or_else(JoinSet::new);
         let mut listener_stops = std::mem::take(&mut g.listener_stops);
         g.on = false;
-        stop_tproxy_listener_tasks(&mut listener_stops, &mut listener_tasks).await;
+        stop_listener_tasks(&mut listener_stops, &mut listener_tasks).await;
         Self::revert_rules(&self.plan);
         rule_cleanup.armed = false;
         info!(target: "capture", "linux tproxy stopped");

--- a/crates/core-capture/src/platform/linux_auto_redirect.rs
+++ b/crates/core-capture/src/platform/linux_auto_redirect.rs
@@ -1,0 +1,2076 @@
+//! Linux TUN `auto_redirect` 的 TCP NAT REDIRECT 规则后端。
+//!
+//! 这个模块只负责 TCP NAT 快路径，不创建策略路由，也不接管 UDP/ICMP。
+//! TCP 被重定向到调用方已预绑定的本地临时端口；UDP/ICMP 是否进入 TUN
+//! 由独立 policy-route lease 决定。这里的 `return` 只表示“不走 TCP REDIRECT”，绝不
+//! 等价于绕过 TUN；调用方必须用 policy-route bypass/用户态策略补齐全协议
+//! 语义，或在激活阶段拒绝无法补齐的配置。生产激活只使用经过校验后单批
+//! 原子加载的 nftables；iptables/ip6tables 生成器保留测试覆盖，等待跨错误
+//! lease 后再开放。任何路径都不生成 TPROXY、NFQUEUE、reset 或 packet mark。
+
+use std::{
+    collections::BTreeSet,
+    fmt::Write as _,
+    io::{self, Write as _},
+    net::IpAddr,
+    process::{Command, Stdio},
+};
+
+use core_config::model::{CaptureTraffic, DEFAULT_AUTO_REDIRECT_OUTPUT_MARK};
+
+use crate::engine::{CaptureError, CapturePlan};
+
+const NFT_TABLE: &str = "wuther_auto_redirect";
+#[cfg(test)]
+const IPTABLES_CHAIN: &str = "WUTHER_AUTO_REDIRECT";
+#[cfg(test)]
+const IPTABLES_HOOK_COMMENT: &str = "wuther:auto-redirect";
+const MAX_INTERFACE_NAME_BYTES: usize = 15;
+#[cfg(test)]
+const MAX_IPTABLES_REDIRECT_RULES: usize = 4_096;
+
+/// 调用方已预绑定的 TCP REDIRECT 监听端口。
+///
+/// IPv4 端口始终必须存在；仅当 TUN 计划启用 IPv6 且存在 IPv6 TUN 网段时
+/// 才允许提供 IPv6 端口。端口 `0` 不是已绑定的临时端口，因此会被拒绝。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RedirectPorts {
+    pub ipv4: u16,
+    pub ipv6: Option<u16>,
+}
+
+impl RedirectPorts {
+    pub const fn new(ipv4: u16, ipv6: Option<u16>) -> Self {
+        Self { ipv4, ipv6 }
+    }
+}
+
+/// iptables 后端实际挂载的 netfilter hook。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoRedirectHook {
+    Output,
+    Prerouting,
+}
+
+impl AutoRedirectHook {
+    #[cfg(test)]
+    fn chain(self) -> &'static str {
+        match self {
+            Self::Output => "OUTPUT",
+            Self::Prerouting => "PREROUTING",
+        }
+    }
+}
+
+/// 成功安装后的精确规则账本。
+///
+/// 生产后端仅使用 nftables 独立表作为清理边界。iptables 变体只在测试
+/// fallback harness 中存在，用于验证未来事务账本的规则生成与回滚。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoRedirectBackend {
+    Nftables,
+    #[cfg(test)]
+    Iptables {
+        hook: AutoRedirectHook,
+        ipv4: bool,
+        ipv6: bool,
+    },
+}
+
+/// 无 shell 的规则命令描述；参数始终逐项传给 `Command`。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleCommand {
+    program: &'static str,
+    args: Vec<String>,
+    stdin: Option<String>,
+}
+
+impl RuleCommand {
+    fn new(program: &'static str, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            program,
+            args: args.into_iter().map(Into::into).collect(),
+            stdin: None,
+        }
+    }
+
+    fn with_stdin(mut self, stdin: String) -> Self {
+        self.stdin = Some(stdin);
+        self
+    }
+
+    pub fn program(&self) -> &'static str {
+        self.program
+    }
+
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+
+    pub fn stdin(&self) -> Option<&str> {
+        self.stdin.as_deref()
+    }
+}
+
+/// 规则命令的最小执行结果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleCommandOutput {
+    pub success: bool,
+    pub stderr: String,
+}
+
+impl RuleCommandOutput {
+    #[cfg(test)]
+    pub fn success() -> Self {
+        Self {
+            success: true,
+            stderr: String::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn failure(stderr: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            stderr: stderr.into(),
+        }
+    }
+}
+
+/// 可替换的命令执行边界，便于验证失败回滚且保证生产路径不经过 shell。
+pub trait RuleExecutor {
+    fn execute(&self, command: &RuleCommand) -> io::Result<RuleCommandOutput>;
+}
+
+/// 使用 `std::process::Command` 的生产执行器。
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemRuleExecutor;
+
+impl RuleExecutor for SystemRuleExecutor {
+    fn execute(&self, command: &RuleCommand) -> io::Result<RuleCommandOutput> {
+        let mut child = Command::new(command.program())
+            .args(command.args())
+            .stdin(if command.stdin().is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        if let Some(input) = command.stdin() {
+            let write_result = child
+                .stdin
+                .take()
+                .ok_or_else(|| io::Error::other("rule command stdin unavailable"))?
+                .write_all(input.as_bytes());
+            if let Err(error) = write_result {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+        }
+
+        let output = child.wait_with_output()?;
+        Ok(RuleCommandOutput {
+            success: output.status.success(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+/// 使用系统命令安装规则。
+///
+/// 当前激活路径只接受 nftables：单个 batch 具备原子提交语义，失败时不会把
+/// 无法表达的“部分所有权”丢给 supervisor。iptables 生成/回滚器保留为纯测试
+/// 覆盖，待其 lease 能跨错误返回后再开放生产回落。
+pub fn install(
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+) -> Result<AutoRedirectBackend, CaptureError> {
+    install_nftables_with_executor(plan, ports, &SystemRuleExecutor)
+}
+
+/// 按成功安装时返回的账本精确卸载规则。
+pub fn uninstall(backend: AutoRedirectBackend) -> Result<(), CaptureError> {
+    uninstall_with_executor(backend, &SystemRuleExecutor)
+}
+
+fn install_nftables_with_executor<E: RuleExecutor + ?Sized>(
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+    executor: &E,
+) -> Result<AutoRedirectBackend, CaptureError> {
+    let script = build_nft_script(plan, ports)?;
+    match probe_nft_table(executor) {
+        NftTableProbe::Absent => {}
+        NftTableProbe::Present => {
+            return Err(nat_error(format!(
+                "nftables 表 inet {NFT_TABLE} 已存在；可能是仍在工作的实例或崩溃后遗留规则，拒绝覆盖"
+            )));
+        }
+        NftTableProbe::ToolUnavailable => {
+            return Err(nat_error(
+                "nft 命令不可用；当前事务化 auto_redirect 激活路径要求 nftables",
+            ));
+        }
+        NftTableProbe::Unknown(reason) => {
+            return Err(nat_error(format!(
+                "无法证明 nftables 表 inet {NFT_TABLE} 不存在: {reason}"
+            )));
+        }
+    }
+
+    let check = RuleCommand::new("nft", ["-c", "-f", "-"]).with_stdin(script.clone());
+    execute_checked(executor, &check)
+        .map_err(|error| nat_error(format!("nft 原子批次校验失败: {error}")))?;
+    let load = RuleCommand::new("nft", ["-f", "-"]).with_stdin(script);
+    execute_checked(executor, &load)
+        .map_err(|error| nat_error(format!("nft 原子批次加载失败: {error}")))?;
+    Ok(AutoRedirectBackend::Nftables)
+}
+
+/// 测试专用 fallback harness。先对 nft 脚本执行 `nft -c -f -`，通过后才以
+/// 单次 `nft -f -` 原子加载。nft 不可用时，仅在 iptables 能无损表达当前
+/// TCP NAT 快路径的静态决策时回落。
+#[cfg(test)]
+pub fn install_with_executor<E: RuleExecutor + ?Sized>(
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+    executor: &E,
+) -> Result<AutoRedirectBackend, CaptureError> {
+    let script = build_nft_script(plan, ports)?;
+    let initial_probe = probe_nft_table(executor);
+    if let NftTableProbe::Present = initial_probe {
+        return Err(nat_error(format!(
+            "nftables 表 inet {NFT_TABLE} 已存在；可能是仍在工作的实例或崩溃后遗留规则，拒绝叠加后端"
+        )));
+    }
+    let check = RuleCommand::new("nft", ["-c", "-f", "-"]).with_stdin(script.clone());
+    let nft_check_error = match execute_checked(executor, &check) {
+        Ok(()) => {
+            let load = RuleCommand::new("nft", ["-f", "-"]).with_stdin(script);
+            match execute_checked(executor, &load) {
+                Ok(()) => return Ok(AutoRedirectBackend::Nftables),
+                Err(error) => {
+                    // 标准 nft batch 是原子事务，加载失败不会遗留本批规则。
+                    // 再探测一次可捕获 check/load 间的并发建表；若发现表，
+                    // 无法证明所有权，必须保留现场并拒绝叠加 iptables。
+                    ensure_nft_absent_before_fallback(executor, initial_probe, &error)?;
+                    format!("nft 原子加载失败: {error}")
+                }
+            }
+        }
+        Err(error) => {
+            ensure_nft_absent_before_fallback(executor, initial_probe, &error)?;
+            format!("nft 校验不可用: {error}")
+        }
+    };
+
+    let ledgers = build_iptables_ledgers(plan, ports).map_err(|error| {
+        CaptureError::Nat(format!(
+            "{nft_check_error}；禁止有损回落到 iptables: {error}"
+        ))
+    })?;
+
+    install_iptables_ledgers(executor, &ledgers).map_err(|error| {
+        CaptureError::Nat(format!(
+            "auto_redirect 安装失败；{nft_check_error}；iptables 回落失败: {error}"
+        ))
+    })
+}
+
+/// 使用指定执行器按账本卸载，始终尝试完整清理后再汇总错误。
+pub fn uninstall_with_executor<E: RuleExecutor + ?Sized>(
+    backend: AutoRedirectBackend,
+    executor: &E,
+) -> Result<(), CaptureError> {
+    let commands = match backend {
+        AutoRedirectBackend::Nftables => vec![nft_cleanup_command()],
+        #[cfg(test)]
+        AutoRedirectBackend::Iptables { hook, ipv4, ipv6 } => {
+            let mut commands = Vec::new();
+            if ipv4 {
+                commands.extend(iptables_cleanup_commands("iptables", hook));
+            }
+            if ipv6 {
+                commands.extend(iptables_cleanup_commands("ip6tables", hook));
+            }
+            commands
+        }
+    };
+
+    let failures = execute_cleanup_all(executor, &commands);
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(CaptureError::Nat(format!(
+            "auto_redirect 卸载未完全成功: {}",
+            failures.join("；")
+        )))
+    }
+}
+
+/// 生成完整 nftables batch。该函数是纯函数，不读取环境也不执行命令。
+pub fn build_nft_script(plan: &CapturePlan, ports: RedirectPorts) -> Result<String, CaptureError> {
+    validate_plan(plan, ports)?;
+
+    let hook = hook_for(plan.traffic);
+    let chain = match hook {
+        AutoRedirectHook::Output => "output",
+        AutoRedirectHook::Prerouting => "prerouting",
+    };
+    let mut script = String::new();
+    writeln!(script, "add table inet {NFT_TABLE}").expect("write String");
+    writeln!(
+        script,
+        "add chain inet {NFT_TABLE} {chain} {{ type nat hook {chain} priority -100; policy accept; }}"
+    )
+    .expect("write String");
+
+    match hook {
+        AutoRedirectHook::Output => write_nft_output_rules(&mut script, plan, ports)?,
+        AutoRedirectHook::Prerouting => write_nft_lan_rules(&mut script, plan, ports)?,
+    }
+
+    debug_assert!(!contains_forbidden_rule_primitive(&script));
+    Ok(script)
+}
+
+fn hook_for(traffic: CaptureTraffic) -> AutoRedirectHook {
+    match traffic {
+        CaptureTraffic::System | CaptureTraffic::Apps => AutoRedirectHook::Output,
+        CaptureTraffic::Lan => AutoRedirectHook::Prerouting,
+    }
+}
+
+fn validate_plan(plan: &CapturePlan, ports: RedirectPorts) -> Result<(), CaptureError> {
+    if ports.ipv4 == 0 || ports.ipv6 == Some(0) {
+        return Err(nat_error("REDIRECT 监听端口必须是已绑定的非零端口"));
+    }
+    if ports.ipv6.is_some() && (!plan.ipv6_enabled || plan.tun_v6_cidr.is_none()) {
+        return Err(nat_error(
+            "提供了 IPv6 REDIRECT 端口，但当前 TUN 计划没有启用 IPv6",
+        ));
+    }
+    if !plan.route_address_set.is_empty() || !plan.route_exclude_address_set.is_empty() {
+        return Err(nat_error(
+            "auto_redirect 无法在内核 NAT 前无损解析动态 route_address_set/route_exclude_address_set",
+        ));
+    }
+    if !plan.exclude_processes.is_empty()
+        || !plan.filters.include_package.is_empty()
+        || !plan.filters.exclude_package.is_empty()
+    {
+        return Err(nat_error(
+            "auto_redirect 规则后端无法无损表达进程名或包名过滤，请先解析为 UID",
+        ));
+    }
+
+    validate_interface("interface_name", &plan.interface_name)?;
+    for interface in &plan.filters.include_interface {
+        validate_interface("include_interface", interface)?;
+    }
+    for interface in &plan.filters.exclude_interface {
+        validate_interface("exclude_interface", interface)?;
+    }
+    for mac in plan
+        .filters
+        .include_mac
+        .iter()
+        .chain(&plan.filters.exclude_mac)
+    {
+        validate_mac(mac)?;
+    }
+    validate_ranges("include_uid_range", &plan.filters.include_uid_range)?;
+    validate_ranges("exclude_uid_range", &plan.filters.exclude_uid_range)?;
+    validate_ranges("include_gid_range", &plan.filters.include_gid_range)?;
+    validate_ranges("exclude_gid_range", &plan.filters.exclude_gid_range)?;
+    for user in &plan.filters.include_android_user {
+        user.checked_mul(100_000)
+            .and_then(|low| low.checked_add(99_999))
+            .ok_or_else(|| nat_error("include_android_user 转换 UID 范围时溢出"))?;
+    }
+
+    match hook_for(plan.traffic) {
+        AutoRedirectHook::Output => {
+            if !plan.filters.include_interface.is_empty()
+                || !plan.filters.exclude_interface.is_empty()
+                || !plan.filters.include_mac.is_empty()
+                || !plan.filters.exclude_mac.is_empty()
+            {
+                return Err(nat_error(
+                    "OUTPUT auto_redirect 不会把 LAN 接口/MAC 过滤误解释为本机流量过滤",
+                ));
+            }
+        }
+        AutoRedirectHook::Prerouting => {
+            if has_owner_filters(plan) {
+                return Err(nat_error(
+                    "PREROUTING/LAN 流量没有可靠 socket owner，不能无损应用 UID/GID/Android user 过滤",
+                ));
+            }
+        }
+    }
+
+    let captures_v4 = family_has_capture(plan, AddressFamily::V4);
+    let captures_v6 = ports.ipv6.is_some() && family_has_capture(plan, AddressFamily::V6);
+    if !captures_v4 && !captures_v6 {
+        return Err(nat_error(
+            "静态 route_address 白名单与已绑定 REDIRECT 地址族没有交集",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn validate_iptables_compatible(plan: &CapturePlan) -> Result<(), CaptureError> {
+    if plan.exclude_mptcp {
+        return Err(nat_error(
+            "exclude_mptcp 需要 nftables TCP option 表达式，iptables 回落会改变 TCP NAT 快路径语义",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_interface(field: &str, value: &str) -> Result<(), CaptureError> {
+    let valid = !value.is_empty()
+        && value.len() <= MAX_INTERFACE_NAME_BYTES
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'@')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(nat_error(format!(
+            "{field} 包含不安全字符或超过 Linux IFNAMSIZ: {value:?}"
+        )))
+    }
+}
+
+fn validate_mac(value: &str) -> Result<(), CaptureError> {
+    let bytes = value.as_bytes();
+    let valid = bytes.len() == 17
+        && bytes.iter().enumerate().all(|(index, byte)| {
+            if matches!(index, 2 | 5 | 8 | 11 | 14) {
+                *byte == b':'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(nat_error(format!("无效或不安全的 MAC 地址: {value:?}")))
+    }
+}
+
+fn validate_ranges(field: &str, ranges: &[(u32, u32)]) -> Result<(), CaptureError> {
+    if let Some((start, end)) = ranges.iter().find(|(start, end)| start > end) {
+        Err(nat_error(format!(
+            "{field} 范围起点大于终点: {start}-{end}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn has_owner_filters(plan: &CapturePlan) -> bool {
+    !plan.filters.include_uid.is_empty()
+        || !plan.filters.include_uid_range.is_empty()
+        || !plan.filters.exclude_uid.is_empty()
+        || !plan.filters.exclude_uid_range.is_empty()
+        || !plan.filters.include_gid.is_empty()
+        || !plan.filters.include_gid_range.is_empty()
+        || !plan.filters.exclude_gid.is_empty()
+        || !plan.filters.exclude_gid_range.is_empty()
+        || !plan.filters.include_android_user.is_empty()
+}
+
+fn write_nft_output_rules(
+    script: &mut String,
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+) -> Result<(), CaptureError> {
+    let chain = "output";
+    let outbound_mark = plan
+        .auto_redirect_marks
+        .output
+        .unwrap_or(DEFAULT_AUTO_REDIRECT_OUTPUT_MARK);
+    writeln!(
+        script,
+        "add rule inet {NFT_TABLE} {chain} meta mark {outbound_mark:#x} return"
+    )
+    .expect("write String");
+
+    for (family, port) in active_families(plan, ports) {
+        write_nft_listener_bypass(script, chain, family, port);
+    }
+    write_nft_owner_filters(script, chain, plan)?;
+    write_nft_ip_exclusions(script, chain, plan);
+    if plan.exclude_mptcp {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} tcp option mptcp exists return"
+        )
+        .expect("write String");
+    }
+
+    let interface = nft_quoted(&plan.interface_name);
+    for (family, port) in active_families(plan, ports) {
+        write_nft_redirect_rules(script, chain, plan, family, port, Some(&interface));
+    }
+    Ok(())
+}
+
+fn write_nft_lan_rules(
+    script: &mut String,
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+) -> Result<(), CaptureError> {
+    let chain = "prerouting";
+    for (family, port) in active_families(plan, ports) {
+        write_nft_listener_bypass(script, chain, family, port);
+    }
+
+    writeln!(
+        script,
+        "add rule inet {NFT_TABLE} {chain} iifname {} return",
+        nft_quoted(&plan.interface_name)
+    )
+    .expect("write String");
+    for interface in sorted_strings(&plan.filters.exclude_interface) {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} iifname {} return",
+            nft_quoted(interface)
+        )
+        .expect("write String");
+    }
+    if !plan.filters.include_interface.is_empty() {
+        let interfaces = sorted_strings(&plan.filters.include_interface)
+            .into_iter()
+            .map(nft_quoted)
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} iifname != {{ {interfaces} }} return"
+        )
+        .expect("write String");
+    }
+
+    for mac in normalized_macs(&plan.filters.exclude_mac) {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} ether saddr {mac} return"
+        )
+        .expect("write String");
+    }
+    if !plan.filters.include_mac.is_empty() {
+        let macs = normalized_macs(&plan.filters.include_mac).join(", ");
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} ether saddr != {{ {macs} }} return"
+        )
+        .expect("write String");
+    }
+
+    write_nft_ip_exclusions(script, chain, plan);
+    if plan.exclude_mptcp {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} tcp option mptcp exists return"
+        )
+        .expect("write String");
+    }
+    for (family, port) in active_families(plan, ports) {
+        write_nft_redirect_rules(script, chain, plan, family, port, None);
+    }
+    Ok(())
+}
+
+fn write_nft_listener_bypass(script: &mut String, chain: &str, family: AddressFamily, port: u16) {
+    writeln!(
+        script,
+        "add rule inet {NFT_TABLE} {chain} meta nfproto {} fib daddr type local tcp dport {port} return",
+        family.nft_nfproto()
+    )
+    .expect("write String");
+}
+
+fn write_nft_owner_filters(
+    script: &mut String,
+    chain: &str,
+    plan: &CapturePlan,
+) -> Result<(), CaptureError> {
+    for owner in numeric_values(&plan.filters.exclude_uid, &plan.filters.exclude_uid_range) {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} meta skuid {owner} return"
+        )
+        .expect("write String");
+    }
+    let include_uid = include_uids(plan)?;
+    if !include_uid.is_empty() {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} meta skuid != {{ {} }} return",
+            include_uid.join(", ")
+        )
+        .expect("write String");
+    }
+
+    for owner in numeric_values(&plan.filters.exclude_gid, &plan.filters.exclude_gid_range) {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} meta skgid {owner} return"
+        )
+        .expect("write String");
+    }
+    let include_gid = numeric_values(&plan.filters.include_gid, &plan.filters.include_gid_range);
+    if !include_gid.is_empty() {
+        writeln!(
+            script,
+            "add rule inet {NFT_TABLE} {chain} meta skgid != {{ {} }} return",
+            include_gid.join(", ")
+        )
+        .expect("write String");
+    }
+    Ok(())
+}
+
+fn write_nft_ip_exclusions(script: &mut String, chain: &str, plan: &CapturePlan) {
+    for family in [AddressFamily::V4, AddressFamily::V6] {
+        for network in family_exclusions(plan, family) {
+            writeln!(
+                script,
+                "add rule inet {NFT_TABLE} {chain} {} daddr {network} return",
+                family.nft_address_keyword()
+            )
+            .expect("write String");
+        }
+    }
+}
+
+fn write_nft_redirect_rules(
+    script: &mut String,
+    chain: &str,
+    plan: &CapturePlan,
+    family: AddressFamily,
+    port: u16,
+    output_interface: Option<&str>,
+) {
+    let includes = family_includes(plan, family);
+    if !plan.route_addresses.is_empty() && includes.is_empty() {
+        return;
+    }
+
+    let mut prefix = format!(
+        "add rule inet {NFT_TABLE} {chain} meta nfproto {}",
+        family.nft_nfproto()
+    );
+    if let Some(interface) = output_interface {
+        write!(prefix, " oifname {interface}").expect("write String");
+    }
+    if includes.is_empty() {
+        writeln!(script, "{prefix} meta l4proto tcp redirect to :{port}").expect("write String");
+    } else {
+        for network in includes {
+            writeln!(
+                script,
+                "{prefix} {} daddr {network} meta l4proto tcp redirect to :{port}",
+                family.nft_address_keyword()
+            )
+            .expect("write String");
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AddressFamily {
+    V4,
+    V6,
+}
+
+impl AddressFamily {
+    fn nft_nfproto(self) -> &'static str {
+        match self {
+            Self::V4 => "ipv4",
+            Self::V6 => "ipv6",
+        }
+    }
+
+    fn nft_address_keyword(self) -> &'static str {
+        match self {
+            Self::V4 => "ip",
+            Self::V6 => "ip6",
+        }
+    }
+
+    #[cfg(test)]
+    fn program(self) -> &'static str {
+        match self {
+            Self::V4 => "iptables",
+            Self::V6 => "ip6tables",
+        }
+    }
+}
+
+fn active_families(
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+) -> impl Iterator<Item = (AddressFamily, u16)> {
+    let mut families = Vec::with_capacity(2);
+    if family_has_capture(plan, AddressFamily::V4) {
+        families.push((AddressFamily::V4, ports.ipv4));
+    }
+    match ports.ipv6 {
+        Some(port) if family_has_capture(plan, AddressFamily::V6) => {
+            families.push((AddressFamily::V6, port));
+        }
+        _ => {}
+    }
+    families.into_iter()
+}
+
+fn family_has_capture(plan: &CapturePlan, family: AddressFamily) -> bool {
+    plan.route_addresses.is_empty()
+        || plan
+            .route_addresses
+            .iter()
+            .any(|network| family.matches_ip(network.addr()))
+}
+
+impl AddressFamily {
+    fn matches_ip(self, address: IpAddr) -> bool {
+        matches!(
+            (self, address),
+            (Self::V4, IpAddr::V4(_)) | (Self::V6, IpAddr::V6(_))
+        )
+    }
+}
+
+fn family_includes(plan: &CapturePlan, family: AddressFamily) -> Vec<String> {
+    let mut networks = plan
+        .route_addresses
+        .iter()
+        .filter(|network| family.matches_ip(network.addr()))
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    networks.sort();
+    networks.dedup();
+    networks
+}
+
+fn family_exclusions(plan: &CapturePlan, family: AddressFamily) -> Vec<String> {
+    let mut networks = BTreeSet::new();
+    match family {
+        AddressFamily::V4 => {
+            networks.insert("127.0.0.0/8".to_owned());
+            networks.insert(plan.tun_v4_cidr.to_string());
+        }
+        AddressFamily::V6 => {
+            networks.insert("::1/128".to_owned());
+            if let Some(network) = plan.tun_v6_cidr {
+                networks.insert(network.to_string());
+            }
+        }
+    }
+    for network in plan
+        .exclude_cidrs
+        .iter()
+        .chain(&plan.route_exclude_addresses)
+    {
+        if family.matches_ip(network.addr()) {
+            networks.insert(network.to_string());
+        }
+    }
+    for address in &plan.loopback_addresses {
+        if family.matches_ip(*address) {
+            let suffix = match address {
+                IpAddr::V4(_) => 32,
+                IpAddr::V6(_) => 128,
+            };
+            networks.insert(format!("{address}/{suffix}"));
+        }
+    }
+    networks.into_iter().collect()
+}
+
+fn sorted_strings(values: &[String]) -> Vec<&str> {
+    values
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn normalized_macs(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.to_ascii_lowercase())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn numeric_values(values: &[u32], ranges: &[(u32, u32)]) -> Vec<String> {
+    let mut result = values
+        .iter()
+        .map(ToString::to_string)
+        .collect::<BTreeSet<_>>();
+    result.extend(ranges.iter().map(|(start, end)| format!("{start}-{end}")));
+    result.into_iter().collect()
+}
+
+fn include_uids(plan: &CapturePlan) -> Result<Vec<String>, CaptureError> {
+    let mut values = numeric_values(&plan.filters.include_uid, &plan.filters.include_uid_range);
+    if values.is_empty() {
+        for user in &plan.filters.include_android_user {
+            let low = user
+                .checked_mul(100_000)
+                .ok_or_else(|| nat_error("include_android_user 转换 UID 范围时溢出"))?;
+            let high = low
+                .checked_add(99_999)
+                .ok_or_else(|| nat_error("include_android_user 转换 UID 范围时溢出"))?;
+            values.push(format!("{low}-{high}"));
+        }
+        values.sort();
+        values.dedup();
+    }
+    Ok(values)
+}
+
+fn nft_quoted(value: &str) -> String {
+    debug_assert!(value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'@')
+    }));
+    format!("\"{value}\"")
+}
+
+fn contains_forbidden_rule_primitive(script: &str) -> bool {
+    let lower = script.to_ascii_lowercase();
+    ["tproxy", "queue", "nfqueue", "reject", "reset"]
+        .iter()
+        .any(|token| lower.contains(token))
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct IptablesLedger {
+    family: AddressFamily,
+    hook: AutoRedirectHook,
+    install: Vec<RuleCommand>,
+}
+
+#[cfg(test)]
+fn build_iptables_ledgers(
+    plan: &CapturePlan,
+    ports: RedirectPorts,
+) -> Result<Vec<IptablesLedger>, CaptureError> {
+    validate_plan(plan, ports)?;
+    validate_iptables_compatible(plan)?;
+    let hook = hook_for(plan.traffic);
+    active_families(plan, ports)
+        .map(|(family, port)| build_iptables_family(plan, hook, family, port))
+        .collect()
+}
+
+#[cfg(test)]
+fn build_iptables_family(
+    plan: &CapturePlan,
+    hook: AutoRedirectHook,
+    family: AddressFamily,
+    port: u16,
+) -> Result<IptablesLedger, CaptureError> {
+    let program = family.program();
+    let mut commands = vec![RuleCommand::new(
+        program,
+        ["-t", "nat", "-N", IPTABLES_CHAIN],
+    )];
+
+    match hook {
+        AutoRedirectHook::Output => {
+            let mark = plan
+                .auto_redirect_marks
+                .output
+                .unwrap_or(DEFAULT_AUTO_REDIRECT_OUTPUT_MARK);
+            push_chain_rule(
+                &mut commands,
+                program,
+                [
+                    "-m",
+                    "mark",
+                    "--mark",
+                    &format!("{mark:#x}"),
+                    "-j",
+                    "RETURN",
+                ],
+            );
+            push_listener_bypass(&mut commands, program, port);
+            push_owner_exclusions(&mut commands, program, plan);
+        }
+        AutoRedirectHook::Prerouting => {
+            push_listener_bypass(&mut commands, program, port);
+            push_chain_rule(
+                &mut commands,
+                program,
+                ["-i", plan.interface_name.as_str(), "-j", "RETURN"],
+            );
+            for interface in sorted_strings(&plan.filters.exclude_interface) {
+                push_chain_rule(&mut commands, program, ["-i", interface, "-j", "RETURN"]);
+            }
+            for mac in normalized_macs(&plan.filters.exclude_mac) {
+                push_chain_rule(
+                    &mut commands,
+                    program,
+                    ["-m", "mac", "--mac-source", &mac, "-j", "RETURN"],
+                );
+            }
+        }
+    }
+
+    for network in family_exclusions(plan, family) {
+        push_chain_rule(
+            &mut commands,
+            program,
+            ["-d", network.as_str(), "-j", "RETURN"],
+        );
+    }
+
+    let redirects = build_iptables_redirect_commands(plan, hook, family, port)?;
+    commands.extend(redirects);
+    commands.push(iptables_hook_install_command(program, hook));
+    Ok(IptablesLedger {
+        family,
+        hook,
+        install: commands,
+    })
+}
+
+#[cfg(test)]
+fn push_chain_rule<'a>(
+    commands: &mut Vec<RuleCommand>,
+    program: &'static str,
+    args: impl IntoIterator<Item = &'a str>,
+) {
+    let mut full = vec![
+        "-t".to_owned(),
+        "nat".to_owned(),
+        "-A".to_owned(),
+        IPTABLES_CHAIN.to_owned(),
+    ];
+    full.extend(args.into_iter().map(str::to_owned));
+    commands.push(RuleCommand::new(program, full));
+}
+
+#[cfg(test)]
+fn push_listener_bypass(commands: &mut Vec<RuleCommand>, program: &'static str, port: u16) {
+    push_chain_rule(
+        commands,
+        program,
+        [
+            "-p",
+            "tcp",
+            "-m",
+            "addrtype",
+            "--dst-type",
+            "LOCAL",
+            "--dport",
+            &port.to_string(),
+            "-j",
+            "RETURN",
+        ],
+    );
+}
+
+#[cfg(test)]
+fn push_owner_exclusions(
+    commands: &mut Vec<RuleCommand>,
+    program: &'static str,
+    plan: &CapturePlan,
+) {
+    for owner in numeric_values(&plan.filters.exclude_uid, &plan.filters.exclude_uid_range) {
+        push_chain_rule(
+            commands,
+            program,
+            ["-m", "owner", "--uid-owner", &owner, "-j", "RETURN"],
+        );
+    }
+    for owner in numeric_values(&plan.filters.exclude_gid, &plan.filters.exclude_gid_range) {
+        push_chain_rule(
+            commands,
+            program,
+            ["-m", "owner", "--gid-owner", &owner, "-j", "RETURN"],
+        );
+    }
+}
+
+#[cfg(test)]
+fn build_iptables_redirect_commands(
+    plan: &CapturePlan,
+    hook: AutoRedirectHook,
+    family: AddressFamily,
+    port: u16,
+) -> Result<Vec<RuleCommand>, CaptureError> {
+    let routes = family_includes(plan, family);
+    if !plan.route_addresses.is_empty() && routes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let routes = optional_values(routes);
+
+    let (interfaces, macs, uids, gids) = match hook {
+        AutoRedirectHook::Output => (
+            vec![None],
+            vec![None],
+            optional_values(include_uids(plan)?),
+            optional_values(numeric_values(
+                &plan.filters.include_gid,
+                &plan.filters.include_gid_range,
+            )),
+        ),
+        AutoRedirectHook::Prerouting => (
+            optional_values(
+                sorted_strings(&plan.filters.include_interface)
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            optional_values(normalized_macs(&plan.filters.include_mac)),
+            vec![None],
+            vec![None],
+        ),
+    };
+
+    let count = [
+        routes.len(),
+        interfaces.len(),
+        macs.len(),
+        uids.len(),
+        gids.len(),
+    ]
+    .into_iter()
+    .try_fold(1usize, |total, next| total.checked_mul(next))
+    .ok_or_else(|| nat_error("iptables REDIRECT 规则组合数量溢出"))?;
+    if count > MAX_IPTABLES_REDIRECT_RULES {
+        return Err(nat_error(format!(
+            "iptables REDIRECT 需要 {count} 条组合规则，超过安全上限 {MAX_IPTABLES_REDIRECT_RULES}"
+        )));
+    }
+
+    let mut commands = Vec::with_capacity(count);
+    for route in &routes {
+        for interface in &interfaces {
+            for mac in &macs {
+                for uid in &uids {
+                    for gid in &gids {
+                        let mut args = vec![
+                            "-t".to_owned(),
+                            "nat".to_owned(),
+                            "-A".to_owned(),
+                            IPTABLES_CHAIN.to_owned(),
+                        ];
+                        if hook == AutoRedirectHook::Output {
+                            args.extend(["-o".to_owned(), plan.interface_name.clone()]);
+                        }
+                        if let Some(interface) = interface {
+                            args.extend(["-i".to_owned(), interface.clone()]);
+                        }
+                        if let Some(mac) = mac {
+                            args.extend([
+                                "-m".to_owned(),
+                                "mac".to_owned(),
+                                "--mac-source".to_owned(),
+                                mac.clone(),
+                            ]);
+                        }
+                        if let Some(route) = route {
+                            args.extend(["-d".to_owned(), route.clone()]);
+                        }
+                        if uid.is_some() || gid.is_some() {
+                            args.extend(["-m".to_owned(), "owner".to_owned()]);
+                        }
+                        if let Some(uid) = uid {
+                            args.extend(["--uid-owner".to_owned(), uid.clone()]);
+                        }
+                        if let Some(gid) = gid {
+                            args.extend(["--gid-owner".to_owned(), gid.clone()]);
+                        }
+                        args.extend([
+                            "-p".to_owned(),
+                            "tcp".to_owned(),
+                            "-j".to_owned(),
+                            "REDIRECT".to_owned(),
+                            "--to-ports".to_owned(),
+                            port.to_string(),
+                        ]);
+                        commands.push(RuleCommand::new(family.program(), args));
+                    }
+                }
+            }
+        }
+    }
+    Ok(commands)
+}
+
+#[cfg(test)]
+fn optional_values(values: Vec<String>) -> Vec<Option<String>> {
+    if values.is_empty() {
+        vec![None]
+    } else {
+        values.into_iter().map(Some).collect()
+    }
+}
+
+#[cfg(test)]
+fn install_iptables_ledgers<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    ledgers: &[IptablesLedger],
+) -> Result<AutoRedirectBackend, String> {
+    let mut created = Vec::new();
+    // 第一阶段只创建并填充私有链，不把任何链挂到活动 hook。这样缺少
+    // ip6tables、某条过滤规则失败等常见错误不会留下“IPv4 已活动、IPv6
+    // 未安装”的半配置。
+    for ledger in ledgers {
+        let prepare_len = ledger.install.len().saturating_sub(1);
+        for (index, command) in ledger.install[..prepare_len].iter().enumerate() {
+            if let Err(error) = execute_checked(executor, command) {
+                return Err(iptables_failure_with_rollback(
+                    executor, &created, command, error,
+                ));
+            }
+            if index == 0 {
+                created.push((ledger.family.program(), ledger.hook));
+            }
+        }
+    }
+
+    // 第二阶段才按确定位置挂载 hook；每个 ledger 的最后一条命令由构建器
+    // 保证是带所有权 comment 的 `-I <HOOK> 1`。
+    for ledger in ledgers {
+        let command = ledger
+            .install
+            .last()
+            .ok_or_else(|| "iptables 地址族账本为空".to_owned())?;
+        if let Err(error) = execute_checked(executor, command) {
+            return Err(iptables_failure_with_rollback(
+                executor, &created, command, error,
+            ));
+        }
+    }
+
+    let hook = ledgers
+        .first()
+        .map(|ledger| ledger.hook)
+        .ok_or_else(|| "没有可安装的地址族".to_owned())?;
+    Ok(AutoRedirectBackend::Iptables {
+        hook,
+        ipv4: ledgers
+            .iter()
+            .any(|ledger| ledger.family == AddressFamily::V4),
+        ipv6: ledgers
+            .iter()
+            .any(|ledger| ledger.family == AddressFamily::V6),
+    })
+}
+
+#[cfg(test)]
+fn iptables_failure_with_rollback<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    created: &[(&'static str, AutoRedirectHook)],
+    failed_command: &RuleCommand,
+    error: String,
+) -> String {
+    let cleanup_failures = rollback_iptables(executor, created);
+    let cleanup = if cleanup_failures.is_empty() {
+        String::new()
+    } else {
+        format!("；回滚失败: {}", cleanup_failures.join("；"))
+    };
+    format!("{}: {error}{cleanup}", render_command(failed_command))
+}
+
+#[cfg(test)]
+fn rollback_iptables<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    created: &[(&'static str, AutoRedirectHook)],
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    for (program, hook) in created.iter().rev() {
+        failures.extend(execute_cleanup_all(
+            executor,
+            &iptables_cleanup_commands(program, *hook),
+        ));
+    }
+    failures
+}
+
+#[cfg(test)]
+fn iptables_cleanup_commands(program: &'static str, hook: AutoRedirectHook) -> Vec<RuleCommand> {
+    vec![
+        RuleCommand::new(
+            program,
+            [
+                "-t",
+                "nat",
+                "-D",
+                hook.chain(),
+                "-m",
+                "comment",
+                "--comment",
+                IPTABLES_HOOK_COMMENT,
+                "-j",
+                IPTABLES_CHAIN,
+            ],
+        ),
+        RuleCommand::new(program, ["-t", "nat", "-F", IPTABLES_CHAIN]),
+        RuleCommand::new(program, ["-t", "nat", "-X", IPTABLES_CHAIN]),
+    ]
+}
+
+#[cfg(test)]
+fn iptables_hook_install_command(program: &'static str, hook: AutoRedirectHook) -> RuleCommand {
+    RuleCommand::new(
+        program,
+        [
+            "-t",
+            "nat",
+            "-I",
+            hook.chain(),
+            "1",
+            "-m",
+            "comment",
+            "--comment",
+            IPTABLES_HOOK_COMMENT,
+            "-j",
+            IPTABLES_CHAIN,
+        ],
+    )
+}
+
+fn nft_cleanup_command() -> RuleCommand {
+    RuleCommand::new("nft", ["delete", "table", "inet", NFT_TABLE])
+}
+
+fn execute_checked<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    command: &RuleCommand,
+) -> Result<(), String> {
+    let output = executor
+        .execute(command)
+        .map_err(|error| format!("无法执行 {}: {error}", command.program()))?;
+    if output.success {
+        Ok(())
+    } else {
+        let stderr = sanitize_stderr(&output.stderr);
+        if stderr.is_empty() {
+            Err("命令返回非零状态".to_owned())
+        } else {
+            Err(stderr)
+        }
+    }
+}
+
+fn execute_cleanup_all<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    commands: &[RuleCommand],
+) -> Vec<String> {
+    commands
+        .iter()
+        .filter_map(|command| {
+            execute_cleanup_checked(executor, command)
+                .err()
+                .map(|error| format!("{}: {error}", render_command(command)))
+        })
+        .collect()
+}
+
+fn execute_cleanup_checked<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    command: &RuleCommand,
+) -> Result<(), String> {
+    let output = executor
+        .execute(command)
+        .map_err(|error| format!("无法执行 {}: {error}", command.program()))?;
+    if output.success || is_absent_cleanup(command, &output.stderr) {
+        Ok(())
+    } else {
+        let stderr = sanitize_stderr(&output.stderr);
+        if stderr.is_empty() {
+            Err("清理命令返回非零状态".to_owned())
+        } else {
+            Err(stderr)
+        }
+    }
+}
+
+fn is_absent_cleanup(command: &RuleCommand, stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    if command.program() == "nft" {
+        // A generic loader/plugin/namespace "not found" does not prove that
+        // our table is absent. Require nft's diagnostic to echo the exact
+        // owned table before releasing the backend ledger.
+        let names_owned_table = lower.contains(NFT_TABLE)
+            && (lower.contains("table inet") || lower.contains("list table inet"));
+        return names_owned_table
+            && (lower.contains("no such file or directory") || lower.contains("does not exist"));
+    }
+    if matches!(command.program(), "iptables" | "ip6tables") {
+        return lower.contains("bad rule")
+            || lower.contains("does a matching rule exist")
+            || lower.contains("no chain/target/match by that name")
+            || lower.contains("chain already deleted");
+    }
+    false
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NftTableProbe {
+    Absent,
+    Present,
+    ToolUnavailable,
+    Unknown(String),
+}
+
+fn probe_nft_table<E: RuleExecutor + ?Sized>(executor: &E) -> NftTableProbe {
+    let command = RuleCommand::new("nft", ["list", "table", "inet", NFT_TABLE]);
+    match executor.execute(&command) {
+        Ok(output) if output.success => NftTableProbe::Present,
+        Ok(output) if is_absent_cleanup(&command, &output.stderr) => NftTableProbe::Absent,
+        Ok(output) => NftTableProbe::Unknown(sanitize_stderr(&output.stderr)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => NftTableProbe::ToolUnavailable,
+        Err(error) => NftTableProbe::Unknown(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+fn ensure_nft_absent_before_fallback<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    initial_probe: NftTableProbe,
+    nft_error: &str,
+) -> Result<(), CaptureError> {
+    if initial_probe == NftTableProbe::ToolUnavailable {
+        return Ok(());
+    }
+    match probe_nft_table(executor) {
+        NftTableProbe::Absent => Ok(()),
+        NftTableProbe::Present => Err(nat_error(format!(
+            "nft 失败后发现 inet {NFT_TABLE} 仍处于活动状态，无法确认所有权，拒绝叠加 iptables: {nft_error}"
+        ))),
+        NftTableProbe::ToolUnavailable => Err(nat_error(format!(
+            "nft 失败后工具又变得不可用，无法再次证明 inet {NFT_TABLE} 不存在，拒绝叠加 iptables: {nft_error}"
+        ))),
+        NftTableProbe::Unknown(reason) => Err(nat_error(format!(
+            "nft 失败后无法证明 inet {NFT_TABLE} 不存在（{reason}），拒绝叠加 iptables: {nft_error}"
+        ))),
+    }
+}
+
+fn render_command(command: &RuleCommand) -> String {
+    std::iter::once(command.program())
+        .chain(command.args().iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_stderr(stderr: &str) -> String {
+    stderr
+        .chars()
+        .filter(|character| !character.is_control() || *character == ' ')
+        .take(512)
+        .collect::<String>()
+        .trim()
+        .to_owned()
+}
+
+fn nat_error(message: impl Into<String>) -> CaptureError {
+    CaptureError::Nat(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use core_config::model::{Capture, CaptureMethod};
+
+    use super::*;
+
+    struct RecordingExecutor<F> {
+        handler: F,
+        commands: Mutex<Vec<RuleCommand>>,
+    }
+
+    impl<F> RecordingExecutor<F> {
+        fn new(handler: F) -> Self {
+            Self {
+                handler,
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn commands(&self) -> Vec<RuleCommand> {
+            self.commands.lock().expect("commands lock").clone()
+        }
+    }
+
+    impl<F> RuleExecutor for RecordingExecutor<F>
+    where
+        F: Fn(&RuleCommand, usize) -> io::Result<RuleCommandOutput>,
+    {
+        fn execute(&self, command: &RuleCommand) -> io::Result<RuleCommandOutput> {
+            let index = {
+                let mut commands = self.commands.lock().expect("commands lock");
+                let index = commands.len();
+                commands.push(command.clone());
+                index
+            };
+            (self.handler)(command, index)
+        }
+    }
+
+    fn base_plan(traffic: CaptureTraffic) -> CapturePlan {
+        let mut plan = CapturePlan::from_config(&Capture {
+            on: true,
+            method: CaptureMethod::VirtualNic,
+            ..Capture::default()
+        })
+        .expect("base capture plan");
+        plan.traffic = traffic;
+        plan.interface_name = "wuther0".to_owned();
+        plan.ipv6_enabled = true;
+        plan.tun_v6_cidr = Some("fdfe:dcba:9876::1/126".parse().expect("v6 TUN CIDR"));
+        plan.exclude_mptcp = false;
+        plan
+    }
+
+    fn dual_ports() -> RedirectPorts {
+        RedirectPorts::new(41_231, Some(51_432))
+    }
+
+    fn command_text(command: &RuleCommand) -> String {
+        render_command(command)
+    }
+
+    fn nft_table_absent_output() -> RuleCommandOutput {
+        RuleCommandOutput::failure(format!(
+            "Error: Could not process rule: No such file or directory\nlist table inet {NFT_TABLE}"
+        ))
+    }
+
+    fn nft_absent_or_check_fails(
+        command: &RuleCommand,
+        _index: usize,
+    ) -> io::Result<RuleCommandOutput> {
+        if command.program() == "nft" && command.args().first().map(String::as_str) == Some("list")
+        {
+            Ok(nft_table_absent_output())
+        } else if command.program() == "nft" {
+            Ok(RuleCommandOutput::failure("nft unavailable"))
+        } else {
+            Ok(RuleCommandOutput::success())
+        }
+    }
+
+    #[test]
+    fn system_and_apps_use_only_output_while_lan_uses_only_prerouting() {
+        for traffic in [CaptureTraffic::System, CaptureTraffic::Apps] {
+            let script = build_nft_script(&base_plan(traffic), dual_ports()).unwrap();
+            assert!(script.contains("type nat hook output priority -100"));
+            assert!(!script.contains("hook prerouting"));
+        }
+
+        let script = build_nft_script(&base_plan(CaptureTraffic::Lan), dual_ports()).unwrap();
+        assert!(script.contains("type nat hook prerouting priority -100"));
+        assert!(!script.contains("hook output"));
+    }
+
+    #[test]
+    fn output_redirects_only_tcp_originally_routed_to_tun_after_bypasses() {
+        let plan = base_plan(CaptureTraffic::System);
+        let script = build_nft_script(&plan, dual_ports()).unwrap();
+        let mark = script.find("meta mark").unwrap();
+        let listener = script
+            .find("fib daddr type local tcp dport 41231 return")
+            .unwrap();
+        let redirect = script
+            .find("oifname \"wuther0\" meta l4proto tcp redirect to :41231")
+            .unwrap();
+        assert!(mark < listener && listener < redirect);
+        assert!(!script.contains("meta l4proto udp redirect"));
+        assert!(!script.contains("icmp redirect"));
+    }
+
+    #[test]
+    fn dynamic_ephemeral_ports_and_dual_stack_are_rendered_exactly() {
+        let script = build_nft_script(
+            &base_plan(CaptureTraffic::System),
+            RedirectPorts::new(32_111, Some(48_222)),
+        )
+        .unwrap();
+        assert!(script.contains("meta nfproto ipv4 fib daddr type local tcp dport 32111 return"));
+        assert!(script.contains("meta nfproto ipv6 fib daddr type local tcp dport 48222 return"));
+        assert!(
+            script.contains(
+                "meta nfproto ipv4 oifname \"wuther0\" meta l4proto tcp redirect to :32111"
+            )
+        );
+        assert!(
+            script.contains(
+                "meta nfproto ipv6 oifname \"wuther0\" meta l4proto tcp redirect to :48222"
+            )
+        );
+        assert!(!script.contains("7894"));
+    }
+
+    #[test]
+    fn lan_tcp_redirect_fast_path_renders_interface_mac_and_static_address_filters() {
+        let mut plan = base_plan(CaptureTraffic::Lan);
+        plan.filters.include_interface = vec!["eth1".into(), "eth0".into()];
+        plan.filters.exclude_interface = vec!["docker0".into()];
+        plan.filters.include_mac = vec!["AA:BB:CC:DD:EE:02".into()];
+        plan.filters.exclude_mac = vec!["AA:BB:CC:DD:EE:01".into()];
+        plan.route_addresses = vec![
+            "203.0.113.0/24".parse().unwrap(),
+            "2001:db8:1::/48".parse().unwrap(),
+        ];
+        plan.route_exclude_addresses = vec!["203.0.113.64/26".parse().unwrap()];
+        plan.exclude_cidrs = vec!["198.51.100.0/24".parse().unwrap()];
+        plan.loopback_addresses = vec!["192.0.2.7".parse().unwrap()];
+
+        let script = build_nft_script(&plan, dual_ports()).unwrap();
+        assert!(script.contains("iifname \"wuther0\" return"));
+        assert!(script.contains("iifname \"docker0\" return"));
+        assert!(script.contains("iifname != { \"eth0\", \"eth1\" } return"));
+        assert!(script.contains("ether saddr aa:bb:cc:dd:ee:01 return"));
+        assert!(script.contains("ether saddr != { aa:bb:cc:dd:ee:02 } return"));
+        assert!(script.contains("ip daddr 198.51.100.0/24 return"));
+        assert!(script.contains("ip daddr 203.0.113.64/26 return"));
+        assert!(script.contains("ip daddr 192.0.2.7/32 return"));
+        assert!(script.contains(&format!("ip daddr {} return", plan.tun_v4_cidr)));
+        assert!(script.contains("ip daddr 203.0.113.0/24 meta l4proto tcp redirect"));
+        assert!(script.contains("ip6 daddr 2001:db8:1::/48 meta l4proto tcp redirect"));
+    }
+
+    #[test]
+    fn output_tcp_redirect_fast_path_renders_owner_filters() {
+        let mut plan = base_plan(CaptureTraffic::Apps);
+        plan.filters.exclude_uid = vec![0, 999];
+        plan.filters.include_uid_range = vec![(10_000, 19_999)];
+        plan.filters.exclude_gid_range = vec![(20, 29)];
+        plan.filters.include_gid = vec![3000, 3001];
+        let script = build_nft_script(&plan, dual_ports()).unwrap();
+        assert!(script.contains("meta skuid 0 return"));
+        assert!(script.contains("meta skuid != { 10000-19999 } return"));
+        assert!(script.contains("meta skgid 20-29 return"));
+        assert!(script.contains("meta skgid != { 3000, 3001 } return"));
+    }
+
+    #[test]
+    fn route_sets_fail_closed_before_any_command() {
+        let mut plan = base_plan(CaptureTraffic::System);
+        plan.route_address_set = vec!["geoip-cn".into()];
+        let executor = RecordingExecutor::new(nft_absent_or_check_fails);
+        let error = install_with_executor(&plan, dual_ports(), &executor).unwrap_err();
+        assert!(error.to_string().contains("route_address_set"));
+        assert!(executor.commands().is_empty());
+    }
+
+    #[test]
+    fn injected_interface_and_mac_strings_are_rejected() {
+        let mut output = base_plan(CaptureTraffic::System);
+        output.interface_name = "tun0\"; delete table inet x".into();
+        assert!(build_nft_script(&output, dual_ports()).is_err());
+
+        let mut lan = base_plan(CaptureTraffic::Lan);
+        lan.filters.include_interface = vec!["eth0\nadd rule".into()];
+        assert!(build_nft_script(&lan, dual_ports()).is_err());
+
+        let mut lan = base_plan(CaptureTraffic::Lan);
+        lan.filters.exclude_mac = vec!["aa:bb:cc:dd:ee:ff;drop".into()];
+        assert!(build_nft_script(&lan, dual_ports()).is_err());
+    }
+
+    #[test]
+    fn generated_rules_never_use_tproxy_queue_reset_reject_udp_or_icmp() {
+        let mut plan = base_plan(CaptureTraffic::Lan);
+        plan.auto_redirect_marks.input = Some(0x2023);
+        plan.auto_redirect_marks.reset = Some(0x2025);
+        plan.auto_redirect_marks.nfqueue = Some(123);
+        let script = build_nft_script(&plan, dual_ports()).unwrap();
+        let lower = script.to_ascii_lowercase();
+        for forbidden in ["tproxy", "queue", "nfqueue", "reset", "reject"] {
+            assert!(
+                !lower.contains(forbidden),
+                "unexpected {forbidden}: {script}"
+            );
+        }
+        assert!(!lower.contains("udp"));
+        assert!(!lower.contains("icmp"));
+    }
+
+    #[test]
+    fn nft_is_checked_before_single_atomic_load() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft"
+                && command.args().first().map(String::as_str) == Some("list")
+            {
+                Ok(nft_table_absent_output())
+            } else {
+                Ok(RuleCommandOutput::success())
+            }
+        });
+        let backend =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap();
+        assert_eq!(backend, AutoRedirectBackend::Nftables);
+        let commands = executor.commands();
+        assert_eq!(commands.len(), 3);
+        assert_eq!(commands[0].args(), ["list", "table", "inet", NFT_TABLE]);
+        assert_eq!(commands[1].args(), ["-c", "-f", "-"]);
+        assert_eq!(commands[2].args(), ["-f", "-"]);
+        assert_eq!(commands[1].stdin(), commands[2].stdin());
+    }
+
+    #[test]
+    fn production_installer_is_nft_only_and_atomic() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft"
+                && command.args().first().map(String::as_str) == Some("list")
+            {
+                Ok(nft_table_absent_output())
+            } else {
+                Ok(RuleCommandOutput::success())
+            }
+        });
+
+        let backend = install_nftables_with_executor(
+            &base_plan(CaptureTraffic::System),
+            dual_ports(),
+            &executor,
+        )
+        .unwrap();
+
+        assert_eq!(backend, AutoRedirectBackend::Nftables);
+        assert!(
+            executor
+                .commands()
+                .iter()
+                .all(|command| command.program() == "nft")
+        );
+    }
+
+    #[test]
+    fn production_installer_never_falls_back_when_nft_is_unavailable() {
+        let executor = RecordingExecutor::new(|_command: &RuleCommand, _index: usize| {
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing nft"))
+        });
+
+        let error = install_nftables_with_executor(
+            &base_plan(CaptureTraffic::System),
+            dual_ports(),
+            &executor,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("要求 nftables"));
+        assert_eq!(executor.commands().len(), 1);
+    }
+
+    #[test]
+    fn stale_nft_table_fails_closed_without_touching_iptables() {
+        let executor =
+            RecordingExecutor::new(|_command: &RuleCommand, _| Ok(RuleCommandOutput::success()));
+        let error =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap_err();
+        assert!(error.to_string().contains("已存在"));
+        let commands = executor.commands();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].args().first().map(String::as_str), Some("list"));
+    }
+
+    #[test]
+    fn nft_check_race_never_stacks_iptables_over_live_table() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, index| {
+            if command.program() == "nft"
+                && command.args().first().map(String::as_str) == Some("list")
+            {
+                return if index == 0 {
+                    Ok(nft_table_absent_output())
+                } else {
+                    Ok(RuleCommandOutput::success())
+                };
+            }
+            Ok(RuleCommandOutput::failure("check conflict"))
+        });
+        let error =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap_err();
+        assert!(error.to_string().contains("仍处于活动状态"));
+        assert!(
+            executor
+                .commands()
+                .iter()
+                .all(|command| command.program() == "nft")
+        );
+    }
+
+    #[test]
+    fn failed_atomic_nft_load_falls_back_only_after_table_is_proven_absent() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() != "nft" {
+                return Ok(RuleCommandOutput::success());
+            }
+            match command.args().first().map(String::as_str) {
+                Some("list") => Ok(nft_table_absent_output()),
+                Some("-c") => Ok(RuleCommandOutput::success()),
+                _ => Ok(RuleCommandOutput::failure("atomic load rejected")),
+            }
+        });
+        let backend =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap();
+        assert!(matches!(backend, AutoRedirectBackend::Iptables { .. }));
+        let commands = executor.commands();
+        assert_eq!(commands[0].args().first().map(String::as_str), Some("list"));
+        assert_eq!(commands[1].args().first().map(String::as_str), Some("-c"));
+        assert_eq!(commands[2].args(), ["-f", "-"]);
+        assert_eq!(commands[3].args().first().map(String::as_str), Some("list"));
+        assert!(!commands.iter().any(|command| {
+            command.program() == "nft"
+                && command.args().first().map(String::as_str) == Some("delete")
+        }));
+    }
+
+    #[test]
+    fn ambiguous_nft_ownership_failure_never_falls_back() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft" {
+                Ok(RuleCommandOutput::failure("Operation not permitted"))
+            } else {
+                Ok(RuleCommandOutput::success())
+            }
+        });
+        let error =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap_err();
+        assert!(error.to_string().contains("无法证明"));
+        assert!(
+            executor
+                .commands()
+                .iter()
+                .all(|command| command.program() == "nft")
+        );
+    }
+
+    #[test]
+    fn iptables_fallback_uses_dynamic_ports_first_hook_position_and_comment() {
+        let executor = RecordingExecutor::new(nft_absent_or_check_fails);
+        let backend =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap();
+        assert_eq!(
+            backend,
+            AutoRedirectBackend::Iptables {
+                hook: AutoRedirectHook::Output,
+                ipv4: true,
+                ipv6: true,
+            }
+        );
+        let commands = executor.commands();
+        assert!(commands.iter().any(|command| {
+            command_text(command).contains(
+                "iptables -t nat -I OUTPUT 1 -m comment --comment wuther:auto-redirect -j WUTHER_AUTO_REDIRECT",
+            )
+        }));
+        assert!(commands.iter().any(|command| {
+            command.program() == "iptables"
+                && command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["--to-ports", "41231"])
+        }));
+        assert!(commands.iter().any(|command| {
+            command.program() == "ip6tables"
+                && command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["--to-ports", "51432"])
+        }));
+        assert!(!commands.iter().any(|command| {
+            command
+                .args()
+                .windows(2)
+                .any(|args| args == ["-A", "OUTPUT"])
+        }));
+    }
+
+    #[test]
+    fn lan_iptables_tcp_fast_path_preserves_static_filters_and_prerouting_hook() {
+        let mut plan = base_plan(CaptureTraffic::Lan);
+        plan.filters.include_interface = vec!["eth0".into(), "eth1".into()];
+        plan.filters.exclude_interface = vec!["docker0".into()];
+        plan.filters.include_mac = vec!["aa:bb:cc:dd:ee:01".into()];
+        plan.filters.exclude_mac = vec!["aa:bb:cc:dd:ee:02".into()];
+        plan.route_addresses = vec![
+            "203.0.113.0/24".parse().unwrap(),
+            "2001:db8:1::/48".parse().unwrap(),
+        ];
+        plan.route_exclude_addresses = vec!["198.51.100.0/24".parse().unwrap()];
+        let ledgers = build_iptables_ledgers(&plan, dual_ports()).unwrap();
+        assert_eq!(ledgers.len(), 2);
+        let rendered = ledgers
+            .iter()
+            .flat_map(|ledger| ledger.install.iter())
+            .map(command_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(rendered.contains("-i docker0 -j RETURN"));
+        assert!(rendered.contains("--mac-source aa:bb:cc:dd:ee:02 -j RETURN"));
+        assert!(rendered.contains("-i eth0 -m mac --mac-source aa:bb:cc:dd:ee:01"));
+        assert!(rendered.contains("-d 203.0.113.0/24 -p tcp -j REDIRECT"));
+        assert!(rendered.contains("-I PREROUTING 1 -m comment --comment wuther:auto-redirect"));
+        assert!(!rendered.contains(" OUTPUT "));
+        assert!(!rendered.to_ascii_lowercase().contains("tproxy"));
+        assert!(!rendered.to_ascii_lowercase().contains("queue"));
+    }
+
+    #[test]
+    fn iptables_failure_rolls_back_only_chains_created_by_this_attempt() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft" {
+                if command.args().first().map(String::as_str) == Some("list") {
+                    return Ok(nft_table_absent_output());
+                }
+                return Ok(RuleCommandOutput::failure("nft unavailable"));
+            }
+            if command
+                .args()
+                .iter()
+                .any(|argument| argument == "--to-ports")
+            {
+                return Ok(RuleCommandOutput::failure("permission denied"));
+            }
+            Ok(RuleCommandOutput::success())
+        });
+        let error =
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor)
+                .unwrap_err();
+        assert!(error.to_string().contains("permission denied"));
+        let commands = executor.commands();
+        assert!(commands.iter().any(|command| {
+            command.program() == "iptables"
+                && command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["-F", IPTABLES_CHAIN])
+        }));
+        assert!(commands.iter().any(|command| {
+            command.program() == "iptables"
+                && command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["-X", IPTABLES_CHAIN])
+        }));
+    }
+
+    #[test]
+    fn dual_stack_chains_are_fully_prepared_before_either_hook_becomes_active() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft" {
+                if command.args().first().map(String::as_str) == Some("list") {
+                    return Ok(nft_table_absent_output());
+                }
+                return Ok(RuleCommandOutput::failure("nft unavailable"));
+            }
+            if command.program() == "ip6tables"
+                && command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["-N", IPTABLES_CHAIN])
+            {
+                return Ok(RuleCommandOutput::failure("ip6tables unavailable"));
+            }
+            Ok(RuleCommandOutput::success())
+        });
+        assert!(
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor,)
+                .is_err()
+        );
+        let commands = executor.commands();
+        assert!(
+            !commands
+                .iter()
+                .any(|command| command.args().iter().any(|argument| argument == "-I"))
+        );
+        assert!(commands.iter().any(|command| {
+            command.program() == "iptables"
+                && command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["-X", IPTABLES_CHAIN])
+        }));
+    }
+
+    #[test]
+    fn preexisting_iptables_chain_is_preserved_on_collision() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft" {
+                return Err(io::Error::new(io::ErrorKind::NotFound, "missing nft"));
+            }
+            if command
+                .args()
+                .windows(2)
+                .any(|args| args == ["-N", IPTABLES_CHAIN])
+            {
+                return Ok(RuleCommandOutput::failure("Chain already exists"));
+            }
+            Ok(RuleCommandOutput::success())
+        });
+        assert!(
+            install_with_executor(&base_plan(CaptureTraffic::System), dual_ports(), &executor,)
+                .is_err()
+        );
+        let commands = executor.commands();
+        assert!(!commands.iter().any(|command| {
+            command.args().iter().any(|argument| argument == "-F")
+                || command.args().iter().any(|argument| argument == "-X")
+        }));
+    }
+
+    #[test]
+    fn uninstall_is_idempotent_when_owned_table_or_chains_are_already_absent() {
+        let executor = RecordingExecutor::new(|command: &RuleCommand, _| {
+            if command.program() == "nft" {
+                Ok(nft_table_absent_output())
+            } else {
+                Ok(RuleCommandOutput::failure(
+                    "No chain/target/match by that name.",
+                ))
+            }
+        });
+        uninstall_with_executor(AutoRedirectBackend::Nftables, &executor).unwrap();
+        uninstall_with_executor(
+            AutoRedirectBackend::Iptables {
+                hook: AutoRedirectHook::Prerouting,
+                ipv4: true,
+                ipv6: true,
+            },
+            &executor,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn unrelated_nft_not_found_does_not_release_owned_backend() {
+        let executor = RecordingExecutor::new(|_command: &RuleCommand, _| {
+            Ok(RuleCommandOutput::failure(
+                "nft: error while loading shared libraries: libnftables.so: No such file or directory",
+            ))
+        });
+
+        let error = uninstall_with_executor(AutoRedirectBackend::Nftables, &executor).unwrap_err();
+
+        assert!(error.to_string().contains("libnftables.so"));
+    }
+
+    #[test]
+    fn uninstall_attempts_all_symmetric_cleanup_commands_before_erroring() {
+        let executor = RecordingExecutor::new(|_command: &RuleCommand, _| {
+            Ok(RuleCommandOutput::failure("permission denied"))
+        });
+        let error = uninstall_with_executor(
+            AutoRedirectBackend::Iptables {
+                hook: AutoRedirectHook::Output,
+                ipv4: true,
+                ipv6: true,
+            },
+            &executor,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("permission denied"));
+        let commands = executor.commands();
+        assert_eq!(commands.len(), 6);
+        for program in ["iptables", "ip6tables"] {
+            assert!(commands.iter().any(|command| {
+                command.program() == program
+                    && command_text(command).contains(
+                        "-D OUTPUT -m comment --comment wuther:auto-redirect -j WUTHER_AUTO_REDIRECT",
+                    )
+            }));
+        }
+    }
+
+    #[test]
+    fn nft_only_mptcp_fast_path_filter_forbids_lossy_iptables_fallback() {
+        let mut plan = base_plan(CaptureTraffic::System);
+        plan.exclude_mptcp = true;
+        let executor = RecordingExecutor::new(nft_absent_or_check_fails);
+        let error = install_with_executor(&plan, dual_ports(), &executor).unwrap_err();
+        assert!(error.to_string().contains("exclude_mptcp"));
+        assert!(
+            executor
+                .commands()
+                .iter()
+                .all(|command| command.program() == "nft")
+        );
+    }
+
+    #[test]
+    fn static_route_whitelist_omits_unmatched_address_family() {
+        let mut plan = base_plan(CaptureTraffic::System);
+        plan.route_addresses = vec!["203.0.113.0/24".parse().unwrap()];
+        let script = build_nft_script(&plan, dual_ports()).unwrap();
+        assert!(script.contains("redirect to :41231"));
+        assert!(!script.contains("redirect to :51432"));
+
+        let executor = RecordingExecutor::new(nft_absent_or_check_fails);
+        let backend = install_with_executor(&plan, dual_ports(), &executor).unwrap();
+        assert_eq!(
+            backend,
+            AutoRedirectBackend::Iptables {
+                hook: AutoRedirectHook::Output,
+                ipv4: true,
+                ipv6: false,
+            }
+        );
+        assert!(
+            !executor
+                .commands()
+                .iter()
+                .any(|command| command.program() == "ip6tables")
+        );
+    }
+
+    #[test]
+    fn zero_ports_and_semantically_unavailable_ipv6_fail_closed() {
+        let plan = base_plan(CaptureTraffic::System);
+        assert!(build_nft_script(&plan, RedirectPorts::new(0, None)).is_err());
+
+        let mut v4_only = plan;
+        v4_only.ipv6_enabled = false;
+        v4_only.tun_v6_cidr = None;
+        assert!(build_nft_script(&v4_only, RedirectPorts::new(12_345, Some(23_456))).is_err());
+    }
+
+    #[test]
+    fn lan_owner_filters_and_output_lan_filters_fail_closed() {
+        let mut lan = base_plan(CaptureTraffic::Lan);
+        lan.filters.include_uid = vec![1000];
+        assert!(build_nft_script(&lan, dual_ports()).is_err());
+
+        let mut output = base_plan(CaptureTraffic::Apps);
+        output.filters.include_mac = vec!["aa:bb:cc:dd:ee:ff".into()];
+        assert!(build_nft_script(&output, dual_ports()).is_err());
+    }
+
+    #[test]
+    fn reversed_owner_ranges_are_rejected() {
+        let mut plan = base_plan(CaptureTraffic::Apps);
+        plan.filters.include_uid_range = vec![(2000, 1000)];
+        assert!(build_nft_script(&plan, dual_ports()).is_err());
+    }
+}

--- a/crates/core-capture/src/platform/linux_auto_redirect_route.rs
+++ b/crates/core-capture/src/platform/linux_auto_redirect_route.rs
@@ -1,0 +1,1809 @@
+//! Linux root-managed TUN `auto_redirect` policy routing.
+//!
+//! The data plane is activated in two phases:
+//!
+//! 1. [`prepare_routes`] writes split-default routes into an otherwise inactive
+//!    custom table. `RouteTable` owns their rollback ledger.
+//! 2. [`install`] adds policy rules only after the TUN dispatcher is ready.
+//!    Every successful rule is recorded immediately in
+//!    [`AutoRedirectRouteLease`], so a partially failed activation remains
+//!    exactly retryable by [`uninstall`].
+//!
+//! The capture selectors deliberately model only locally generated system
+//! traffic (`iif lo`) and only TCP/UDP. Forwarded packets, LAN ingress, ICMP,
+//! and every other protocol continue through the pre-existing routing policy.
+
+use std::{
+    collections::BTreeMap,
+    io,
+    process::{Command, Stdio},
+};
+
+use core_config::model::{
+    CaptureTraffic, DEFAULT_AUTO_REDIRECT_OUTPUT_MARK, MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX,
+};
+use ipnet::IpNet;
+use tracing::{debug, info, warn};
+
+use crate::{
+    engine::{CaptureError, CapturePlan},
+    route_table::{ManagedRoute, RouteTable},
+};
+
+const IPV4_ROUTE_PROBE_TARGET: &str = "1.1.1.1";
+const IPV6_ROUTE_PROBE_TARGET: &str = "2606:4700:4700::1111";
+const IPV4_SPLIT_DEFAULTS: [&str; 2] = ["0.0.0.0/1", "128.0.0.0/1"];
+const IPV6_SPLIT_DEFAULTS: [&str; 2] = ["::/1", "8000::/1"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IpFamily {
+    V4,
+    V6,
+}
+
+impl IpFamily {
+    const fn command_flag(self) -> &'static str {
+        match self {
+            Self::V4 => "-4",
+            Self::V6 => "-6",
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::V4 => "IPv4",
+            Self::V6 => "IPv6",
+        }
+    }
+
+    const fn route_probe_target(self) -> &'static str {
+        match self {
+            Self::V4 => IPV4_ROUTE_PROBE_TARGET,
+            Self::V6 => IPV6_ROUTE_PROBE_TARGET,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuleLayer {
+    Dependency,
+    Capture,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OwnedIpRule {
+    family: IpFamily,
+    layer: RuleLayer,
+    selector: Vec<String>,
+}
+
+impl OwnedIpRule {
+    fn command(&self, verb: &'static str) -> RuleCommand {
+        let mut args = Vec::with_capacity(self.selector.len() + 3);
+        args.push(self.family.command_flag().to_owned());
+        args.push("rule".to_owned());
+        args.push(verb.to_owned());
+        args.extend(self.selector.iter().cloned());
+        RuleCommand::new("ip", args)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DefaultRouteProbe {
+    lookup_table: String,
+    interface: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct BypassLookupTables {
+    ipv4: String,
+    ipv6: Option<String>,
+}
+
+impl BypassLookupTables {
+    fn for_family(&self, family: IpFamily) -> Result<&str, CaptureError> {
+        match family {
+            IpFamily::V4 => Ok(&self.ipv4),
+            IpFamily::V6 => self.ipv6.as_deref().ok_or_else(|| {
+                route_error("IPv6 policy rule requested without an IPv6 bypass lookup table")
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OutboundInterfaceRestore {
+    previous: Option<String>,
+    installed: String,
+}
+
+/// Exact ownership ledger for the active `auto_redirect` RPDB transaction.
+///
+/// A lease is intentionally not `Clone`: duplicating it would duplicate rule
+/// ownership. When installation fails, the successfully installed prefix stays
+/// here for the caller's ordered `pre_stop` retry.
+#[derive(Debug, Default)]
+pub(crate) struct AutoRedirectRouteLease {
+    rules: Vec<OwnedIpRule>,
+    bypass_lookup_tables: Option<BypassLookupTables>,
+    outbound_interface_restore: Option<OutboundInterfaceRestore>,
+}
+
+impl AutoRedirectRouteLease {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+            && self.bypass_lookup_tables.is_none()
+            && self.outbound_interface_restore.is_none()
+    }
+}
+
+/// A shell-free command description used by both the production executor and
+/// deterministic fault-injection tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuleCommand {
+    program: &'static str,
+    args: Vec<String>,
+}
+
+impl RuleCommand {
+    fn new(program: &'static str, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            program,
+            args: args.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub(crate) fn program(&self) -> &'static str {
+        self.program
+    }
+
+    pub(crate) fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
+/// Captured command result. Exit status, stdout, and stderr are retained so no
+/// kernel/iproute2 failure is reduced to an opaque boolean.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuleCommandOutput {
+    pub(crate) success: bool,
+    pub(crate) status: Option<i32>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+impl RuleCommandOutput {
+    #[cfg(test)]
+    fn success(stdout: impl Into<String>) -> Self {
+        Self {
+            success: true,
+            status: Some(0),
+            stdout: stdout.into(),
+            stderr: String::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn failure(status: i32, stderr: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            status: Some(status),
+            stdout: String::new(),
+            stderr: stderr.into(),
+        }
+    }
+}
+
+/// Injectable boundary for every `ip` invocation.
+pub(crate) trait RuleExecutor {
+    fn execute(&self, command: &RuleCommand) -> io::Result<RuleCommandOutput>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct SystemRuleExecutor;
+
+impl RuleExecutor for SystemRuleExecutor {
+    fn execute(&self, command: &RuleCommand) -> io::Result<RuleCommandOutput> {
+        let output = Command::new(command.program())
+            .args(command.args())
+            .stdin(Stdio::null())
+            .output()?;
+        Ok(RuleCommandOutput {
+            success: output.status.success(),
+            status: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+trait OutboundInterfaceStore {
+    fn get(&self) -> Option<String>;
+    fn set(&self, interface: Option<String>);
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct SystemOutboundInterfaceStore;
+
+impl OutboundInterfaceStore for SystemOutboundInterfaceStore {
+    fn get(&self) -> Option<String> {
+        core_outbound::outbound_interface()
+    }
+
+    fn set(&self, interface: Option<String>) {
+        core_outbound::set_outbound_interface(interface);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RulePriorities {
+    tun_subnet: u32,
+    route_bypass: u32,
+    outbound_mark: u32,
+    capture: u32,
+}
+
+/// Prepare the inactive custom route table.
+///
+/// Every successful route is already owned by `RouteTable`; a later failure is
+/// returned without erasing that prefix so the caller's normal route rollback
+/// can retry it exactly.
+pub(crate) fn prepare_routes(
+    routes: &RouteTable,
+    plan: &CapturePlan,
+    ipv6: bool,
+) -> Result<(), CaptureError> {
+    validate_plan(plan, ipv6)?;
+
+    for cidr in IPV4_SPLIT_DEFAULTS {
+        add_split_default(routes, plan, cidr)?;
+    }
+    if ipv6 {
+        for cidr in IPV6_SPLIT_DEFAULTS {
+            add_split_default(routes, plan, cidr)?;
+        }
+    }
+    Ok(())
+}
+
+/// Activate the policy-routing transaction with the system `ip` command.
+pub(crate) fn install(
+    plan: &CapturePlan,
+    ipv6: bool,
+    lease: &mut AutoRedirectRouteLease,
+) -> Result<(), CaptureError> {
+    install_with_dependencies(
+        plan,
+        ipv6,
+        lease,
+        &SystemRuleExecutor,
+        &SystemOutboundInterfaceStore,
+    )
+}
+
+/// Remove all owned rules in reverse order and restore the previous outbound
+/// interface only after every rule is gone.
+pub(crate) fn uninstall(lease: &mut AutoRedirectRouteLease) -> Result<(), CaptureError> {
+    uninstall_with_dependencies(lease, &SystemRuleExecutor, &SystemOutboundInterfaceStore)
+}
+
+fn add_split_default(
+    routes: &RouteTable,
+    plan: &CapturePlan,
+    cidr: &'static str,
+) -> Result<(), CaptureError> {
+    let dest = cidr.parse::<IpNet>().map_err(|error| {
+        route_error(format!(
+            "internal split-default CIDR {cidr:?} is invalid: {error}"
+        ))
+    })?;
+    routes
+        .add(ManagedRoute {
+            dest,
+            gateway: None,
+            interface: plan.interface_name.clone(),
+            metric: 0,
+            table: Some(plan.iproute2_table_index),
+        })
+        .map_err(|error| {
+            route_error(format!(
+                "add split-default route {cidr} via {} table {}: {error}",
+                plan.interface_name, plan.iproute2_table_index
+            ))
+        })
+}
+
+fn install_with_dependencies<E, I>(
+    plan: &CapturePlan,
+    ipv6: bool,
+    lease: &mut AutoRedirectRouteLease,
+    executor: &E,
+    interfaces: &I,
+) -> Result<(), CaptureError>
+where
+    E: RuleExecutor + ?Sized,
+    I: OutboundInterfaceStore + ?Sized,
+{
+    if !lease.is_empty() {
+        return Err(route_error(
+            "auto_redirect route lease is already active or awaiting cleanup",
+        ));
+    }
+    validate_plan(plan, ipv6)?;
+
+    let priorities = rule_priorities(plan.iproute2_rule_index)?;
+    probe_ip_rule_support(executor, IpFamily::V4, priorities)?;
+    if ipv6 {
+        probe_ip_rule_support(executor, IpFamily::V6, priorities)?;
+    }
+    probe_custom_table_ownership(executor, IpFamily::V4, plan)?;
+    if ipv6 {
+        probe_custom_table_ownership(executor, IpFamily::V6, plan)?;
+    }
+
+    let ipv4_route = probe_default_route(executor, IpFamily::V4, plan)?;
+    let ipv6_route = if ipv6 {
+        Some(probe_default_route(executor, IpFamily::V6, plan)?)
+    } else {
+        None
+    };
+    match ipv6_route.as_ref() {
+        Some(route) if route.interface != ipv4_route.interface => {
+            return Err(route_error(format!(
+                "IPv4 and IPv6 default routes use different interfaces ({} vs {}); the current outbound interface binding is not family-specific",
+                ipv4_route.interface, route.interface
+            )));
+        }
+        _ => {}
+    }
+    let bypass_tables = BypassLookupTables {
+        ipv4: ipv4_route.lookup_table.clone(),
+        ipv6: ipv6_route.as_ref().map(|route| route.lookup_table.clone()),
+    };
+    let rules = build_rules(plan, ipv6, &bypass_tables)?;
+
+    // Record the reversible global mutation before applying it. Capture rules
+    // are installed last, but any earlier rule-add failure is still cleaned by
+    // the same lease rather than silently leaking DefaultInterface state.
+    lease.bypass_lookup_tables = Some(bypass_tables);
+    lease.outbound_interface_restore = Some(OutboundInterfaceRestore {
+        previous: interfaces.get(),
+        installed: ipv4_route.interface.clone(),
+    });
+    interfaces.set(Some(ipv4_route.interface));
+
+    for rule in rules {
+        let command = rule.command("add");
+        execute_checked(executor, "install auto_redirect policy rule", &command)?;
+        lease.rules.push(rule);
+    }
+
+    info!(
+        target: "capture::linux::tun",
+        rules = lease.rules.len(),
+        ipv6,
+        table = plan.iproute2_table_index,
+        rule_priority = plan.iproute2_rule_index,
+        "auto_redirect local TCP/UDP policy routing installed"
+    );
+    Ok(())
+}
+
+fn uninstall_with_dependencies<E, I>(
+    lease: &mut AutoRedirectRouteLease,
+    executor: &E,
+    interfaces: &I,
+) -> Result<(), CaptureError>
+where
+    E: RuleExecutor + ?Sized,
+    I: OutboundInterfaceStore + ?Sized,
+{
+    if lease.is_empty() {
+        return Ok(());
+    }
+
+    let mut pending = std::mem::take(&mut lease.rules);
+    let mut failures = Vec::new();
+    while let Some(layer) = pending.last().map(|rule| rule.layer) {
+        let layer_start = pending
+            .iter()
+            .rposition(|rule| rule.layer != layer)
+            .map_or(0, |index| index + 1);
+        let layer_rules = pending.split_off(layer_start);
+        let mut failed_layer = Vec::new();
+        for rule in layer_rules.into_iter().rev() {
+            let command = rule.command("del");
+            match executor.execute(&command) {
+                Ok(output) if output.success => {
+                    debug!(
+                        target: "capture::linux::tun",
+                        command = %render_command(&command),
+                        "auto_redirect policy rule removed"
+                    );
+                }
+                Ok(output) if is_absent_delete(&command, &output) => {
+                    debug!(
+                        target: "capture::linux::tun",
+                        command = %render_command(&command),
+                        "auto_redirect policy rule was already absent"
+                    );
+                }
+                Ok(output) => {
+                    failures.push(command_failure(&command, &output));
+                    failed_layer.push(rule);
+                }
+                Err(error) => {
+                    failures.push(format!("spawn {}: {error}", render_command(&command)));
+                    failed_layer.push(rule);
+                }
+            }
+        }
+        // A surviving capture rule still depends on output-mark bypass and the
+        // custom-table routes. Keep every lower layer untouched until all
+        // rules in the current layer are gone.
+        if !failed_layer.is_empty() {
+            failed_layer.reverse();
+            pending.extend(failed_layer);
+            break;
+        }
+    }
+    lease.rules = pending;
+
+    if lease.rules.is_empty() {
+        if let Some(restore) = lease.outbound_interface_restore.take() {
+            let current = interfaces.get();
+            if current.as_deref() == Some(restore.installed.as_str()) {
+                debug!(
+                    target: "capture::linux::tun",
+                    installed = %restore.installed,
+                    previous = ?restore.previous,
+                    "restore outbound interface after policy-rule cleanup"
+                );
+                interfaces.set(restore.previous);
+            } else {
+                warn!(
+                    target: "capture::linux::tun",
+                    installed = %restore.installed,
+                    current = ?current,
+                    "outbound interface changed after auto_redirect activation; preserve newer value"
+                );
+            }
+        }
+        lease.bypass_lookup_tables = None;
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        warn!(
+            target: "capture::linux::tun",
+            remaining_rules = lease.rules.len(),
+            errors = %failures.join("; "),
+            "auto_redirect policy-rule cleanup incomplete"
+        );
+        Err(route_error(format!(
+            "auto_redirect policy-rule cleanup incomplete: {}",
+            failures.join("; ")
+        )))
+    }
+}
+
+fn validate_plan(plan: &CapturePlan, ipv6: bool) -> Result<(), CaptureError> {
+    if !plan.on || !plan.auto_route || !plan.auto_redirect {
+        return Err(route_error(
+            "auto_redirect local policy routing requires capture.on, auto_route, and auto_redirect",
+        ));
+    }
+    if plan.traffic != CaptureTraffic::System {
+        return Err(route_error(
+            "auto_redirect local policy routing supports only traffic=system",
+        ));
+    }
+    if plan.strict_route {
+        return Err(route_error(
+            "auto_redirect local TCP/UDP policy routing cannot promise strict_route for ICMP/other protocols",
+        ));
+    }
+    if !plan.route_address_set.is_empty() || !plan.route_exclude_address_set.is_empty() {
+        return Err(route_error(
+            "dynamic route_address_set/route_exclude_address_set must be rejected before auto_redirect activation",
+        ));
+    }
+    if plan.interface_name.trim().is_empty() || plan.interface_name == "lo" {
+        return Err(route_error(
+            "auto_redirect custom TUN interface must be non-empty and must not be loopback",
+        ));
+    }
+    if plan.iproute2_table_index == 0 || matches!(plan.iproute2_table_index, 253..=255) {
+        return Err(route_error(
+            "auto_redirect iproute2_table_index must be a non-reserved private table",
+        ));
+    }
+    rule_priorities(plan.iproute2_rule_index)?;
+    if ipv6 && (!plan.ipv6_enabled || plan.tun_v6_cidr.is_none()) {
+        return Err(route_error(
+            "IPv6 policy routing requested without an enabled IPv6 TUN subnet",
+        ));
+    }
+    Ok(())
+}
+
+fn rule_priorities(capture: u32) -> Result<RulePriorities, CaptureError> {
+    if capture > MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX {
+        return Err(route_error(format!(
+            "iproute2_rule_index {capture} must precede the Linux main rule priority 32766"
+        )));
+    }
+    let tun_subnet = capture.checked_sub(3).filter(|priority| *priority > 0);
+    let Some(tun_subnet) = tun_subnet else {
+        return Err(route_error(format!(
+            "iproute2_rule_index {capture} is too small; auto_redirect needs four ordered priorities"
+        )));
+    };
+    Ok(RulePriorities {
+        tun_subnet,
+        route_bypass: capture - 2,
+        outbound_mark: capture - 1,
+        capture,
+    })
+}
+
+fn probe_ip_rule_support<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    family: IpFamily,
+    priorities: RulePriorities,
+) -> Result<(), CaptureError> {
+    let command = RuleCommand::new("ip", [family.command_flag(), "rule", "list"]);
+    let output = execute_checked(executor, "probe ip rule support", &command)?;
+    let response = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+    for unsupported in [
+        "unknown",
+        "unrecognized",
+        "not implemented",
+        "no such",
+        "feature not available",
+        "try `ip address help'",
+        "usage:",
+    ] {
+        if response.contains(unsupported) {
+            return Err(route_error(format!(
+                "{} ip rule probe returned unsupported output for {}: {}",
+                family.label(),
+                render_command(&command),
+                response.trim()
+            )));
+        }
+    }
+    for line in output.stdout.lines() {
+        let Some((priority, _)) = line.trim().split_once(':') else {
+            continue;
+        };
+        let Ok(priority) = priority.trim().parse::<u32>() else {
+            continue;
+        };
+        if [
+            priorities.tun_subnet,
+            priorities.route_bypass,
+            priorities.outbound_mark,
+            priorities.capture,
+        ]
+        .contains(&priority)
+        {
+            return Err(route_error(format!(
+                "{} ip rule priority {priority} is already occupied; refusing ambiguous ownership",
+                family.label()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn probe_custom_table_ownership<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    family: IpFamily,
+    plan: &CapturePlan,
+) -> Result<(), CaptureError> {
+    let table = plan.iproute2_table_index.to_string();
+    let command = RuleCommand::new(
+        "ip",
+        [
+            family.command_flag().to_owned(),
+            "route".to_owned(),
+            "show".to_owned(),
+            "table".to_owned(),
+            table.clone(),
+        ],
+    );
+    let output = execute_checked(
+        executor,
+        "verify auto_redirect private route table",
+        &command,
+    )?;
+    let expected = match family {
+        IpFamily::V4 => IPV4_SPLIT_DEFAULTS.as_slice(),
+        IpFamily::V6 => IPV6_SPLIT_DEFAULTS.as_slice(),
+    };
+    let mut seen = Vec::new();
+    for line in output
+        .stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let tokens = line.split_ascii_whitespace().collect::<Vec<_>>();
+        let destination = tokens.first().copied().unwrap_or_default();
+        let interfaces = tokens
+            .windows(2)
+            .filter(|pair| pair[0] == "dev")
+            .map(|pair| pair[1])
+            .collect::<Vec<_>>();
+        let metrics = tokens
+            .windows(2)
+            .filter(|pair| pair[0] == "metric")
+            .map(|pair| pair[1])
+            .collect::<Vec<_>>();
+        let protocols = tokens
+            .windows(2)
+            .filter(|pair| pair[0] == "proto")
+            .map(|pair| pair[1])
+            .collect::<Vec<_>>();
+        let owns_interface = tokens.iter().filter(|token| **token == "dev").count()
+            == interfaces.len()
+            && interfaces.as_slice() == [plan.interface_name.as_str()];
+        let owns_metric = tokens.iter().filter(|token| **token == "metric").count()
+            == metrics.len()
+            && matches!(metrics.as_slice(), [] | ["0"]);
+        let owns_protocol = tokens.iter().filter(|token| **token == "proto").count()
+            == protocols.len()
+            && matches!(protocols.as_slice(), [] | ["boot"]);
+        let has_gateway = tokens.contains(&"via") || tokens.contains(&"nexthop");
+        if !expected.contains(&destination)
+            || !owns_interface
+            || !owns_metric
+            || !owns_protocol
+            || has_gateway
+        {
+            return Err(route_error(format!(
+                "{} private table {table} contains an unowned route: {line}",
+                family.label()
+            )));
+        }
+        seen.push(destination);
+    }
+    seen.sort_unstable();
+    let mut expected_sorted = expected.to_vec();
+    expected_sorted.sort_unstable();
+    if seen != expected_sorted {
+        return Err(route_error(format!(
+            "{} private table {table} does not contain exactly the owned split-default routes via {}",
+            family.label(),
+            plan.interface_name
+        )));
+    }
+    Ok(())
+}
+
+fn probe_default_route<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    family: IpFamily,
+    plan: &CapturePlan,
+) -> Result<DefaultRouteProbe, CaptureError> {
+    let command = RuleCommand::new(
+        "ip",
+        [
+            family.command_flag(),
+            "route",
+            "get",
+            family.route_probe_target(),
+        ],
+    );
+    let output = execute_checked(executor, "probe outbound route", &command)?;
+    let lookup_table = super::route_probe::outbound_bypass_table_from_route_get(&output.stdout);
+    let interface = super::route_probe::outbound_interface_from_route_get(&output.stdout)
+        .ok_or_else(|| {
+            route_error(format!(
+                "{} outbound route probe did not report a dev interface: {}",
+                family.label(),
+                output.stdout.trim()
+            ))
+        })?;
+    if interface == plan.interface_name {
+        return Err(route_error(format!(
+            "{} outbound route resolves through the TUN interface {}; refusing a routing loop",
+            family.label(),
+            interface
+        )));
+    }
+    if table_matches_index(&lookup_table, plan.iproute2_table_index) {
+        return Err(route_error(format!(
+            "{} outbound bypass table {lookup_table} equals custom TUN table {}; refusing a routing loop",
+            family.label(),
+            plan.iproute2_table_index
+        )));
+    }
+    verify_default_route_in_table(executor, family, &lookup_table, &interface)?;
+    Ok(DefaultRouteProbe {
+        lookup_table,
+        interface,
+    })
+}
+
+fn verify_default_route_in_table<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    family: IpFamily,
+    table: &str,
+    interface: &str,
+) -> Result<(), CaptureError> {
+    let command = RuleCommand::new(
+        "ip",
+        [
+            family.command_flag().to_owned(),
+            "route".to_owned(),
+            "show".to_owned(),
+            "table".to_owned(),
+            table.to_owned(),
+            "default".to_owned(),
+        ],
+    );
+    let output = execute_checked(executor, "verify outbound default route", &command)?;
+    let tokens = output.stdout.split_ascii_whitespace().collect::<Vec<_>>();
+    let has_default = output
+        .stdout
+        .lines()
+        .any(|line| line.trim_start().starts_with("default "));
+    let has_interface = tokens.windows(2).any(|pair| pair == ["dev", interface]);
+    if !has_default || !has_interface {
+        return Err(route_error(format!(
+            "{} bypass table {table} has no usable default route via {interface}",
+            family.label()
+        )));
+    }
+    Ok(())
+}
+
+fn table_matches_index(table: &str, index: u32) -> bool {
+    match table {
+        "default" => index == 253,
+        "main" => index == 254,
+        "local" => index == 255,
+        _ => table.parse::<u32>() == Ok(index),
+    }
+}
+
+fn build_rules(
+    plan: &CapturePlan,
+    ipv6: bool,
+    bypass_tables: &BypassLookupTables,
+) -> Result<Vec<OwnedIpRule>, CaptureError> {
+    let priorities = rule_priorities(plan.iproute2_rule_index)?;
+    let custom_table = plan.iproute2_table_index.to_string();
+    let mut rules = Vec::new();
+
+    // Install every real-network dependency before any rule that can direct a
+    // packet to the custom TUN table.
+    for net in merged_bypass_targets(plan) {
+        let family = family_for_net(&net);
+        if family == IpFamily::V6 && !ipv6 {
+            continue;
+        }
+        rules.push(destination_rule(
+            family,
+            priorities.route_bypass,
+            Some(&net),
+            true,
+            None,
+            bypass_tables.for_family(family)?,
+            RuleLayer::Dependency,
+        ));
+    }
+
+    let output_mark = plan
+        .auto_redirect_marks
+        .output
+        .filter(|mark| *mark != 0)
+        .unwrap_or(DEFAULT_AUTO_REDIRECT_OUTPUT_MARK);
+    for family in enabled_families(ipv6) {
+        rules.push(mark_rule(
+            family,
+            priorities.outbound_mark,
+            output_mark,
+            bypass_tables.for_family(family)?,
+        ));
+    }
+
+    // Internal TUN peer traffic takes precedence over broad bypass CIDRs (for
+    // example 172.16.0.0/12), but remains local-only and TCP/UDP-only.
+    for protocol in ["tcp", "udp"] {
+        rules.push(destination_rule(
+            IpFamily::V4,
+            priorities.tun_subnet,
+            Some(&IpNet::V4(plan.tun_v4_cidr)),
+            true,
+            Some(protocol),
+            &custom_table,
+            RuleLayer::Capture,
+        ));
+    }
+    if ipv6 {
+        let tun_v6 = plan.tun_v6_cidr.ok_or_else(|| {
+            route_error("IPv6 policy routing requested without an IPv6 TUN subnet")
+        })?;
+        for protocol in ["tcp", "udp"] {
+            rules.push(destination_rule(
+                IpFamily::V6,
+                priorities.tun_subnet,
+                Some(&IpNet::V6(tun_v6)),
+                true,
+                Some(protocol),
+                &custom_table,
+                RuleLayer::Capture,
+            ));
+        }
+    }
+
+    let route_addresses = canonical_nets(&plan.route_addresses);
+    if route_addresses.is_empty() {
+        for family in enabled_families(ipv6) {
+            for protocol in ["tcp", "udp"] {
+                rules.push(destination_rule(
+                    family,
+                    priorities.capture,
+                    None,
+                    true,
+                    Some(protocol),
+                    &custom_table,
+                    RuleLayer::Capture,
+                ));
+            }
+        }
+    } else {
+        for net in route_addresses {
+            let family = family_for_net(&net);
+            if family == IpFamily::V6 && !ipv6 {
+                continue;
+            }
+            for protocol in ["tcp", "udp"] {
+                rules.push(destination_rule(
+                    family,
+                    priorities.capture,
+                    Some(&net),
+                    true,
+                    Some(protocol),
+                    &custom_table,
+                    RuleLayer::Capture,
+                ));
+            }
+        }
+    }
+    Ok(rules)
+}
+
+fn destination_rule(
+    family: IpFamily,
+    priority: u32,
+    destination: Option<&IpNet>,
+    local_only: bool,
+    protocol: Option<&'static str>,
+    lookup: &str,
+    layer: RuleLayer,
+) -> OwnedIpRule {
+    let mut selector = vec!["priority".to_owned(), priority.to_string()];
+    if local_only {
+        selector.extend(["iif".to_owned(), "lo".to_owned()]);
+    }
+    if let Some(protocol) = protocol {
+        selector.extend(["ipproto".to_owned(), protocol.to_owned()]);
+    }
+    if let Some(destination) = destination {
+        selector.extend(["to".to_owned(), destination.to_string()]);
+    }
+    selector.extend(["lookup".to_owned(), lookup.to_owned()]);
+    OwnedIpRule {
+        family,
+        layer,
+        selector,
+    }
+}
+
+fn mark_rule(family: IpFamily, priority: u32, mark: u32, lookup: &str) -> OwnedIpRule {
+    OwnedIpRule {
+        family,
+        layer: RuleLayer::Dependency,
+        selector: vec![
+            "priority".to_owned(),
+            priority.to_string(),
+            "iif".to_owned(),
+            "lo".to_owned(),
+            "fwmark".to_owned(),
+            format!("{mark:#x}"),
+            "lookup".to_owned(),
+            lookup.to_owned(),
+        ],
+    }
+}
+
+fn merged_bypass_targets(plan: &CapturePlan) -> Vec<IpNet> {
+    let mut targets = plan.exclude_cidrs.clone();
+    targets.extend(plan.route_exclude_addresses.iter().copied());
+    targets.extend(plan.loopback_addresses.iter().filter_map(|address| {
+        let prefix = if address.is_ipv4() { 32 } else { 128 };
+        IpNet::new(*address, prefix).ok()
+    }));
+    canonical_nets(&targets)
+}
+
+fn canonical_nets(nets: &[IpNet]) -> Vec<IpNet> {
+    let mut unique = BTreeMap::new();
+    for net in nets {
+        unique.entry(net.to_string()).or_insert(*net);
+    }
+    unique.into_values().collect()
+}
+
+fn family_for_net(net: &IpNet) -> IpFamily {
+    match net {
+        IpNet::V4(_) => IpFamily::V4,
+        IpNet::V6(_) => IpFamily::V6,
+    }
+}
+
+fn enabled_families(ipv6: bool) -> impl Iterator<Item = IpFamily> {
+    [IpFamily::V4, IpFamily::V6]
+        .into_iter()
+        .filter(move |family| *family == IpFamily::V4 || ipv6)
+}
+
+fn execute_checked<E: RuleExecutor + ?Sized>(
+    executor: &E,
+    phase: &str,
+    command: &RuleCommand,
+) -> Result<RuleCommandOutput, CaptureError> {
+    let output = executor.execute(command).map_err(|error| {
+        route_error(format!(
+            "{phase}: spawn {}: {error}",
+            render_command(command)
+        ))
+    })?;
+    if output.success {
+        Ok(output)
+    } else {
+        Err(route_error(format!(
+            "{phase}: {}",
+            command_failure(command, &output)
+        )))
+    }
+}
+
+fn command_failure(command: &RuleCommand, output: &RuleCommandOutput) -> String {
+    let detail = if output.stderr.trim().is_empty() {
+        output.stdout.trim()
+    } else {
+        output.stderr.trim()
+    };
+    format!(
+        "{} failed (status={:?}, stderr={:?}, detail={detail:?})",
+        render_command(command),
+        output.status,
+        output.stderr.trim()
+    )
+}
+
+fn is_absent_delete(command: &RuleCommand, output: &RuleCommandOutput) -> bool {
+    let args = command
+        .args()
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let detail = format!("{}\n{}", output.stderr, output.stdout);
+    super::is_absent_ip_rule_delete(command.program(), &args, &detail)
+        || detail
+            .to_ascii_lowercase()
+            .contains("rtnetlink answers: no such process")
+}
+
+fn render_command(command: &RuleCommand) -> String {
+    std::iter::once(command.program())
+        .chain(command.args().iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn route_error(message: impl Into<String>) -> CaptureError {
+    CaptureError::Route(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use core_config::model::{Capture, CaptureMethod};
+
+    use crate::route_table::RouteBackend;
+
+    use super::*;
+
+    struct RecordingExecutor<F> {
+        handler: F,
+        commands: Mutex<Vec<RuleCommand>>,
+    }
+
+    impl<F> RecordingExecutor<F> {
+        fn new(handler: F) -> Self {
+            Self {
+                handler,
+                commands: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn commands(&self) -> Vec<RuleCommand> {
+            self.commands.lock().expect("command ledger lock").clone()
+        }
+    }
+
+    impl<F> RuleExecutor for RecordingExecutor<F>
+    where
+        F: Fn(&RuleCommand, usize) -> io::Result<RuleCommandOutput>,
+    {
+        fn execute(&self, command: &RuleCommand) -> io::Result<RuleCommandOutput> {
+            let index = {
+                let mut commands = self.commands.lock().expect("command ledger lock");
+                let index = commands.len();
+                commands.push(command.clone());
+                index
+            };
+            (self.handler)(command, index)
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeInterfaceStore {
+        value: Mutex<Option<String>>,
+    }
+
+    impl FakeInterfaceStore {
+        fn new(value: Option<&str>) -> Self {
+            Self {
+                value: Mutex::new(value.map(str::to_owned)),
+            }
+        }
+
+        fn value(&self) -> Option<String> {
+            self.value.lock().expect("interface store lock").clone()
+        }
+    }
+
+    impl OutboundInterfaceStore for FakeInterfaceStore {
+        fn get(&self) -> Option<String> {
+            self.value()
+        }
+
+        fn set(&self, interface: Option<String>) {
+            *self.value.lock().expect("interface store lock") = interface;
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingRouteBackend {
+        added: Mutex<Vec<ManagedRoute>>,
+        deleted: Mutex<Vec<ManagedRoute>>,
+        calls: AtomicUsize,
+        fail_at: Option<usize>,
+    }
+
+    impl RecordingRouteBackend {
+        fn with_failure(fail_at: usize) -> Self {
+            Self {
+                fail_at: Some(fail_at),
+                ..Self::default()
+            }
+        }
+
+        fn added(&self) -> Vec<ManagedRoute> {
+            self.added.lock().expect("route add ledger lock").clone()
+        }
+    }
+
+    impl RouteBackend for RecordingRouteBackend {
+        fn add(&self, route: &ManagedRoute) -> Result<(), String> {
+            let index = self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_at == Some(index) {
+                return Err(format!("injected add failure at {index}"));
+            }
+            self.added
+                .lock()
+                .expect("route add ledger lock")
+                .push(route.clone());
+            Ok(())
+        }
+
+        fn del(&self, route: &ManagedRoute) -> Result<(), String> {
+            self.deleted
+                .lock()
+                .expect("route delete ledger lock")
+                .push(route.clone());
+            Ok(())
+        }
+    }
+
+    fn base_plan() -> CapturePlan {
+        let mut plan = CapturePlan::from_config(&Capture {
+            on: true,
+            method: CaptureMethod::VirtualNic,
+            ..Capture::default()
+        })
+        .expect("base capture plan");
+        plan.on = true;
+        plan.auto_route = true;
+        plan.auto_redirect = true;
+        plan.strict_route = false;
+        plan.traffic = CaptureTraffic::System;
+        plan.interface_name = "wuther0".to_owned();
+        plan.tun_v4_cidr = "198.18.0.1/30".parse().expect("v4 TUN CIDR");
+        plan.tun_v6_cidr = Some("fdfe:dcba:9876::1/126".parse().expect("v6 TUN CIDR"));
+        plan.ipv6_enabled = true;
+        plan.iproute2_table_index = 2_022;
+        plan.iproute2_rule_index = 9_000;
+        plan.exclude_cidrs.clear();
+        plan.route_addresses.clear();
+        plan.route_exclude_addresses.clear();
+        plan.route_address_set.clear();
+        plan.route_exclude_address_set.clear();
+        plan.loopback_addresses.clear();
+        plan
+    }
+
+    fn successful_environment(
+        command: &RuleCommand,
+        _index: usize,
+    ) -> io::Result<RuleCommandOutput> {
+        if command
+            .args()
+            .windows(2)
+            .any(|args| args == ["route", "show"])
+        {
+            let ipv6 = command.args().first().map(String::as_str) == Some("-6");
+            if command.args().last().map(String::as_str) == Some("default") {
+                let output = if ipv6 {
+                    "default via 2001:db8::1 dev eth-test"
+                } else {
+                    "default via 192.0.2.1 dev eth-test"
+                };
+                return Ok(RuleCommandOutput::success(output));
+            }
+            let output = if ipv6 {
+                "::/1 dev wuther0 metric 0\n8000::/1 dev wuther0 metric 0"
+            } else {
+                "0.0.0.0/1 dev wuther0 metric 0\n128.0.0.0/1 dev wuther0 metric 0"
+            };
+            return Ok(RuleCommandOutput::success(output));
+        }
+        if command
+            .args()
+            .windows(2)
+            .any(|args| args == ["route", "get"])
+        {
+            if command.args().first().map(String::as_str) == Some("-6") {
+                return Ok(RuleCommandOutput::success(
+                    "2606:4700:4700::1111 via 2001:db8::1 dev eth-test table 200 src 2001:db8::2",
+                ));
+            }
+            return Ok(RuleCommandOutput::success(
+                "1.1.1.1 via 192.0.2.1 dev eth-test table 100 src 192.0.2.2",
+            ));
+        }
+        Ok(RuleCommandOutput::success(""))
+    }
+
+    fn is_rule_command(command: &RuleCommand, verb: &str) -> bool {
+        command.args().get(1).map(String::as_str) == Some("rule")
+            && command.args().get(2).map(String::as_str) == Some(verb)
+    }
+
+    fn argument_after<'a>(command: &'a RuleCommand, needle: &str) -> Option<&'a str> {
+        command
+            .args()
+            .windows(2)
+            .find(|pair| pair[0] == needle)
+            .map(|pair| pair[1].as_str())
+    }
+
+    #[test]
+    fn prepare_routes_is_explicit_ipv4_or_dual_stack() {
+        let plan = base_plan();
+        let v4_backend = Arc::new(RecordingRouteBackend::default());
+        let v4_routes = RouteTable::with_backend(v4_backend.clone());
+        prepare_routes(&v4_routes, &plan, false).unwrap();
+        let v4 = v4_backend.added();
+        assert_eq!(
+            v4.iter()
+                .map(|route| route.dest.to_string())
+                .collect::<Vec<_>>(),
+            ["0.0.0.0/1", "128.0.0.0/1"]
+        );
+        assert!(v4.iter().all(|route| {
+            route.interface == "wuther0" && route.table == Some(2_022) && route.metric == 0
+        }));
+
+        let dual_backend = Arc::new(RecordingRouteBackend::default());
+        let dual_routes = RouteTable::with_backend(dual_backend.clone());
+        prepare_routes(&dual_routes, &plan, true).unwrap();
+        assert_eq!(
+            dual_backend
+                .added()
+                .iter()
+                .map(|route| route.dest.to_string())
+                .collect::<Vec<_>>(),
+            ["0.0.0.0/1", "128.0.0.0/1", "::/1", "8000::/1"]
+        );
+    }
+
+    #[test]
+    fn prepare_routes_returns_first_add_failure_and_preserves_owned_prefix() {
+        let plan = base_plan();
+        let backend = Arc::new(RecordingRouteBackend::with_failure(1));
+        let routes = RouteTable::with_backend(backend.clone());
+
+        let error = prepare_routes(&routes, &plan, false).unwrap_err();
+
+        assert!(error.to_string().contains("128.0.0.0/1"));
+        assert!(error.to_string().contains("injected add failure at 1"));
+        assert_eq!(routes.len(), 1);
+        assert_eq!(backend.added()[0].dest.to_string(), "0.0.0.0/1");
+    }
+
+    #[test]
+    fn capture_rules_are_local_tcp_udp_only_and_never_capture_forward_or_icmp() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, true, &mut lease, &executor, &interfaces).unwrap();
+
+        let capture_priority = plan.iproute2_rule_index.to_string();
+        let capture = executor
+            .commands()
+            .into_iter()
+            .filter(|command| {
+                is_rule_command(command, "add")
+                    && argument_after(command, "priority") == Some(capture_priority.as_str())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(capture.len(), 4);
+        for command in &capture {
+            assert_eq!(argument_after(command, "iif"), Some("lo"));
+            assert!(matches!(
+                argument_after(command, "ipproto"),
+                Some("tcp" | "udp")
+            ));
+            assert_eq!(
+                argument_after(command, "lookup"),
+                Some(plan.iproute2_table_index.to_string().as_str())
+            );
+            assert!(matches!(
+                command.args().first().map(String::as_str),
+                Some("-4" | "-6")
+            ));
+        }
+        assert!(!executor.commands().iter().any(|command| {
+            argument_after(command, "ipproto") == Some("icmp")
+                || argument_after(command, "ipproto") == Some("icmpv6")
+        }));
+        let custom_table = plan.iproute2_table_index.to_string();
+        assert!(
+            executor
+                .commands()
+                .iter()
+                .filter(|command| {
+                    is_rule_command(command, "add")
+                        && argument_after(command, "lookup") == Some(custom_table.as_str())
+                })
+                .all(|command| {
+                    argument_after(command, "iif") == Some("lo")
+                        && matches!(argument_after(command, "ipproto"), Some("tcp" | "udp"))
+                })
+        );
+
+        let cleanup = RecordingExecutor::new(successful_environment);
+        uninstall_with_dependencies(&mut lease, &cleanup, &interfaces).unwrap();
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+    }
+
+    #[test]
+    fn bypass_targets_merge_deduplicate_and_convert_loopback_hosts() {
+        let mut plan = base_plan();
+        plan.exclude_cidrs = vec!["10.0.0.0/8".parse().unwrap(), "10.0.0.0/8".parse().unwrap()];
+        plan.route_exclude_addresses = vec![
+            "10.0.0.0/8".parse().unwrap(),
+            "192.0.2.0/24".parse().unwrap(),
+        ];
+        plan.loopback_addresses = vec!["127.0.0.1".parse().unwrap(), "::1".parse().unwrap()];
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(None);
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, true, &mut lease, &executor, &interfaces).unwrap();
+
+        let bypass_priority = (plan.iproute2_rule_index - 2).to_string();
+        let bypass_destinations = executor
+            .commands()
+            .iter()
+            .filter(|command| {
+                is_rule_command(command, "add")
+                    && argument_after(command, "priority") == Some(bypass_priority.as_str())
+            })
+            .filter_map(|command| argument_after(command, "to").map(str::to_owned))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            bypass_destinations,
+            ["10.0.0.0/8", "127.0.0.1/32", "192.0.2.0/24", "::1/128"]
+        );
+        assert!(
+            executor
+                .commands()
+                .iter()
+                .filter(|command| {
+                    argument_after(command, "priority") == Some(bypass_priority.as_str())
+                        && argument_after(command, "iif") == Some("lo")
+                })
+                .count()
+                == 4
+        );
+
+        let cleanup = RecordingExecutor::new(successful_environment);
+        uninstall_with_dependencies(&mut lease, &cleanup, &interfaces).unwrap();
+    }
+
+    #[test]
+    fn static_route_addresses_expand_to_each_family_and_transport() {
+        let mut plan = base_plan();
+        plan.route_addresses = vec![
+            "203.0.113.0/24".parse().unwrap(),
+            "2001:db8:42::/48".parse().unwrap(),
+        ];
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(None);
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, true, &mut lease, &executor, &interfaces).unwrap();
+
+        let capture_priority = plan.iproute2_rule_index.to_string();
+        let capture = executor
+            .commands()
+            .into_iter()
+            .filter(|command| {
+                is_rule_command(command, "add")
+                    && argument_after(command, "priority") == Some(capture_priority.as_str())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(capture.len(), 4);
+        for destination in ["203.0.113.0/24", "2001:db8:42::/48"] {
+            for protocol in ["tcp", "udp"] {
+                assert!(capture.iter().any(|command| {
+                    argument_after(command, "to") == Some(destination)
+                        && argument_after(command, "ipproto") == Some(protocol)
+                        && argument_after(command, "iif") == Some("lo")
+                }));
+            }
+        }
+
+        let cleanup = RecordingExecutor::new(successful_environment);
+        uninstall_with_dependencies(&mut lease, &cleanup, &interfaces).unwrap();
+    }
+
+    #[test]
+    fn priorities_are_strictly_ordered_and_mark_rules_use_actual_family_tables() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(None);
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, true, &mut lease, &executor, &interfaces).unwrap();
+
+        let priorities = rule_priorities(plan.iproute2_rule_index).unwrap();
+        assert!(priorities.tun_subnet < priorities.route_bypass);
+        assert!(priorities.route_bypass < priorities.outbound_mark);
+        assert!(priorities.outbound_mark < priorities.capture);
+        let mark_rules = executor
+            .commands()
+            .into_iter()
+            .filter(|command| {
+                is_rule_command(command, "add")
+                    && argument_after(command, "priority")
+                        == Some(priorities.outbound_mark.to_string().as_str())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(mark_rules.len(), 2);
+        assert!(
+            mark_rules
+                .iter()
+                .all(|command| argument_after(command, "iif") == Some("lo"))
+        );
+        assert!(mark_rules.iter().any(|command| {
+            command.args().first().map(String::as_str) == Some("-4")
+                && argument_after(command, "lookup") == Some("100")
+        }));
+        assert!(mark_rules.iter().any(|command| {
+            command.args().first().map(String::as_str) == Some("-6")
+                && argument_after(command, "lookup") == Some("200")
+        }));
+        assert_eq!(
+            lease.bypass_lookup_tables,
+            Some(BypassLookupTables {
+                ipv4: "100".to_owned(),
+                ipv6: Some("200".to_owned())
+            })
+        );
+
+        let cleanup = RecordingExecutor::new(successful_environment);
+        uninstall_with_dependencies(&mut lease, &cleanup, &interfaces).unwrap();
+    }
+
+    #[test]
+    fn rule_priorities_fail_closed_after_linux_main_rule() {
+        assert!(rule_priorities(MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX).is_ok());
+        let error = rule_priorities(MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX + 1).unwrap_err();
+        assert!(error.to_string().contains("main rule priority 32766"));
+    }
+
+    #[test]
+    fn every_rule_add_failure_retains_exact_successful_prefix() {
+        let plan = base_plan();
+        let baseline = RecordingExecutor::new(successful_environment);
+        let baseline_interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut baseline_lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(
+            &plan,
+            false,
+            &mut baseline_lease,
+            &baseline,
+            &baseline_interfaces,
+        )
+        .unwrap();
+        let add_count = baseline
+            .commands()
+            .iter()
+            .filter(|command| is_rule_command(command, "add"))
+            .count();
+        let cleanup = RecordingExecutor::new(successful_environment);
+        uninstall_with_dependencies(&mut baseline_lease, &cleanup, &baseline_interfaces).unwrap();
+
+        for fail_at in 0..add_count {
+            let add_seen = Arc::new(AtomicUsize::new(0));
+            let counter = add_seen.clone();
+            let executor = RecordingExecutor::new(move |command: &RuleCommand, index| {
+                if is_rule_command(command, "add") {
+                    let add_index = counter.fetch_add(1, Ordering::SeqCst);
+                    if add_index == fail_at {
+                        return Ok(RuleCommandOutput::failure(
+                            77,
+                            format!("injected rule add failure {fail_at}"),
+                        ));
+                    }
+                }
+                successful_environment(command, index)
+            });
+            let interfaces = FakeInterfaceStore::new(Some("before0"));
+            let mut lease = AutoRedirectRouteLease::default();
+
+            let error = install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces)
+                .unwrap_err();
+
+            assert!(error.to_string().contains("status=Some(77)"));
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("injected rule add failure {fail_at}"))
+            );
+            assert_eq!(lease.rules.len(), fail_at);
+            assert_eq!(interfaces.value(), Some("eth-test".to_owned()));
+            let cleanup = RecordingExecutor::new(successful_environment);
+            uninstall_with_dependencies(&mut lease, &cleanup, &interfaces).unwrap();
+            assert!(lease.is_empty());
+            assert_eq!(interfaces.value(), Some("before0".to_owned()));
+        }
+    }
+
+    #[test]
+    fn uninstall_keeps_dependencies_behind_capture_failure_barrier_and_retries() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces).unwrap();
+        let owned = lease.rules.clone();
+
+        let delete_seen = Arc::new(AtomicUsize::new(0));
+        let counter = delete_seen.clone();
+        let partial_cleanup = RecordingExecutor::new(move |command: &RuleCommand, index| {
+            if is_rule_command(command, "del") {
+                let delete_index = counter.fetch_add(1, Ordering::SeqCst);
+                if delete_index == 0 || delete_index == 2 {
+                    return Ok(RuleCommandOutput::failure(
+                        13,
+                        format!("cleanup denied at {delete_index}"),
+                    ));
+                }
+            }
+            successful_environment(command, index)
+        });
+
+        let error =
+            uninstall_with_dependencies(&mut lease, &partial_cleanup, &interfaces).unwrap_err();
+        assert!(error.to_string().contains("cleanup denied at 0"));
+        assert!(error.to_string().contains("cleanup denied at 2"));
+
+        let attempted = partial_cleanup.commands();
+        let expected_capture = owned
+            .iter()
+            .filter(|rule| rule.layer == RuleLayer::Capture)
+            .rev()
+            .map(|rule| rule.command("del"))
+            .collect::<Vec<_>>();
+        assert_eq!(attempted, expected_capture);
+        assert_eq!(
+            lease
+                .rules
+                .iter()
+                .filter(|rule| rule.layer == RuleLayer::Dependency)
+                .count(),
+            owned
+                .iter()
+                .filter(|rule| rule.layer == RuleLayer::Dependency)
+                .count()
+        );
+        assert_eq!(
+            lease
+                .rules
+                .iter()
+                .filter(|rule| rule.layer == RuleLayer::Capture)
+                .count(),
+            2
+        );
+        assert_eq!(interfaces.value(), Some("eth-test".to_owned()));
+        assert!(lease.bypass_lookup_tables.is_some());
+
+        let retained = lease.rules.clone();
+        let retry = RecordingExecutor::new(successful_environment);
+        uninstall_with_dependencies(&mut lease, &retry, &interfaces).unwrap();
+        assert_eq!(
+            retry.commands(),
+            retained
+                .iter()
+                .rev()
+                .map(|rule| rule.command("del"))
+                .collect::<Vec<_>>()
+        );
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+    }
+
+    #[test]
+    fn absent_delete_is_success_and_restores_interface() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces).unwrap();
+        let absent = RecordingExecutor::new(|_command: &RuleCommand, _| {
+            Ok(RuleCommandOutput::failure(
+                2,
+                "RTNETLINK answers: No such file or directory",
+            ))
+        });
+
+        uninstall_with_dependencies(&mut lease, &absent, &interfaces).unwrap();
+
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+    }
+
+    #[test]
+    fn ip_rule_probe_and_spawn_failures_are_visible_without_mutating_lease() {
+        let plan = base_plan();
+        let unsupported = RecordingExecutor::new(|_command: &RuleCommand, _| {
+            Ok(RuleCommandOutput::success("Usage: ip address help"))
+        });
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+        let error = install_with_dependencies(&plan, false, &mut lease, &unsupported, &interfaces)
+            .unwrap_err();
+        assert!(error.to_string().contains("unsupported output"));
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+
+        let spawn_failure = RecordingExecutor::new(|_command: &RuleCommand, _| {
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing ip binary"))
+        });
+        let error =
+            install_with_dependencies(&plan, false, &mut lease, &spawn_failure, &interfaces)
+                .unwrap_err();
+        assert!(error.to_string().contains("spawn ip -4 rule list"));
+        assert!(error.to_string().contains("missing ip binary"));
+        assert!(lease.is_empty());
+    }
+
+    #[test]
+    fn occupied_rule_priority_fails_before_route_or_interface_mutation() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(|command: &RuleCommand, index| {
+            if command
+                .args()
+                .windows(2)
+                .any(|args| args == ["rule", "list"])
+            {
+                return Ok(RuleCommandOutput::success(
+                    "0: from all lookup local\n9000: from all lookup 2022",
+                ));
+            }
+            successful_environment(command, index)
+        });
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+
+        let error = install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces)
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("priority 9000 is already occupied")
+        );
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+        assert!(!executor.commands().iter().any(|command| {
+            command
+                .args()
+                .windows(2)
+                .any(|args| args == ["route", "get"])
+        }));
+    }
+
+    #[test]
+    fn private_table_with_unowned_route_fails_closed() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(|command: &RuleCommand, index| {
+            if command
+                .args()
+                .windows(2)
+                .any(|args| args == ["route", "show"])
+                && command.args().last().map(String::as_str) != Some("default")
+            {
+                return Ok(RuleCommandOutput::success(
+                    "0.0.0.0/1 dev wuther0\n128.0.0.0/1 dev wuther0\n203.0.113.0/24 dev other0",
+                ));
+            }
+            successful_environment(command, index)
+        });
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+
+        let error = install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("contains an unowned route"));
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+    }
+
+    #[test]
+    fn private_table_rejects_duplicate_or_qualified_split_defaults() {
+        for (case, private_routes) in [
+            (
+                "duplicate destination",
+                "0.0.0.0/1 dev wuther0 metric 0\n\
+                 0.0.0.0/1 dev wuther0 metric 0\n\
+                 128.0.0.0/1 dev wuther0 metric 0",
+            ),
+            (
+                "nonzero metric",
+                "0.0.0.0/1 dev wuther0 metric 42\n\
+                 128.0.0.0/1 dev wuther0 metric 0",
+            ),
+            (
+                "gateway",
+                "0.0.0.0/1 via 192.0.2.1 dev wuther0 metric 0\n\
+                 128.0.0.0/1 dev wuther0 metric 0",
+            ),
+            (
+                "foreign protocol",
+                "0.0.0.0/1 dev wuther0 proto static metric 0\n\
+                 128.0.0.0/1 dev wuther0 metric 0",
+            ),
+        ] {
+            let plan = base_plan();
+            let executor = RecordingExecutor::new(move |command: &RuleCommand, index| {
+                if command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["route", "show"])
+                    && command.args().last().map(String::as_str) != Some("default")
+                {
+                    return Ok(RuleCommandOutput::success(private_routes));
+                }
+                successful_environment(command, index)
+            });
+            let interfaces = FakeInterfaceStore::new(Some("before0"));
+            let mut lease = AutoRedirectRouteLease::default();
+
+            let error = install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces)
+                .unwrap_err();
+
+            assert!(
+                error.to_string().contains("private table 2022"),
+                "{case}: {error}"
+            );
+            assert!(lease.is_empty(), "{case}");
+            assert_eq!(interfaces.value(), Some("before0".to_owned()), "{case}");
+            assert!(
+                !executor.commands().iter().any(|command| {
+                    command
+                        .args()
+                        .windows(2)
+                        .any(|args| args == ["route", "get"])
+                }),
+                "{case}: route/interface discovery must happen only after ownership validation"
+            );
+        }
+    }
+
+    #[test]
+    fn route_get_host_route_without_table_default_is_rejected() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(|command: &RuleCommand, index| {
+            if command
+                .args()
+                .windows(2)
+                .any(|args| args == ["route", "show"])
+                && command.args().last().map(String::as_str) == Some("default")
+            {
+                return Ok(RuleCommandOutput::success(""));
+            }
+            successful_environment(command, index)
+        });
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+
+        let error = install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("has no usable default route"));
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("before0".to_owned()));
+    }
+
+    #[test]
+    fn cleanup_preserves_a_newer_outbound_interface_value() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(Some("before0"));
+        let mut lease = AutoRedirectRouteLease::default();
+        install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces).unwrap();
+        interfaces.set(Some("newer0".to_owned()));
+        let cleanup = RecordingExecutor::new(successful_environment);
+
+        uninstall_with_dependencies(&mut lease, &cleanup, &interfaces).unwrap();
+
+        assert!(lease.is_empty());
+        assert_eq!(interfaces.value(), Some("newer0".to_owned()));
+    }
+
+    #[test]
+    fn active_or_dirty_lease_is_rejected_before_any_command() {
+        let plan = base_plan();
+        let executor = RecordingExecutor::new(successful_environment);
+        let interfaces = FakeInterfaceStore::new(None);
+        let mut lease = AutoRedirectRouteLease {
+            rules: Vec::new(),
+            bypass_lookup_tables: Some(BypassLookupTables {
+                ipv4: "main".to_owned(),
+                ipv6: None,
+            }),
+            outbound_interface_restore: None,
+        };
+
+        assert!(
+            install_with_dependencies(&plan, false, &mut lease, &executor, &interfaces,).is_err()
+        );
+        assert!(executor.commands().is_empty());
+    }
+}

--- a/crates/core-capture/src/platform/linux_tproxy.rs
+++ b/crates/core-capture/src/platform/linux_tproxy.rs
@@ -1,5 +1,8 @@
-//! Linux 完整 TPROXY socket —— 真正接管被 nftables / iptables `TPROXY` 标记
-//! 重定向到本地端口的连接。
+//! Linux TCP/UDP TPROXY socket 与 TCP NAT REDIRECT listener。
+//!
+//! TPROXY socket 真正接管被 nftables / iptables `TPROXY` 标记并路由到本地
+//! 端口的连接；普通 TCP REDIRECT listener 则供 TUN `auto_redirect` 的 NAT
+//! 链使用，不设置 `IP_TRANSPARENT`。
 //!
 //! ## 工作流
 //!
@@ -76,6 +79,31 @@ impl TproxyListeners {
     }
 }
 
+/// One ordinary TCP listener used by Linux NAT `REDIRECT`.
+///
+/// Unlike [`TproxyListeners`], this socket deliberately has neither
+/// `IP_TRANSPARENT` nor either UDP original-destination socket option. The
+/// kernel records the pre-NAT TCP destination in conntrack and the accept loop
+/// retrieves it with `SO_ORIGINAL_DST`.
+pub(crate) struct RedirectTcpListener {
+    listener: TcpListener,
+    local_addr: SocketAddr,
+}
+
+impl RedirectTcpListener {
+    /// Return the address actually selected by the kernel for this family.
+    ///
+    /// Redirect listeners always bind port zero, so firewall rules must use
+    /// this address's port rather than the requested bind address.
+    pub(crate) fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub(crate) fn into_parts(self) -> (TcpListener, SocketAddr) {
+        (self.listener, self.local_addr)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TransparentSocketKind {
     Tcp,
@@ -116,6 +144,24 @@ fn configure_transparent_socket<O: TransparentSocketOps>(
     if kind == TransparentSocketKind::Tcp {
         ops.listen(&socket)?;
     }
+    Ok(socket)
+}
+
+fn configure_redirect_tcp_socket<O: TransparentSocketOps>(
+    ops: &mut O,
+    addr: SocketAddr,
+) -> io::Result<O::Socket> {
+    let socket = ops.socket(addr, TransparentSocketKind::Tcp)?;
+    if addr.is_ipv6() {
+        // Keep IPv4 and IPv6 REDIRECT sockets independent even on hosts whose
+        // net.ipv6.bindv6only sysctl defaults to zero.
+        ops.set_ipv6_only(&socket)?;
+    }
+    // A NAT REDIRECT listener is an ordinary local TCP socket. In particular,
+    // do not call set_ip_transparent or set_recv_original_dst here.
+    ops.set_reuse_addr(&socket)?;
+    ops.bind(&socket, addr)?;
+    ops.listen(&socket)?;
     Ok(socket)
 }
 
@@ -236,6 +282,85 @@ pub(crate) fn bind_tproxy_listener_set(
     bind_tproxy_listener_set_with(port, ipv6_enabled, bind_tproxy_listeners)
 }
 
+fn redirect_tcp_bind_addrs(ipv6_enabled: bool) -> Vec<SocketAddr> {
+    let mut binds = vec![ipv4_tproxy_bind_addr(0)];
+    if ipv6_enabled {
+        binds.push(ipv6_tproxy_bind_addr(0));
+    }
+    binds
+}
+
+fn bind_tcp_redirect_listener(bind: SocketAddr) -> Result<RedirectTcpListener, CaptureError> {
+    let mut ops = LibcTransparentSocketOps;
+    let fd = configure_redirect_tcp_socket(&mut ops, bind).map_err(|error| {
+        CaptureError::DeviceFailed(format!("prepare TCP REDIRECT listener {bind}: {error}"))
+    })?;
+    let listener: std::net::TcpListener = fd.into();
+    let local_addr = listener.local_addr().map_err(|error| {
+        CaptureError::DeviceFailed(format!(
+            "read TCP REDIRECT listener address for {bind}: {error}"
+        ))
+    })?;
+    listener.set_nonblocking(true).map_err(|error| {
+        CaptureError::DeviceFailed(format!(
+            "make TCP REDIRECT listener {local_addr} nonblocking: {error}"
+        ))
+    })?;
+    let listener = TcpListener::from_std(listener).map_err(|error| {
+        CaptureError::DeviceFailed(format!(
+            "register TCP REDIRECT listener {local_addr} with Tokio: {error}"
+        ))
+    })?;
+    Ok(RedirectTcpListener {
+        listener,
+        local_addr,
+    })
+}
+
+fn bind_tcp_redirect_listener_set_with<L>(
+    ipv6_enabled: bool,
+    mut bind: impl FnMut(SocketAddr) -> Result<L, CaptureError>,
+) -> Result<Vec<L>, CaptureError> {
+    redirect_tcp_bind_addrs(ipv6_enabled)
+        .into_iter()
+        .map(&mut bind)
+        .collect()
+}
+
+/// Pre-bind one ordinary, ephemeral TCP REDIRECT listener per enabled family.
+///
+/// IPv4 and IPv6 deliberately receive independent kernel-selected ports. The
+/// caller must install each family's NAT rule with [`RedirectTcpListener::local_addr`]
+/// before starting [`run_tcp_redirect`]. If any family fails, already-bound
+/// listeners are dropped before this function returns.
+pub(crate) fn bind_tcp_redirect_listener_set(
+    ipv6_enabled: bool,
+) -> Result<Vec<RedirectTcpListener>, CaptureError> {
+    bind_tcp_redirect_listener_set_with(ipv6_enabled, bind_tcp_redirect_listener)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TcpInterceptMode {
+    Tproxy,
+    Redirect,
+}
+
+impl TcpInterceptMode {
+    fn log_name(self) -> &'static str {
+        match self {
+            Self::Tproxy => "tproxy",
+            Self::Redirect => "redirect",
+        }
+    }
+
+    fn metadata(self) -> (&'static str, &'static str) {
+        match self {
+            Self::Tproxy => ("tproxy", "TPROXY"),
+            Self::Redirect => ("redirect", "REDIRECT"),
+        }
+    }
+}
+
 /// 启动一个 TPROXY TCP listener；accept 后立即 dial 出站并双向 splice，
 /// 同时推一条事件给 supervisor 用于 NAT / 调试日志。
 ///
@@ -245,25 +370,59 @@ pub(crate) async fn run_tcp_tproxy(
     listener: TcpListener,
     events: mpsc::Sender<CaptureEvent>,
     runtime: Arc<core_runtime::Runtime>,
+    stop: oneshot::Receiver<()>,
+) -> Result<(), CaptureError> {
+    run_tcp_intercept(listener, events, runtime, stop, TcpInterceptMode::Tproxy).await
+}
+
+/// Run an ordinary TCP NAT REDIRECT listener.
+///
+/// The listener itself is not transparent. Every accepted connection must
+/// have a distinct, valid `SO_ORIGINAL_DST`; direct access to the internal
+/// ephemeral endpoint is rejected instead of being proxied recursively.
+pub(crate) async fn run_tcp_redirect(
+    listener: TcpListener,
+    events: mpsc::Sender<CaptureEvent>,
+    runtime: Arc<core_runtime::Runtime>,
+    stop: oneshot::Receiver<()>,
+) -> Result<(), CaptureError> {
+    run_tcp_intercept(listener, events, runtime, stop, TcpInterceptMode::Redirect).await
+}
+
+async fn run_tcp_intercept(
+    listener: TcpListener,
+    events: mpsc::Sender<CaptureEvent>,
+    runtime: Arc<core_runtime::Runtime>,
     mut stop: oneshot::Receiver<()>,
+    mode: TcpInterceptMode,
 ) -> Result<(), CaptureError> {
     let bind = listener.local_addr()?;
-    // JoinSet owns every accepted relay. The engine stop path drops this
-    // listener future, and JoinSet::drop aborts all relays so none survive a
-    // reported TPROXY shutdown.
+    // JoinSet owns every accepted relay. Dropping this listener future aborts
+    // all relays, while the explicit stop path closes the accept socket first
+    // and then waits for every abort to finish.
     let mut connections = JoinSet::new();
-    info!(target: "capture::tproxy", addr = %bind, "tcp tproxy listening (dial+splice inline)");
+    info!(
+        target: "capture::tproxy",
+        addr = %bind,
+        mode = mode.log_name(),
+        "tcp transparent listener started (dial+splice inline)"
+    );
 
     loop {
         let accepted = tokio::select! {
+            biased;
             _ = &mut stop => {
-                connections.shutdown().await;
-                return Ok(());
+                break;
             }
             accepted = listener.accept() => Some(accepted),
             joined = connections.join_next(), if !connections.is_empty() => {
                 if let Some(Err(error)) = joined {
-                    debug!(target: "capture::tproxy", %error, "tcp relay task ended unexpectedly");
+                    debug!(
+                        target: "capture::tproxy",
+                        mode = mode.log_name(),
+                        %error,
+                        "tcp relay task ended unexpectedly"
+                    );
                 }
                 None
             }
@@ -274,7 +433,12 @@ pub(crate) async fn run_tcp_tproxy(
         let (stream, peer) = match accepted {
             Ok(p) => p,
             Err(e) => {
-                warn!(target: "capture::tproxy", error = %e, "accept failed");
+                warn!(
+                    target: "capture::tproxy",
+                    mode = mode.log_name(),
+                    error = %e,
+                    "accept failed"
+                );
                 continue;
             }
         };
@@ -283,6 +447,7 @@ pub(crate) async fn run_tcp_tproxy(
             Err(error) => {
                 warn!(
                     target: "capture::tproxy",
+                    mode = mode.log_name(),
                     %peer,
                     %error,
                     "cannot read accepted TCP local address; closing inbound"
@@ -291,11 +456,12 @@ pub(crate) async fn run_tcp_tproxy(
             }
         };
         let fd = stream.as_raw_fd();
-        let original_dst = match resolve_tcp_original_dst(fd, accepted_local, bind) {
+        let original_dst = match resolve_tcp_original_dst(fd, accepted_local, bind, mode) {
             Ok(addr) => addr,
             Err(error) => {
                 warn!(
                     target: "capture::tproxy",
+                    mode = mode.log_name(),
                     %peer,
                     local = %accepted_local,
                     %error,
@@ -318,16 +484,24 @@ pub(crate) async fn run_tcp_tproxy(
             let host = original_dst.ip().to_string();
             let port = original_dst.port();
             let handler = ListenerHandler::new(runtime);
-            let metadata =
-                InboundMetadata::tcp("tproxy", "TPROXY", peer, bind_local, host.clone(), port)
-                    .with_destination_ip(Some(original_dst.ip()))
-                    .with_route_ip(Some(original_dst.ip()));
+            let (inbound_tag, inbound_kind) = mode.metadata();
+            let metadata = InboundMetadata::tcp(
+                inbound_tag,
+                inbound_kind,
+                peer,
+                bind_local,
+                host.clone(),
+                port,
+            )
+            .with_destination_ip(Some(original_dst.ip()))
+            .with_route_ip(Some(original_dst.ip()));
             match handler.prepare_tcp(metadata).await {
                 Ok(prepared) => {
                     let outbound = prepared.result.outbound.clone();
                     if let Err(e) = handler.relay_prepared_tcp(stream, prepared).await {
                         debug!(
                             target: "capture::tproxy",
+                            mode = mode.log_name(),
                             %host, port, outbound = %outbound,
                             error = %e,
                             "splice ended (inbound/outbound EOF or error)"
@@ -337,14 +511,26 @@ pub(crate) async fn run_tcp_tproxy(
                 Err(e) => {
                     warn!(
                         target: "capture::tproxy",
+                        mode = mode.log_name(),
                         %host, port,
                         error = %e,
-                        "tproxy dial failed; closing inbound"
+                        "transparent TCP dial failed; closing inbound"
                     );
                 }
             }
         });
     }
+
+    shutdown_tcp_listener(listener, &mut connections).await;
+    Ok(())
+}
+
+async fn shutdown_tcp_listener(listener: TcpListener, connections: &mut JoinSet<()>) {
+    // Close the ingress endpoint before waiting for accepted relays. This
+    // makes stop externally visible immediately and prevents a final accept
+    // racing with relay cancellation.
+    drop(listener);
+    connections.shutdown().await;
 }
 
 /// UDP TPROXY —— `IP_TRANSPARENT` + `IP_RECVORIGDSTADDR`，`recvmsg` 解析 cmsg
@@ -1014,13 +1200,21 @@ fn resolve_tcp_original_dst(
     fd: RawFd,
     accepted_local: SocketAddr,
     listener_bind: SocketAddr,
+    mode: TcpInterceptMode,
 ) -> std::io::Result<SocketAddr> {
     let socket_original = if accepted_local.is_ipv4() {
         get_orig_dst_v4(fd).map(SocketAddr::V4)
     } else {
         get_orig_dst_v6(fd).map(SocketAddr::V6)
     };
-    select_tcp_original_dst(socket_original, accepted_local, listener_bind)
+    match mode {
+        TcpInterceptMode::Tproxy => {
+            select_tcp_original_dst(socket_original, accepted_local, listener_bind)
+        }
+        TcpInterceptMode::Redirect => {
+            select_tcp_redirect_original_dst(socket_original, accepted_local, listener_bind)
+        }
+    }
 }
 
 fn select_tcp_original_dst(
@@ -1061,6 +1255,45 @@ fn select_tcp_original_dst(
              accepted local address {accepted_local} is not a safe fallback"
         ),
     ))
+}
+
+fn select_tcp_redirect_original_dst(
+    socket_original: std::io::Result<SocketAddr>,
+    accepted_local: SocketAddr,
+    listener_bind: SocketAddr,
+) -> std::io::Result<SocketAddr> {
+    let addr = socket_original.map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("SO_ORIGINAL_DST failed for TCP REDIRECT: {error}"),
+        )
+    })?;
+    if addr.is_ipv4() != listener_bind.is_ipv4() || addr.ip().is_unspecified() || addr.port() == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("SO_ORIGINAL_DST returned unusable TCP REDIRECT address {addr}"),
+        ));
+    }
+
+    // A direct connection to the internal listener has no pre-NAT destination:
+    // Linux reports that listener endpoint as SO_ORIGINAL_DST. Never feed it
+    // back through routing. Compare IP and port rather than SocketAddr equality
+    // so IPv6 flowinfo cannot disguise the same endpoint.
+    if same_socket_endpoint(addr, accepted_local) || same_socket_endpoint(addr, listener_bind) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "SO_ORIGINAL_DST {addr} points at the internal TCP REDIRECT listener; \
+                 direct listener access is not proxyable"
+            ),
+        ));
+    }
+
+    Ok(addr)
+}
+
+fn same_socket_endpoint(left: SocketAddr, right: SocketAddr) -> bool {
+    left.ip() == right.ip() && left.port() == right.port()
 }
 
 #[allow(unsafe_code)]
@@ -1268,6 +1501,45 @@ mod tests {
     }
 
     #[test]
+    fn tcp_redirect_socket_never_enables_transparent_or_udp_original_dst_options() {
+        let mut ops = RecordingSocketOps::default();
+
+        configure_redirect_tcp_socket(&mut ops, ipv4_tproxy_bind_addr(0)).unwrap();
+
+        assert_eq!(
+            ops.steps,
+            [
+                SocketStep::Socket,
+                SocketStep::ReuseAddr,
+                SocketStep::Bind,
+                SocketStep::Listen,
+            ]
+        );
+        assert!(!ops.steps.contains(&SocketStep::Transparent));
+        assert!(!ops.steps.contains(&SocketStep::RecvOriginalDst));
+    }
+
+    #[test]
+    fn ipv6_tcp_redirect_sets_v6only_before_bind_without_transparent_options() {
+        let mut ops = RecordingSocketOps::default();
+
+        configure_redirect_tcp_socket(&mut ops, ipv6_tproxy_bind_addr(0)).unwrap();
+
+        assert_eq!(
+            ops.steps,
+            [
+                SocketStep::Socket,
+                SocketStep::Ipv6Only,
+                SocketStep::ReuseAddr,
+                SocketStep::Bind,
+                SocketStep::Listen,
+            ]
+        );
+        assert!(!ops.steps.contains(&SocketStep::Transparent));
+        assert!(!ops.steps.contains(&SocketStep::RecvOriginalDst));
+    }
+
+    #[test]
     fn udp_transparent_options_are_set_before_bind() {
         let mut ops = RecordingSocketOps::default();
 
@@ -1330,6 +1602,21 @@ mod tests {
     }
 
     #[test]
+    fn redirect_listener_set_uses_independent_ephemeral_family_binds() {
+        assert_eq!(
+            redirect_tcp_bind_addrs(true),
+            [
+                "0.0.0.0:0".parse::<SocketAddr>().unwrap(),
+                "[::]:0".parse::<SocketAddr>().unwrap(),
+            ]
+        );
+        assert_eq!(
+            redirect_tcp_bind_addrs(false),
+            ["0.0.0.0:0".parse::<SocketAddr>().unwrap()]
+        );
+    }
+
+    #[test]
     fn ipv6_bind_failure_drops_the_already_bound_ipv4_listener() {
         struct DropProbe(Arc<AtomicBool>);
 
@@ -1353,6 +1640,48 @@ mod tests {
 
         assert!(matches!(result, Err(CaptureError::DeviceFailed(_))));
         assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn redirect_ipv6_bind_failure_drops_the_already_bound_ipv4_listener() {
+        struct DropProbe(Arc<AtomicBool>);
+
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let probe = dropped.clone();
+        let result = bind_tcp_redirect_listener_set_with(true, |addr| {
+            if addr.is_ipv4() {
+                Ok(DropProbe(probe.clone()))
+            } else {
+                Err(CaptureError::DeviceFailed(
+                    "injected REDIRECT IPv6 bind failure".into(),
+                ))
+            }
+        });
+
+        assert!(matches!(result, Err(CaptureError::DeviceFailed(_))));
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn redirect_listener_reports_the_kernel_selected_ephemeral_port() {
+        let mut listeners = bind_tcp_redirect_listener_set(false).unwrap();
+        assert_eq!(listeners.len(), 1);
+
+        let listener = listeners.pop().unwrap();
+        let local_addr = listener.local_addr();
+        assert!(local_addr.is_ipv4());
+        assert!(local_addr.ip().is_unspecified());
+        assert_ne!(local_addr.port(), 0);
+
+        let (socket, parts_addr) = listener.into_parts();
+        assert_eq!(parts_addr, local_addr);
+        assert_eq!(socket.local_addr().unwrap(), local_addr);
     }
 
     #[test]
@@ -1412,6 +1741,98 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert!(error.to_string().contains("safe fallback"));
+    }
+
+    #[test]
+    fn tcp_intercept_metadata_preserves_tproxy_and_distinguishes_redirect() {
+        assert_eq!(TcpInterceptMode::Tproxy.metadata(), ("tproxy", "TPROXY"));
+        assert_eq!(
+            TcpInterceptMode::Redirect.metadata(),
+            ("redirect", "REDIRECT")
+        );
+    }
+
+    #[test]
+    fn tcp_redirect_requires_so_original_dst_without_local_fallback() {
+        let accepted_local: SocketAddr = "127.0.0.1:45123".parse().unwrap();
+        let listener_bind = ipv4_tproxy_bind_addr(45123);
+
+        let error = select_tcp_redirect_original_dst(
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "no conntrack original destination",
+            )),
+            accepted_local,
+            listener_bind,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("SO_ORIGINAL_DST failed"));
+    }
+
+    #[test]
+    fn tcp_redirect_rejects_direct_access_to_its_internal_listener() {
+        let internal: SocketAddr = "127.0.0.1:45123".parse().unwrap();
+
+        let error =
+            select_tcp_redirect_original_dst(Ok(internal), internal, ipv4_tproxy_bind_addr(45123))
+                .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("internal TCP REDIRECT listener"));
+    }
+
+    #[test]
+    fn tcp_redirect_accepts_a_distinct_valid_socket_original_destination() {
+        let original: SocketAddr = "198.51.100.20:443".parse().unwrap();
+
+        let selected = select_tcp_redirect_original_dst(
+            Ok(original),
+            "127.0.0.1:45123".parse().unwrap(),
+            ipv4_tproxy_bind_addr(45123),
+        )
+        .unwrap();
+
+        assert_eq!(selected, original);
+    }
+
+    #[tokio::test]
+    async fn tcp_listener_shutdown_closes_ingress_and_aborts_all_relays() {
+        struct RelayDropProbe(Arc<AtomicBool>);
+
+        impl Drop for RelayDropProbe {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let mut listeners = bind_tcp_redirect_listener_set(false).unwrap();
+        let (listener, local_addr) = listeners.pop().unwrap().into_parts();
+        let connect_addr =
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, local_addr.port()));
+        let relay_dropped = Arc::new(AtomicBool::new(false));
+        let relay_probe = relay_dropped.clone();
+        let (started_tx, started_rx) = oneshot::channel();
+        let mut connections = JoinSet::new();
+        connections.spawn(async move {
+            let _probe = RelayDropProbe(relay_probe);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        started_rx.await.unwrap();
+
+        shutdown_tcp_listener(listener, &mut connections).await;
+
+        assert!(relay_dropped.load(Ordering::SeqCst));
+        assert!(connections.is_empty());
+        let connect_result = tokio::time::timeout(
+            Duration::from_secs(1),
+            tokio::net::TcpStream::connect(connect_addr),
+        )
+        .await
+        .expect("closed local listener must refuse promptly");
+        assert!(connect_result.is_err());
     }
 
     #[tokio::test]

--- a/crates/core-capture/src/platform/mod.rs
+++ b/crates/core-capture/src/platform/mod.rs
@@ -13,6 +13,12 @@ use crate::engine::{CaptureEngine, CaptureError, CapturePlan};
 // Linux 与 Android 共享 /dev/net/tun + nftables 路径。
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux;
+// Linux TUN auto_redirect 的规则生成器在测试构建中也参与编译，便于在
+// 非 Linux 主机验证命令账本；真实安装入口仅由 Linux/Android 后端调用。
+#[cfg(any(test, target_os = "linux", target_os = "android"))]
+pub(crate) mod linux_auto_redirect;
+#[cfg(any(test, target_os = "linux", target_os = "android"))]
+pub(crate) mod linux_auto_redirect_route;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux_identity_bypass;
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -66,6 +72,13 @@ pub mod android_tun_io;
 pub mod vpnservice_tun_io;
 
 pub fn build_engine(plan: CapturePlan) -> Result<Arc<dyn CaptureEngine>, CaptureError> {
+    #[cfg(not(target_os = "linux"))]
+    if plan.auto_redirect {
+        return Err(CaptureError::Unsupported(
+            "capture.tun.auto_redirect is supported only by root-managed Linux TUN".into(),
+        ));
+    }
+
     #[cfg(target_os = "linux")]
     {
         return linux::build_engine(plan);
@@ -147,6 +160,8 @@ fn strip_ip_family_prefix<'a, 'b>(args: &'a [&'b str]) -> &'a [&'b str] {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_os = "linux"))]
+    use super::build_engine;
     use super::is_absent_ip_rule_delete;
 
     #[test]
@@ -180,5 +195,29 @@ mod tests {
             &["rule", "add", "fwmark", "0xff", "lookup", "main"],
             "RTNETLINK answers: No such file or directory\n",
         ));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_low_level_engine_build_rejects_auto_redirect() {
+        let capture = core_config::model::Capture {
+            on: true,
+            method: core_config::model::CaptureMethod::VirtualNic,
+            traffic: core_config::model::CaptureTraffic::System,
+            tun: core_config::model::TunInboundOptions {
+                auto_route: true,
+                auto_redirect: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let plan = crate::engine::CapturePlan::from_config(&capture).unwrap();
+
+        let error = match build_engine(plan) {
+            Ok(_) => panic!("non-Linux auto_redirect must fail at the platform boundary"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, crate::engine::CaptureError::Unsupported(_)));
+        assert!(error.to_string().contains("root-managed Linux"));
     }
 }

--- a/crates/core-capture/src/route_table.rs
+++ b/crates/core-capture/src/route_table.rs
@@ -193,10 +193,28 @@ fn platform_add(r: &ManagedRoute) -> Result<(), String> {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn platform_del(r: &ManagedRoute) -> Result<(), String> {
     let dest = r.dest.to_string();
+    let metric = r.metric.to_string();
     let mut args: Vec<&str> = if r.dest.addr().is_ipv6() {
-        vec!["-6", "route", "del", &dest, "dev", &r.interface]
+        vec![
+            "-6",
+            "route",
+            "del",
+            &dest,
+            "dev",
+            &r.interface,
+            "metric",
+            &metric,
+        ]
     } else {
-        vec!["route", "del", &dest, "dev", &r.interface]
+        vec![
+            "route",
+            "del",
+            &dest,
+            "dev",
+            &r.interface,
+            "metric",
+            &metric,
+        ]
     };
     let table_str;
     if let Some(table) = r.table {

--- a/crates/core-capture/src/supervisor.rs
+++ b/crates/core-capture/src/supervisor.rs
@@ -100,21 +100,62 @@ enum CleanupStep {
     NetworkListener,
     PurgeTask,
     EventTask,
+    EngineIngress,
     Dispatcher,
     SystemProxy,
     Engine,
+    OutboundFwmark,
     DnsListener,
 }
 
-const CLEANUP_ORDER: [CleanupStep; 7] = [
+const CLEANUP_ORDER: [CleanupStep; 9] = [
     CleanupStep::NetworkListener,
     CleanupStep::PurgeTask,
     CleanupStep::EventTask,
+    CleanupStep::EngineIngress,
     CleanupStep::Dispatcher,
     CleanupStep::SystemProxy,
     CleanupStep::Engine,
+    CleanupStep::OutboundFwmark,
     CleanupStep::DnsListener,
 ];
+
+#[derive(Debug)]
+struct OutboundFwmarkLease {
+    previous: u32,
+    installed: u32,
+}
+
+impl OutboundFwmarkLease {
+    fn install(requested: u32) -> Result<Option<Self>, CaptureError> {
+        if requested == 0 {
+            return Ok(None);
+        }
+        match core_outbound::compare_exchange_outbound_fwmark(0, requested) {
+            Ok(previous) => Ok(Some(Self {
+                previous,
+                installed: requested,
+            })),
+            Err(active) => Err(CaptureError::DeviceFailed(format!(
+                "cannot activate capture outbound fwmark {requested:#x}: \
+                 process-wide fwmark {active:#x} is already owned"
+            ))),
+        }
+    }
+
+    fn release(self) {
+        if let Err(active) =
+            core_outbound::compare_exchange_outbound_fwmark(self.installed, self.previous)
+        {
+            warn!(
+                target: "capture",
+                installed = self.installed,
+                active,
+                "outbound fwmark ownership changed before cleanup; preserving newer value"
+            );
+        }
+    }
+}
 
 #[derive(Default)]
 struct SupervisorResources {
@@ -125,9 +166,16 @@ struct SupervisorResources {
     network_listener_handle: Option<JoinHandle<()>>,
     dispatcher: Option<DispatcherHandles>,
     sys_proxy: Option<SystemProxyGuard>,
+    outbound_fwmark: Option<OutboundFwmarkLease>,
 }
 
 impl SupervisorResources {
+    fn release_outbound_fwmark(&mut self) {
+        if let Some(lease) = self.outbound_fwmark.take() {
+            lease.release();
+        }
+    }
+
     async fn shutdown(
         &mut self,
         engine: Arc<dyn CaptureEngine>,
@@ -148,6 +196,12 @@ impl SupervisorResources {
                     }
                     stop_and_join(self.event_handle.take()).await;
                 }
+                CleanupStep::EngineIngress if stop_engine => {
+                    // Keep the dispatcher alive until kernel/user-space
+                    // ingress has stopped accepting new traffic.
+                    engine.clone().pre_stop().await?;
+                }
+                CleanupStep::EngineIngress => {}
                 CleanupStep::Dispatcher => {
                     if let Some(dispatcher) = self.dispatcher.take() {
                         dispatcher.stop();
@@ -162,6 +216,14 @@ impl SupervisorResources {
                     engine_result = engine.clone().stop().await;
                 }
                 CleanupStep::Engine => {}
+                CleanupStep::OutboundFwmark => {
+                    // Platform rules must be gone before sockets lose their
+                    // loop-prevention mark. Failed cleanup keeps the lease for
+                    // the CleanupFailed retry path.
+                    if engine_result.is_ok() || !stop_engine {
+                        self.release_outbound_fwmark();
+                    }
+                }
                 CleanupStep::DnsListener => {
                     // If platform rollback failed, keep the resolver live while
                     // system DNS may still point at it. A later stop retry
@@ -177,8 +239,7 @@ impl SupervisorResources {
         engine_result
     }
 
-    /// Cancellation fallback for a dropped start/stop future. Async engine
-    /// cleanup is scheduled separately by [`CleanupTransaction::drop`].
+    /// Synchronous fallback when no Tokio runtime can host ordered cleanup.
     fn abort_sync(&mut self) {
         for handle in [
             self.network_listener_handle.take(),
@@ -200,6 +261,12 @@ impl SupervisorResources {
         }
         if let Some(proxy) = self.sys_proxy.take() {
             proxy.revert();
+        }
+        if self.outbound_fwmark.is_some() {
+            warn!(
+                target: "capture",
+                "synchronous abort cannot prove platform rollback; preserving outbound fwmark"
+            );
         }
     }
 }
@@ -303,41 +370,26 @@ impl Drop for CleanupTransaction {
         if !self.armed {
             return;
         }
-        if let Some(resources) = self.resources.as_mut() {
-            resources.abort_sync();
-        }
-        let dns_listeners = self
-            .resources
-            .as_mut()
-            .map(|resources| std::mem::take(&mut resources.dns_listeners))
-            .unwrap_or_default();
-
         let owner = self.owner.clone();
         if self.stop_engine {
             let engine = self.engine.clone();
             if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                let mut resources = self.resources.take().unwrap_or_default();
                 runtime.spawn(async move {
-                    if let Err(error) = engine.stop().await {
+                    if let Err(error) = resources.shutdown(engine, true).await {
                         warn!(
                             target: "capture",
                             %error,
                             "cancelled lifecycle transition: engine rollback failed"
                         );
                         if let Some(owner) = owner.upgrade() {
-                            let recovery = SupervisorResources {
-                                dns_listeners,
-                                ..SupervisorResources::default()
-                            };
                             {
                                 let mut slot = owner.resources.lock();
-                                *slot = Some(recovery);
+                                *slot = Some(resources);
                             }
                             owner.finish_transition(Lifecycle::CleanupFailed);
                         }
                         return;
-                    }
-                    for listener in dns_listeners.into_iter().rev() {
-                        listener.shutdown().await;
                     }
                     if let Some(owner) = owner.upgrade() {
                         owner.finish_transition(Lifecycle::Stopped);
@@ -346,7 +398,21 @@ impl Drop for CleanupTransaction {
                 return;
             }
         }
-        drop(dns_listeners);
+        if self.stop_engine {
+            let mut resources = self.resources.take().unwrap_or_default();
+            resources.abort_sync();
+            if let Some(owner) = owner.upgrade() {
+                {
+                    let mut slot = owner.resources.lock();
+                    *slot = Some(resources);
+                }
+                owner.finish_transition(Lifecycle::CleanupFailed);
+            }
+            return;
+        }
+        if let Some(resources) = self.resources.as_mut() {
+            resources.abort_sync();
+        }
         if let Some(owner) = owner.upgrade() {
             owner.finish_transition(Lifecycle::Stopped);
         }
@@ -578,10 +644,15 @@ impl CaptureSupervisor {
                 transaction.resources_mut().dns_listeners.push(listener);
             }
         }
+        transaction.resources_mut().outbound_fwmark =
+            OutboundFwmarkLease::install(runtime.capture_outbound_fwmark())?;
         transaction.mark_engine_started();
 
         let start_result: Result<(), CaptureError> = async {
-            self.engine.clone().start(tx, runtime.clone()).await?;
+            self.engine
+                .clone()
+                .start(tx.clone(), runtime.clone())
+                .await?;
             if failpoint == StartFailpoint::AfterEngine {
                 return Err(CaptureError::DeviceFailed(
                     "injected supervisor failure after engine start".into(),
@@ -649,6 +720,13 @@ impl CaptureSupervisor {
                 };
                 transaction.resources_mut().dispatcher = Some(handles);
             }
+            // Platform ingress hooks are activated only after the TUN
+            // dispatcher owns packet I/O. This prevents auto-redirect from
+            // accepting traffic into a half-started data plane.
+            self.engine
+                .clone()
+                .post_start(tx.clone(), runtime.clone())
+                .await?;
 
             let pool = self.fake_pool.clone();
             let nat = self.nat.clone();
@@ -1094,9 +1172,11 @@ route:
                 CleanupStep::NetworkListener,
                 CleanupStep::PurgeTask,
                 CleanupStep::EventTask,
+                CleanupStep::EngineIngress,
                 CleanupStep::Dispatcher,
                 CleanupStep::SystemProxy,
                 CleanupStep::Engine,
+                CleanupStep::OutboundFwmark,
                 CleanupStep::DnsListener,
             ]
         );
@@ -1125,11 +1205,14 @@ route:
         assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
         assert!(sup.resources.lock().is_none());
         assert_eq!(engine.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(engine.post_starts.load(Ordering::SeqCst), 1);
+        assert_eq!(engine.pre_stops.load(Ordering::SeqCst), 1);
         assert_eq!(engine.stops.load(Ordering::SeqCst), 1);
 
         sup.start(runtime).await.expect("retry after rollback");
         assert_eq!(sup.lifecycle(), Lifecycle::Running);
         assert_eq!(engine.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(engine.post_starts.load(Ordering::SeqCst), 2);
 
         sup.stop().await.expect("first stop");
         assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
@@ -1139,6 +1222,163 @@ route:
             engine.stops.load(Ordering::SeqCst),
             2,
             "already-stopped engine must not be stopped twice"
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_stop_failure_preserves_cleanup_state_for_retry() {
+        let engine = Arc::new(LifecycleEngine::new(false));
+        let sup = lifecycle_supervisor(engine.clone());
+        let runtime = lifecycle_runtime();
+        sup.start(runtime).await.unwrap();
+        engine.fail_pre_stop_once.store(true, Ordering::SeqCst);
+
+        let error = sup
+            .stop()
+            .await
+            .expect_err("injected pre-stop failure must escape stop");
+        assert!(
+            error
+                .to_string()
+                .contains("injected engine pre-stop failure")
+        );
+        assert_eq!(sup.lifecycle(), Lifecycle::CleanupFailed);
+        assert!(sup.resources.lock().is_some());
+        assert_eq!(engine.pre_stops.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            engine.stops.load(Ordering::SeqCst),
+            0,
+            "engine/TUN teardown must wait until ingress is detached"
+        );
+
+        sup.stop().await.expect("pre-stop retry succeeds");
+        assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
+        assert!(sup.resources.lock().is_none());
+        assert_eq!(engine.pre_stops.load(Ordering::SeqCst), 2);
+        assert_eq!(engine.stops.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn post_start_failure_rolls_back_engine_and_allows_retry() {
+        let engine = Arc::new(LifecycleEngine::new(false));
+        let sup = lifecycle_supervisor(engine.clone());
+        let runtime = lifecycle_runtime();
+        engine.fail_post_start_once.store(true, Ordering::SeqCst);
+
+        let error = sup
+            .start(runtime.clone())
+            .await
+            .expect_err("injected post-start failure must escape start");
+        assert!(
+            error
+                .to_string()
+                .contains("injected engine post-start failure")
+        );
+        assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
+        assert!(sup.resources.lock().is_none());
+        assert_eq!(engine.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(engine.post_starts.load(Ordering::SeqCst), 1);
+        assert_eq!(engine.pre_stops.load(Ordering::SeqCst), 1);
+        assert_eq!(engine.stops.load(Ordering::SeqCst), 1);
+
+        sup.start(runtime).await.expect("retry after rollback");
+        assert_eq!(sup.lifecycle(), Lifecycle::Running);
+        assert_eq!(engine.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(engine.post_starts.load(Ordering::SeqCst), 2);
+        sup.stop().await.expect("clean stop after retry");
+    }
+
+    #[tokio::test]
+    async fn outbound_fwmark_lease_tracks_capture_lifecycle_and_cleanup_retry() {
+        struct ResetFwmark;
+        impl Drop for ResetFwmark {
+            fn drop(&mut self) {
+                core_outbound::set_outbound_fwmark(0);
+            }
+        }
+
+        let _reset = ResetFwmark;
+        core_outbound::set_outbound_fwmark(0);
+        let engine = Arc::new(LifecycleEngine::new(false));
+        let sup = lifecycle_supervisor(engine.clone());
+        let runtime = lifecycle_runtime_with_fwmark();
+        assert_eq!(runtime.capture_outbound_fwmark(), 0x2d0);
+        assert_eq!(
+            core_outbound::outbound_fwmark(),
+            0,
+            "building Runtime must not activate process-wide socket state"
+        );
+
+        sup.start(runtime.clone()).await.expect("capture start");
+        assert_eq!(core_outbound::outbound_fwmark(), 0x2d0);
+
+        engine.fail_pre_stop_once.store(true, Ordering::SeqCst);
+        sup.stop()
+            .await
+            .expect_err("pre-stop failure must retain the active mark");
+        assert_eq!(sup.lifecycle(), Lifecycle::CleanupFailed);
+        assert_eq!(
+            core_outbound::outbound_fwmark(),
+            0x2d0,
+            "platform ingress may still be active after failed pre-stop"
+        );
+        sup.stop().await.expect("cleanup retry");
+        assert_eq!(core_outbound::outbound_fwmark(), 0);
+
+        engine.fail_post_start_once.store(true, Ordering::SeqCst);
+        sup.start(runtime.clone())
+            .await
+            .expect_err("post-start failure must roll back the lease");
+        assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
+        assert_eq!(core_outbound::outbound_fwmark(), 0);
+
+        engine.fail_post_start_once.store(true, Ordering::SeqCst);
+        engine.fail_stop_once.store(true, Ordering::SeqCst);
+        sup.start(runtime.clone())
+            .await
+            .expect_err("failed startup rollback must publish CleanupFailed");
+        assert_eq!(sup.lifecycle(), Lifecycle::CleanupFailed);
+        assert_eq!(
+            core_outbound::outbound_fwmark(),
+            0x2d0,
+            "startup rollback failure must retain the mark and cleanup ledger"
+        );
+
+        engine.fail_stop_once.store(true, Ordering::SeqCst);
+        sup.stop()
+            .await
+            .expect_err("caller cleanup retry failure must remain retryable");
+        assert_eq!(sup.lifecycle(), Lifecycle::CleanupFailed);
+        assert_eq!(core_outbound::outbound_fwmark(), 0x2d0);
+        sup.stop().await.expect("later caller cleanup retry");
+        assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
+        assert_eq!(core_outbound::outbound_fwmark(), 0);
+
+        sup.start(runtime.clone())
+            .await
+            .expect("ownership restore test");
+        core_outbound::set_outbound_fwmark(0x7788);
+        sup.stop()
+            .await
+            .expect("platform cleanup with newer mark owner");
+        assert_eq!(
+            core_outbound::outbound_fwmark(),
+            0x7788,
+            "lease release must not overwrite a newer process-wide owner"
+        );
+        core_outbound::set_outbound_fwmark(0);
+
+        core_outbound::set_outbound_fwmark(0x55aa);
+        let error = sup
+            .start(runtime)
+            .await
+            .expect_err("a second process-wide fwmark owner must be rejected");
+        assert!(error.to_string().contains("already owned"));
+        assert_eq!(sup.lifecycle(), Lifecycle::Stopped);
+        assert_eq!(
+            core_outbound::outbound_fwmark(),
+            0x55aa,
+            "failed lease acquisition must preserve the existing owner"
         );
     }
 
@@ -1264,7 +1504,11 @@ route:
     struct LifecycleEngine {
         plan: CapturePlan,
         starts: AtomicUsize,
+        post_starts: AtomicUsize,
+        pre_stops: AtomicUsize,
         stops: AtomicUsize,
+        fail_post_start_once: AtomicBool,
+        fail_pre_stop_once: AtomicBool,
         fail_stop_once: AtomicBool,
         block_start_once: AtomicBool,
         entered: Semaphore,
@@ -1280,7 +1524,11 @@ route:
             Self {
                 plan,
                 starts: AtomicUsize::new(0),
+                post_starts: AtomicUsize::new(0),
+                pre_stops: AtomicUsize::new(0),
                 stops: AtomicUsize::new(0),
+                fail_post_start_once: AtomicBool::new(false),
+                fail_pre_stop_once: AtomicBool::new(false),
                 fail_stop_once: AtomicBool::new(false),
                 block_start_once: AtomicBool::new(block_start_once),
                 entered: Semaphore::new(0),
@@ -1312,6 +1560,30 @@ route:
                     .await
                     .expect("start release semaphore")
                     .forget();
+            }
+            Ok(())
+        }
+
+        async fn post_start(
+            self: Arc<Self>,
+            _events: mpsc::Sender<CaptureEvent>,
+            _runtime: Arc<core_runtime::Runtime>,
+        ) -> Result<(), CaptureError> {
+            self.post_starts.fetch_add(1, Ordering::SeqCst);
+            if self.fail_post_start_once.swap(false, Ordering::SeqCst) {
+                return Err(CaptureError::DeviceFailed(
+                    "injected engine post-start failure".into(),
+                ));
+            }
+            Ok(())
+        }
+
+        async fn pre_stop(self: Arc<Self>) -> Result<(), CaptureError> {
+            self.pre_stops.fetch_add(1, Ordering::SeqCst);
+            if self.fail_pre_stop_once.swap(false, Ordering::SeqCst) {
+                return Err(CaptureError::DeviceFailed(
+                    "injected engine pre-stop failure".into(),
+                ));
             }
             Ok(())
         }
@@ -1385,6 +1657,23 @@ route:
             )
             .unwrap(),
         ))
+    }
+
+    fn lifecycle_runtime_with_fwmark() -> Arc<core_runtime::Runtime> {
+        let mut plan = core_config::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+route:
+  preset: direct
+"#,
+        )
+        .unwrap();
+        plan.capture.on = true;
+        plan.capture.method = CaptureMethod::Tproxy;
+        Arc::new(core_runtime::Runtime::build(plan))
     }
 
     fn dummy_engine() -> Arc<dyn CaptureEngine> {

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -857,7 +857,7 @@ impl Default for FakeIpFilterMode {
 
 /* ---------------- capture ---------------- */
 
-/// Capture / TUN 入站 —— 与 mihomo / sing-box `inbounds[type=tun]` 字段全量对齐。
+/// Capture / TUN 入站 —— 兼容 mihomo / sing-box 常用 `inbounds[type=tun]` 字段。
 ///
 /// Friendly 字段（顶层）保留 WutherCore 简洁语义；`tun` 子字段对齐 sing-box JSON。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -959,31 +959,32 @@ pub struct CaptureExclude {
     pub process: Vec<String>,
 }
 
-/* ---------------- sing-box 完整 TUN 字段 ---------------- */
+/* -------- sing-box 风格 TUN 字段模型（各数据面按能力校验） -------- */
 
 /// sing-tun auto_redirect input mark 默认值（`DefaultAutoRedirectInputMark`）。
 ///
-/// 进入 redirect chain 的入站 fwmark；TUN 抓包后由 nftables / iptables 给
-/// 入站方向的会话打标，`ip rule fwmark <input_mark> lookup <tun_table>` 把这
-/// 些会话回送到 TUN 表完成代理。对应 sing-tun `redirect.go::13`。
+/// auto_redirect mark/NFQUEUE 数据面的连接入站 mark。当前 Linux 安全子集
+/// 使用 TCP NAT REDIRECT、UDP TUN，并且不为 ICMP/其他协议添加导流 rule；
+/// 后者继续按已有主路由策略处理。显式配置
+/// input mark 会在配置编译阶段失败，避免伪装成已生效。
 pub const DEFAULT_AUTO_REDIRECT_INPUT_MARK: u32 = 0x2023;
 
 /// sing-tun auto_redirect output mark 默认值（`DefaultAutoRedirectOutputMark`）。
 ///
-/// TUN auto_route 下 outbound socket 必须使用同一个 mark 绕开 TUN 路由表；
-/// 即使未启用 auto_redirect，也复用该默认值保证与 mihomo/sing-tun 行为一致。
-/// 对应 sing-tun `redirect.go::14`。
+/// auto_redirect 的连接出站 mark；同时复用于 TUN outbound socket 的
+/// auto_route 绕行，避免代理自身流量再次进入 TUN。
 pub const DEFAULT_AUTO_REDIRECT_OUTPUT_MARK: u32 = 0x2024;
 
 /// sing-tun auto_redirect reset mark 默认值（`DefaultAutoRedirectResetMark`）。
 ///
-/// 用于 conntrack RST 包标记，避免 TPROXY 模式下 reset 包反复进入 redirect
-/// chain。对应 sing-tun `redirect.go::15`。
+/// auto_redirect 预匹配的连接 reset mark。只有启用配套 NFQUEUE
+/// 预匹配消费者时才生效；当前数据面保留该字段但不会静默安装队列规则。
 pub const DEFAULT_AUTO_REDIRECT_RESET_MARK: u32 = 0x2025;
 
 /// sing-tun auto_redirect nfqueue 默认编号（`DefaultAutoRedirectNFQueue`）。
 ///
-/// nf_queue 用户态 fast-fail 队列编号；对应 sing-tun `redirect.go::16`。
+/// NFQUEUE 预匹配消费者的默认队列编号。当前数据面尚未提供消费者，因此
+/// 显式配置该字段会在配置编译阶段失败，避免把流量送入无人读取的队列。
 pub const DEFAULT_AUTO_REDIRECT_NFQUEUE: u16 = 100;
 
 /// sing-tun fallback ip rule 优先级（`DefaultIPRoute2AutoRedirectFallbackRuleIndex`）。
@@ -993,9 +994,38 @@ pub const DEFAULT_AUTO_REDIRECT_NFQUEUE: u16 = 100;
 /// 把流量送回 TUN 表。对应 sing-tun `tun.go::70`。
 pub const DEFAULT_IPROUTE2_AUTO_REDIRECT_FALLBACK_RULE_INDEX: u32 = 32768;
 
-/// sing-box `inbounds[type=tun]` 全字段映射 —— 见
+/// Linux 内置 `main` rule 默认优先级为 32766；capture rule 必须排在它之前。
+pub const MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX: u32 = 32765;
+
+/// 解析 sing-box/mihomo 兼容的十进制或 `0x` 十六进制 mark。
+pub fn parse_auto_redirect_mark(value: &str) -> Option<u32> {
+    let value = value.trim();
+    if let Some(hex) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        u32::from_str_radix(hex, 16).ok()
+    } else {
+        value.parse().ok()
+    }
+}
+
+/// 解析并归一化 auto_redirect mark。
+///
+/// sing-tun 与 mihomo 都把未设置或显式 `0` 视作“使用默认值”。无效文本返回
+/// `None`，由配置编译器决定是否在当前激活的数据面上报错。
+pub fn normalize_auto_redirect_mark(value: Option<&str>, default: u32) -> Option<u32> {
+    match value {
+        None => Some(default),
+        Some(value) => {
+            parse_auto_redirect_mark(value).map(|mark| if mark == 0 { default } else { mark })
+        }
+    }
+}
+
+/// sing-box `inbounds[type=tun]` 兼容字段映射 —— 见
 /// <https://sing-box.sagernet.org/configuration/inbound/tun/>
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TunInboundOptions {
     /// `interface_name` —— 优先级高于 WutherCore 默认 `rpktun0/utun7/WutherCoreTun`。
@@ -1018,19 +1048,22 @@ pub struct TunInboundOptions {
     /// `iproute2_rule_index` —— `ip rule` 优先级起始 id。
     #[serde(default = "default_iproute2_rule")]
     pub iproute2_rule_index: u32,
-    /// `auto_redirect` —— 自动注入 nftables redirect 规则（更优于 `auto_route`）。
+    /// `auto_redirect` —— 在 auto_route TUN 数据面上，为 TCP 注入
+    /// nftables NAT REDIRECT。当前安全契约只把本机 UDP 送入 TUN；
+    /// ICMP/其他协议不新增导流 rule，继续按已有主路由策略处理。
     #[serde(default)]
     pub auto_redirect: bool,
-    /// `auto_redirect_input_mark` —— 进入 redirect chain 的 fwmark（hex 字串如 `"0x2023"`）。
+    /// `auto_redirect_input_mark` —— 保留的 mark/NFQUEUE 入站 mark；当前
+    /// Linux REDIRECT 安全子集不消费，显式配置会失败。
     #[serde(default)]
     pub auto_redirect_input_mark: Option<String>,
     /// `auto_redirect_output_mark` —— 跳过 redirect chain 的 fwmark。
     #[serde(default)]
     pub auto_redirect_output_mark: Option<String>,
-    /// `auto_redirect_reset_mark` —— RST 包 fwmark（用于 conntrack reset）。
+    /// `auto_redirect_reset_mark` —— NFQUEUE 预匹配的连接 reset mark（保留字段）。
     #[serde(default)]
     pub auto_redirect_reset_mark: Option<String>,
-    /// `auto_redirect_nfqueue` —— nfqueue 编号（用户态 fast-fail）。
+    /// `auto_redirect_nfqueue` —— NFQUEUE 预匹配队列编号（当前无消费者）。
     #[serde(default)]
     pub auto_redirect_nfqueue: Option<u16>,
     /// `auto_redirect_iproute2_fallback_rule_index` —— fallback ip rule 优先级。
@@ -1116,6 +1149,50 @@ pub struct TunInboundOptions {
     /// `platform.http_proxy` —— iOS/Android 系统代理透传。
     #[serde(default)]
     pub platform: Option<TunPlatformOptions>,
+}
+
+impl Default for TunInboundOptions {
+    fn default() -> Self {
+        Self {
+            interface_name: None,
+            address: Vec::new(),
+            inet6: true,
+            auto_route: true,
+            iproute2_table_index: default_iproute2_table(),
+            iproute2_rule_index: default_iproute2_rule(),
+            auto_redirect: false,
+            auto_redirect_input_mark: None,
+            auto_redirect_output_mark: None,
+            auto_redirect_reset_mark: None,
+            auto_redirect_nfqueue: None,
+            auto_redirect_iproute2_fallback_rule_index: None,
+            strict_route: false,
+            route_address: Vec::new(),
+            route_exclude_address: Vec::new(),
+            route_address_set: Vec::new(),
+            route_exclude_address_set: Vec::new(),
+            endpoint_independent_nat: false,
+            udp_timeout: default_udp_timeout(),
+            exclude_mptcp: false,
+            loopback_address: Vec::new(),
+            include_interface: Vec::new(),
+            exclude_interface: Vec::new(),
+            include_uid: Vec::new(),
+            include_uid_range: Vec::new(),
+            exclude_uid: Vec::new(),
+            exclude_uid_range: Vec::new(),
+            include_gid: Vec::new(),
+            include_gid_range: Vec::new(),
+            exclude_gid: Vec::new(),
+            exclude_gid_range: Vec::new(),
+            include_android_user: Vec::new(),
+            include_package: Vec::new(),
+            exclude_package: Vec::new(),
+            include_mac_address: Vec::new(),
+            exclude_mac_address: Vec::new(),
+            platform: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -956,10 +956,136 @@ fn try_classical_to_dsl(line: &str) -> Option<String> {
 }
 
 fn validate_capture_platform(c: &Capture) -> ConfigResult<()> {
+    validate_capture_platform_for_os(c, std::env::consts::OS)
+}
+
+fn validate_capture_platform_for_os(c: &Capture, os: &str) -> ConfigResult<()> {
     if !c.on {
         return Ok(());
     }
-    let os = std::env::consts::OS;
+    validate_capture_literals(c)?;
+
+    if c.tun.auto_redirect {
+        if !c.tun.auto_route {
+            return Err(
+                ConfigError::invalid("capture.tun.auto_redirect 依赖 auto_route")
+                    .hint("启用 capture.tun.auto_route，或关闭 auto_redirect"),
+            );
+        }
+        if c.method != CaptureMethod::VirtualNic {
+            return Err(ConfigError::invalid(
+                "capture.tun.auto_redirect 只属于 TUN 数据面，要求 capture.method=virtual_nic",
+            )
+            .hint("独立 TPROXY/REDIRECT 是不同入口；不要用 auto_redirect 替代"));
+        }
+        if os != "linux" {
+            return Err(
+                ConfigError::new(crate::error::ConfigErrorKind::UnsupportedPlatform(format!(
+                    "capture.tun.auto_redirect 当前仅支持 root-managed Linux；当前平台为 {os}"
+                )))
+                .hint("关闭 auto_redirect；Android root/VpnService 数据面将在独立能力中实现"),
+            );
+        }
+        if c.traffic != CaptureTraffic::System {
+            return Err(ConfigError::invalid(
+                "capture.tun.auto_redirect 当前只支持 traffic=system 的本机 TCP/UDP 数据面",
+            )
+            .hint("LAN/Apps 需要独立的全协议 policy-routing 过滤能力，不能仅靠 NAT return"));
+        }
+        if c.tun.strict_route {
+            return Err(ConfigError::invalid(
+                "capture.tun.auto_redirect 当前不支持 strict_route",
+            )
+            .hint("当前不为 ICMP/非 TCP-UDP 协议安装导流 rule，它们按已有主路由策略处理；启用 strict_route 会产生虚假的防泄漏承诺"));
+        }
+        if !c.tun.route_address_set.is_empty() || !c.tun.route_exclude_address_set.is_empty() {
+            return Err(ConfigError::invalid(
+                "auto_redirect 暂不能安全同步 route_address_set/route_exclude_address_set 的动态 IP 快照",
+            )
+            .hint("关闭 auto_redirect 可继续由 TUN 路由层使用动态规则集；内核 nft set 同步完成前禁止静默忽略"));
+        }
+        if c.tun.auto_redirect_nfqueue.is_some() {
+            return Err(ConfigError::invalid(
+                "auto_redirect_nfqueue 需要配套 NFQUEUE 用户态消费者，当前数据面未启用该能力",
+            )
+            .hint("删除 auto_redirect_nfqueue；TCP REDIRECT 与 UDP TUN 数据面不依赖 NFQUEUE"));
+        }
+        if c.tun.auto_redirect_input_mark.is_some()
+            || c.tun.auto_redirect_reset_mark.is_some()
+            || c.tun.auto_redirect_iproute2_fallback_rule_index.is_some()
+        {
+            return Err(ConfigError::invalid(
+                "显式 auto_redirect input/reset/fallback 配置属于 NFQUEUE/mark 数据面，当前 TCP REDIRECT 后端不会消费",
+            )
+            .hint("删除这些保留字段；auto_redirect_output_mark 已完整用于 outbound 绕行"));
+        }
+        if c.tun.exclude_mptcp {
+            return Err(ConfigError::invalid(
+                "auto_redirect 暂不支持 exclude_mptcp 的全协议旁路语义",
+            ));
+        }
+        if !c.exclude.process.is_empty() {
+            return Err(ConfigError::invalid(
+                "auto_redirect 暂不支持按进程名做内核级全协议旁路",
+            ));
+        }
+        let has_interface_filters =
+            !c.tun.include_interface.is_empty() || !c.tun.exclude_interface.is_empty();
+        let has_mac_filters =
+            !c.tun.include_mac_address.is_empty() || !c.tun.exclude_mac_address.is_empty();
+        if has_interface_filters || has_mac_filters {
+            return Err(ConfigError::invalid(
+                "traffic=system auto_redirect 暂不支持 interface/MAC 过滤",
+            )
+            .hint("NAT 链 return 不能撤销 auto_route，禁止把 TCP 快路径过滤误当成全协议旁路"));
+        }
+        let has_identity_filters = !c.tun.include_uid.is_empty()
+            || !c.tun.include_uid_range.is_empty()
+            || !c.tun.exclude_uid.is_empty()
+            || !c.tun.exclude_uid_range.is_empty()
+            || !c.tun.include_gid.is_empty()
+            || !c.tun.include_gid_range.is_empty()
+            || !c.tun.exclude_gid.is_empty()
+            || !c.tun.exclude_gid_range.is_empty()
+            || !c.tun.include_android_user.is_empty()
+            || !c.tun.include_package.is_empty()
+            || !c.tun.exclude_package.is_empty();
+        if has_identity_filters {
+            return Err(ConfigError::invalid(
+                "auto_redirect 身份过滤尚未具备双栈、可回滚的 policy-routing 事务",
+            )
+            .hint("删除 UID/GID/Android user/package 过滤；该能力会以独立提交补全"));
+        }
+        let rule_index = if c.tun.iproute2_rule_index == 0 {
+            9000
+        } else {
+            c.tun.iproute2_rule_index
+        };
+        if rule_index < 4 {
+            return Err(ConfigError::invalid(
+                "auto_redirect iproute2_rule_index 必须至少为 4，才能保留 TUN 子网和 bypass 优先级",
+            ));
+        }
+        if rule_index > MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX {
+            return Err(ConfigError::invalid(format!(
+                "auto_redirect iproute2_rule_index={rule_index} 必须小于 Linux main rule 优先级 32766"
+            ))
+            .hint("使用 4..=32765 的空闲优先级，例如默认值 9000"));
+        }
+        let table_index = if c.tun.iproute2_table_index == 0 {
+            2022
+        } else {
+            c.tun.iproute2_table_index
+        };
+        if matches!(table_index, 253..=255) {
+            return Err(ConfigError::invalid(format!(
+                "auto_redirect iproute2_table_index={table_index} 是 Linux 保留路由表，不能作为 TUN 私有表"
+            ))
+            .hint("使用独立的自定义表号，例如默认值 2022"));
+        }
+        validate_auto_redirect_marks(&c.tun)?;
+    }
+
     let ok = match c.method {
         CaptureMethod::Auto | CaptureMethod::VirtualNic => true,
         CaptureMethod::Tproxy | CaptureMethod::Redirect => os == "linux" || os == "android",
@@ -976,6 +1102,93 @@ fn validate_capture_platform(c: &Capture) -> ConfigResult<()> {
     Ok(())
 }
 
+fn validate_capture_literals(c: &Capture) -> ConfigResult<()> {
+    fn cidrs(field: &str, values: &[String]) -> ConfigResult<()> {
+        for (index, value) in values.iter().enumerate() {
+            value.parse::<ipnet::IpNet>().map_err(|_| {
+                ConfigError::invalid(format!("{field}[{index}] 不是合法的 CIDR: {value}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn addresses(field: &str, values: &[String]) -> ConfigResult<()> {
+        for (index, value) in values.iter().enumerate() {
+            if value.parse::<ipnet::Ipv4Net>().is_err() && value.parse::<ipnet::Ipv6Net>().is_err()
+            {
+                return Err(ConfigError::invalid(format!(
+                    "{field}[{index}] 不是合法的 IPv4/IPv6 CIDR: {value}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn ips(field: &str, values: &[String]) -> ConfigResult<()> {
+        for (index, value) in values.iter().enumerate() {
+            value.parse::<std::net::IpAddr>().map_err(|_| {
+                ConfigError::invalid(format!("{field}[{index}] 不是合法的 IP 地址: {value}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn ranges(field: &str, values: &[String]) -> ConfigResult<()> {
+        for (index, value) in values.iter().enumerate() {
+            let valid = value
+                .split_once(':')
+                .and_then(|(start, end)| {
+                    Some((start.parse::<u32>().ok()?, end.parse::<u32>().ok()?))
+                })
+                .is_some_and(|(start, end)| start <= end);
+            if !valid {
+                return Err(ConfigError::invalid(format!(
+                    "{field}[{index}] 必须是 start:end 闭区间且 start <= end: {value}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    cidrs("capture.exclude.cidr", &c.exclude.cidr)?;
+    addresses("capture.tun.address", &c.tun.address)?;
+    cidrs("capture.tun.route_address", &c.tun.route_address)?;
+    cidrs(
+        "capture.tun.route_exclude_address",
+        &c.tun.route_exclude_address,
+    )?;
+    ips("capture.tun.loopback_address", &c.tun.loopback_address)?;
+    ranges("capture.tun.include_uid_range", &c.tun.include_uid_range)?;
+    ranges("capture.tun.exclude_uid_range", &c.tun.exclude_uid_range)?;
+    ranges("capture.tun.include_gid_range", &c.tun.include_gid_range)?;
+    ranges("capture.tun.exclude_gid_range", &c.tun.exclude_gid_range)?;
+    Ok(())
+}
+
+fn validate_auto_redirect_marks(tun: &TunInboundOptions) -> ConfigResult<()> {
+    fn parse(name: &str, value: Option<&str>, default: u32) -> ConfigResult<u32> {
+        normalize_auto_redirect_mark(value, default)
+            .ok_or_else(|| ConfigError::invalid(format!("{name} 不是合法的 u32/十六进制 mark")))
+    }
+
+    let _input = parse(
+        "auto_redirect_input_mark",
+        tun.auto_redirect_input_mark.as_deref(),
+        DEFAULT_AUTO_REDIRECT_INPUT_MARK,
+    )?;
+    let _output = parse(
+        "auto_redirect_output_mark",
+        tun.auto_redirect_output_mark.as_deref(),
+        DEFAULT_AUTO_REDIRECT_OUTPUT_MARK,
+    )?;
+    let _reset = parse(
+        "auto_redirect_reset_mark",
+        tun.auto_redirect_reset_mark.as_deref(),
+        DEFAULT_AUTO_REDIRECT_RESET_MARK,
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -985,6 +1198,240 @@ mod tests {
         let mut cfg: UserConfig = serde_yaml::from_str(yaml).unwrap();
         apply_defaults(&mut cfg);
         compile(cfg).unwrap()
+    }
+
+    fn auto_redirect_capture() -> Capture {
+        let mut capture = Capture {
+            on: true,
+            method: CaptureMethod::VirtualNic,
+            ..Capture::default()
+        };
+        capture.tun.auto_route = true;
+        capture.tun.auto_redirect = true;
+        capture
+    }
+
+    #[test]
+    fn omitted_tun_and_empty_tun_have_identical_serde_defaults() {
+        let omitted: Capture = serde_yaml::from_str("{}").unwrap();
+        let empty: Capture = serde_yaml::from_str("tun: {}").unwrap();
+
+        assert_eq!(omitted.tun.inet6, empty.tun.inet6);
+        assert_eq!(omitted.tun.auto_route, empty.tun.auto_route);
+        assert_eq!(
+            omitted.tun.iproute2_table_index,
+            empty.tun.iproute2_table_index
+        );
+        assert_eq!(
+            omitted.tun.iproute2_rule_index,
+            empty.tun.iproute2_rule_index
+        );
+        assert_eq!(omitted.tun.udp_timeout, empty.tun.udp_timeout);
+        assert!(omitted.tun.inet6);
+        assert!(omitted.tun.auto_route);
+        assert_eq!(omitted.tun.iproute2_table_index, 2022);
+        assert_eq!(omitted.tun.iproute2_rule_index, 9000);
+        assert_eq!(omitted.tun.udp_timeout, Duration::from_secs(5 * 60));
+    }
+
+    #[test]
+    fn auto_redirect_requires_auto_route() {
+        let mut capture = auto_redirect_capture();
+        capture.tun.auto_route = false;
+
+        let error = validate_capture_platform_for_os(&capture, "linux").unwrap_err();
+
+        assert!(error.to_string().contains("依赖 auto_route"));
+    }
+
+    #[test]
+    fn auto_redirect_requires_virtual_nic_data_plane() {
+        let mut capture = auto_redirect_capture();
+        capture.method = CaptureMethod::Tproxy;
+
+        let error = validate_capture_platform_for_os(&capture, "linux").unwrap_err();
+
+        assert!(error.to_string().contains("method=virtual_nic"));
+    }
+
+    #[test]
+    fn auto_redirect_platform_contract_is_explicit() {
+        let capture = auto_redirect_capture();
+
+        validate_capture_platform_for_os(&capture, "linux").unwrap();
+        let android = validate_capture_platform_for_os(&capture, "android").unwrap_err();
+        let error = validate_capture_platform_for_os(&capture, "windows").unwrap_err();
+
+        assert!(android.to_string().contains("root-managed Linux"));
+        assert!(error.to_string().contains("root-managed Linux"));
+    }
+
+    #[test]
+    fn disabled_capture_ignores_dormant_auto_redirect_fields() {
+        let mut capture = auto_redirect_capture();
+        capture.on = false;
+        capture.method = CaptureMethod::Redirect;
+        capture.tun.auto_route = false;
+        capture.tun.auto_redirect_nfqueue = Some(100);
+        capture.tun.auto_redirect_input_mark = Some("not-a-mark".into());
+
+        validate_capture_platform_for_os(&capture, "windows").unwrap();
+    }
+
+    #[test]
+    fn auto_redirect_rejects_dynamic_route_sets_until_kernel_snapshots_exist() {
+        for exclude in [false, true] {
+            let mut capture = auto_redirect_capture();
+            if exclude {
+                capture.tun.route_exclude_address_set = vec!["geoip-private".into()];
+            } else {
+                capture.tun.route_address_set = vec!["geoip-proxy".into()];
+            }
+
+            let error = validate_capture_platform_for_os(&capture, "linux").unwrap_err();
+
+            assert!(error.to_string().contains("动态 IP 快照"));
+        }
+    }
+
+    #[test]
+    fn auto_redirect_rejects_unowned_nfqueue_configuration() {
+        let mut capture = auto_redirect_capture();
+        capture.tun.auto_redirect_nfqueue = Some(100);
+
+        let error = validate_capture_platform_for_os(&capture, "linux").unwrap_err();
+
+        assert!(error.to_string().contains("NFQUEUE 用户态消费者"));
+    }
+
+    #[test]
+    fn auto_redirect_rejects_unimplemented_cross_protocol_contracts() {
+        let mut lan = auto_redirect_capture();
+        lan.traffic = CaptureTraffic::Lan;
+        assert!(
+            validate_capture_platform_for_os(&lan, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("traffic=system")
+        );
+
+        let mut strict = auto_redirect_capture();
+        strict.tun.strict_route = true;
+        assert!(
+            validate_capture_platform_for_os(&strict, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("strict_route")
+        );
+
+        let mut interface = auto_redirect_capture();
+        interface.tun.exclude_interface = vec!["eth0".into()];
+        assert!(
+            validate_capture_platform_for_os(&interface, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("interface/MAC")
+        );
+
+        let mut identity = auto_redirect_capture();
+        identity.tun.exclude_uid = vec![1000];
+        assert!(
+            validate_capture_platform_for_os(&identity, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("身份过滤")
+        );
+    }
+
+    #[test]
+    fn auto_redirect_rejects_reserved_mark_data_plane_fields() {
+        for field in ["input", "reset", "fallback"] {
+            let mut capture = auto_redirect_capture();
+            match field {
+                "input" => capture.tun.auto_redirect_input_mark = Some("0x2023".into()),
+                "reset" => capture.tun.auto_redirect_reset_mark = Some("0x2025".into()),
+                "fallback" => {
+                    capture.tun.auto_redirect_iproute2_fallback_rule_index = Some(32768);
+                }
+                _ => unreachable!(),
+            }
+
+            assert!(
+                validate_capture_platform_for_os(&capture, "linux")
+                    .unwrap_err()
+                    .to_string()
+                    .contains("保留字段")
+            );
+        }
+    }
+
+    #[test]
+    fn auto_redirect_rejects_linux_reserved_route_tables() {
+        for table in 253..=255 {
+            let mut capture = auto_redirect_capture();
+            capture.tun.iproute2_table_index = table;
+            let error = validate_capture_platform_for_os(&capture, "linux").unwrap_err();
+            assert!(error.to_string().contains("Linux 保留路由表"));
+        }
+    }
+
+    #[test]
+    fn auto_redirect_rule_priority_must_precede_linux_main_rule() {
+        let mut capture = auto_redirect_capture();
+        capture.tun.iproute2_rule_index = MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX;
+        validate_capture_platform_for_os(&capture, "linux").unwrap();
+
+        capture.tun.iproute2_rule_index = MAX_IPROUTE2_AUTO_REDIRECT_RULE_INDEX + 1;
+        let error = validate_capture_platform_for_os(&capture, "linux").unwrap_err();
+        assert!(error.to_string().contains("main rule 优先级 32766"));
+    }
+
+    #[test]
+    fn active_capture_literals_fail_closed() {
+        let mut invalid_cidr = auto_redirect_capture();
+        invalid_cidr.tun.route_address = vec!["not-a-cidr".into()];
+        assert!(
+            validate_capture_platform_for_os(&invalid_cidr, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("route_address[0]")
+        );
+
+        let mut reversed_range = auto_redirect_capture();
+        reversed_range.tun.include_uid_range = vec!["2000:1000".into()];
+        assert!(
+            validate_capture_platform_for_os(&reversed_range, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("start <= end")
+        );
+    }
+
+    #[test]
+    fn auto_redirect_marks_are_parsed_and_zero_uses_defaults() {
+        let mut invalid = auto_redirect_capture();
+        invalid.tun.auto_redirect_output_mark = Some("0xnot-hex".into());
+        assert!(
+            validate_capture_platform_for_os(&invalid, "linux")
+                .unwrap_err()
+                .to_string()
+                .contains("不是合法")
+        );
+
+        let mut zero = auto_redirect_capture();
+        zero.tun.auto_redirect_output_mark = Some("0".into());
+        validate_capture_platform_for_os(&zero, "linux").unwrap();
+        assert_eq!(
+            normalize_auto_redirect_mark(
+                zero.tun.auto_redirect_output_mark.as_deref(),
+                DEFAULT_AUTO_REDIRECT_OUTPUT_MARK
+            ),
+            Some(DEFAULT_AUTO_REDIRECT_OUTPUT_MARK)
+        );
+
+        let mut valid = auto_redirect_capture();
+        valid.tun.auto_redirect_output_mark = Some("50".into());
+        validate_capture_platform_for_os(&valid, "linux").unwrap();
     }
 
     #[test]

--- a/crates/core-outbound/src/adapter.rs
+++ b/crates/core-outbound/src/adapter.rs
@@ -248,6 +248,16 @@ pub fn set_outbound_fwmark(mark: u32) {
     OUTBOUND_FWMARK.store(mark, Ordering::Release);
 }
 
+/// Atomically replace the process-wide outbound fwmark when it still equals
+/// `current`.
+///
+/// Capture supervisors use this as a lease boundary: only one running
+/// supervisor may own the non-zero mark, and cleanup must not overwrite a
+/// newer owner.
+pub fn compare_exchange_outbound_fwmark(current: u32, new: u32) -> Result<u32, u32> {
+    OUTBOUND_FWMARK.compare_exchange(current, new, Ordering::AcqRel, Ordering::Acquire)
+}
+
 pub fn outbound_fwmark() -> u32 {
     OUTBOUND_FWMARK.load(Ordering::Acquire)
 }

--- a/crates/core-outbound/src/lib.rs
+++ b/crates/core-outbound/src/lib.rs
@@ -28,8 +28,9 @@ pub mod transport;
 pub use adapter::{
     BoxedStream, BoxedUdp, Capabilities, DialContext, DialResolver, OutboundAdapter,
     ProtectedSocket, ProxyStream, SocketProtector, UdpSocketLike, apply_outbound_mark,
-    apply_outbound_mark_for_addr, bind_outbound_socket, bind_to_device, create_outbound_udp_socket,
-    global_dial_resolver, has_socket_protector, next_dial_id, outbound_fwmark, outbound_interface,
+    apply_outbound_mark_for_addr, bind_outbound_socket, bind_to_device,
+    compare_exchange_outbound_fwmark, create_outbound_udp_socket, global_dial_resolver,
+    has_socket_protector, next_dial_id, outbound_fwmark, outbound_interface,
     outbound_interface_index_v4, outbound_interface_index_v6, prepare_outbound_udp_socket,
     prepare_outbound_udp_socket_for_addr, protect_socket, resolve_host, set_global_dial_resolver,
     set_outbound_fwmark, set_outbound_interface, set_outbound_interface_index,

--- a/crates/core-runtime/src/engine.rs
+++ b/crates/core-runtime/src/engine.rs
@@ -158,13 +158,9 @@ impl Runtime {
         core_outbound::set_global_dns_responder(Arc::new(DnsResponderAdapter {
             service: dns_service.clone(),
         }));
-        // 注入 outbound fwmark：对齐 mihomo `dialer.DefaultRoutingMark`。
-        // 默认值必须是 0（禁用），否则普通 Mixed/Direct 在无 CAP_NET_ADMIN 的
-        // Linux 环境会因 SO_MARK=EPERM 直接无法出站。只有显式配置
-        // auto_redirect_output_mark、TUN auto_route、或 TPROXY iptables 接管时，
-        // 才使用 mark 绕过 redirect/tproxy chain。
-        let out_mark = outbound_fwmark_for_plan(&plan);
-        core_outbound::set_outbound_fwmark(out_mark);
+        // Runtime 构造本身不能激活进程级 outbound fwmark：capture 可能稍后
+        // 启动失败，甚至根本没有 supervisor。非零 mark 由 CaptureSupervisor
+        // 在平台 ingress 启动前事务化持有，并在平台回滚成功后释放。
         core_resolver::upstream::marked::set_dns_socket_factory(Arc::new(OutboundDnsSocketFactory));
         // 订阅 / 规则集拉取的 HTTP client 由 core-fetch 自管理：内部直接走
         // hyper + tokio-rustls + bind_outbound_socket，net_monitor 同步的
@@ -226,6 +222,14 @@ impl Runtime {
             urltest: parking_lot::RwLock::new(None),
             process_finder,
         }
+    }
+
+    /// Capture 数据面运行期间需要持有的进程级 outbound fwmark。
+    ///
+    /// 此方法只计算配置结果，不修改全局 socket 状态；生命周期所有权由
+    /// `core-capture` 的 supervisor 管理。
+    pub fn capture_outbound_fwmark(&self) -> u32 {
+        outbound_fwmark_for_plan(&self.plan)
     }
 
     /// 由 main.rs 在 UrlTester::new 之后注入，让策略组的 URLTest/Fallback/LB
@@ -1175,28 +1179,16 @@ pub struct UdpDialResult {
     pub rule_payload: String,
 }
 
-/// "0x2024" / "8228" → u32。
-fn parse_hex_u32(s: &str) -> Option<u32> {
-    let s = s.trim();
-    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
-        u32::from_str_radix(rest, 16).ok()
-    } else {
-        s.parse().ok()
-    }
-}
-
 fn outbound_fwmark_for_plan(plan: &RuntimePlan) -> u32 {
-    if let Some(mark) = plan
-        .capture
-        .tun
-        .auto_redirect_output_mark
-        .as_deref()
-        .and_then(parse_hex_u32)
-    {
-        return mark;
-    }
     if capture_uses_tun_auto_route(&plan.capture) {
-        core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK
+        core_config::model::normalize_auto_redirect_mark(
+            plan.capture.tun.auto_redirect_output_mark.as_deref(),
+            core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK,
+        )
+        // RuntimePlan normally came through validation. A manually-mutated plan
+        // must still use the same safe default as CapturePlan instead of
+        // silently disabling the loop-prevention mark.
+        .unwrap_or(core_config::model::DEFAULT_AUTO_REDIRECT_OUTPUT_MARK)
     } else if plan.capture.on && capture_uses_tproxy(&plan.capture) {
         0x2d0
     } else {
@@ -1461,23 +1453,62 @@ route:
 
     #[test]
     fn runtime_uses_auto_redirect_default_output_mark_only_when_enabled() {
-        let plan = load_plan(
+        let mut plan = load_plan(
             r#"
 version: 1
 profile: desktop
 listen:
   panel: false
-capture:
-  on: true
-  method: virtual_nic
-  tun:
-    auto_redirect: true
 route:
   preset: direct
 "#,
         );
+        plan.capture.on = true;
+        plan.capture.method = core_config::model::CaptureMethod::VirtualNic;
+        plan.capture.tun.auto_route = true;
+        plan.capture.tun.auto_redirect = true;
 
         assert_eq!(outbound_fwmark_for_plan(&plan), 0x2024);
+    }
+
+    #[test]
+    fn runtime_normalizes_explicit_zero_auto_redirect_output_mark() {
+        let mut plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+route:
+  preset: direct
+"#,
+        );
+        plan.capture.on = true;
+        plan.capture.method = core_config::model::CaptureMethod::VirtualNic;
+        plan.capture.tun.auto_route = true;
+        plan.capture.tun.auto_redirect = true;
+        plan.capture.tun.auto_redirect_output_mark = Some("0".into());
+
+        assert_eq!(outbound_fwmark_for_plan(&plan), 0x2024);
+        plan.capture.on = false;
+        assert_eq!(outbound_fwmark_for_plan(&plan), 0);
+    }
+
+    #[test]
+    fn runtime_ignores_dormant_explicit_output_mark() {
+        let mut plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+route:
+  preset: direct
+"#,
+        );
+        plan.capture.tun.auto_redirect_output_mark = Some("0x5151".into());
+
+        assert_eq!(outbound_fwmark_for_plan(&plan), 0);
     }
 
     #[test]

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -678,6 +678,16 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
             }));
             if let Err(e) = sup.start(runtime.clone()).await {
                 warn!(target: "capture", error = %e, "capture supervisor start failed");
+                // start() 已尝试一次事务回滚；若平台 pre_stop/stop 当次失败，
+                // supervisor 会保留 CleanupFailed 账本。调用方必须显式重试，
+                // 否则 drop supervisor 会同时丢失路由/fwmark 的恢复入口。
+                if let Err(cleanup_error) = sup.stop().await {
+                    return Err(anyhow::anyhow!(
+                        "capture start failed ({e}); cleanup retry also failed \
+                         ({cleanup_error}); refusing to continue with possibly active \
+                         transparent-capture state"
+                    ));
+                }
             } else {
                 capture_handle = Some(sup);
             }

--- a/docs/LINUX-TUN-AUTO-REDIRECT.md
+++ b/docs/LINUX-TUN-AUTO-REDIRECT.md
@@ -1,0 +1,138 @@
+# Linux TUN `auto_redirect`
+
+`auto_redirect` 是 Linux root-managed TUN 的混合透明接管模式：
+
+- 本机 TCP 由 nftables `nat output` 的 `redirect` 送入 WutherCore 的临时 TCP listener；
+- listener 通过 `SO_ORIGINAL_DST` 恢复原始目标，再交给现有路由与出站引擎；
+- 本机 UDP 仍由策略路由送入 TUN，由 `TunDispatcher` 处理；
+- `auto_redirect` 不为 ICMP 和其他非 TCP/UDP 协议安装导流 rule；它们继续按已有主路由策略处理，本功能不承诺代理或转发 ICMP；
+- `iif lo` policy rule 只匹配本机产生的 TCP/UDP，不接管转发或 LAN 流量。
+
+这个契约参考 sing-box、mihomo 使用的 sing-tun REDIRECT 数据面，但只承诺下文列出的安全子集，不等同于完整兼容它们的所有 TUN 选项。
+
+## 前置条件
+
+- Linux；Android、macOS、Windows 不支持此模式。
+- 以 root 运行，或具备配置 TUN、路由和 nftables 所需的等价 capability。
+- 可用的 `iproute2`（`ip` 命令）和 nftables（`nft` 命令）。
+- 内核支持 TUN、nftables NAT REDIRECT 和 `SO_ORIGINAL_DST`。
+- TUN 接口的 MTU、IPv4 地址、启用时的 IPv6 地址和 link-up 必须全部配置成功。
+- 自定义路由表必须是私有表；Linux 的 `default/main/local` 表号 253–255 会被拒绝。
+- 本功能使用的四个连续 rule priority 必须空闲，且 capture priority 必须位于 `4..=32765`，排在 Linux 默认 `main` rule（32766）之前；不会覆盖同优先级的外部规则。
+- 实际出站表必须有可用的同地址族 default route。启用双栈时，IPv4/IPv6 default route 必须使用同一个出站接口，因为当前 socket 接口绑定不是按地址族拆分的。
+
+生产激活只使用 nftables。安装前会探测表名冲突并执行 `nft -c`；实际规则通过一次 nft batch 原子提交。iptables 规则生成器目前只用于测试，不会作为失败后的生产回退路径。
+
+## 最小配置
+
+```yaml
+version: 1
+profile: desktop
+
+listen:
+  panel: false
+
+capture:
+  on: true
+  method: virtual_nic
+  traffic: system
+  exclude:
+    cidr:
+      - "127.0.0.0/8"
+      - "::1/128"
+  tun:
+    interface_name: rpktun0
+    address:
+      - "172.19.0.1/30"
+      - "fdfe:dcba:9876::1/126"
+    inet6: true
+    auto_route: true
+    auto_redirect: true
+    iproute2_table_index: 2022
+    iproute2_rule_index: 9000
+    auto_redirect_output_mark: "0x2024"
+    route_exclude_address:
+      - "192.168.0.0/16"
+      - "100.64.0.0/10"
+      - "fd7a:115c:a1e0::/48"
+    loopback_address:
+      - "127.0.0.1"
+      - "::1"
+
+route:
+  preset: direct
+```
+
+`auto_redirect_output_mark` 可以省略。省略或显式配置为 `0` 时使用默认值 `0x2024`。配置中的地址、CIDR、mark 和 UID/GID range 会严格解析；活动配置中存在非法字面量时，启动会直接失败，不会静默缩小 bypass 集。
+
+`capture.exclude.cidr`、`route_exclude_address` 和 `loopback_address` 会合并、按地址族去重，并作为策略路由 bypass。代理自身带 output mark 的 socket 也会使用安装时探测并记录的真实出站路由表，避免再次进入 TUN。
+
+启动还会核对私有表只含本次成功写入、指向当前 TUN 的两条 split-default route；重复前缀、非零 metric、外部 gateway/nexthop 或非 `boot` protocol 也不视为自有路由。私有表存在额外路由、实际出站表缺少 default route、rule priority 碰撞或单个探测目标仅命中 host route 时都会失败并回滚。
+
+## 支持边界
+
+| 项目 | 当前行为 |
+| --- | --- |
+| 平台 | 仅 root-managed Linux |
+| 流量范围 | 仅 `traffic: system` |
+| TCP | nftables NAT REDIRECT + `SO_ORIGINAL_DST` |
+| UDP | TUN |
+| ICMP/其他协议 | 不安装 `auto_redirect` 导流 rule；按已有主路由处理，不承诺代理/转发 |
+| IPv4 | 支持 |
+| IPv6 | TUN v6、系统 v6 和独立 v6 listener 都可用时支持 |
+| 静态 `route_address` / `route_exclude_address` | 支持 |
+| `capture.exclude.cidr` / `loopback_address` | 支持并参与 policy bypass |
+| output mark | 支持；`0` 归一化为默认值 |
+
+以下组合会在任何内核写入前被拒绝：
+
+- `auto_route: false`、`strict_route: true` 或非 `virtual_nic`；
+- `traffic: lan`、Android/VpnService 或 platform-preconfigured TUN；
+- `route_address_set`、`route_exclude_address_set` 等动态集合；
+- interface、MAC、process、MPTCP、UID/GID、Android user/package 过滤；
+- 显式 input/reset mark、NFQUEUE 或 fallback rule index。
+
+动态规则集并不是被忽略：配置校验会明确报错。在 SRS/MRS/provider 能提供版本化 IP 快照和更新订阅、capture 层能原子同步 nft set 之前，禁止把这类配置当作已经生效。
+
+## 启停与失败恢复
+
+构造 `Runtime` 不会修改进程级 fwmark。supervisor 在启动 capture 前通过原子 compare-and-set 独占非零 output mark；已有 owner 时拒绝启动。只有平台 ingress、policy rule 和 TUN 都已成功回滚后才释放 mark；若清理失败，mark 与精确账本一起保留在 `CleanupFailed` 状态供 `stop()` 重试。主程序在启动错误后会主动执行一次清理重试，重试仍失败时拒绝继续启动普通 Mixed/API/DNS 数据面。
+
+启动按以下顺序进行：
+
+1. 打开并完整配置 TUN；
+2. 预绑定 IPv4 和可用时的 IPv6 TCP listener；
+3. 等待 `TunDispatcher` 接管 TUN；
+4. 启动 listener task；
+5. 安装并核验 split-default route，先写真实网络 bypass 依赖，再写本机 TCP/UDP capture rule；
+6. 最后原子安装 nftables REDIRECT 表。
+
+停止顺序相反：先撤销 nftables 入口，再停 listener，然后先删除全部 capture rule，确认成功后才拆 output-mark/bypass 依赖和 route，最后关闭 TUN。任一 capture rule 删除失败都会形成阶段屏障，不会继续拆掉它依赖的防回环规则。删除失败的项会保留在所有权账本中，停止返回错误；后续重试只处理残余资源，避免误删外部规则或在 dispatcher 已关闭时留下黑洞。
+
+程序不会接管已存在的同名 nftables 表。若上次进程被强制终止，请先确认表确实属于已退出的 WutherCore 实例，再由管理员处理；不要在不确认所有权时自动覆盖。
+
+## 排查
+
+```bash
+ip -4 rule show
+ip -6 rule show
+ip -4 route show table 2022
+ip -6 route show table 2022
+nft list table inet wuther_auto_redirect
+```
+
+重点检查：
+
+- policy rule 是否带 `iif lo` 和 `ipproto tcp` / `ipproto udp`；
+- TCP rule 是否指向 listener 当前的临时端口；
+- IPv4/IPv6 bypass 是否查安装时记录的真实出站表；
+- 没有 catch-all rule、TPROXY、NFQUEUE 或 ICMP 导流规则；
+- 日志中没有 `nft -c`、route add、rule add 或 `SO_ORIGINAL_DST` 错误。
+
+## 上游语义依据
+
+- [sing-box TUN inbound](https://sing-box.sagernet.org/configuration/inbound/tun/)
+- [mihomo TUN configuration](https://wiki.metacubex.one/en/config/inbound/tun/)
+- [sing-tun nftables REDIRECT rules](https://github.com/SagerNet/sing-tun/blob/e5d2fab03586e41fbcb0ca8c5ff4db18e5d3365e/redirect_nftables_rules.go#L648-L674)
+- [sing-tun REDIRECT listener](https://github.com/SagerNet/sing-tun/blob/e5d2fab03586e41fbcb0ca8c5ff4db18e5d3365e/redirect_server.go)
+- [Linux transparent proxy documentation](https://docs.kernel.org/networking/tproxy.html)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 | --- | --- |
 | [功能矩阵](FEATURES.md) | 当前有哪些能力，哪些行为依赖平台或服务端 |
 | [配置指南](CONFIGURATION.md) | 如何选择 Profile、组织配置、校验与迁移 |
+| [Linux TUN auto_redirect](LINUX-TUN-AUTO-REDIRECT.md) | 本机 TCP REDIRECT + UDP TUN 的前置条件、安全边界和回滚 |
 | [管理 API](API.md) | 如何鉴权、查询状态和控制运行时 |
 | [排错手册](TROUBLESHOOTING.md) | TUN、DNS、订阅、权限和连接失败如何定位 |
 | [示例配置](../examples/) | Desktop、Router、Android、Feed 与手动节点模板 |

--- a/examples/android.yaml
+++ b/examples/android.yaml
@@ -214,7 +214,7 @@ capture:
     auto_route: true
     iproute2_table_index: 2024
     iproute2_rule_index:  9100
-    auto_redirect: false        # 默认关；root 设备 + nft/iptables 才打开（见 6.B）
+    auto_redirect: false        # Android 当前明确不支持；仅 Linux root-managed TUN 可按专门文档启用
     strict_route: false         # 严格防泄漏会切断 LAN，移动端关
     route_address: []           # 空 = 全部走 TUN
 
@@ -301,31 +301,14 @@ capture:
           - "*.local"
 
 # -----------------------------------------------------------------------------
-# 6.B 【可选】root + KernelSU 高性能模板
-#     条件：手机已 root + 装了 magisk-iptables 或 nftables 模块。
-#     取消注释 + 把上方 6 节的 capture 整段删掉。
+# 6.B Android auto_redirect 说明
 # -----------------------------------------------------------------------------
-# capture:
-#   on: true
-#   method: tproxy            # 真透明代理；纯 nftables/iptables，零用户态栈
-#   traffic: system
-#   resolver: hijack
-#   stack: native
-#   exclude:
-#     cidr: ["100.64.0.0/10", "fd7a:115c:a1e0::/48"]
-#   tun:
-#     interface_name: "rpktun0"
-#     auto_route: true
-#     auto_redirect: true
-#     auto_redirect_input_mark:  "0x2023"
-#     auto_redirect_output_mark: "0x2024"
-#     auto_redirect_reset_mark:  "0x2025"
-#     iproute2_table_index: 2024
-#     iproute2_rule_index:  9100
-#     include_uid_range: ["10000:99999"]    # 仅普通 app
-#     exclude_uid: [1000, 0]                # 排除 system + root
-#     loopback_address: ["127.0.0.1", "::1"]
-#     route_exclude_address_set: ["geoip-cn", "geoip-private"]
+# 当前安全实现只接受 Linux root-managed TUN + virtual_nic + traffic=system。
+# Android/VpnService、method=tproxy、identity 过滤、input/reset mark 和动态 route
+# set 组合会在配置阶段明确拒绝，不能把这些字段当作已经生效。
+#
+# Android 请继续使用上方 6 节的 VpnService/TUN 配置；Linux root-managed 主机参见：
+# docs/LINUX-TUN-AUTO-REDIRECT.md
 
 # ---------------------------------------------------------------------------
 # 7. route —— 分流规则


### PR DESCRIPTION
## 目标

实现 Linux root-managed TUN 的安全版 `auto_redirect` 混合透明接管，并替换原有会忽略失败、缺乏精确所有权与回滚账本的试验性路径。

本 PR 是一个独立、可验证的窄功能，不声称已经完整兼容 sing-box/mihomo 的全部 TUN 选项。

## 已实现

- 仅接受 Linux、`method: virtual_nic`、`traffic: system`、`auto_route: true`。
- 本机 TCP：nftables `nat output` REDIRECT → 临时双栈 listener → `SO_ORIGINAL_DST` → 现有路由/出站引擎。
- 本机 UDP：通过带 `iif lo`/`ipproto udp` 的策略路由继续进入 TUN。
- 不为 ICMP/其他协议安装 auto_redirect 导流 rule；它们继续按主路由处理，本功能不承诺代理或转发 ICMP。
- `iif lo` 限定本机流量，不接管 forwarded/LAN 流量。
- 生产只使用 nftables：冲突探测、`nft -c` 预检、单 batch 原子安装、精确表所有权和清理账本；iptables 生成器仅保留给测试。
- 路由事务：
  - 私有表 split-default 精确所有权校验；
  - 四个连续空闲 rule priority；
  - 静态 route/exclude、`capture.exclude.cidr`、loopback policy bypass；
  - 实际出站表默认路由与双栈同接口校验；
  - capture/dependency 分层清理屏障，失败后保留残余账本供重试。
- 两阶段生命周期：dispatcher 接管 TUN 后才开放 nft ingress；停止时先撤 ingress/listener，再拆 policy route 和 TUN。
- output fwmark 事务租约：Runtime 构造无全局副作用，CAS 独占、冲突拒绝、仅在平台资源成功清理后恢复；`CleanupFailed` 保留 mark 和账本。
- 配置字面量严格解析；`0` output mark 与省略配置统一归一为默认值。
- 非 Linux、Android/VpnService、platform-preconfigured TUN 在执行边界 fail closed。
- 新增完整使用/边界/恢复文档，并修正 Android 示例中的过度承诺。

## 明确不在本 PR 中

以下能力不会被静默忽略，而是在激活前明确拒绝：

- SRS/MRS/provider 驱动的动态 `route_address_set` / `route_exclude_address_set`；
- Android、LAN/forwarded capture、`strict_route`；
- UID/GID、Android user/package、process、interface、MAC、MPTCP 过滤；
- input/reset mark、NFQUEUE、fallback rule index；
- 完整 sing-box/mihomo TUN 选项兼容。

动态 SRS/MRS 路由集合需要 ruleset 层先提供版本化 IPv4/IPv6 prefix 快照和更新订阅，再由 capture 层原子同步 nft set，后续应以独立提交实现。

## 安全与失败语义

- TUN MTU、地址或 link-up 任一步失败都会终止激活。
- listener、route、rule、nft 均在首次内核写入前发布清理账本。
- 私有表存在额外/重复 route、非零 metric、gateway/nexthop、非 boot protocol，或 priority/table 冲突时拒绝接管。
- 任一 capture rule 删除失败都会阻止继续拆除防回环依赖。
- 启动失败后 CLI 主动重试清理；清理仍失败则拒绝继续启动普通 Mixed/API/DNS 数据面。
- 不覆盖已存在的同名 nftables 表，避免误删其他实例或管理员规则。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- Windows：`cargo test --workspace --target-dir target/final-windows`
- WSL/Linux：`cargo test -p core-capture --target-dir target/final-wsl -- --nocapture`（322 个单元测试及集成/doc tests 通过）
- `cargo clippy -p core-capture -p core-config -p core-runtime -p core-outbound -p wuther-core --all-targets --no-deps --target-dir target/final-clippy`
- `cargo doc -p core-capture -p core-config -p core-runtime -p core-outbound --no-deps --target-dir target/final-doc`
- WSL 实机语法/操作检查：
  - nftables 1.1.6 双栈代表性规则 `nft -c -f -`；
  - `ip rule` 的 `iif lo fwmark` 语法；
  - 隔离 network namespace 中 split-default route 的 add/show/delete（含 metric 所有权语义）。
- 最终知识图谱影响审计与独立只读交付审计：无 P0/P1，未修改代理协议实现。

尚未完成带真实 TCP/UDP 业务流量的 privileged network-namespace 端到端测试，因此不在此 PR 中声称该级别验证。仓库锁定依赖本身需要高于 1.85 的工具链，本 PR 也不声称已验证 Rust 1.85 MSRV。

## 上游语义依据

- sing-box TUN inbound：https://sing-box.sagernet.org/configuration/inbound/tun/
- mihomo TUN：https://wiki.metacubex.one/en/config/inbound/tun/
- sing-tun nftables REDIRECT：https://github.com/SagerNet/sing-tun/blob/e5d2fab03586e41fbcb0ca8c5ff4db18e5d3365e/redirect_nftables_rules.go#L648-L674
- sing-tun REDIRECT listener：https://github.com/SagerNet/sing-tun/blob/e5d2fab03586e41fbcb0ca8c5ff4db18e5d3365e/redirect_server.go
- Linux transparent proxy：https://docs.kernel.org/networking/tproxy.html
