### PR TITLE
fix(ci): stabilize cross builds and collect release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,19 +95,19 @@ jobs:
           local-cache: true
 
       - name: Cache Cargo
+        # Cross runs builds inside target-specific containers. Do not restore or
+        # save host-side Cargo/target caches for those jobs.
+        if: matrix.platform.is_android == true
         uses: Swatinem/rust-cache@v2.9.1
         with:
-          shared-key: release
+          prefix-key: v1-wuther-core
+          shared-key: build-android
           key: ${{ matrix.platform.target }}
           workspaces: |
             . -> target
           cache-bin: false
           cache-on-failure: true
-          # cross executes host-side proc macros inside target-specific containers.
-          # Reusing target/ outside those containers can introduce an incompatible
-          # glibc ABI, so Cross jobs cache registries only. Android builds run on
-          # the host and can safely reuse their target directories.
-          cache-targets: ${{ matrix.platform.is_android }}
+          cache-targets: true
 
       - name: Install cargo-ndk
         if: matrix.platform.is_android == true
@@ -166,8 +166,8 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: wuther-core-${{ matrix.platform.name }}
           path: ./dist/*.zip
           if-no-files-found: error
-          compression-level: 0
+          archive: false
+          overwrite: true
           retention-days: ${{ inputs.retention-days || 1 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2.9.1
         with:
+          prefix-key: v1-wuther-core
           shared-key: required-ci
           workspaces: |
             . -> target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2.9.1
         with:
+          prefix-key: v1-wuther-core
           shared-key: release-native
           key: ${{ matrix.platform.target }}
           workspaces: |
@@ -230,18 +231,68 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: wuther-core-${{ matrix.platform.name }}
           path: dist/*.zip
           if-no-files-found: error
+          archive: false
+          overwrite: true
+          retention-days: 14
+
+  collect:
+    name: Collect release assets
+    needs:
+      - prepare
+      - build-cross
+      - build-native
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: wuther-core-${{ needs.prepare.outputs.version }}-*.zip
+          path: dist
+          merge-multiple: true
+          skip-decompress: true
+
+      - name: Validate and checksum release assets
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          archives=(dist/wuther-core-"$RELEASE_VERSION"-*.zip)
+          if [ "${#archives[@]}" -ne 12 ]; then
+            echo "::error::Expected 12 release archives, found ${#archives[@]}."
+            printf 'Found: %s\n' "${archives[@]:-none}"
+            exit 1
+          fi
+
+          cd dist
+          printf '%s\0' wuther-core-"$RELEASE_VERSION"-*.zip \
+            | sort -z \
+            | xargs -0 sha256sum > SHA256SUMS
+          test -s SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload collected release assets
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-assets
+          path: |
+            dist/*.zip
+            dist/SHA256SUMS
+          if-no-files-found: error
           compression-level: 0
+          overwrite: true
           retention-days: 14
 
   publish:
     name: Publish GitHub release
     needs:
       - prepare
-      - build-cross
-      - build-native
+      - collect
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -250,21 +301,11 @@ jobs:
       attestations: write
 
     steps:
-      - name: Download release artifacts
+      - name: Download and decompress collected assets
         uses: actions/download-artifact@v8.0.1
         with:
+          name: release-assets
           path: dist
-          merge-multiple: true
-
-      - name: Generate SHA-256 checksums
-        run: |
-          set -euo pipefail
-          cd dist
-          find . -maxdepth 1 -type f -name '*.zip' -printf '%f\0' \
-            | sort -z \
-            | xargs -0 sha256sum > SHA256SUMS
-          test -s SHA256SUMS
-          cat SHA256SUMS
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@v4.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-api"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "core-capture"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "core-config"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "core-feeds"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "core-fetch"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "brotli 7.0.0",
  "bytes",
@@ -961,7 +961,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-inbound"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "core-mesh"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "core-observe"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "core-outbound"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "core-process"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "jni",
  "libc",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "core-reality"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "core-resolver"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "core-route"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "core-config",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "core-ruleset"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "core-runtime"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "core-smart"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "core-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "core-store"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "ahash",
  "once_cell",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "tests-e2e"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "core-config",
  "core-inbound",
@@ -5342,7 +5342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wuther-core"
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-api"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "core-capture"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "core-config"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "core-feeds"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "core-fetch"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "brotli 7.0.0",
  "bytes",
@@ -961,7 +961,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-inbound"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "core-mesh"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "core-observe"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "core-outbound"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "core-process"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "jni",
  "libc",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "core-reality"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "core-resolver"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "core-route"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "ahash",
  "core-config",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "core-ruleset"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "core-runtime"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "core-smart"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "ahash",
  "core-config",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "core-store"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "ahash",
  "once_cell",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "tests-e2e"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "core-config",
  "core-inbound",
@@ -5342,7 +5342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wuther-core"
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1-rc.2"
+version = "0.3.1-rc.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1-rc.3"
+version = "0.3.1-rc.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/core-capture/src/platform/macos_tun_io.rs
+++ b/crates/core-capture/src/platform/macos_tun_io.rs
@@ -60,6 +60,7 @@ pub fn open(plan: &CapturePlan) -> Result<Arc<MacUtunIo>, TunIoError> {
 
 impl MacUtunIo {
     /// 用 NEPacketTunnelProvider 注入的 fd 构造 —— fd 已经绑好 utun，无需 ioctl。
+    #[allow(unsafe_code)]
     pub fn from_injected_fd(fd: i32, name: String, mtu: u32) -> Result<Self, TunIoError> {
         // SAFETY: fd 由 Swift 侧 dup 给本进程，所有权交本进程；不会被宿主再 close。
         let owned = unsafe { OwnedFd::from_raw_fd(fd) };

--- a/crates/core-process/src/macos.rs
+++ b/crates/core-process/src/macos.rs
@@ -306,7 +306,10 @@ unsafe fn read_pidpath(pid: i32) -> Option<String> {
         return None;
     }
     buf.truncate(r as usize);
-    let cstr = CStr::from_bytes_with_nul(&[&buf[..], &[0]].concat()).ok()?;
+    let path_len = buf.iter().position(|&byte| byte == 0).unwrap_or(buf.len());
+    buf.truncate(path_len);
+    buf.push(0);
+    let cstr = CStr::from_bytes_with_nul(&buf).ok()?;
     Some(cstr.to_string_lossy().into_owned())
 }
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,9 +59,11 @@ git push origin v0.4.0
 2. 确认正式版提交属于 `main`；
 3. 在标签对应源码上运行完整 `Required CI`；
 4. 构建并冒烟验证所有原生平台产物；
-5. 生成版本化 ZIP、`SHA256SUMS` 和 GitHub Artifact Attestation；
-6. 使用 `.github/release.yml` 自动分类 Release Notes；
-7. 发布 GitHub Release，并按照标签设置 Pre-release 或 Latest。
+5. 将每个平台 ZIP 作为非嵌套 artifact 上传，再按 `wuther-core-$VERSION-*` 前缀收集全部 12 个产物；
+6. 生成 `SHA256SUMS`，再汇总为零压缩的 `release-assets` artifact；
+7. 下载并解包汇总产物，生成 GitHub Artifact Attestation；
+8. 使用 `.github/release.yml` 自动分类 Release Notes；
+9. 直接上传文件到 GitHub Release，并按照标签设置 Pre-release 或 Latest。
 
 正式发布不会覆盖已经发布的同名 Release。若首次发布在上传阶段中断，重新运行可以续传仍处于 Draft 状态的 Release；已发布的资产保持不可变。
 


### PR DESCRIPTION
## Summary

- fix the macOS process-path buffer lifetime and locally allow the audited injected-utun fd ownership transfer
- use the real `rust-cache` `prefix-key` input consistently and disable Cargo caching entirely for Cross jobs
- upload each platform ZIP as a raw Actions artifact (`archive: false`), avoiding ZIP-in-ZIP packaging
- add a `collect` job that selects the versioned artifact prefix, downloads raw ZIPs without decompression, validates all 12 targets, and generates `SHA256SUMS`
- download/decompress the single zero-compression `release-assets` collection and upload its files directly to GitHub Release

## Validation

- complete `v0.3.1-rc.4` release matrix passed for all 12 targets before the collection refactor
- official `actionlint v1.7.12` passed for every workflow
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `python scripts/check-repository.py`
- `cargo run --quiet --locked -p wuther-core -- --version` → `wuther-core 0.3.1-rc.4`
