### PR TITLE
fix(capture): recover stale traffic takeover state

### DIFF
--- a/crates/core-capture/src/platform/linux.rs
+++ b/crates/core-capture/src/platform/linux.rs
@@ -72,6 +72,7 @@ struct TunState {
     redirect_listeners: Vec<RedirectTcpListener>,
     redirect_backend: Option<AutoRedirectBackend>,
     redirect_route_lease: Option<AutoRedirectRouteLease>,
+    crash_recovery: Option<crate::platform::linux_recovery::LinuxCaptureGuard>,
     redirect_tasks: Option<JoinSet<()>>,
     redirect_stops: Vec<oneshot::Sender<()>>,
 }
@@ -648,6 +649,12 @@ impl CaptureEngine for LinuxTun {
             ));
         }
         if manage_linux_config {
+            // The device is now known to be root-managed rather than an
+            // Android VpnService fd. Persist crash ownership before the first
+            // route, rule, firewall, or interface mutation.
+            g.crash_recovery = Some(crate::platform::linux_recovery::LinuxCaptureGuard::acquire(
+                &effective_plan,
+            )?);
             Self::configure_iface(&effective_plan, device.as_ref())?;
 
             // Bind every required address family before routes or firewall
@@ -1047,6 +1054,9 @@ impl CaptureEngine for LinuxTun {
             "ip",
             &["tuntap", "del", "dev", &plan.interface_name, "mode", "tun"],
         );
+        if let Some(guard) = g.crash_recovery.take() {
+            guard.mark_clean()?;
+        }
         g.started = false;
         g.effective_plan = None;
         info!(target: "capture", iface = %plan.interface_name, "linux tun stopped");

--- a/crates/core-capture/src/platform/linux_recovery.rs
+++ b/crates/core-capture/src/platform/linux_recovery.rs
@@ -1,0 +1,471 @@
+//! Crash-safe ownership for Linux/Android host-network capture state.
+//!
+//! Kernel routes and firewall rules outlive an abruptly killed process.  This
+//! module keeps an advisory process lock plus a small, fsync'd recovery record.
+//! A successor must remove the previous owner's reserved resources before it
+//! is allowed to install new capture state.
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::os::fd::AsRawFd;
+
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::engine::{CaptureError, CapturePlan};
+
+const JOURNAL_VERSION: u32 = 1;
+const MAX_PRIORITY_DELETES: usize = 64;
+const NFT_TABLES: [&str; 2] = ["wuther_auto_redirect", "wuthercore_redirect"];
+const IPTABLES_CHAINS: [(&str, &str, &str); 5] = [
+    ("mangle", "OUTPUT", "WUTHERCORE_BYPASS"),
+    ("mangle", "PREROUTING", "WUTHERCORE_REDIR"),
+    ("nat", "PREROUTING", "WUTHERCORE_REDIR"),
+    ("mangle", "PREROUTING", "WUTHERCORE_PREROUTING"),
+    ("mangle", "OUTPUT", "WUTHERCORE_OUTPUT"),
+];
+const TPROXY_TABLE: &str = "0x2d0";
+const TPROXY_MARK: &str = "0x2d0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RecoveryRecord {
+    version: u32,
+    pid: u32,
+    interface_name: String,
+    table: u32,
+    rule_priority: u32,
+    auto_route: bool,
+    auto_redirect: bool,
+    strict_route: bool,
+    bypass_tables: Vec<String>,
+}
+
+impl RecoveryRecord {
+    fn from_plan(plan: &CapturePlan) -> Self {
+        Self {
+            version: JOURNAL_VERSION,
+            pid: std::process::id(),
+            interface_name: plan.interface_name.clone(),
+            table: plan.iproute2_table_index,
+            rule_priority: plan.iproute2_rule_index,
+            auto_route: plan.auto_route,
+            auto_redirect: plan.auto_redirect,
+            strict_route: plan.strict_route,
+            bypass_tables: if plan.auto_route || plan.auto_redirect {
+                probe_bypass_tables()
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    fn priorities(&self) -> Vec<u32> {
+        let mut priorities = Vec::new();
+        if self.auto_route || self.auto_redirect {
+            priorities.extend([
+                self.rule_priority.saturating_sub(3).max(1),
+                self.rule_priority.saturating_sub(2).max(1),
+                self.rule_priority.saturating_sub(1).max(1),
+                self.rule_priority,
+            ]);
+        }
+        if self.strict_route {
+            priorities.push(self.rule_priority.saturating_add(1));
+        }
+        priorities.sort_unstable();
+        priorities.dedup();
+        priorities
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct LinuxCaptureGuard {
+    file: File,
+    path: PathBuf,
+    record: RecoveryRecord,
+    clean: bool,
+}
+
+impl LinuxCaptureGuard {
+    pub(crate) fn acquire(plan: &CapturePlan) -> Result<Self, CaptureError> {
+        let path = journal_path()?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|error| recovery_error(format!("open {}: {error}", path.display())))?;
+        lock_exclusive(&file, &path)?;
+
+        let previous = read_record(&mut file, &path)?;
+        if let Some(previous) = previous {
+            warn!(
+                target: "capture::recovery",
+                previous_pid = previous.pid,
+                iface = %previous.interface_name,
+                table = previous.table,
+                rule_priority = previous.rule_priority,
+                "unclean capture shutdown detected; recovering host network before startup"
+            );
+            recover(&previous)?;
+            info!(
+                target: "capture::recovery",
+                previous_pid = previous.pid,
+                "stale capture state recovered"
+            );
+        }
+
+        let record = RecoveryRecord::from_plan(plan);
+        write_record(&mut file, &record, &path)?;
+        Ok(Self {
+            file,
+            path,
+            record,
+            clean: false,
+        })
+    }
+
+    pub(crate) fn mark_clean(mut self) -> Result<(), CaptureError> {
+        // Ordinary engine cleanup contains legacy best-effort branches. Run
+        // the same ownership-bounded sweep used after a crash before declaring
+        // the durable journal clean.
+        recover(&self.record)?;
+        self.file
+            .set_len(0)
+            .and_then(|_| self.file.sync_all())
+            .map_err(|error| recovery_error(format!("clear {}: {error}", self.path.display())))?;
+        self.clean = true;
+        Ok(())
+    }
+}
+
+impl Drop for LinuxCaptureGuard {
+    fn drop(&mut self) {
+        if !self.clean {
+            warn!(
+                target: "capture::recovery",
+                journal = %self.path.display(),
+                "capture recovery record retained for the next process"
+            );
+        }
+    }
+}
+
+fn journal_path() -> Result<PathBuf, CaptureError> {
+    let base = std::env::var_os("WUTHER_CAPTURE_STATE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join("wuther-core"));
+    std::fs::create_dir_all(&base)
+        .map_err(|error| recovery_error(format!("create {}: {error}", base.display())))?;
+    Ok(base.join("capture-recovery.lock"))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn lock_exclusive(file: &File, path: &PathBuf) -> Result<(), CaptureError> {
+    nix::fcntl::flock(
+        file.as_raw_fd(),
+        nix::fcntl::FlockArg::LockExclusiveNonblock,
+    )
+    .map_err(|error| {
+        recovery_error(format!(
+            "another capture process owns {} ({error})",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(all(test, not(any(target_os = "linux", target_os = "android"))))]
+fn lock_exclusive(_file: &File, _path: &PathBuf) -> Result<(), CaptureError> {
+    Ok(())
+}
+
+fn read_record(file: &mut File, path: &PathBuf) -> Result<Option<RecoveryRecord>, CaptureError> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| recovery_error(format!("seek {}: {error}", path.display())))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|error| recovery_error(format!("read {}: {error}", path.display())))?;
+    if bytes.iter().all(u8::is_ascii_whitespace) {
+        return Ok(None);
+    }
+    let record: RecoveryRecord = serde_json::from_slice(&bytes)
+        .map_err(|error| recovery_error(format!("invalid {}: {error}", path.display())))?;
+    if record.version != JOURNAL_VERSION {
+        return Err(recovery_error(format!(
+            "unsupported recovery journal version {} in {}",
+            record.version,
+            path.display()
+        )));
+    }
+    Ok(Some(record))
+}
+
+fn write_record(
+    file: &mut File,
+    record: &RecoveryRecord,
+    path: &PathBuf,
+) -> Result<(), CaptureError> {
+    let bytes = serde_json::to_vec(record)
+        .map_err(|error| recovery_error(format!("encode {}: {error}", path.display())))?;
+    file.set_len(0)
+        .and_then(|_| file.seek(SeekFrom::Start(0)).map(|_| ()))
+        .and_then(|_| file.write_all(&bytes))
+        .and_then(|_| file.sync_all())
+        .map_err(|error| recovery_error(format!("persist {}: {error}", path.display())))
+}
+
+fn recover(record: &RecoveryRecord) -> Result<(), CaptureError> {
+    // Disable packet interception first, then remove policy rules and routes.
+    for table in NFT_TABLES {
+        delete_nft_table(table);
+    }
+    cleanup_iptables();
+
+    if record.auto_route || record.auto_redirect || record.strict_route {
+        ensure_ip_available()?;
+        let custom_table = record.table.to_string();
+        for family in ["-4", "-6"] {
+            for priority in [
+                record.rule_priority.saturating_sub(3).max(1),
+                record.rule_priority,
+            ] {
+                delete_all_matching_rules(family, priority, Some(&custom_table), false)?;
+            }
+            for table in &record.bypass_tables {
+                for priority in [
+                    record.rule_priority.saturating_sub(2).max(1),
+                    record.rule_priority.saturating_sub(1).max(1),
+                ] {
+                    delete_all_matching_rules(family, priority, Some(table), false)?;
+                }
+            }
+            if record.strict_route {
+                delete_all_matching_rules(
+                    family,
+                    record.rule_priority.saturating_add(1),
+                    None,
+                    true,
+                )?;
+            }
+        }
+        flush_table(record.table);
+    }
+
+    // Standalone TPROXY has fixed ownership selectors, independent of tun
+    // table configuration.
+    for family in ["inet", "inet6"] {
+        delete_exact_ip_rule(family, TPROXY_MARK, TPROXY_TABLE);
+        flush_named_table(family, TPROXY_TABLE);
+    }
+    delete_tun(&record.interface_name);
+    Ok(())
+}
+
+fn ensure_ip_available() -> Result<(), CaptureError> {
+    Command::new("ip")
+        .arg("-Version")
+        .stdin(Stdio::null())
+        .output()
+        .map(|_| ())
+        .map_err(|error| recovery_error(format!("cannot run ip for stale-rule recovery: {error}")))
+}
+
+fn delete_all_matching_rules(
+    family: &str,
+    priority: u32,
+    lookup: Option<&str>,
+    blackhole: bool,
+) -> Result<(), CaptureError> {
+    let priority = priority.to_string();
+    for _ in 0..MAX_PRIORITY_DELETES {
+        let mut args = vec![family, "rule", "del", "priority", priority.as_str()];
+        if let Some(table) = lookup {
+            args.extend(["lookup", table]);
+        }
+        if blackhole {
+            args.extend(["blackhole", "default"]);
+        }
+        let output = command_output("ip", &args)?;
+        if output.status.success() {
+            continue;
+        }
+        if is_absent(&output) {
+            return Ok(());
+        }
+        return Err(command_error("ip", &output));
+    }
+    Err(recovery_error(format!(
+        "too many stale {family} rules at priority {priority}"
+    )))
+}
+
+fn probe_bypass_tables() -> Vec<String> {
+    let mut tables = Vec::new();
+    for (family, target) in [("-4", "1.1.1.1"), ("-6", "2606:4700:4700::1111")] {
+        let Some(output) = command_output("ip", &[family, "route", "get", target])
+            .ok()
+            .filter(|output| output.status.success())
+        else {
+            continue;
+        };
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let words = stdout.split_whitespace().collect::<Vec<_>>();
+        let table = words
+            .windows(2)
+            .find_map(|pair| (pair[0] == "table").then_some(pair[1]))
+            .unwrap_or("main");
+        if !tables.iter().any(|known| known == table) {
+            tables.push(table.to_owned());
+        }
+    }
+    if tables.is_empty() {
+        tables.push("main".to_owned());
+    }
+    tables
+}
+
+fn flush_table(table: u32) {
+    let table = table.to_string();
+    for family in ["-4", "-6"] {
+        let _ = command_output("ip", &[family, "route", "flush", "table", &table]);
+    }
+}
+
+fn delete_exact_ip_rule(family: &str, mark: &str, table: &str) {
+    loop {
+        let Ok(output) = command_output(
+            "ip",
+            &["-f", family, "rule", "del", "fwmark", mark, "lookup", table],
+        ) else {
+            break;
+        };
+        if !output.status.success() {
+            break;
+        }
+    }
+}
+
+fn flush_named_table(family: &str, table: &str) {
+    let _ = command_output("ip", &["-f", family, "route", "flush", "table", table]);
+}
+
+fn delete_nft_table(table: &str) {
+    let _ = command_output("nft", &["delete", "table", "inet", table]);
+}
+
+fn cleanup_iptables() {
+    for program in ["iptables", "ip6tables"] {
+        for (table, hook, chain) in IPTABLES_CHAINS {
+            while command_output(program, &["-t", table, "-D", hook, "-j", chain])
+                .is_ok_and(|output| output.status.success())
+            {}
+            let _ = command_output(program, &["-t", table, "-F", chain]);
+            let _ = command_output(program, &["-t", table, "-X", chain]);
+        }
+        for chain in [
+            "WUTHERCORE_DIVERT",
+            "WUTHERCORE_PREROUTING",
+            "WUTHERCORE_OUTPUT",
+        ] {
+            let _ = command_output(program, &["-t", "mangle", "-F", chain]);
+            let _ = command_output(program, &["-t", "mangle", "-X", chain]);
+        }
+    }
+}
+
+fn delete_tun(interface: &str) {
+    if interface.is_empty() || interface == "lo" {
+        return;
+    }
+    let _ = command_output("ip", &["tuntap", "del", "dev", interface, "mode", "tun"]);
+}
+
+fn command_output(program: &str, args: &[&str]) -> Result<Output, CaptureError> {
+    Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|error| recovery_error(format!("spawn {program}: {error}")))
+}
+
+fn is_absent(output: &Output) -> bool {
+    let text = format!(
+        "{} {}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    )
+    .to_ascii_lowercase();
+    [
+        "no such process",
+        "no such file",
+        "cannot find",
+        "not found",
+        "does not exist",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
+fn command_error(program: &str, output: &Output) -> CaptureError {
+    let detail = if output.stderr.is_empty() {
+        String::from_utf8_lossy(&output.stdout)
+    } else {
+        String::from_utf8_lossy(&output.stderr)
+    };
+    recovery_error(format!(
+        "{program} failed (status={:?}): {}",
+        output.status.code(),
+        detail.trim()
+    ))
+}
+
+fn recovery_error(message: impl Into<String>) -> CaptureError {
+    CaptureError::Route(format!("capture crash recovery: {}", message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_priorities_cover_all_reserved_auto_route_layers() {
+        let record = RecoveryRecord {
+            version: JOURNAL_VERSION,
+            pid: 1,
+            interface_name: "wuther0".into(),
+            table: 2022,
+            rule_priority: 9000,
+            auto_route: true,
+            auto_redirect: false,
+            strict_route: true,
+            bypass_tables: vec!["main".into()],
+        };
+        assert_eq!(record.priorities(), [8997, 8998, 8999, 9000, 9001]);
+    }
+
+    #[test]
+    fn journal_round_trip_is_stable() {
+        let record = RecoveryRecord {
+            version: JOURNAL_VERSION,
+            pid: 42,
+            interface_name: "wuther0".into(),
+            table: 2022,
+            rule_priority: 9000,
+            auto_route: true,
+            auto_redirect: true,
+            strict_route: false,
+            bypass_tables: vec!["main".into(), "97".into()],
+        };
+        let bytes = serde_json::to_vec(&record).unwrap();
+        assert_eq!(
+            serde_json::from_slice::<RecoveryRecord>(&bytes).unwrap(),
+            record
+        );
+    }
+}

--- a/crates/core-capture/src/platform/mod.rs
+++ b/crates/core-capture/src/platform/mod.rs
@@ -21,6 +21,8 @@ pub(crate) mod linux_auto_redirect;
 pub(crate) mod linux_auto_redirect_route;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux_identity_bypass;
+#[cfg(any(test, target_os = "linux", target_os = "android"))]
+pub(crate) mod linux_recovery;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux_tproxy;
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/crates/core-capture/src/supervisor.rs
+++ b/crates/core-capture/src/supervisor.rs
@@ -167,6 +167,8 @@ struct SupervisorResources {
     dispatcher: Option<DispatcherHandles>,
     sys_proxy: Option<SystemProxyGuard>,
     outbound_fwmark: Option<OutboundFwmarkLease>,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    crash_recovery: Option<crate::platform::linux_recovery::LinuxCaptureGuard>,
 }
 
 impl SupervisorResources {
@@ -234,6 +236,12 @@ impl SupervisorResources {
                         }
                     }
                 }
+            }
+        }
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if engine_result.is_ok() || !stop_engine {
+            if let Some(guard) = self.crash_recovery.take() {
+                guard.mark_clean()?;
             }
         }
         engine_result
@@ -646,6 +654,12 @@ impl CaptureSupervisor {
         }
         transaction.resources_mut().outbound_fwmark =
             OutboundFwmarkLease::install(runtime.capture_outbound_fwmark())?;
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if self.plan.kind != EngineKind::Tun {
+            transaction.resources_mut().crash_recovery = Some(
+                crate::platform::linux_recovery::LinuxCaptureGuard::acquire(&self.plan)?,
+            );
+        }
         transaction.mark_engine_started();
 
         let start_result: Result<(), CaptureError> = async {

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -1022,7 +1022,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     info!("WutherCore started, press Ctrl-C to stop.");
     let mut mesh_updates = mesh_supervisor.subscribe();
     let shutdown_signal = tokio::select! {
-        signal = tokio::signal::ctrl_c() => {
+        signal = wait_for_shutdown_signal() => {
             info!("shutdown signal, bye.");
             signal
         }
@@ -1059,6 +1059,22 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
     shutdown_signal?;
     Ok(())
+}
+
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> std::io::Result<()> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut terminate = signal(SignalKind::terminate())?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result,
+        _ = terminate.recv() => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> std::io::Result<()> {
+    tokio::signal::ctrl_c().await
 }
 
 async fn wait_for_mesh_fail_stop(


### PR DESCRIPTION
## Summary

- persist an fsync-backed recovery journal and advisory lock before mutating host networking
- recover stale nftables/iptables rules, policy rules, route tables, and TUN state at the next startup
- distinguish Android VpnService mode from root-managed Android/Linux traffic takeover
- include SIGTERM in the ordered shutdown path

## Root cause

Traffic cleanup depended on the process reaching the cooperative asynchronous `stop` path. A crash or forced termination could leave kernel networking rules installed, causing the host—especially a rooted Android device—to lose connectivity.

## Impact

A successor process now self-heals stale takeover state before installing new rules, while the advisory lock prevents two instances from managing the same host state concurrently. SIGTERM performs immediate ordered cleanup; uncatchable termination such as SIGKILL is recovered on the next startup.

## Checks

- `cargo check -p wuther-core`
- `cargo test -p core-capture --lib platform::linux_recovery::tests`
- full `cargo test -p core-capture --lib`: 313 passed during implementation

Linux cross-compilation reached third-party native dependencies but could not complete because the local environment lacks a Linux C sysroot (for example `assert.h` and `sys/types.h`).