### PR TITLE
fix(config): 非本机 API 强制 secret 并拒绝未实现 chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### Security
+
+- 非本机管理面板（`listen.share: home|all` 或非 loopback `listen.panel`）在 `ui.secret` 为空时拒绝编译/启动。
+
+### Fixed
+
+- `groups.*.choose: chain` 在配置编译期拒绝，避免静默退化为单跳第一节点。
+
 ### Added
 
 - 组网后端能力/附件模型、冻结 descriptor、强类型宿主资源声明与语义化系统资源冲突预检；

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -175,6 +175,7 @@ pub fn compile(mut cfg: UserConfig) -> ConfigResult<RuntimePlan> {
     validate_capture_platform(&capture)?;
     let smart = cfg.smart.unwrap_or_default();
     let ui = cfg.ui.unwrap_or_default();
+    validate_ui_secret_for_bind(&listen, &ui)?;
     let mesh = cfg.mesh.unwrap_or_default();
     let find_process_mode = cfg.find_process_mode;
     Ok(RuntimePlan {
@@ -381,6 +382,16 @@ fn compile_groups(
     let valid_feeds: std::collections::HashSet<&str> =
         cfg.feeds.keys().map(|s| s.as_str()).collect();
     for (name, g) in &cfg.groups {
+        if g.choose == ChooseStrategy::Chain {
+            return Err(ConfigError::invalid(format!(
+                "groups.{name}.choose = chain 尚未实现多跳 relay"
+            ))
+            .at(format!("groups.{name}.choose"))
+            .hint(
+                "请改用 manual / smart / fast / stable / spread；\
+                     多跳链路实现前不会静默退化为单跳",
+            ));
+        }
         let mut members = Vec::new();
         for src in &g.r#use {
             if src == "nodes" {
@@ -965,6 +976,50 @@ fn try_classical_to_dsl(line: &str) -> Option<String> {
     Some(format!("{} -> {}", lhs_parts.join(","), policy))
 }
 
+/// 非本机 API 面板暴露时必须配置 `ui.secret`，避免空 secret 的全开控制面。
+fn validate_ui_secret_for_bind(listen: &ListenPlan, ui: &Ui) -> ConfigResult<()> {
+    if !ui.on {
+        return Ok(());
+    }
+    let Some(panel) = listen.panel.as_ref() else {
+        return Ok(());
+    };
+    if is_loopback_bind_host(&panel.host) {
+        return Ok(());
+    }
+    let secret_ok = ui
+        .secret
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty());
+    if secret_ok {
+        return Ok(());
+    }
+    Err(ConfigError::invalid(
+        "管理 API 绑定了非本机地址，但 ui.secret 为空；拒绝启动以避免未鉴权控制面",
+    )
+    .at("ui.secret")
+    .hint(
+        "为 ui.secret 设置足够长的随机串，或把 listen.panel / listen.share 限制在 127.0.0.1 / ::1；\
+             share: home|all 会把面板绑到 0.0.0.0",
+    ))
+}
+
+fn is_loopback_bind_host(host: &str) -> bool {
+    let host = host
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim();
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    match host.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        Err(_) => false,
+    }
+}
+
 fn validate_capture_platform(c: &Capture) -> ConfigResult<()> {
     validate_capture_platform_for_os(c, std::env::consts::OS)
 }
@@ -1504,6 +1559,87 @@ listen:
         assert_eq!(
             plan.listen.panel.unwrap().socket_addr().unwrap(),
             "[::1]:9090".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn non_loopback_panel_requires_ui_secret() {
+        let error = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 9090
+  share: home
+ui:
+  on: true
+"#,
+        )
+        .unwrap_err();
+        let msg = error.to_string();
+        assert!(
+            msg.contains("ui.secret") || msg.contains("未鉴权"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn non_loopback_panel_with_secret_is_allowed() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: 9090
+  share: home
+ui:
+  on: true
+  secret: "test-secret-please-change"
+"#,
+        );
+        assert_eq!(plan.listen.panel.as_ref().unwrap().host, "0.0.0.0");
+        assert_eq!(plan.ui.secret.as_deref(), Some("test-secret-please-change"));
+    }
+
+    #[test]
+    fn loopback_panel_allows_empty_secret() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: "127.0.0.1:9090"
+  share: false
+ui:
+  on: true
+"#,
+        );
+        assert!(plan.ui.secret.is_none() || plan.ui.secret.as_deref() == Some(""));
+    }
+
+    #[test]
+    fn choose_chain_is_rejected_at_compile() {
+        let error = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#A"]
+groups:
+  relay:
+    choose: chain
+    use: [nodes]
+    path: [A]
+route:
+  preset: direct
+"#,
+        )
+        .unwrap_err();
+        let msg = error.to_string();
+        assert!(
+            msg.contains("chain") && msg.contains("尚未实现"),
+            "unexpected error: {msg}"
         );
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ sequenceDiagram
 ## 安全边界
 
 - API 密钥、订阅、节点密码、UUID、PSK 和私钥不得写入普通日志。
-- 管理 API 暴露到非本机地址时必须配置 `ui.secret` 和 CORS allowlist。
+- 管理 API 暴露到非本机地址时必须配置 `ui.secret` 和 CORS allowlist；缺少 `ui.secret` 时配置编译失败。
 - 系统路由与防火墙修改应保留恢复路径。
 - 协议规定的固定向量、测试凭据和真实硬编码凭据必须在安全扫描中区分处理。
 - 外部输入包括 YAML、订阅、规则集、DNS 响应和管理 API；解析失败应返回边界清楚的错误。

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -146,10 +146,13 @@ ui:
 
 面板暴露到局域网前：
 
-- 配置 `ui.secret`；
+- 配置 `ui.secret`（**硬门禁**：`listen.share: home|all` 或非 loopback `listen.panel` 且 `ui.secret` 为空时，`check`/`run` 直接失败）；
+- `profile: router` 默认 `share: home`，因此也必须显式填写 `ui.secret`；
 - 将 `ui.cors` 限制为实际 Dashboard 来源；
 - 不要在 URL、日志或截图中公开密钥；
 - 用防火墙限制管理端口。
+
+策略组 `choose: chain`（多跳 relay）尚未实现，配置编译期会拒绝，不会静默退化为单跳。
 
 端点和鉴权方式见 [管理 API](API.md)。
 

--- a/examples/router.yaml
+++ b/examples/router.yaml
@@ -5,7 +5,13 @@ name: "transparent-gateway"
 listen:
   local: 7890
   panel: 9090
+  # share: home 会把 Mixed/API 绑到 0.0.0.0；非本机 API 必须配置 ui.secret。
   share: home
+
+ui:
+  on: true
+  # 部署前请换成足够长的随机串；空 secret + 非本机 panel 会在 check/run 阶段被拒绝。
+  secret: "change-me-router-panel-secret"
 
 feeds:
   my_airport: "https://example.com/sub"


### PR DESCRIPTION
## 背景

`share: home|all` 可将管理面板绑到 `0.0.0.0`，但 `ui.secret` 默认可为空，形成未鉴权控制面。
`choose: chain` 配置存在却无多跳实现，旧逻辑会静默退化为单跳。

## 实现

- 配置编译校验：非 loopback panel + 空 secret → 错误
- `choose: chain` 编译期拒绝
- `examples/router.yaml` 补充 secret
- CONFIGURATION / ARCHITECTURE 文档同步

## 安全与兼容边界

- loopback panel 仍允许无 secret（本机开发）
- 不实现多跳 relay，仅拒绝静默降级

## 验证

- [ ] `cargo test -p core-config`
- [ ] 空 secret + `share: home` 时 `check` 失败
- [ ] `choose: chain` 配置 `check` 失败
- [ ] `examples/router.yaml` 可 `check`