### PR TITLE
fix(macos): keep process path buffer alive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,9 +73,6 @@ jobs:
           - target: s390x-unknown-linux-gnu
             name: linux-s390x
             is_android: false
-          - target: x86_64-pc-windows-gnu
-            name: windows-amd64-gnu
-            is_android: false
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -106,6 +103,11 @@ jobs:
             . -> target
           cache-bin: false
           cache-on-failure: true
+          # cross executes host-side proc macros inside target-specific containers.
+          # Reusing target/ outside those containers can introduce an incompatible
+          # glibc ABI, so Cross jobs cache registries only. Android builds run on
+          # the host and can safely reuse their target directories.
+          cache-targets: ${{ matrix.platform.is_android }}
 
       - name: Install cargo-ndk
         if: matrix.platform.is_android == true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-api"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "core-capture"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "core-config"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "core-feeds"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "core-fetch"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "brotli 7.0.0",
  "bytes",
@@ -961,7 +961,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-inbound"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "core-mesh"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "core-observe"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "core-outbound"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "core-process"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "jni",
  "libc",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "core-reality"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "core-resolver"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "core-route"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "ahash",
  "core-config",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "core-ruleset"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "core-runtime"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "core-smart"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "ahash",
  "core-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "core-store"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "ahash",
  "once_cell",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "tests-e2e"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "core-config",
  "core-inbound",
@@ -5342,7 +5342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wuther-core"
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-api"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "core-capture"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "core-config"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "core-feeds"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "core-fetch"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "brotli 7.0.0",
  "bytes",
@@ -961,7 +961,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-inbound"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "core-mesh"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "core-observe"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "core-outbound"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "core-process"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "jni",
  "libc",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "core-reality"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "core-resolver"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "core-route"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "core-config",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "core-ruleset"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "core-runtime"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "core-smart"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "core-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "core-store"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "once_cell",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "tests-e2e"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "core-config",
  "core-inbound",
@@ -5342,7 +5342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wuther-core"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-api"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "core-capture"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "core-config"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "core-feeds"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "core-fetch"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "brotli 7.0.0",
  "bytes",
@@ -961,7 +961,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-inbound"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "core-mesh"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "core-observe"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "core-outbound"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "core-process"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "jni",
  "libc",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "core-reality"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "core-resolver"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "core-route"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "ahash",
  "core-config",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "core-ruleset"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "core-runtime"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "core-smart"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "ahash",
  "core-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "core-store"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "ahash",
  "once_cell",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "tests-e2e"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "core-config",
  "core-inbound",
@@ -5342,7 +5342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wuther-core"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1-rc.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1-rc.1"
+version = "0.3.1-rc.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/core-capture/src/platform/linux_tproxy.rs
+++ b/crates/core-capture/src/platform/linux_tproxy.rs
@@ -1105,7 +1105,8 @@ fn recvmsg_with_origdst(
     hdr.msg_iov = &mut iov;
     hdr.msg_iovlen = 1;
     hdr.msg_control = control.0.as_mut_ptr() as *mut libc::c_void;
-    hdr.msg_controllen = control.0.len() as libc::size_t;
+    // glibc exposes msg_controllen as size_t while musl uses socklen_t.
+    hdr.msg_controllen = control.0.len() as _;
 
     // SAFETY: msghdr 字段全部初始化；recvmsg 写入 name/iov/control 不超过提供长度。
     let n = unsafe { libc::recvmsg(fd, &mut hdr, 0) };
@@ -1139,7 +1140,7 @@ unsafe fn extract_origdst(hdr: &libc::msghdr) -> Option<SocketAddr> {
             && cmsg_len
                 >= unsafe {
                     libc::CMSG_LEN(std::mem::size_of::<libc::sockaddr_in>() as libc::c_uint)
-                } as usize
+                } as _
         {
             let data = unsafe { libc::CMSG_DATA(cmsg) } as *const libc::sockaddr_in;
             let sa = unsafe { std::ptr::read_unaligned(data) };
@@ -1152,7 +1153,7 @@ unsafe fn extract_origdst(hdr: &libc::msghdr) -> Option<SocketAddr> {
             && cmsg_len
                 >= unsafe {
                     libc::CMSG_LEN(std::mem::size_of::<libc::sockaddr_in6>() as libc::c_uint)
-                } as usize
+                } as _
         {
             let data = unsafe { libc::CMSG_DATA(cmsg) } as *const libc::sockaddr_in6;
             let sa = unsafe { std::ptr::read_unaligned(data) };

--- a/crates/core-process/src/macos.rs
+++ b/crates/core-process/src/macos.rs
@@ -306,7 +306,10 @@ unsafe fn read_pidpath(pid: i32) -> Option<String> {
         return None;
     }
     buf.truncate(r as usize);
-    let cstr = CStr::from_bytes_with_nul(&[&buf[..], &[0]].concat()).ok()?;
+    let path_len = buf.iter().position(|&byte| byte == 0).unwrap_or(buf.len());
+    buf.truncate(path_len);
+    buf.push(0);
+    let cstr = CStr::from_bytes_with_nul(&buf).ok()?;
     Some(cstr.to_string_lossy().into_owned())
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -72,7 +72,6 @@ git push origin v0.4.0
 | Linux GNU | AMD64、ARM64、i686、s390x |
 | Linux musl | AMD64、ARM64 |
 | Android | ARM64、ARMv7 |
-| Windows GNU | AMD64 |
 | Windows MSVC | AMD64、ARM64 |
 | macOS | Intel、Apple Silicon |
 


### PR DESCRIPTION
## What changed

- retain the NUL-terminated process-path buffer for the full lifetime of the borrowed `CStr`
- normalize any existing terminator returned by `proc_pidpath`
- advance the release candidate to `0.3.1-rc.3`

## Root cause

Both macOS runners rejected a `CStr` that borrowed from a temporary `concat()` result. The temporary was dropped at the end of the statement before the next line converted the string.

## Impact

The macOS Intel and Apple Silicon release builds can compile `core-process` without changing process path semantics. This branch includes the already validated Cross/musl fixes from #33.

## Validation

- `cargo check -p wuther-core`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- Release `rc.2`: all 8 Cross/Android jobs passed; both macOS jobs exposed the same E0716 fixed here
