### PR TITLE
fix(runtime): UDP 不回退 TCP-only 且 dial 失败短期排除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- UDP 选路在过滤无 UDP 能力节点后，不再回退到任意 TCP-only 成员；
+- dial 失败后短期 mark_dead，选点跳过已失败节点，避免 Manual/粘性死循环；
+- 运行时 `choose: chain` 返回空选择，避免静默单跳（配置层拒绝见独立 PR）。
+
 ### Added
 
 - 组网后端能力/附件模型、冻结 descriptor、强类型宿主资源声明与语义化系统资源冲突预检；

--- a/crates/core-runtime/src/engine.rs
+++ b/crates/core-runtime/src/engine.rs
@@ -479,6 +479,8 @@ impl Runtime {
         meta.dst_ip = ctx.ip;
         let tester = self.urltest.read().clone();
         let registry = self.outbounds.read();
+        // UDP 只允许具备 UDP 能力的节点。过滤后不得再回退到任意 TCP-only 成员，
+        // 否则会静默选中无 UDP relay 的协议，最终 Unsupported 或错误转发。
         let pick = if ctx.network == NetworkKind::Udp {
             g.pick_eligible(&meta, &self.smart, tester.as_ref(), |name| {
                 registry
@@ -486,7 +488,6 @@ impl Runtime {
                     .map(|ob| ob.capabilities().udp)
                     .unwrap_or(false)
             })
-            .or_else(|| g.pick(&meta, &self.smart, tester.as_ref()))
         } else {
             g.pick(&meta, &self.smart, tester.as_ref())
         };
@@ -495,6 +496,12 @@ impl Runtime {
                 return (name, ob);
             }
             warn!(target: "route", node = %name, "节点未注册，阻断流量避免回退 DIRECT");
+        } else if ctx.network == NetworkKind::Udp {
+            warn!(
+                target: "route",
+                group,
+                "分组内无支持 UDP 的节点，阻断流量避免回退 TCP-only 出站"
+            );
         } else if g.has_unresolved_feed_placeholders() {
             warn!(target: "route", group, "订阅节点尚未加载或为空，阻断流量避免回退 DIRECT");
         }
@@ -544,6 +551,8 @@ impl Runtime {
         let mut attempted = BTreeSet::new();
         let mut last_err: Option<std::io::Error> = None;
         for attempt in 1..=DIAL_MAX_RETRIES {
+            // 已失败节点通过 UrlTester 短期 dead + pick_eligible 的 alive 过滤排除；
+            // attempted 仍作本轮硬排除，防止 Manual 固定节点在 mark_temp_dead 前再次命中。
             let pick = self.pick_outbound_for_context(ctx.clone());
             info!(
                 target: "dial",
@@ -562,7 +571,7 @@ impl Runtime {
                     "blocked",
                 ));
             }
-            if !attempted.insert(pick.label.clone()) {
+            if attempted.contains(&pick.label) {
                 if let Some(err) = last_err {
                     debug!(
                         target: "dial",
@@ -571,11 +580,12 @@ impl Runtime {
                         %host, port,
                         outbound = %pick.label,
                         error = %err,
-                        "retry stopped because group selected the same outbound again",
+                        "retry stopped because group selected an already-failed outbound",
                     );
                     return Err(err);
                 }
             }
+            attempted.insert(pick.label.clone());
             let dial_ctx = DialContext {
                 host: host.to_string(),
                 port,
@@ -642,6 +652,10 @@ impl Runtime {
                     );
                     if pick.label != "DIRECT" && pick.label != "BLOCK" {
                         self.smart.record_failure(&pick.label, e.to_string());
+                        // 短期 mark_dead，让后续 pick 跳过本节点。
+                        if let Some(t) = self.urltest.read().clone() {
+                            t.mark_temp_dead(&pick.label);
+                        }
                     }
                     if let Some(name) = &group_for_event {
                         if let Some(g) = self.groups.read().get(name).cloned() {
@@ -1771,6 +1785,37 @@ find-process-mode: strict
         assert!(
             runtime.process_finder.is_some(),
             "find-process-mode: strict → finder 必须构建"
+        );
+    }
+
+    #[test]
+    fn udp_pick_does_not_fall_back_to_tcp_only_member() {
+        // VLESS 出站 capabilities.udp=false；组内只有 VLESS 时 UDP 必须 BLOCK，
+        // 不得回退到 TCP-only 成员。
+        let plan = load_plan(
+            r#"
+version: 1
+profile: desktop
+listen:
+  panel: false
+nodes:
+  - "vless://11111111-1111-1111-1111-111111111111@1.2.3.4:443?security=tls&type=tcp#vless-only"
+groups:
+  main:
+    choose: manual
+    use: [nodes]
+route:
+  preset: global
+  final: main
+"#,
+        );
+        let runtime = Runtime::build(plan);
+        let tcp = runtime.pick_outbound("1.1.1.1", 443, NetworkKind::Tcp);
+        assert_eq!(tcp.label, "vless-only");
+        let udp = runtime.pick_outbound("1.1.1.1", 443, NetworkKind::Udp);
+        assert_eq!(
+            udp.label, "BLOCK",
+            "UDP must not fall back to TCP-only nodes"
         );
     }
 

--- a/crates/core-runtime/src/group_selector.rs
+++ b/crates/core-runtime/src/group_selector.rs
@@ -6,7 +6,7 @@
 //! | `url-test`            | `Smart` / `Fast`               | URLTest 最低延迟 + tolerance + singledo              |
 //! | `fallback`            | `Stable`                       | 顺序找首个 alive；fixed 选择优先                     |
 //! | `load-balance`        | `Spread`                       | consistent-hashing / round-robin / sticky-sessions   |
-//! | `relay` (chain)       | `Chain`                        | 按 path 顺序拼链                                     |
+//! | `relay` (chain)       | `Chain`                        | **未实现**；配置编译拒绝，运行时返回 None              |
 //!
 //! ## 关键能力（与 mihomo 等价）
 //!
@@ -412,7 +412,7 @@ impl GroupSelector {
                 unresolved_feeds,
                 candidates_before_eligibility = before_eligibility,
                 network = meta.network,
-                "no selectable members after filter/provider expansion -> caller will fall back",
+                "no selectable members after filter/provider/capability expansion",
             );
             return None;
         }
@@ -421,6 +421,24 @@ impl GroupSelector {
                 .map(|t| t.current_config().default_url)
                 .unwrap_or_default()
         });
+        // 排除本轮 dial 已失败 / 短期 dead 的节点。Manual 若固定节点已在排除集，
+        // 会落到其它成员；全灭时返回 None，由上层 BLOCK 而不是死循环。
+        if !members.is_empty() {
+            if let Some(t) = tester {
+                let before = members.len();
+                members.retain(|m| t.alive_for_url(m, &url));
+                if members.is_empty() {
+                    tracing::warn!(
+                        target: "group::pick",
+                        group = %self.plan.name,
+                        host = %meta.host,
+                        candidates_before_alive = before,
+                        "all candidates temporarily dead / excluded"
+                    );
+                    return None;
+                }
+            }
+        }
         let started = std::time::Instant::now();
         let chosen = match self.plan.choose {
             ChooseStrategy::Manual => self.pick_manual(&members, &url, tester.map(|t| t.as_ref())),
@@ -685,13 +703,15 @@ impl GroupSelector {
     Chain / Relay
     ==================================================================== */
 
-    fn pick_chain(&self, members: &[String]) -> Option<String> {
-        // chain 第一跳 = path[0]；具体 outbound 拼接由 dispatcher / runtime.dial 完成。
-        self.plan
-            .path
-            .first()
-            .cloned()
-            .or_else(|| members.first().cloned())
+    fn pick_chain(&self, _members: &[String]) -> Option<String> {
+        // 多跳 relay 尚未实现。配置编译期会拒绝 `choose: chain`；
+        // 这里再返回 None，避免运行时静默退化成单跳第一节点。
+        tracing::warn!(
+            target: "group::pick",
+            group = %self.plan.name,
+            "choose=chain is not implemented; blocking instead of silent single-hop"
+        );
+        None
     }
 
     /* ====================================================================
@@ -1007,12 +1027,16 @@ mod tests {
     }
 
     #[test]
-    fn chain_returns_path_first() {
+    fn chain_does_not_silently_pick_first_hop() {
         let mut p = plan(ChooseStrategy::Chain, &["a", "b"]);
         p.path = vec!["hop1".into(), "hop2".into()];
         let g = GroupSelector::new(p);
         let s = smart();
-        assert_eq!(g.pick(&meta("h"), &s, None).as_deref(), Some("hop1"));
+        assert_eq!(
+            g.pick(&meta("h"), &s, None),
+            None,
+            "chain must not degrade to path[0] / members[0]"
+        );
     }
 
     #[test]

--- a/crates/core-runtime/src/health.rs
+++ b/crates/core-runtime/src/health.rs
@@ -46,6 +46,8 @@ use crate::{engine::Runtime, int_ranges::IntRanges};
 
 /// `LastDelayForTestUrl` 死节点返回值；与 mihomo `0xFFFF` 等价语义但宽度扩为 u32。
 pub const DEAD_DELAY: u32 = u32::MAX;
+/// 拨号失败后的短期 dead TTL —— 避免 Manual/粘性策略反复撞同一坏节点。
+pub const TEMP_DEAD_TTL: Duration = Duration::from_secs(30);
 /// 单个节点最多保留多少条历史（与 mihomo `defaultHistoriesNum = 10`）。
 pub const HISTORY_CAP: usize = 10;
 /// `single_flight` 缓存窗口（与 mihomo `singledo.NewSingle(time.Second * 10)`）。
@@ -117,6 +119,8 @@ pub struct NodeUrlStats {
     pub alive: AtomicBool,
     pub last_delay_ms: AtomicU32, // 0 = 未测；DEAD_DELAY = 死
     pub last_seen_ms: AtomicU64,
+    /// 临时 dead 截止时间（unix ms）；0 表示无临时 dead。
+    temp_dead_until_ms: AtomicU64,
     history: Mutex<std::collections::VecDeque<HistoryEntry>>,
 }
 
@@ -132,6 +136,7 @@ impl Default for NodeUrlStats {
             alive: AtomicBool::new(true),
             last_delay_ms: AtomicU32::new(0),
             last_seen_ms: AtomicU64::new(0),
+            temp_dead_until_ms: AtomicU64::new(0),
             history: Mutex::new(std::collections::VecDeque::with_capacity(HISTORY_CAP)),
         }
     }
@@ -144,6 +149,9 @@ impl NodeUrlStats {
         self.last_delay_ms
             .store(if alive { delay_ms } else { DEAD_DELAY }, Ordering::Release);
         self.last_seen_ms.store(now, Ordering::Release);
+        if alive {
+            self.temp_dead_until_ms.store(0, Ordering::Release);
+        }
         let mut g = self.history.lock();
         g.push_back(HistoryEntry {
             time_ms: now,
@@ -153,14 +161,37 @@ impl NodeUrlStats {
             g.pop_front();
         }
     }
+
+    /// 拨号失败后的短期排除，不永久杀死节点。
+    pub fn mark_temp_dead(&self, ttl: Duration) {
+        let until = now_ms().saturating_add(ttl.as_millis() as u64);
+        self.temp_dead_until_ms.store(until, Ordering::Release);
+        self.alive.store(false, Ordering::Release);
+        self.last_delay_ms.store(DEAD_DELAY, Ordering::Release);
+        self.last_seen_ms.store(now_ms(), Ordering::Release);
+    }
+
     pub fn last_delay(&self) -> u32 {
-        if self.alive.load(Ordering::Acquire) {
+        if self.is_alive() {
             self.last_delay_ms.load(Ordering::Acquire)
         } else {
             DEAD_DELAY
         }
     }
     pub fn is_alive(&self) -> bool {
+        let until = self.temp_dead_until_ms.load(Ordering::Acquire);
+        if until != 0 {
+            let now = now_ms();
+            if now < until {
+                return false;
+            }
+            // TTL 过期：清掉临时 dead，回到 alive=true（除非正式 probe 仍标记失败）。
+            self.temp_dead_until_ms.store(0, Ordering::Release);
+            // 若 last formal record 是 failure 且没有成功过，仍看 alive 原子位。
+            // mark_temp_dead 把 alive 置 false；TTL 到期后恢复 true。
+            self.alive.store(true, Ordering::Release);
+            return true;
+        }
         self.alive.load(Ordering::Acquire)
     }
     pub fn history(&self) -> Vec<HistoryEntry> {
@@ -239,6 +270,24 @@ impl UrlTester {
             .get(&(node.to_string(), url.to_string()))
             .map(|s| s.is_alive())
             .unwrap_or(true)
+    }
+
+    /// 将节点在默认 probe URL 上标记为短期 dead，供 dial 失败后的排除集使用。
+    pub fn mark_temp_dead(&self, node: &str) {
+        let url = self.cfg.read().default_url.clone();
+        self.mark_temp_dead_for_url(node, &url);
+    }
+
+    pub fn mark_temp_dead_for_url(&self, node: &str, url: &str) {
+        let stats = self.ensure_stats(node, url);
+        stats.mark_temp_dead(TEMP_DEAD_TTL);
+        debug!(
+            target: "urltest",
+            node,
+            url,
+            ttl_secs = TEMP_DEAD_TTL.as_secs(),
+            "marked temporarily dead after dial failure"
+        );
     }
 
     pub fn history(&self, node: &str, url: &str) -> Vec<HistoryEntry> {
@@ -730,6 +779,16 @@ mod tests {
     #[test]
     fn rejects_unsupported_scheme() {
         assert!(parse_test_url("ws://x").is_err());
+    }
+
+    #[test]
+    fn temp_dead_expires() {
+        let stats = NodeUrlStats::default();
+        assert!(stats.is_alive());
+        stats.mark_temp_dead(Duration::from_millis(1));
+        assert!(!stats.is_alive());
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(stats.is_alive(), "temp dead must expire");
     }
 
     #[test]


### PR DESCRIPTION
## 背景

UDP 选路在过滤无 UDP 能力节点后仍回退任意成员；dial 失败后 Manual/粘性策略会反复撞同一坏节点；chain 会静默单跳。

## 实现

- UDP 选路不再 `or_else` 回退 TCP-only
- dial 失败后短期 mark_dead 并参与选点过滤
- 运行时 `pick_chain` 返回 None

## 安全与兼容边界

- 不改控制面 API 与配置编译（见独立 PR）
- 不改 SSRF 策略（见独立 PR）

## 验证

- [ ] `cargo test -p core-runtime`
- [ ] 全 VLESS 组 UDP 选路为 BLOCK
- [ ] dial 失败后下一轮不重复同一节点