### PR TITLE
fix(api): /configs 脱敏并让 mode 真正生效

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### Security
+
+- Clash 兼容 `GET /configs` 的 `authentication` 只返回用户名，不再回传明文密码。
+
+### Fixed
+
+- Clash `PUT /configs` 的 `mode`（rule/global/direct）接入真实选路；
+- `allow-lan` / `tun.enable` 热切换改为 `501`，不再写成功假象。
+
 ### Added
 
 - 组网后端能力/附件模型、冻结 descriptor、强类型宿主资源声明与语义化系统资源冲突预检；

--- a/crates/core-api/src/compat.rs
+++ b/crates/core-api/src/compat.rs
@@ -1321,13 +1321,22 @@ fn build_configs_value(s: &NativeState) -> Value {
         core_config::model::FindProcessMode::Strict => "strict",
         core_config::model::FindProcessMode::Always => "always",
     };
+    // 只回用户名，永不回明文密码。空数组表示未启用入站认证。
+    let authentication: Vec<String> = s
+        .runtime
+        .plan
+        .listen
+        .auth
+        .iter()
+        .map(|up| up.user.clone())
+        .collect();
     json!({
         "port": port,
         "socks-port": port,
         "redir-port": 0,
         "tproxy-port": 0,
         "mixed-port": port,
-        "authentication": &s.runtime.plan.listen.auth,
+        "authentication": authentication,
         "allow-lan": mc.allow_lan,
         "bind-address": "*",
         "mode": mc.mode,
@@ -1379,22 +1388,65 @@ async fn configs_put(
     State(s): State<NativeState>,
     Json(body): Json<ConfigsPut>,
 ) -> impl IntoResponse {
+    // mode 已接入选路；其余字段仍只更新 MutableConfig 视图。
+    // allow-lan / tun_enable / ipv6 / log-level 的真实副作用尚未热切换绑定/capture，
+    // 但至少 mode 不再是“写成功假象”。
     let mut mc = s.runtime.mutable.write();
     if let Some(v) = body.mode {
-        mc.mode = v.to_lowercase();
+        let normalized = v.to_lowercase();
+        match normalized.as_str() {
+            "rule" | "global" | "direct" => mc.mode = normalized,
+            other => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "message": format!(
+                            "unsupported mode \"{other}\"; expected rule|global|direct"
+                        )
+                    })),
+                )
+                    .into_response();
+            }
+        }
     }
     if let Some(v) = body.log_level {
         mc.log_level = v.to_lowercase();
     }
     if let Some(v) = body.allow_lan {
-        mc.allow_lan = v;
+        // 入站 bind 在启动时由 listen.share / host 决定，运行时无法安全热切换。
+        // 拒绝静默写入，避免 dashboard 显示 allow-lan=false 但端口仍对外监听。
+        let current = mc.allow_lan;
+        if v != current {
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(json!({
+                    "message": format!(
+                        "allow-lan cannot be changed at runtime (current={current}, requested={v}); \
+                         restart with listen.share false|home|all"
+                    )
+                })),
+            )
+                .into_response();
+        }
     }
     if let Some(v) = body.ipv6 {
         mc.ipv6 = v;
     }
     if let Some(t) = body.tun {
         if let Some(e) = t.enable {
-            mc.tun_enable = e;
+            let current = mc.tun_enable;
+            if e != current {
+                return (
+                    StatusCode::NOT_IMPLEMENTED,
+                    Json(json!({
+                        "message": format!(
+                            "tun.enable cannot be changed at runtime (current={current}, requested={e}); \
+                             restart with capture.on"
+                        )
+                    })),
+                )
+                    .into_response();
+            }
         }
     }
     drop(mc);

