### PR TITLE
fix: 收口控制面安全与静默降级路径

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ## [Unreleased]
 
+### Security
+
+- 非本机管理面板（`listen.share: home|all` 或非 loopback `listen.panel`）在 `ui.secret` 为空时拒绝编译/启动；
+- Clash 兼容 `GET /configs` 的 `authentication` 只返回用户名，不再回传明文密码；
+- URLTest 与订阅/规则集 fetch 默认拒绝 loopback/私网/链路本地/云元数据目标（含 redirect 跳后复查）；
+- fetch 日志只记录 host，避免订阅 token 落入 debug/warn。
+
+### Fixed
+
+- UDP 选路在过滤无 UDP 能力节点后，不再回退到任意 TCP-only 成员；
+- `groups.*.choose: chain` 在配置编译期拒绝，避免静默退化为单跳第一节点；
+- Clash `PUT /configs` 的 `mode`（rule/global/direct）接入真实选路；
+- dial 失败后短期 mark_dead，选点跳过已失败节点，避免 Manual/粘性死循环；
+- `allow-lan` / `tun.enable` 热切换改为 `501`，不再写成功假象；
+- `auto_route` / TPROXY / REDIRECT 下 capture 启动失败改为 fail-closed。
+
 ### Added
 
 - 组网后端能力/附件模型、冻结 descriptor、强类型宿主资源声明与语义化系统资源冲突预检；

--- a/crates/core-api/src/compat.rs
+++ b/crates/core-api/src/compat.rs
@@ -1321,13 +1321,22 @@ fn build_configs_value(s: &NativeState) -> Value {
         core_config::model::FindProcessMode::Strict => "strict",
         core_config::model::FindProcessMode::Always => "always",
     };
+    // 只回用户名，永不回明文密码。空数组表示未启用入站认证。
+    let authentication: Vec<String> = s
+        .runtime
+        .plan
+        .listen
+        .auth
+        .iter()
+        .map(|up| up.user.clone())
+        .collect();
     json!({
         "port": port,
         "socks-port": port,
         "redir-port": 0,
         "tproxy-port": 0,
         "mixed-port": port,
-        "authentication": &s.runtime.plan.listen.auth,
+        "authentication": authentication,
         "allow-lan": mc.allow_lan,
         "bind-address": "*",
         "mode": mc.mode,
@@ -1379,22 +1388,65 @@ async fn configs_put(
     State(s): State<NativeState>,
     Json(body): Json<ConfigsPut>,
 ) -> impl IntoResponse {
+    // mode 已接入选路；其余字段仍只更新 MutableConfig 视图。
+    // allow-lan / tun_enable / ipv6 / log-level 的真实副作用尚未热切换绑定/capture，
+    // 但至少 mode 不再是“写成功假象”。
     let mut mc = s.runtime.mutable.write();
     if let Some(v) = body.mode {
-        mc.mode = v.to_lowercase();
+        let normalized = v.to_lowercase();
+        match normalized.as_str() {
+            "rule" | "global" | "direct" => mc.mode = normalized,
+            other => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "message": format!(
+                            "unsupported mode \"{other}\"; expected rule|global|direct"
+                        )
+                    })),
+                )
+                    .into_response();
+            }
+        }
     }
     if let Some(v) = body.log_level {
         mc.log_level = v.to_lowercase();
     }
     if let Some(v) = body.allow_lan {
-        mc.allow_lan = v;
+        // 入站 bind 在启动时由 listen.share / host 决定，运行时无法安全热切换。
+        // 拒绝静默写入，避免 dashboard 显示 allow-lan=false 但端口仍对外监听。
+        let current = mc.allow_lan;
+        if v != current {
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(json!({
+                    "message": format!(
+                        "allow-lan cannot be changed at runtime (current={current}, requested={v}); \
+                         restart with listen.share false|home|all"
+                    )
+                })),
+            )
+                .into_response();
+        }
     }
     if let Some(v) = body.ipv6 {
         mc.ipv6 = v;
     }
     if let Some(t) = body.tun {
         if let Some(e) = t.enable {
-            mc.tun_enable = e;
+            let current = mc.tun_enable;
+            if e != current {
+                return (
+                    StatusCode::NOT_IMPLEMENTED,
+                    Json(json!({
+                        "message": format!(
+                            "tun.enable cannot be changed at runtime (current={current}, requested={e}); \
+                             restart with capture.on"
+                        )
+                    })),
+                )
+                    .into_response();
+            }
         }
     }
     drop(mc);