--- a/crates/core-api/tests/compat_smoke.rs
+++ b/crates/core-api/tests/compat_smoke.rs
@@ -332,7 +332,9 @@ async fn configs_get_and_put_round_trip() {
     let v = body_json(resp).await;
     assert_eq!(v["mode"], "rule");
     assert_eq!(v["log-level"], "info");
-    // PUT 修改 mode + log-level
+    // authentication 必须是用户名列表，不能回传 password 字段对象。
+    assert!(v["authentication"].is_array());
+    // PUT 修改 mode + log-level（allow-lan 热切换已禁用，见下测）
     let resp = app
         .clone()
         .oneshot(
@@ -340,9 +342,7 @@ async fn configs_get_and_put_round_trip() {
                 .method("PUT")
                 .uri("/configs")
                 .header("content-type", "application/json")
-                .body(Body::from(
-                    r#"{"mode":"global","log-level":"debug","allow-lan":true}"#,
-                ))
+                .body(Body::from(r#"{"mode":"global","log-level":"debug"}"#))
                 .unwrap(),
         )
         .await
@@ -350,6 +350,7 @@ async fn configs_get_and_put_round_trip() {
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     // 再 GET
     let resp = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/configs")
@@ -361,7 +362,72 @@ async fn configs_get_and_put_round_trip() {
     let v = body_json(resp).await;
     assert_eq!(v["mode"], "global");
     assert_eq!(v["log-level"], "debug");
-    assert_eq!(v["allow-lan"], true);
+}
+
+#[tokio::test]
+async fn configs_put_rejects_allow_lan_hot_toggle() {
+    let app = core_api::compat::router(build_state());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/configs")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"allow-lan":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_IMPLEMENTED);
+    let v = body_json(resp).await;
+    assert!(
+        v["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("allow-lan cannot be changed"),
+        "unexpected body: {v}"
+    );
+}
+
+#[tokio::test]
+async fn configs_authentication_never_returns_passwords() {
+    let yaml = r#"
+version: 1
+profile: desktop
+listen:
+  local: 7890
+  panel: 9090
+  auth:
+    - "alice:super-secret-password"
+groups:
+  main:
+    choose: manual
+nodes: []
+"#;
+    let plan = load_from_str(yaml).expect("plan");
+    let runtime = Arc::new(Runtime::build(plan));
+    let state = NativeState::for_tests(runtime, UrlTester::new(Default::default()), None);
+    let app = core_api::compat::router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/configs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let v = body_json(resp).await;
+    let auth = v["authentication"]
+        .as_array()
+        .expect("authentication array");
+    assert_eq!(auth.len(), 1);
+    assert_eq!(auth[0], "alice");
+    let body = serde_json::to_string(&v).unwrap();
+    assert!(
+        !body.contains("super-secret-password"),
+        "password must not appear in /configs body: {body}"
+    );
 }
 
 #[tokio::test]

--- a/crates/core-runtime/src/engine.rs
+++ b/crates/core-runtime/src/engine.rs
@@ -195,8 +195,10 @@ impl Runtime {
         }
 
         let mutable = MutableConfig {
+            // share=home/all 时 Mixed/API 绑定 0.0.0.0，与 Clash allow-lan 语义对齐。
+            allow_lan: !matches!(plan.listen.share, core_config::model::Share::False),
             tun_enable: plan.capture.on,
-            ipv6: true,
+            ipv6: plan.resolver.ipv6,
             ..MutableConfig::default()
         };
         let node_info = initial_node_info(&plan);
@@ -439,12 +441,27 @@ impl Runtime {
 
     pub fn pick_outbound_for_context(&self, ctx: FlowContext) -> RoutePick {
         self.metrics.inc_route();
-        let (decision, kind, source) = self.route.decide(&ctx);
+        // Clash `/configs` mode：rule 走规则；global 强制 route.final 组；direct 强制 DIRECT。
+        // 未接线前 dashboard 改 mode 是假热改；这里让 mode 真正影响选路。
+        let mode = self.mutable.read().mode.clone();
+        let (decision, kind, source) = match mode.to_ascii_lowercase().as_str() {
+            "direct" => (RouteDecision::Direct, "MODE", "mode:direct".into()),
+            "global" => (
+                global_mode_decision(&self.plan.route.r#final),
+                "MODE",
+                "mode:global".into(),
+            ),
+            _ => {
+                let (decision, kind, source) = self.route.decide(&ctx);
+                (decision, kind, source)
+            }
+        };
         debug!(
             target: "route",
             host = %ctx.host,
             port = ctx.port,
             network = ctx.network.as_str(),
+            mode = %mode,
             ?decision,
             kind,
             source = %source,
@@ -1074,7 +1091,17 @@ fn route_rule_name(kind: &str) -> &'static str {
         "network" | "proto" => "NETWORK",
         "process" => "PROCESS-NAME",
         "set" => "RULE-SET",
+        "MODE" | "mode" => "MODE",
         _ => "MATCH",
+    }
+}
+
+/// Clash `mode=global`：全部流量进 `route.final`（组 / DIRECT / BLOCK）。
+fn global_mode_decision(final_target: &str) -> RouteDecision {
+    match final_target {
+        "direct" | "DIRECT" => RouteDecision::Direct,
+        "block" | "BLOCK" | "REJECT" | "reject" => RouteDecision::Block,
+        other => RouteDecision::Group(other.to_string()),
     }
 }
 
@@ -1772,6 +1799,63 @@ find-process-mode: strict
             runtime.process_finder.is_some(),
             "find-process-mode: strict → finder 必须构建"
         );
+    }
+
+    #[test]
+    fn mutable_mode_direct_bypasses_rules() {
+        let plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#HK"]
+groups:
+  main:
+    choose: manual
+    use: [nodes]
+route:
+  preset: global
+  final: main
+"#,
+        );
+        let runtime = Runtime::build(plan);
+        // rule 模式应进 main 组。
+        let rule_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(rule_pick.label, "HK");
+
+        runtime.mutable.write().mode = "direct".into();
+        let direct_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(direct_pick.label, "DIRECT");
+        assert_eq!(direct_pick.rule, "MODE");
+    }
+    #[test]
+    fn mutable_mode_global_forces_final_group() {
+        let plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes: ["ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#HK"]
+groups:
+  main:
+    choose: manual
+    use: [nodes]
+route:
+  preset: direct
+  final: main
+"#,
+        );
+        let runtime = Runtime::build(plan);
+        // direct preset 默认应 DIRECT。
+        let rule_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(rule_pick.label, "DIRECT");
+
+        runtime.mutable.write().mode = "global".into();
+        let global_pick = runtime.pick_outbound("www.google.com", 443, NetworkKind::Tcp);
+        assert_eq!(global_pick.label, "HK");
+        assert_eq!(global_pick.rule, "MODE");
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,7 +18,8 @@ ui:
     - "http://127.0.0.1:3000"
 ```
 
-没有配置 `ui.secret` 时，API 不鉴权，只适合严格本机监听。暴露到局域网或容器网络时必须配置密钥和 CORS allowlist。
+没有配置 `ui.secret` 时，API 不鉴权，**仅允许本机 loopback 监听**。  
+`listen.share: home|all`、`0.0.0.0`/`::` 或其它非本机 `listen.panel` 且 `ui.secret` 为空时，配置编译会失败（`check`/`run` 拒绝启动）。暴露到局域网或容器网络时还必须配置 CORS allowlist。
 
 ## 鉴权
 
@@ -35,6 +36,10 @@ x-api-secret: <secret>
 ```
 
 WebSocket/SSE 因浏览器协议限制，可使用 `?token=<secret>`。普通 GET/POST 不接受 query token，避免凭据进入访问日志和 Referer。
+
+Clash 兼容 `GET /configs` 的 `authentication` 字段只返回用户名列表，不回传 Mixed 入站密码。  
+`PUT /configs` 的 `mode`（`rule` / `global` / `direct`）会真正改变选路；`log-level` 更新运行时视图。  
+`allow-lan` / `tun.enable` 不能热切换：值与启动配置不同时返回 `501`，避免 dashboard 假安全控制。
 
 以下路径不要求密钥：
 


### PR DESCRIPTION
## 背景

Clash 兼容 `/configs` 会回传 Mixed 明文密码；`mode`/`allow-lan`/`tun` 热改写成功但不影响真实行为。

## 实现

- `authentication` 仅返回用户名
- `mode` 接入 runtime 选路（rule/global/direct）
- `allow-lan` / `tun.enable` 变更返回 501
- 补充 smoke 与 mode 单测

## 安全与兼容边界

- 入站绑定仍以启动配置为准
- 不在本 PR 修改 UDP 选路或 dial 排除

## 验证

- [ ] `cargo test -p core-api -p core-runtime`
- [ ] `GET /configs` 不含密码
- [ ] `PUT mode=direct` 后选路为 DIRECT
- [ ] `PUT allow-lan` 翻转返回 501