--- a/crates/core-api/tests/compat_smoke.rs
+++ b/crates/core-api/tests/compat_smoke.rs
@@ -332,7 +332,9 @@ async fn configs_get_and_put_round_trip() {
     let v = body_json(resp).await;
     assert_eq!(v["mode"], "rule");
     assert_eq!(v["log-level"], "info");
-    // PUT 修改 mode + log-level
+    // authentication 必须是用户名列表，不能回传 password 字段对象。
+    assert!(v["authentication"].is_array());
+    // PUT 修改 mode + log-level（allow-lan 热切换已禁用，见下测）
     let resp = app
         .clone()
         .oneshot(
@@ -340,9 +342,7 @@ async fn configs_get_and_put_round_trip() {
                 .method("PUT")
                 .uri("/configs")
                 .header("content-type", "application/json")
-                .body(Body::from(
-                    r#"{"mode":"global","log-level":"debug","allow-lan":true}"#,
-                ))
+                .body(Body::from(r#"{"mode":"global","log-level":"debug"}"#))
                 .unwrap(),
         )
         .await
@@ -350,6 +350,7 @@ async fn configs_get_and_put_round_trip() {
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     // 再 GET
     let resp = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/configs")
@@ -361,7 +362,70 @@ async fn configs_get_and_put_round_trip() {
     let v = body_json(resp).await;
     assert_eq!(v["mode"], "global");
     assert_eq!(v["log-level"], "debug");
-    assert_eq!(v["allow-lan"], true);
+}
+
+#[tokio::test]
+async fn configs_put_rejects_allow_lan_hot_toggle() {
+    let app = core_api::compat::router(build_state());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/configs")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"allow-lan":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    let v = body_json(resp).await;
+    assert!(
+        v["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("allow-lan cannot be changed"),
+        "unexpected body: {v}"
+    );
+}
+
+#[tokio::test]
+async fn configs_authentication_never_returns_passwords() {
+    let yaml = r#"
+version: 1
+profile: desktop
+listen:
+  local: 7890
+  panel: 9090
+  auth:
+    - "alice:super-secret-password"
+groups:
+  main:
+    choose: manual
+nodes: []
+"#;
+    let plan = load_from_str(yaml).expect("plan");
+    let runtime = Arc::new(Runtime::build(plan));
+    let state = NativeState::for_tests(runtime, UrlTester::new(Default::default()), None);
+    let app = core_api::compat::router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/configs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = body_json(resp).await;
+    let auth = v["authentication"].as_array().expect("authentication array");
+    assert_eq!(auth.len(), 1);
+    assert_eq!(auth[0], "alice");
+    let body = serde_json::to_string(&v).unwrap();
+    assert!(
+        !body.contains("super-secret-password"),
+        "password must not appear in /configs body: {body}"
+    );
 }
 
 #[tokio::test]

--- a/crates/core-api/tests/compat_smoke.rs
+++ b/crates/core-api/tests/compat_smoke.rs
@@ -418,7 +418,9 @@ nodes: []
         .await
         .unwrap();
     let v = body_json(resp).await;
-    let auth = v["authentication"].as_array().expect("authentication array");
+    let auth = v["authentication"]
+        .as_array()
+        .expect("authentication array");
     assert_eq!(auth.len(), 1);
     assert_eq!(auth[0], "alice");
     let body = serde_json::to_string(&v).unwrap();

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -383,16 +383,14 @@ fn compile_groups(
         cfg.feeds.keys().map(|s| s.as_str()).collect();
     for (name, g) in &cfg.groups {
         if g.choose == ChooseStrategy::Chain {
-            return Err(
-                ConfigError::invalid(format!(
-                    "groups.{name}.choose = chain 尚未实现多跳 relay"
-                ))
-                .at(format!("groups.{name}.choose"))
-                .hint(
-                    "请改用 manual / smart / fast / stable / spread；\
+            return Err(ConfigError::invalid(format!(
+                "groups.{name}.choose = chain 尚未实现多跳 relay"
+            ))
+            .at(format!("groups.{name}.choose"))
+            .hint(
+                "请改用 manual / smart / fast / stable / spread；\
                      多跳链路实现前不会静默退化为单跳",
-                ),
-            );
+            ));
         }
         let mut members = Vec::new();
         for src in &g.r#use {
@@ -997,16 +995,14 @@ fn validate_ui_secret_for_bind(listen: &ListenPlan, ui: &Ui) -> ConfigResult<()>
     if secret_ok {
         return Ok(());
     }
-    Err(
-        ConfigError::invalid(
-            "管理 API 绑定了非本机地址，但 ui.secret 为空；拒绝启动以避免未鉴权控制面",
-        )
-        .at("ui.secret")
-        .hint(
-            "为 ui.secret 设置足够长的随机串，或把 listen.panel / listen.share 限制在 127.0.0.1 / ::1；\
-             share: home|all 会把面板绑到 0.0.0.0",
-        ),
+    Err(ConfigError::invalid(
+        "管理 API 绑定了非本机地址，但 ui.secret 为空；拒绝启动以避免未鉴权控制面",
     )
+    .at("ui.secret")
+    .hint(
+        "为 ui.secret 设置足够长的随机串，或把 listen.panel / listen.share 限制在 127.0.0.1 / ::1；\
+             share: home|all 会把面板绑到 0.0.0.0",
+    ))
 }
 
 fn is_loopback_bind_host(host: &str) -> bool {
@@ -1602,10 +1598,7 @@ ui:
 "#,
         );
         assert_eq!(plan.listen.panel.as_ref().unwrap().host, "0.0.0.0");
-        assert_eq!(
-            plan.ui.secret.as_deref(),
-            Some("test-secret-please-change")
-        );
+        assert_eq!(plan.ui.secret.as_deref(), Some("test-secret-please-change"));
     }
 
     #[test]

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -175,6 +175,7 @@ pub fn compile(mut cfg: UserConfig) -> ConfigResult<RuntimePlan> {
     validate_capture_platform(&capture)?;
     let smart = cfg.smart.unwrap_or_default();
     let ui = cfg.ui.unwrap_or_default();
+    validate_ui_secret_for_bind(&listen, &ui)?;
     let mesh = cfg.mesh.unwrap_or_default();
     let find_process_mode = cfg.find_process_mode;
     Ok(RuntimePlan {
@@ -381,6 +382,18 @@ fn compile_groups(
     let valid_feeds: std::collections::HashSet<&str> =
         cfg.feeds.keys().map(|s| s.as_str()).collect();
     for (name, g) in &cfg.groups {
+        if g.choose == ChooseStrategy::Chain {
+            return Err(
+                ConfigError::invalid(format!(
+                    "groups.{name}.choose = chain 尚未实现多跳 relay"
+                ))
+                .at(format!("groups.{name}.choose"))
+                .hint(
+                    "请改用 manual / smart / fast / stable / spread；\
+                     多跳链路实现前不会静默退化为单跳",
+                ),
+            );
+        }
         let mut members = Vec::new();
         for src in &g.r#use {
             if src == "nodes" {
@@ -965,6 +978,52 @@ fn try_classical_to_dsl(line: &str) -> Option<String> {
     Some(format!("{} -> {}", lhs_parts.join(","), policy))
 }
 
+/// 非本机 API 面板暴露时必须配置 `ui.secret`，避免空 secret 的全开控制面。
+fn validate_ui_secret_for_bind(listen: &ListenPlan, ui: &Ui) -> ConfigResult<()> {
+    if !ui.on {
+        return Ok(());
+    }
+    let Some(panel) = listen.panel.as_ref() else {
+        return Ok(());
+    };
+    if is_loopback_bind_host(&panel.host) {
+        return Ok(());
+    }
+    let secret_ok = ui
+        .secret
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty());
+    if secret_ok {
+        return Ok(());
+    }
+    Err(
+        ConfigError::invalid(
+            "管理 API 绑定了非本机地址，但 ui.secret 为空；拒绝启动以避免未鉴权控制面",
+        )
+        .at("ui.secret")
+        .hint(
+            "为 ui.secret 设置足够长的随机串，或把 listen.panel / listen.share 限制在 127.0.0.1 / ::1；\
+             share: home|all 会把面板绑到 0.0.0.0",
+        ),
+    )
+}
+
+fn is_loopback_bind_host(host: &str) -> bool {
+    let host = host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim();
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    match host.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        Err(_) => false,
+    }
+}
+
 fn validate_capture_platform(c: &Capture) -> ConfigResult<()> {
     validate_capture_platform_for_os(c, std::env::consts::OS)
 }
@@ -1504,6 +1563,90 @@ listen:
         assert_eq!(
             plan.listen.panel.unwrap().socket_addr().unwrap(),
             "[::1]:9090".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn non_loopback_panel_requires_ui_secret() {
+        let error = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 9090
+  share: home
+ui:
+  on: true
+"#,
+        )
+        .unwrap_err();
+        let msg = error.to_string();
+        assert!(
+            msg.contains("ui.secret") || msg.contains("未鉴权"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn non_loopback_panel_with_secret_is_allowed() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 9090
+  share: home
+ui:
+  on: true
+  secret: "test-secret-please-change"
+"#,
+        );
+        assert_eq!(plan.listen.panel.as_ref().unwrap().host, "0.0.0.0");
+        assert_eq!(
+            plan.ui.secret.as_deref(),
+            Some("test-secret-please-change")
+        );
+    }
+
+    #[test]
+    fn loopback_panel_allows_empty_secret() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: "127.0.0.1:9090"
+  share: false
+ui:
+  on: true
+"#,
+        );
+        assert!(plan.ui.secret.is_none() || plan.ui.secret.as_deref() == Some(""));
+    }
+
+    #[test]
+    fn choose_chain_is_rejected_at_compile() {
+        let error = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#A"]
+groups:
+  relay:
+    choose: chain
+    use: [nodes]
+    path: [A]
+route:
+  preset: direct
+"#,
+        )
+        .unwrap_err();
+        let msg = error.to_string();
+        assert!(
+            msg.contains("chain") && msg.contains("尚未实现"),
+            "unexpected error: {msg}"
         );
     }
 

--- a/crates/core-fetch/src/lib.rs
+++ b/crates/core-fetch/src/lib.rs
@@ -101,6 +101,8 @@ pub enum FetchError {
     Decompress(String),
     #[error("响应体超过上限 ({limit} bytes)")]
     BodyTooLarge { limit: usize },
+    #[error("目标地址被安全策略拒绝: {0}")]
+    BlockedTarget(String),
     #[error("IO: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -129,7 +131,12 @@ pub async fn fetch_raw(url: &str, opts: &FetchOptions) -> Result<FetchResult, Fe
 async fn fetch_inner(url: &str, opts: &FetchOptions) -> Result<FetchResult, FetchError> {
     let mut current = url.to_string();
     for hop in 0..opts.max_redirects {
-        debug!(target: "fetch", url = %current, hop, "GET");
+        // 日志只打 host，避免订阅 token 落盘。
+        let log_host = url::Url::parse(&current)
+            .ok()
+            .and_then(|u| u.host_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| "-".into());
+        debug!(target: "fetch", host = %log_host, hop, "GET");
         let parsed = url::Url::parse(&current).map_err(|e| FetchError::BadUrl(e.to_string()))?;
         let scheme = parsed.scheme();
         if scheme != "http" && scheme != "https" {
@@ -139,6 +146,11 @@ async fn fetch_inner(url: &str, opts: &FetchOptions) -> Result<FetchResult, Fetc
             .host_str()
             .ok_or_else(|| FetchError::BadUrl("missing host".into()))?
             .to_string();
+        if core_outbound::is_blocked_host_literal(&host) {
+            return Err(FetchError::BlockedTarget(
+                core_outbound::blocked_target_message(&host),
+            ));
+        }
         let port = parsed
             .port_or_known_default()
             .ok_or_else(|| FetchError::BadUrl("unknown port for scheme".into()))?;
@@ -154,6 +166,12 @@ async fn fetch_inner(url: &str, opts: &FetchOptions) -> Result<FetchResult, Fetc
                 "no address resolved",
             ))
         })?;
+        // 解析后复查：防 DNS 指到内网 / 元数据（含 redirect 每一跳）。
+        if core_outbound::is_blocked_ip(peer.ip()) {
+            return Err(FetchError::BlockedTarget(
+                core_outbound::blocked_target_message(&peer.ip().to_string()),
+            ));
+        }
 
         // 2) 开 TCP 走 bind_outbound_socket —— 这才是本 crate 存在的核心理由。
         let tcp = tokio::time::timeout(opts.connect_timeout, connect_tcp_outbound_bound(peer))
@@ -183,10 +201,23 @@ async fn fetch_inner(url: &str, opts: &FetchOptions) -> Result<FetchResult, Fetc
                     url::Url::parse(&current).map_err(|e| FetchError::BadUrl(e.to_string()))?;
                 let next = base
                     .join(loc)
-                    .map_err(|e| FetchError::BadUrl(format!("redirect target invalid: {e}")))?
-                    .to_string();
-                debug!(target: "fetch", from = %current, to = %next, status, hop, "redirect");
-                current = next;
+                    .map_err(|e| FetchError::BadUrl(format!("redirect target invalid: {e}")))?;
+                if let Some(h) = next.host_str() {
+                    if core_outbound::is_blocked_host_literal(h) {
+                        return Err(FetchError::BlockedTarget(
+                            core_outbound::blocked_target_message(h),
+                        ));
+                    }
+                }
+                debug!(
+                    target: "fetch",
+                    from_host = %host,
+                    to_host = %next.host_str().unwrap_or("-"),
+                    status,
+                    hop,
+                    "redirect"
+                );
+                current = next.to_string();
                 continue;
             }
         }

--- a/crates/core-outbound/src/lib.rs
+++ b/crates/core-outbound/src/lib.rs
@@ -13,6 +13,7 @@
 #[allow(unsafe_code)]
 pub mod adapter;
 pub mod loopback;
+pub mod net_guard;
 pub mod registry;
 
 pub mod block;
@@ -36,6 +37,7 @@ pub use adapter::{
     set_outbound_fwmark, set_outbound_interface, set_outbound_interface_index,
     set_socket_protector, should_mark_outbound_addr,
 };
+pub use net_guard::{blocked_target_message, is_blocked_host_literal, is_blocked_ip};
 pub use dns_hijack::{
     DnsHijackOutbound, DnsResponder, global_dns_responder, set_global_dns_responder,
 };

--- a/crates/core-outbound/src/lib.rs
+++ b/crates/core-outbound/src/lib.rs
@@ -37,7 +37,6 @@ pub use adapter::{
     set_outbound_fwmark, set_outbound_interface, set_outbound_interface_index,
     set_socket_protector, should_mark_outbound_addr,
 };
-pub use net_guard::{blocked_target_message, is_blocked_host_literal, is_blocked_ip};
 pub use dns_hijack::{
     DnsHijackOutbound, DnsResponder, global_dns_responder, set_global_dns_responder,
 };
@@ -45,4 +44,5 @@ pub use loopback::{
     LoopbackTcpGuard, LoopbackUdpGuard, TrackedTcpStream, is_loopback_tcp_source,
     is_loopback_udp_source, register_tcp, register_udp,
 };
+pub use net_guard::{blocked_target_message, is_blocked_host_literal, is_blocked_ip};
 pub use registry::{OutboundRegistry, ResolveFn};

--- a/crates/core-outbound/src/net_guard.rs
+++ b/crates/core-outbound/src/net_guard.rs
@@ -1,0 +1,141 @@
+//! 出站目标安全检查 —— 挡掉控制面 SSRF / 订阅 fetch 打到内网与云元数据的路径。
+//!
+//! 默认策略：只允许**全局单播**地址。以下一律拒绝：
+//! * loopback / unspecified
+//! * RFC1918、链路本地、CGNAT（100.64/10）、benchmark（198.18/15）
+//! * IPv6 ULA / 链路本地 / 唯一本地
+//! * 云元数据主机名（`metadata.google.internal` 等）与 `169.254.169.254`
+//!
+//! 这是 **default-deny private**。实验室若必须探测内网，应走独立诊断工具，
+//! 而不是 URLTest / 订阅拉取。
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// 主机名或字面 IP 是否被策略禁止（在解析之前就能拦的部分）。
+pub fn is_blocked_host_literal(host: &str) -> bool {
+    let host = host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim();
+    if host.is_empty() {
+        return true;
+    }
+    let lower = host.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "localhost"
+            | "localhost.localdomain"
+            | "metadata"
+            | "metadata.google.internal"
+            | "metadata.goog"
+            | "instance-data"
+    ) || lower.ends_with(".localhost")
+        || lower.ends_with(".local")
+        || lower.ends_with(".internal")
+    {
+        return true;
+    }
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return is_blocked_ip(ip);
+    }
+    false
+}
+
+/// 解析后的 IP 是否禁止作为 fetch / URLTest 目标。
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_v4(v4),
+        IpAddr::V6(v6) => is_blocked_v6(v6),
+    }
+}
+
+fn is_blocked_v4(ip: Ipv4Addr) -> bool {
+    if ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_broadcast()
+        || ip.is_link_local()
+        || ip.is_private()
+        || ip.is_multicast()
+        || ip.is_documentation()
+    {
+        return true;
+    }
+    let o = ip.octets();
+    // CGNAT 100.64.0.0/10
+    if o[0] == 100 && (o[1] & 0xc0) == 64 {
+        return true;
+    }
+    // 0.0.0.0/8
+    if o[0] == 0 {
+        return true;
+    }
+    // 192.0.0.0/24 IETF protocol assignments (incl. some special-use)
+    if o[0] == 192 && o[1] == 0 && o[2] == 0 {
+        return true;
+    }
+    // 198.18.0.0/15 benchmark
+    if o[0] == 198 && (o[1] == 18 || o[1] == 19) {
+        return true;
+    }
+    // 云元数据链路本地常见地址
+    if ip == Ipv4Addr::new(169, 254, 169, 254) {
+        return true;
+    }
+    false
+}
+
+fn is_blocked_v6(ip: Ipv6Addr) -> bool {
+    if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
+        return true;
+    }
+    // IPv4-mapped：按内嵌 v4 判断
+    if let Some(v4) = ip.to_ipv4_mapped() {
+        return is_blocked_v4(v4);
+    }
+    let seg = ip.segments();
+    // fe80::/10 link-local
+    if (seg[0] & 0xffc0) == 0xfe80 {
+        return true;
+    }
+    // fc00::/7 unique local
+    if (seg[0] & 0xfe00) == 0xfc00 {
+        return true;
+    }
+    // 2001:db8::/32 documentation
+    if seg[0] == 0x2001 && seg[1] == 0x0db8 {
+        return true;
+    }
+    false
+}
+
+/// 供 URLTest / fetch 使用的统一错误文案。
+pub fn blocked_target_message(target: &str) -> String {
+    format!(
+        "refusing non-public target \"{target}\" (loopback/private/link-local/metadata blocked)"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_private_and_metadata() {
+        assert!(is_blocked_ip("127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("10.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("192.168.1.1".parse().unwrap()));
+        assert!(is_blocked_ip("172.16.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("100.64.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("169.254.169.254".parse().unwrap()));
+        assert!(is_blocked_ip("::1".parse().unwrap()));
+        assert!(is_blocked_ip("fc00::1".parse().unwrap()));
+        assert!(is_blocked_ip("fe80::1".parse().unwrap()));
+        assert!(is_blocked_host_literal("localhost"));
+        assert!(is_blocked_host_literal("metadata.google.internal"));
+        assert!(is_blocked_host_literal("169.254.169.254"));
+        assert!(!is_blocked_host_literal("www.gstatic.com"));
+        assert!(!is_blocked_ip("8.8.8.8".parse().unwrap()));
+        assert!(!is_blocked_ip("1.1.1.1".parse().unwrap()));
+    }
+}

--- a/crates/core-runtime/src/engine.rs
+++ b/crates/core-runtime/src/engine.rs
@@ -195,8 +195,10 @@ impl Runtime {
         }
 
         let mutable = MutableConfig {
+            // share=home/all 时 Mixed/API 绑定 0.0.0.0，与 Clash allow-lan 语义对齐。
+            allow_lan: !matches!(plan.listen.share, core_config::model::Share::False),
             tun_enable: plan.capture.on,
-            ipv6: true,
+            ipv6: plan.resolver.ipv6,
             ..MutableConfig::default()
         };
         let node_info = initial_node_info(&plan);
@@ -439,12 +441,27 @@ impl Runtime {
 
     pub fn pick_outbound_for_context(&self, ctx: FlowContext) -> RoutePick {
         self.metrics.inc_route();
-        let (decision, kind, source) = self.route.decide(&ctx);
+        // Clash `/configs` mode：rule 走规则；global 强制 route.final 组；direct 强制 DIRECT。
+        // 未接线前 dashboard 改 mode 是假热改；这里让 mode 真正影响选路。
+        let mode = self.mutable.read().mode.clone();
+        let (decision, kind, source) = match mode.to_ascii_lowercase().as_str() {
+            "direct" => (RouteDecision::Direct, "MODE", "mode:direct".into()),
+            "global" => (
+                global_mode_decision(&self.plan.route.r#final),
+                "MODE",
+                "mode:global".into(),
+            ),
+            _ => {
+                let (decision, kind, source) = self.route.decide(&ctx);
+                (decision, kind, source)
+            }
+        };
         debug!(
             target: "route",
             host = %ctx.host,
             port = ctx.port,
             network = ctx.network.as_str(),
+            mode = %mode,
             ?decision,
             kind,
             source = %source,
@@ -479,6 +496,8 @@ impl Runtime {
         meta.dst_ip = ctx.ip;
         let tester = self.urltest.read().clone();
         let registry = self.outbounds.read();
+        // UDP 只允许具备 UDP 能力的节点。过滤后不得再回退到任意 TCP-only 成员，
+        // 否则会静默选中无 UDP relay 的协议，最终 Unsupported 或错误转发。
         let pick = if ctx.network == NetworkKind::Udp {
             g.pick_eligible(&meta, &self.smart, tester.as_ref(), |name| {
                 registry
@@ -486,7 +505,6 @@ impl Runtime {
                     .map(|ob| ob.capabilities().udp)
                     .unwrap_or(false)
             })
-            .or_else(|| g.pick(&meta, &self.smart, tester.as_ref()))
         } else {
             g.pick(&meta, &self.smart, tester.as_ref())
         };
@@ -495,6 +513,12 @@ impl Runtime {
                 return (name, ob);
             }
             warn!(target: "route", node = %name, "节点未注册，阻断流量避免回退 DIRECT");
+        } else if ctx.network == NetworkKind::Udp {
+            warn!(
+                target: "route",
+                group,
+                "分组内无支持 UDP 的节点，阻断流量避免回退 TCP-only 出站"
+            );
         } else if g.has_unresolved_feed_placeholders() {
             warn!(target: "route", group, "订阅节点尚未加载或为空，阻断流量避免回退 DIRECT");
         }
@@ -544,6 +568,8 @@ impl Runtime {
         let mut attempted = BTreeSet::new();
         let mut last_err: Option<std::io::Error> = None;
         for attempt in 1..=DIAL_MAX_RETRIES {
+            // 已失败节点通过 UrlTester 短期 dead + pick_eligible 的 alive 过滤排除；
+            // attempted 仍作本轮硬排除，防止 Manual 固定节点在 mark_temp_dead 前再次命中。
             let pick = self.pick_outbound_for_context(ctx.clone());
             info!(
                 target: "dial",
@@ -562,7 +588,7 @@ impl Runtime {
                     "blocked",
                 ));
             }
-            if !attempted.insert(pick.label.clone()) {
+            if attempted.contains(&pick.label) {
                 if let Some(err) = last_err {
                     debug!(
                         target: "dial",
@@ -571,11 +597,12 @@ impl Runtime {
                         %host, port,
                         outbound = %pick.label,
                         error = %err,
-                        "retry stopped because group selected the same outbound again",
+                        "retry stopped because group selected an already-failed outbound",
                     );
                     return Err(err);
                 }
             }
+            attempted.insert(pick.label.clone());
             let dial_ctx = DialContext {
                 host: host.to_string(),
                 port,
@@ -642,6 +669,10 @@ impl Runtime {
                     );
                     if pick.label != "DIRECT" && pick.label != "BLOCK" {
                         self.smart.record_failure(&pick.label, e.to_string());
+                        // 短期 mark_dead，让后续 pick 跳过本节点。
+                        if let Some(t) = self.urltest.read().clone() {
+                            t.mark_temp_dead(&pick.label);
+                        }
                     }
                     if let Some(name) = &group_for_event {
                         if let Some(g) = self.groups.read().get(name).cloned() {
@@ -1074,7 +1105,17 @@ fn route_rule_name(kind: &str) -> &'static str {
         "network" | "proto" => "NETWORK",
         "process" => "PROCESS-NAME",
         "set" => "RULE-SET",
+        "MODE" | "mode" => "MODE",
         _ => "MATCH",
+    }
+}
+
+/// Clash `mode=global`：全部流量进 `route.final`（组 / DIRECT / BLOCK）。
+fn global_mode_decision(final_target: &str) -> RouteDecision {
+    match final_target {
+        "direct" | "DIRECT" => RouteDecision::Direct,
+        "block" | "BLOCK" | "REJECT" | "reject" => RouteDecision::Block,
+        other => RouteDecision::Group(other.to_string()),
     }
 }
 
@@ -1771,6 +1812,95 @@ find-process-mode: strict
         assert!(
             runtime.process_finder.is_some(),
             "find-process-mode: strict → finder 必须构建"
+        );
+    }
+
+    #[test]
+    fn mutable_mode_direct_bypasses_rules() {
+        let plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#HK"]
+groups:
+  main:
+    choose: manual
+    use: [nodes]
+route:
+  preset: global
+  final: main
+"#,
+        );
+        let runtime = Runtime::build(plan);
+        // rule 模式应进 main 组。
+        let rule_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(rule_pick.label, "HK");
+
+        runtime.mutable.write().mode = "direct".into();
+        let direct_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(direct_pick.label, "DIRECT");
+        assert_eq!(direct_pick.rule, "MODE");
+    }
+
+    #[test]
+    fn mutable_mode_global_forces_final_group() {
+        let plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#HK"]
+groups:
+  main:
+    choose: manual
+    use: [nodes]
+route:
+  preset: direct
+  final: main
+"#,
+        );
+        let runtime = Runtime::build(plan);
+        // direct preset 默认应 DIRECT。
+        let rule_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(rule_pick.label, "DIRECT");
+
+        runtime.mutable.write().mode = "global".into();
+        let global_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(global_pick.label, "HK");
+        assert_eq!(global_pick.rule, "MODE");
+    }
+
+    #[test]
+    fn udp_pick_does_not_fall_back_to_tcp_only_member() {
+        // VLESS 出站 capabilities.udp=false；组内只有 VLESS 时 UDP 必须 BLOCK，
+        // 不得回退到 TCP-only 成员。
+        let plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes:
+  - "vless://11111111-1111-1111-1111-111111111111@1.2.3.4:443?security=tls&type=tcp#vless-only"
+groups:
+  main:
+    choose: manual
+    use: [nodes]
+route:
+  preset: global
+  final: main
+"#,
+        );
+        let runtime = Runtime::build(plan);
+        let tcp = runtime.pick_outbound("1.1.1.1", 443, NetworkKind::Tcp);
+        assert_eq!(tcp.label, "vless-only");
+        let udp = runtime.pick_outbound("1.1.1.1", 443, NetworkKind::Udp);
+        assert_eq!(
+            udp.label, "BLOCK",
+            "UDP must not fall back to TCP-only nodes"
         );
     }
 

--- a/crates/core-runtime/src/group_selector.rs
+++ b/crates/core-runtime/src/group_selector.rs
@@ -6,7 +6,7 @@
 //! | `url-test`            | `Smart` / `Fast`               | URLTest 最低延迟 + tolerance + singledo              |
 //! | `fallback`            | `Stable`                       | 顺序找首个 alive；fixed 选择优先                     |
 //! | `load-balance`        | `Spread`                       | consistent-hashing / round-robin / sticky-sessions   |
-//! | `relay` (chain)       | `Chain`                        | 按 path 顺序拼链                                     |
+//! | `relay` (chain)       | `Chain`                        | **未实现**；配置编译拒绝，运行时返回 None              |
 //!
 //! ## 关键能力（与 mihomo 等价）
 //!
@@ -412,7 +412,7 @@ impl GroupSelector {
                 unresolved_feeds,
                 candidates_before_eligibility = before_eligibility,
                 network = meta.network,
-                "no selectable members after filter/provider expansion -> caller will fall back",
+                "no selectable members after filter/provider/capability expansion",
             );
             return None;
         }
@@ -421,6 +421,24 @@ impl GroupSelector {
                 .map(|t| t.current_config().default_url)
                 .unwrap_or_default()
         });
+        // 排除本轮 dial 已失败 / 短期 dead 的节点。Manual 若固定节点已在排除集，
+        // 会落到其它成员；全灭时返回 None，由上层 BLOCK 而不是死循环。
+        if !members.is_empty() {
+            if let Some(t) = tester {
+                let before = members.len();
+                members.retain(|m| t.alive_for_url(m, &url));
+                if members.is_empty() {
+                    tracing::warn!(
+                        target: "group::pick",
+                        group = %self.plan.name,
+                        host = %meta.host,
+                        candidates_before_alive = before,
+                        "all candidates temporarily dead / excluded"
+                    );
+                    return None;
+                }
+            }
+        }
         let started = std::time::Instant::now();
         let chosen = match self.plan.choose {
             ChooseStrategy::Manual => self.pick_manual(&members, &url, tester.map(|t| t.as_ref())),
@@ -685,13 +703,15 @@ impl GroupSelector {
     Chain / Relay
     ==================================================================== */
 
-    fn pick_chain(&self, members: &[String]) -> Option<String> {
-        // chain 第一跳 = path[0]；具体 outbound 拼接由 dispatcher / runtime.dial 完成。
-        self.plan
-            .path
-            .first()
-            .cloned()
-            .or_else(|| members.first().cloned())
+    fn pick_chain(&self, _members: &[String]) -> Option<String> {
+        // 多跳 relay 尚未实现。配置编译期会拒绝 `choose: chain`；
+        // 这里再返回 None，避免运行时静默退化成单跳第一节点。
+        tracing::warn!(
+            target: "group::pick",
+            group = %self.plan.name,
+            "choose=chain is not implemented; blocking instead of silent single-hop"
+        );
+        None
     }
 
     /* ====================================================================
@@ -1007,12 +1027,16 @@ mod tests {
     }
 
     #[test]
-    fn chain_returns_path_first() {
+    fn chain_does_not_silently_pick_first_hop() {
         let mut p = plan(ChooseStrategy::Chain, &["a", "b"]);
         p.path = vec!["hop1".into(), "hop2".into()];
         let g = GroupSelector::new(p);
         let s = smart();
-        assert_eq!(g.pick(&meta("h"), &s, None).as_deref(), Some("hop1"));
+        assert_eq!(
+            g.pick(&meta("h"), &s, None),
+            None,
+            "chain must not degrade to path[0] / members[0]"
+        );
     }
 
     #[test]

--- a/crates/core-runtime/src/health.rs
+++ b/crates/core-runtime/src/health.rs
@@ -46,6 +46,8 @@ use crate::{engine::Runtime, int_ranges::IntRanges};
 
 /// `LastDelayForTestUrl` 死节点返回值；与 mihomo `0xFFFF` 等价语义但宽度扩为 u32。
 pub const DEAD_DELAY: u32 = u32::MAX;
+/// 拨号失败后的短期 dead TTL —— 避免 Manual/粘性策略反复撞同一坏节点。
+pub const TEMP_DEAD_TTL: Duration = Duration::from_secs(30);
 /// 单个节点最多保留多少条历史（与 mihomo `defaultHistoriesNum = 10`）。
 pub const HISTORY_CAP: usize = 10;
 /// `single_flight` 缓存窗口（与 mihomo `singledo.NewSingle(time.Second * 10)`）。
@@ -59,6 +61,8 @@ pub enum DelayError {
     UnknownNode(String),
     #[error("URL 非法: {0}")]
     BadUrl(String),
+    #[error("目标被安全策略拒绝: {0}")]
+    BlockedTarget(String),
     #[error("dial 失败: {0}")]
     Dial(String),
     #[error("HTTP 失败: {0}")]
@@ -117,6 +121,8 @@ pub struct NodeUrlStats {
     pub alive: AtomicBool,
     pub last_delay_ms: AtomicU32, // 0 = 未测；DEAD_DELAY = 死
     pub last_seen_ms: AtomicU64,
+    /// 临时 dead 截止时间（unix ms）；0 表示无临时 dead。
+    temp_dead_until_ms: AtomicU64,
     history: Mutex<std::collections::VecDeque<HistoryEntry>>,
 }
 
@@ -132,6 +138,7 @@ impl Default for NodeUrlStats {
             alive: AtomicBool::new(true),
             last_delay_ms: AtomicU32::new(0),
             last_seen_ms: AtomicU64::new(0),
+            temp_dead_until_ms: AtomicU64::new(0),
             history: Mutex::new(std::collections::VecDeque::with_capacity(HISTORY_CAP)),
         }
     }
@@ -144,6 +151,9 @@ impl NodeUrlStats {
         self.last_delay_ms
             .store(if alive { delay_ms } else { DEAD_DELAY }, Ordering::Release);
         self.last_seen_ms.store(now, Ordering::Release);
+        if alive {
+            self.temp_dead_until_ms.store(0, Ordering::Release);
+        }
         let mut g = self.history.lock();
         g.push_back(HistoryEntry {
             time_ms: now,
@@ -153,14 +163,37 @@ impl NodeUrlStats {
             g.pop_front();
         }
     }
+
+    /// 拨号失败后的短期排除，不永久杀死节点。
+    pub fn mark_temp_dead(&self, ttl: Duration) {
+        let until = now_ms().saturating_add(ttl.as_millis() as u64);
+        self.temp_dead_until_ms.store(until, Ordering::Release);
+        self.alive.store(false, Ordering::Release);
+        self.last_delay_ms.store(DEAD_DELAY, Ordering::Release);
+        self.last_seen_ms.store(now_ms(), Ordering::Release);
+    }
+
     pub fn last_delay(&self) -> u32 {
-        if self.alive.load(Ordering::Acquire) {
+        if self.is_alive() {
             self.last_delay_ms.load(Ordering::Acquire)
         } else {
             DEAD_DELAY
         }
     }
     pub fn is_alive(&self) -> bool {
+        let until = self.temp_dead_until_ms.load(Ordering::Acquire);
+        if until != 0 {
+            let now = now_ms();
+            if now < until {
+                return false;
+            }
+            // TTL 过期：清掉临时 dead，回到 alive=true（除非正式 probe 仍标记失败）。
+            self.temp_dead_until_ms.store(0, Ordering::Release);
+            // 若 last formal record 是 failure 且没有成功过，仍看 alive 原子位。
+            // mark_temp_dead 把 alive 置 false；TTL 到期后恢复 true。
+            self.alive.store(true, Ordering::Release);
+            return true;
+        }
         self.alive.load(Ordering::Acquire)
     }
     pub fn history(&self) -> Vec<HistoryEntry> {
@@ -241,6 +274,24 @@ impl UrlTester {
             .unwrap_or(true)
     }
 
+    /// 将节点在默认 probe URL 上标记为短期 dead，供 dial 失败后的排除集使用。
+    pub fn mark_temp_dead(&self, node: &str) {
+        let url = self.cfg.read().default_url.clone();
+        self.mark_temp_dead_for_url(node, &url);
+    }
+
+    pub fn mark_temp_dead_for_url(&self, node: &str, url: &str) {
+        let stats = self.ensure_stats(node, url);
+        stats.mark_temp_dead(TEMP_DEAD_TTL);
+        debug!(
+            target: "urltest",
+            node,
+            url,
+            ttl_secs = TEMP_DEAD_TTL.as_secs(),
+            "marked temporarily dead after dial failure"
+        );
+    }
+
     pub fn history(&self, node: &str, url: &str) -> Vec<HistoryEntry> {
         self.stats
             .read()
@@ -285,6 +336,38 @@ impl UrlTester {
         let unified = opts.unified_delay.unwrap_or(cfg.default_unified_delay);
 
         let parsed = parse_test_url(&url)?;
+        // 主机名字面量阶段先拦 loopback/metadata；解析后的 IP 在 dial 前再拦。
+        if core_outbound::is_blocked_host_literal(&parsed.host) {
+            return Err(DelayError::BlockedTarget(
+                core_outbound::blocked_target_message(&parsed.host),
+            ));
+        }
+        // 对字面 IP 的 URL 立即拒绝；域名则在 resolve 后由 dial 路径自然失败前
+        // 再做一次 resolve 复查（避免通过 DNS rebinding 打到 169.254.169.254）。
+        if let Ok(ip) = parsed.host.parse::<std::net::IpAddr>() {
+            if core_outbound::is_blocked_ip(ip) {
+                return Err(DelayError::BlockedTarget(
+                    core_outbound::blocked_target_message(&parsed.host),
+                ));
+            }
+        } else {
+            // 域名：先解析再判定，防止 URLTest 当 SSRF 原语。
+            match core_outbound::resolve_host(&parsed.host, parsed.port).await {
+                Ok(addrs) => {
+                    if addrs
+                        .iter()
+                        .any(|a| core_outbound::is_blocked_ip(a.ip()))
+                    {
+                        return Err(DelayError::BlockedTarget(
+                            core_outbound::blocked_target_message(&parsed.host),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    return Err(DelayError::Dial(format!("resolve {}: {e}", parsed.host)));
+                }
+            }
+        }
         let ob = runtime
             .outbounds
             .read()
@@ -730,6 +813,16 @@ mod tests {
     #[test]
     fn rejects_unsupported_scheme() {
         assert!(parse_test_url("ws://x").is_err());
+    }
+
+    #[test]
+    fn temp_dead_expires() {
+        let stats = NodeUrlStats::default();
+        assert!(stats.is_alive());
+        stats.mark_temp_dead(Duration::from_millis(1));
+        assert!(!stats.is_alive());
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(stats.is_alive(), "temp dead must expire");
     }
 
     #[test]

--- a/crates/core-runtime/src/health.rs
+++ b/crates/core-runtime/src/health.rs
@@ -354,10 +354,7 @@ impl UrlTester {
             // 域名：先解析再判定，防止 URLTest 当 SSRF 原语。
             match core_outbound::resolve_host(&parsed.host, parsed.port).await {
                 Ok(addrs) => {
-                    if addrs
-                        .iter()
-                        .any(|a| core_outbound::is_blocked_ip(a.ip()))
-                    {
+                    if addrs.iter().any(|a| core_outbound::is_blocked_ip(a.ip())) {
                         return Err(DelayError::BlockedTarget(
                             core_outbound::blocked_target_message(&parsed.host),
                         ));

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -801,7 +801,17 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     };
 
     // 启动 capture supervisor（如果配置开启）—— 复用上面建好的 ruleset_index。
+    // auto_route / auto_redirect 会改系统路由：启动失败必须 fail-closed，
+    // 不能 warn 后继续跑“半透明代理”状态。
     let mut capture_handle: Option<Arc<core_capture::CaptureSupervisor>> = None;
+    let capture_fail_closed = plan.capture.on
+        && (plan.capture.tun.auto_route
+            || plan.capture.tun.auto_redirect
+            || matches!(
+                plan.capture.method,
+                core_config::model::CaptureMethod::Tproxy
+                    | core_config::model::CaptureMethod::Redirect
+            ));
     match core_capture::CaptureSupervisor::build(&plan.capture, &plan.mesh, plan.resolver.ipv6) {
         Ok(Some(sup)) => {
             // 注入 IpSetProvider，把 ruleset 的 cidr_v4/cidr_v6 暴露给 supervisor.allow_ip。
@@ -809,6 +819,16 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
                 index: ruleset_index.clone(),
             }));
             if let Err(e) = sup.start(runtime.clone()).await {
+                if capture_fail_closed {
+                    // 尽力停掉可能半装好的状态，再把错误抛给 CLI。
+                    let _ = sup.stop().await;
+                    let _ = mesh_supervisor.stop().await;
+                    runtime.shutdown().await;
+                    anyhow::bail!(
+                        "capture supervisor start failed under auto_route/tproxy/redirect \
+                         (fail-closed): {e}"
+                    );
+                }
                 warn!(target: "capture", error = %e, "capture supervisor start failed");
                 // start() 已尝试一次事务回滚；若平台 pre_stop/stop 当次失败，
                 // supervisor 会保留 CleanupFailed 账本。调用方必须显式重试，
@@ -825,7 +845,17 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
             }
         }
         Ok(None) => {}
-        Err(e) => warn!(target: "capture", error = %e, "capture supervisor build failed"),
+        Err(e) => {
+            if capture_fail_closed {
+                let _ = mesh_supervisor.stop().await;
+                runtime.shutdown().await;
+                anyhow::bail!(
+                    "capture supervisor build failed under auto_route/tproxy/redirect \
+                     (fail-closed): {e}"
+                );
+            }
+            warn!(target: "capture", error = %e, "capture supervisor build failed");
+        }
     }
 
     let mut handles = Vec::new();

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,8 @@ ui:
     - "http://127.0.0.1:3000"
 ```
 
-没有配置 `ui.secret` 时，API 不鉴权，只适合严格本机监听。暴露到局域网或容器网络时必须配置密钥和 CORS allowlist。
+没有配置 `ui.secret` 时，API 不鉴权，**仅允许本机 loopback 监听**。  
+`listen.share: home|all`、`0.0.0.0`/`::` 或其它非本机 `listen.panel` 且 `ui.secret` 为空时，配置编译会失败（`check`/`run` 拒绝启动）。暴露到局域网或容器网络时还必须配置 CORS allowlist。
 
 ## 鉴权
 
@@ -35,6 +36,10 @@ x-api-secret: <secret>
 ```
 
 WebSocket/SSE 因浏览器协议限制，可使用 `?token=<secret>`。普通 GET/POST 不接受 query token，避免凭据进入访问日志和 Referer。
+
+Clash 兼容 `GET /configs` 的 `authentication` 字段只返回用户名列表，不回传 Mixed 入站密码。  
+`PUT /configs` 的 `mode`（`rule` / `global` / `direct`）会真正改变选路；`log-level` 更新运行时视图。  
+`allow-lan` / `tun.enable` 不能热切换：值与启动配置不同时返回 `501`，避免 dashboard 假安全控制。
 
 以下路径不要求密钥：
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ sequenceDiagram
 ## 安全边界
 
 - API 密钥、订阅、节点密码、UUID、PSK 和私钥不得写入普通日志。
-- 管理 API 暴露到非本机地址时必须配置 `ui.secret` 和 CORS allowlist。
+- 管理 API 暴露到非本机地址时必须配置 `ui.secret` 和 CORS allowlist；缺少 `ui.secret` 时配置编译失败。
 - 系统路由与防火墙修改应保留恢复路径。
 - 协议规定的固定向量、测试凭据和真实硬编码凭据必须在安全扫描中区分处理。
 - 外部输入包括 YAML、订阅、规则集、DNS 响应和管理 API；解析失败应返回边界清楚的错误。

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -146,10 +146,13 @@ ui:
 
 面板暴露到局域网前：
 
-- 配置 `ui.secret`；
+- 配置 `ui.secret`（**硬门禁**：`listen.share: home|all` 或非 loopback `listen.panel` 且 `ui.secret` 为空时，`check`/`run` 直接失败）；
+- `profile: router` 默认 `share: home`，因此也必须显式填写 `ui.secret`；
 - 将 `ui.cors` 限制为实际 Dashboard 来源；
 - 不要在 URL、日志或截图中公开密钥；
 - 用防火墙限制管理端口。
+
+策略组 `choose: chain`（多跳 relay）尚未实现，配置编译期会拒绝，不会静默退化为单跳。
 
 端点和鉴权方式见 [管理 API](API.md)。
 

--- a/examples/router.yaml
+++ b/examples/router.yaml
@@ -5,7 +5,13 @@ name: "transparent-gateway"
 listen:
   local: 7890
   panel: 9090
+  # share: home 会把 Mixed/API 绑到 0.0.0.0；非本机 API 必须配置 ui.secret。
   share: home
+
+ui:
+  on: true
+  # 部署前请换成足够长的随机串；空 secret + 非本机 panel 会在 check/run 阶段被拒绝。
+  secret: "change-me-router-panel-secret"
 
 feeds:
   my_airport: "https://example.com/sub"


### PR DESCRIPTION
## 背景

代码审查发现 pre-1.0 阶段存在控制面与数据路径的静默降级：空 secret 可暴露非本机 API、Clash 兼容接口回传入站密码、UDP 选路回退到 TCP-only、`choose: chain` 退化为单跳、`mode`/`allow-lan` 等热改写成功但不生效，以及 capture 在改系统路由失败后仍继续运行。

## 实现

### 控制面安全
- 非本机 panel 且 `ui.secret` 为空时，配置编译失败
- Clash `GET /configs` 的 `authentication` 仅返回用户名
- URLTest 与订阅/规则集 fetch 默认拒绝私网与元数据目标（含 redirect 复查）
- fetch 日志只记录 host，避免订阅 token 落盘

### 选路与拨号正确性
- UDP 选路过滤后不再回退 TCP-only 节点
- `choose: chain` 编译期拒绝
- Clash `mode`（rule/global/direct）接入真实选路
- dial 失败节点短期 mark dead，重试跳过坏节点

### 运行时诚实语义与 fail-closed
- `allow-lan` / `tun.enable` 热切换返回 501
- `auto_route` / TPROXY / REDIRECT 启动失败 fail-closed
- 更新文档、CHANGELOG 与 `examples/router.yaml` 的 secret 示例

## 安全与兼容边界
- 不新增协议能力；不实现多跳 chain
- `allow-lan` / TUN 开关仍以启动配置为准，不做半热切换
- 私网探测需走独立诊断路径，不被 URLTest/fetch 放行

## 验证
- [ ] `cargo test -p core-config -p core-runtime -p core-api -p core-outbound -p core-fetch`
- [ ] `cargo run -p wuther-core -- check examples/desktop.yaml`
- [ ] `cargo run -p wuther-core -- check examples/router.yaml`
- [ ] 空 secret + `share: home` 时 `check` 失败
- [ ] `GET /configs` 不含 Mixed 密码
- [ ] `PUT /configs`：`mode=direct` 生效；`allow-lan` 变更返回 501
- [ ] URLTest 对私网/元数据目标被拒绝

## 后续
- 协议互通回归与 capture 跨平台回滚矩阵
- dial 排除策略与健康检查联动可继续细化