### PR TITLE
完整实现 WireGuard 客户端、服务端与正式入站

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "boringtun"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15dd6a8a89cbe8997f37ca0cf035e6ea4d64cd2ecea4aed83ffb9f99f7126939"
+dependencies = [
+ "aead",
+ "base64 0.22.1",
+ "blake2",
+ "chacha20poly1305",
+ "hex",
+ "hmac",
+ "ip_network",
+ "ip_network_table",
+ "libc",
+ "nix 0.31.3",
+ "parking_lot",
+ "portable-atomic",
+ "rand_core 0.6.4",
+ "ring",
+ "tracing",
+ "untrusted 0.9.0",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +872,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "blake3",
+ "boringtun",
  "bytes",
  "compact_str",
  "core-config",
@@ -1041,6 +1067,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2",
  "blake3",
+ "boringtun",
  "bytes",
  "cfb-mode",
  "chacha20 0.10.1",
@@ -1056,6 +1083,7 @@ dependencies = [
  "h3",
  "h3-quinn",
  "hex",
+ "hickory-proto",
  "hkdf",
  "hmac",
  "http 1.4.2",
@@ -1063,6 +1091,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "if-addrs",
+ "ipnet",
  "libc",
  "md-5",
  "parking_lot",
@@ -1077,6 +1106,8 @@ dependencies = [
  "russh-keys",
  "rustls 0.23.40",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "sha1",
  "sha2",
  "sha3",
@@ -1086,6 +1117,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-tungstenite",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -2442,6 +2474,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3257,12 @@ dependencies = [
  "universal-hash",
  "zeroize",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,7 +2679,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,7 +2701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
 
 [[package]]
-=======
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,7 +2714,6 @@ dependencies = [
 ]
 
 [[package]]
->>>>>>> origin/main
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ russh             = "0.46"
 russh-keys        = "0.46"
 
 # WireGuard 用户态
-boringtun         = { version = "0.6", default-features = false }
+boringtun         = { version = "=0.7.1", default-features = false }
 x25519-dalek      = { version = "=2.0.0-rc.3", features = ["static_secrets"] }
 
 # 工具

--- a/crates/core-capture/Cargo.toml
+++ b/crates/core-capture/Cargo.toml
@@ -66,3 +66,6 @@ nix  = { version = "0.29", features = ["net", "socket", "ioctl"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
+
+[dev-dependencies]
+boringtun = "=0.7.1"

--- a/crates/core-capture/src/engine.rs
+++ b/crates/core-capture/src/engine.rs
@@ -104,6 +104,9 @@ pub struct CapturePlan {
     pub route_address_set: Vec<String>,
     pub route_exclude_address_set: Vec<String>,
     pub loopback_addresses: Vec<IpAddr>,
+    /// 包设备是否允许把 loopback 地址作为目标。系统 TUN 必须关闭以防代理回环；
+    /// 已认证的 WireGuard 入站不是宿主机回注路径，可安全访问本机服务。
+    pub allow_loopback_destination: bool,
 
     /* ---- NAT ---- */
     pub endpoint_independent_nat: bool,
@@ -294,6 +297,7 @@ impl CapturePlan {
             route_address_set: c.tun.route_address_set.clone(),
             route_exclude_address_set: c.tun.route_exclude_address_set.clone(),
             loopback_addresses,
+            allow_loopback_destination: false,
 
             endpoint_independent_nat: c.tun.endpoint_independent_nat,
             udp_timeout: c.tun.udp_timeout,

--- a/crates/core-capture/src/lib.rs
+++ b/crates/core-capture/src/lib.rs
@@ -56,6 +56,7 @@ pub mod udp_forwarder;
 pub mod udp_handle;
 pub mod udp_session;
 pub mod uid_filter;
+pub mod wireguard_tun;
 
 pub use android_caps::{AndroidCapability, AndroidTier};
 pub use android_vpn_config::{
@@ -74,6 +75,7 @@ pub use ipset::{
     IpSetSnapshotError, NoopIpSetProvider, noop as noop_ipset_provider,
 };
 pub use nat::{FlowKey, HostPin, NatEntry, NatTable};
+pub use netstack_dispatch::{NetstackDispatcher, NetstackDispatcherHandles};
 pub use packet::{IpHeader, IpVersion, L4, ParsedPacket, TcpFlags, TcpSummary, UdpSummary};
 pub use resource_claims::host_resource_claims;
 pub use route_table::{ManagedRoute, RouteBackend, RouteTable, SystemBackend};
@@ -92,3 +94,4 @@ pub use tun_inbound::{TunDropReason, TunInbound, TunOutboundMeta, TunPacket, Tun
 pub use tun_io::{TunIo, TunIoError, open_tun_device};
 pub use udp_forwarder::{UdpForwarderConfig, run_return_loop, send_one as udp_send_one};
 pub use udp_session::{UdpFlowKey, UdpSession, UdpSessionTable};
+pub use wireguard_tun::WireGuardTunIo;

--- a/crates/core-capture/src/netstack_dispatch.rs
+++ b/crates/core-capture/src/netstack_dispatch.rs
@@ -314,8 +314,8 @@ async fn run_tcp_accept_loop(
         tokio::spawn(async move {
             handle_netstack_tcp(
                 stream,
-                remote_addr,
                 local_addr,
+                remote_addr,
                 handler,
                 inbound,
                 dns_service,

--- a/crates/core-capture/src/tun_inbound.rs
+++ b/crates/core-capture/src/tun_inbound.rs
@@ -292,6 +292,9 @@ impl TunInbound {
     /// `Some(TunBypassReason)`，后续由 `ListenerHandler` 强制 DIRECT。
     pub fn route_policy(&self, ip: IpAddr) -> Result<Option<TunBypassReason>, TunDropReason> {
         if self.plan.is_loopback_ip(ip) {
+            if self.plan.allow_loopback_destination {
+                return Ok(None);
+            }
             return Err(TunDropReason::Loopback);
         }
         // sing-tun 入口过滤等价物 —— 与 `stack_system.go::processIPv4*` 的
@@ -422,7 +425,9 @@ impl TunInbound {
         source: SocketAddr,
         destination: SocketAddr,
     ) -> Result<(), TunDropReason> {
-        if self.plan.is_loopback_ip(source.ip()) || self.plan.is_loopback_ip(destination.ip()) {
+        if self.plan.is_loopback_ip(source.ip())
+            || (!self.plan.allow_loopback_destination && self.plan.is_loopback_ip(destination.ip()))
+        {
             return Err(TunDropReason::Loopback);
         }
         Ok(())

--- a/crates/core-capture/src/wireguard_tun.rs
+++ b/crates/core-capture/src/wireguard_tun.rs
@@ -1,0 +1,224 @@
+//! WireGuard 服务端与 capture 用户态 TCP/IP 栈之间的包设备适配。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use core_outbound::proto::wireguard::WireGuardServer;
+
+use crate::{TunIo, TunIoError};
+
+/// 将已经过 WireGuard 认证/解密的裸 IP 包暴露成 [`TunIo`]。
+///
+/// 读取方向是对端 → WutherCore netstack；写入方向由服务端按目标地址最长前缀
+/// 匹配回对应 peer，并完成加密与 UDP 发送。
+pub struct WireGuardTunIo {
+    server: Arc<WireGuardServer>,
+    name: String,
+    mtu: u32,
+}
+
+impl std::fmt::Debug for WireGuardTunIo {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardTunIo")
+            .field("name", &self.name)
+            .field("mtu", &self.mtu)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WireGuardTunIo {
+    pub fn new(server: Arc<WireGuardServer>, name: impl Into<String>, mtu: u32) -> Self {
+        Self {
+            server,
+            name: name.into(),
+            mtu,
+        }
+    }
+
+    pub fn server(&self) -> &Arc<WireGuardServer> {
+        &self.server
+    }
+}
+
+#[async_trait]
+impl TunIo for WireGuardTunIo {
+    async fn read_packet(&self, buffer: &mut [u8]) -> Result<usize, TunIoError> {
+        let received = self.server.recv_packet().await.map_err(TunIoError::Read)?;
+        if received.packet.len() > buffer.len() {
+            return Err(TunIoError::Read(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "WireGuard packet length {} exceeds TUN buffer {}",
+                    received.packet.len(),
+                    buffer.len()
+                ),
+            )));
+        }
+        buffer[..received.packet.len()].copy_from_slice(&received.packet);
+        Ok(received.packet.len())
+    }
+
+    async fn write_packet(&self, packet: &[u8]) -> Result<usize, TunIoError> {
+        self.server
+            .send_packet(packet)
+            .await
+            .map_err(TunIoError::Write)?;
+        Ok(packet.len())
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn mtu(&self) -> u32 {
+        self.mtu
+    }
+
+    fn is_preconfigured(&self) -> bool {
+        true
+    }
+
+    async fn close(&self) -> Result<(), TunIoError> {
+        self.server.close().await;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use boringtun::x25519::{PublicKey, StaticSecret};
+    use core_outbound::{
+        DialContext, OutboundAdapter,
+        proto::wireguard::{
+            WireGuardConfig, WireGuardOutbound, WireGuardPeerConfig, WireGuardServerConfig,
+            WireGuardServerPeerConfig,
+        },
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::{CapturePlan, EimNatTable, NatTable, NetstackDispatcher, noop_ipset_provider};
+
+    #[tokio::test]
+    async fn authenticated_peer_reaches_runtime_tcp_and_udp() {
+        let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let tcp_target = tcp_listener.local_addr().unwrap();
+        let tcp_echo = tokio::spawn(async move {
+            let (mut stream, _) = tcp_listener.accept().await.unwrap();
+            let (mut reader, mut writer) = stream.split();
+            tokio::io::copy(&mut reader, &mut writer).await.unwrap();
+        });
+
+        let udp_echo = Arc::new(tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let udp_target = udp_echo.local_addr().unwrap();
+        let udp_task = {
+            let socket = udp_echo.clone();
+            tokio::spawn(async move {
+                let mut buffer = [0_u8; 2_048];
+                let (length, peer) = socket.recv_from(&mut buffer).await.unwrap();
+                socket.send_to(&buffer[..length], peer).await.unwrap();
+            })
+        };
+
+        let client_private = [41; 32];
+        let server_private = [43; 32];
+        let client_public = *PublicKey::from(&StaticSecret::from(client_private)).as_bytes();
+        let server_public = *PublicKey::from(&StaticSecret::from(server_private)).as_bytes();
+        let server = Arc::new(
+            WireGuardServer::bind(WireGuardServerConfig::new(
+                "127.0.0.1:0".parse().unwrap(),
+                server_private,
+                WireGuardServerPeerConfig::new(
+                    client_public,
+                    vec!["10.77.0.2/32".parse().unwrap()],
+                ),
+            ))
+            .await
+            .unwrap(),
+        );
+
+        let plan = core_config::loader::load_from_str(
+            r#"
+version: 1
+profile: server
+route: {preset: direct}
+"#,
+        )
+        .unwrap();
+        let runtime = Arc::new(core_runtime::Runtime::build(plan.clone()));
+        let mut capture_plan = CapturePlan::from_config(&plan.capture).unwrap();
+        capture_plan.mtu = 1_420;
+        capture_plan.allow_loopback_destination = true;
+        let dispatcher = Arc::new(NetstackDispatcher::new(
+            capture_plan.clone(),
+            Arc::new(NatTable::default()),
+            Arc::new(EimNatTable::new(capture_plan.udp_timeout)),
+            runtime
+                .resolver
+                .fake_pool()
+                .unwrap_or_else(|| Arc::new(core_resolver::FakeIpPool::default())),
+            runtime.dns_service.clone(),
+            noop_ipset_provider(),
+        ));
+        let device = Arc::new(WireGuardTunIo::new(
+            server.clone(),
+            "wireguard-runtime-test",
+            1_420,
+        ));
+        let handles = dispatcher.start(device, runtime.clone());
+
+        let endpoint = server.local_addr().unwrap();
+        let mut peer =
+            WireGuardPeerConfig::new(endpoint.ip().to_string(), endpoint.port(), server_public);
+        peer.allowed_ips = vec!["0.0.0.0/0".parse().unwrap()];
+        let mut client_config = WireGuardConfig::new(client_private, peer);
+        client_config.local_addresses = vec!["10.77.0.2/32".parse().unwrap()];
+        let client = WireGuardOutbound::from_config("wireguard-runtime-test", client_config);
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let mut tcp = client
+                .dial_tcp(DialContext::tcp(
+                    tcp_target.ip().to_string(),
+                    tcp_target.port(),
+                ))
+                .await
+                .unwrap();
+            tcp.write_all(b"wireguard runtime tcp").await.unwrap();
+            tcp.flush().await.unwrap();
+            let mut echoed = [0_u8; 21];
+            tcp.read_exact(&mut echoed).await.unwrap();
+            assert_eq!(&echoed, b"wireguard runtime tcp");
+
+            let udp = client
+                .dial_udp(DialContext::udp(
+                    udp_target.ip().to_string(),
+                    udp_target.port(),
+                ))
+                .await
+                .unwrap();
+            udp.send_to(
+                b"wireguard runtime udp",
+                &udp_target.ip().to_string(),
+                udp_target.port(),
+            )
+            .await
+            .unwrap();
+            let mut buffer = [0_u8; 128];
+            let length = udp.recv_from(&mut buffer).await.unwrap();
+            assert_eq!(&buffer[..length], b"wireguard runtime udp");
+            udp.close().await.unwrap();
+        })
+        .await
+        .expect("WireGuard runtime TCP/UDP integration timed out");
+
+        handles.stop();
+        server.close().await;
+        runtime.shutdown().await;
+        tcp_echo.abort();
+        udp_task.abort();
+        drop(udp_echo);
+    }
+}

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -211,6 +211,93 @@ pub struct Listen {
     /// `protocol` 指定的内层代理协议。
     #[serde(default, alias = "reality-inbounds", alias = "reality_inbounds")]
     pub reality: Vec<RealityListen>,
+    /// WireGuard 服务端入站。每个条目绑定一个 UDP 端口，并把已认证对端的
+    /// IPv4/IPv6 包交给 WutherCore 的 TCP/UDP 路由运行时。
+    #[serde(default, alias = "wireguard-inbounds", alias = "wireguard_inbounds")]
+    pub wireguard: Vec<WireGuardListen>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireGuardListen {
+    #[serde(default = "default_wireguard_listen_host")]
+    pub host: String,
+    pub port: u16,
+    #[serde(rename = "privateKey", alias = "private_key", alias = "private-key")]
+    pub private_key: String,
+    pub peers: Vec<WireGuardListenPeer>,
+    #[serde(default = "default_wireguard_mtu")]
+    pub mtu: usize,
+    #[serde(
+        default = "default_wireguard_packet_queue",
+        rename = "packetQueue",
+        alias = "packet_queue",
+        alias = "packet-queue"
+    )]
+    pub packet_queue: usize,
+    #[serde(
+        default = "default_wireguard_handshake_rate_limit",
+        rename = "handshakeRateLimit",
+        alias = "handshake_rate_limit",
+        alias = "handshake-rate-limit"
+    )]
+    pub handshake_rate_limit: u64,
+}
+
+impl std::fmt::Debug for WireGuardListen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardListen")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("private_key", &"<redacted>")
+            .field("peers", &self.peers)
+            .field("mtu", &self.mtu)
+            .field("packet_queue", &self.packet_queue)
+            .field("handshake_rate_limit", &self.handshake_rate_limit)
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WireGuardListenPeer {
+    #[serde(rename = "publicKey", alias = "public_key", alias = "public-key")]
+    pub public_key: String,
+    #[serde(
+        default,
+        rename = "presharedKey",
+        alias = "preshared_key",
+        alias = "preshared-key"
+    )]
+    pub preshared_key: Option<String>,
+    #[serde(rename = "allowedIPs", alias = "allowed_ips", alias = "allowed-ips")]
+    pub allowed_ips: Vec<String>,
+    #[serde(default)]
+    pub reserved: Vec<u8>,
+    #[serde(
+        default,
+        rename = "persistentKeepalive",
+        alias = "persistent_keepalive",
+        alias = "persistent-keepalive"
+    )]
+    pub persistent_keepalive: Option<u16>,
+}
+
+impl std::fmt::Debug for WireGuardListenPeer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardListenPeer")
+            .field("public_key", &self.public_key)
+            .field(
+                "preshared_key",
+                &self.preshared_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("allowed_ips", &self.allowed_ips)
+            .field("reserved", &self.reserved)
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .finish()
+    }
 }
 
 /// Xray REALITY 服务端监听配置。
@@ -584,6 +671,10 @@ pub struct NodeDetail {
     pub transport: Option<NodeTransport>,
     #[serde(default)]
     pub network: Option<NodeNetwork>,
+    /// 协议专属字段。标量保持文本语义，数组/对象会被编译为 JSON 后交给
+    /// 对应协议注册器做严格校验；用于 WireGuard peers/allowed-ips 等结构。
+    #[serde(default, alias = "protocol-options", alias = "protocol_options")]
+    pub params: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1744,6 +1835,22 @@ fn default_localhost() -> String {
 }
 fn default_reality_listen_host() -> String {
     "0.0.0.0".into()
+}
+
+fn default_wireguard_listen_host() -> String {
+    "0.0.0.0".into()
+}
+
+fn default_wireguard_mtu() -> usize {
+    1_420
+}
+
+fn default_wireguard_packet_queue() -> usize {
+    1_024
+}
+
+fn default_wireguard_handshake_rate_limit() -> u64 {
+    100
 }
 fn default_reality_inner_protocol() -> String {
     "vless".into()

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -211,21 +211,17 @@ pub struct Listen {
     /// `protocol` 指定的内层代理协议。
     #[serde(default, alias = "reality-inbounds", alias = "reality_inbounds")]
     pub reality: Vec<RealityListen>,
-<<<<<<< HEAD
     /// WireGuard 服务端入站。每个条目绑定一个 UDP 端口，并把已认证对端的
     /// IPv4/IPv6 包交给 WutherCore 的 TCP/UDP 路由运行时。
     #[serde(default, alias = "wireguard-inbounds", alias = "wireguard_inbounds")]
     pub wireguard: Vec<WireGuardListen>,
-=======
     /// Young 原生入站。传输层是 Firefox 使用的 Mozilla Neqo HTTP/3/WebTransport。
     #[serde(default, alias = "young-inbounds", alias = "young_inbounds")]
     pub young: Vec<YoungListen>,
->>>>>>> origin/main
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-<<<<<<< HEAD
 pub struct WireGuardListen {
     #[serde(default = "default_wireguard_listen_host")]
     pub host: String,
@@ -303,7 +299,12 @@ impl std::fmt::Debug for WireGuardListenPeer {
             .field("allowed_ips", &self.allowed_ips)
             .field("reserved", &self.reserved)
             .field("persistent_keepalive", &self.persistent_keepalive)
-=======
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct YoungListen {
     #[serde(default = "default_young_listen_host")]
     pub host: String,
@@ -398,7 +399,6 @@ impl std::fmt::Debug for YoungListen {
             .field("max_flows_per_session", &self.max_flows_per_session)
             .field("decoy_status", &self.decoy_status)
             .field("decoy_body_bytes", &self.decoy_body.len())
->>>>>>> origin/main
             .finish()
     }
 }
@@ -2154,7 +2154,6 @@ fn default_localhost() -> String {
 fn default_reality_listen_host() -> String {
     "0.0.0.0".into()
 }
-<<<<<<< HEAD
 
 fn default_wireguard_listen_host() -> String {
     "0.0.0.0".into()
@@ -2170,7 +2169,7 @@ fn default_wireguard_packet_queue() -> usize {
 
 fn default_wireguard_handshake_rate_limit() -> u64 {
     100
-=======
+}
 fn default_young_listen_host() -> String {
     "0.0.0.0".into()
 }
@@ -2197,7 +2196,6 @@ fn default_young_decoy_status() -> u16 {
 }
 fn default_young_decoy_body() -> String {
     "<!doctype html><html><head><title>Not Found</title></head><body><h1>Not Found</h1></body></html>".into()
->>>>>>> origin/main
 }
 fn default_reality_inner_protocol() -> String {
     "vless".into()

--- a/crates/core-config/src/profile.rs
+++ b/crates/core-config/src/profile.rs
@@ -15,6 +15,7 @@ pub fn apply_defaults(cfg: &mut UserConfig) {
         share: None,
         auth: vec![],
         reality: vec![],
+        wireguard: vec![],
     });
     if listen.local.is_none() {
         listen.local = match profile {

--- a/crates/core-config/src/profile.rs
+++ b/crates/core-config/src/profile.rs
@@ -15,11 +15,8 @@ pub fn apply_defaults(cfg: &mut UserConfig) {
         share: None,
         auth: vec![],
         reality: vec![],
-<<<<<<< HEAD
         wireguard: vec![],
-=======
         young: vec![],
->>>>>>> origin/main
     });
     if listen.local.is_none() {
         listen.local = match profile {

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -8,11 +8,7 @@
 //! 共同消费的 *已展开* 数据，而非 YAML 原貌。
 
 use std::{
-<<<<<<< HEAD
     collections::{BTreeMap, HashSet},
-=======
-    collections::BTreeMap,
->>>>>>> origin/main
     net::{IpAddr, SocketAddr},
     time::Duration,
 };
@@ -50,17 +46,13 @@ pub struct ListenPlan {
     #[serde(default)]
     pub reality: Vec<RealityListen>,
     #[serde(default)]
-<<<<<<< HEAD
     pub wireguard: Vec<WireGuardListenPlan>,
-=======
     pub young: Vec<YoungListen>,
->>>>>>> origin/main
     pub panel: Option<PanelListen>,
     pub share: Share,
     pub auth: Vec<UserPass>,
 }
 
-<<<<<<< HEAD
 #[derive(Clone, Serialize, Deserialize)]
 pub struct WireGuardListenPlan {
     pub bind: SocketAddr,
@@ -107,7 +99,9 @@ impl std::fmt::Debug for WireGuardListenPeerPlan {
             .field("reserved", &self.reserved)
             .field("persistent_keepalive", &self.persistent_keepalive)
             .finish()
-=======
+    }
+}
+
 impl YoungListen {
     pub fn socket_addr(&self) -> ConfigResult<SocketAddr> {
         let host = self.host.trim();
@@ -119,7 +113,6 @@ impl YoungListen {
             .parse::<IpAddr>()
             .map_err(|_| ConfigError::invalid(format!("非法 Young 监听 IP: {}", self.host)))?;
         Ok(SocketAddr::new(ip, self.port))
->>>>>>> origin/main
     }
 }
 
@@ -283,11 +276,8 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         share: None,
         auth: vec![],
         reality: vec![],
-<<<<<<< HEAD
         wireguard: vec![],
-=======
         young: vec![],
->>>>>>> origin/main
     });
 
     let share = listen.share.unwrap_or(Share::False);
@@ -362,27 +352,20 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         .collect();
 
     let reality = compile_reality_listeners(&listen.reality)?;
-<<<<<<< HEAD
     let wireguard = compile_wireguard_listeners(&listen.wireguard)?;
-=======
     let young = compile_young_listeners(&listen.young)?;
->>>>>>> origin/main
 
     Ok(ListenPlan {
         mixed,
         reality,
-<<<<<<< HEAD
         wireguard,
-=======
         young,
->>>>>>> origin/main
         panel,
         share,
         auth,
     })
 }
 
-<<<<<<< HEAD
 fn compile_wireguard_listeners(
     listeners: &[WireGuardListen],
 ) -> ConfigResult<Vec<WireGuardListenPlan>> {
@@ -519,7 +502,7 @@ fn decode_wireguard_key(value: &str, location: &str) -> ConfigResult<[u8; 32]> {
     decoded
         .try_into()
         .map_err(|_| ConfigError::invalid("WireGuard 密钥必须解码为 32 字节").at(location))
-=======
+}
 fn compile_young_listeners(listeners: &[YoungListen]) -> ConfigResult<Vec<YoungListen>> {
     let mut output = Vec::with_capacity(listeners.len());
     let mut bound = std::collections::HashSet::new();
@@ -606,7 +589,6 @@ fn compile_young_listeners(listeners: &[YoungListen]) -> ConfigResult<Vec<YoungL
         output.push(listener.clone());
     }
     Ok(output)
->>>>>>> origin/main
 }
 
 fn compile_reality_listeners(listeners: &[RealityListen]) -> ConfigResult<Vec<RealityListen>> {

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -7,7 +7,11 @@
 //! 这里产出的结构是给 `core-runtime` / `core-route` / `core-outbound`
 //! 共同消费的 *已展开* 数据，而非 YAML 原貌。
 
-use std::{collections::BTreeMap, net::SocketAddr, time::Duration};
+use std::{
+    collections::{BTreeMap, HashSet},
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -41,9 +45,60 @@ pub struct ListenPlan {
     pub mixed: Option<MixedListen>,
     #[serde(default)]
     pub reality: Vec<RealityListen>,
+    #[serde(default)]
+    pub wireguard: Vec<WireGuardListenPlan>,
     pub panel: Option<PanelListen>,
     pub share: Share,
     pub auth: Vec<UserPass>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct WireGuardListenPlan {
+    pub bind: SocketAddr,
+    pub private_key: [u8; 32],
+    pub peers: Vec<WireGuardListenPeerPlan>,
+    pub mtu: usize,
+    pub packet_queue: usize,
+    pub handshake_rate_limit: u64,
+}
+
+impl std::fmt::Debug for WireGuardListenPlan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardListenPlan")
+            .field("bind", &self.bind)
+            .field("private_key", &"<redacted>")
+            .field("peers", &self.peers)
+            .field("mtu", &self.mtu)
+            .field("packet_queue", &self.packet_queue)
+            .field("handshake_rate_limit", &self.handshake_rate_limit)
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct WireGuardListenPeerPlan {
+    pub public_key: [u8; 32],
+    pub preshared_key: Option<[u8; 32]>,
+    pub allowed_ips: Vec<ipnet::IpNet>,
+    pub reserved: [u8; 3],
+    pub persistent_keepalive: Option<u16>,
+}
+
+impl std::fmt::Debug for WireGuardListenPeerPlan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardListenPeerPlan")
+            .field("public_key", &self.public_key)
+            .field(
+                "preshared_key",
+                &self.preshared_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("allowed_ips", &self.allowed_ips)
+            .field("reserved", &self.reserved)
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,6 +261,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         share: None,
         auth: vec![],
         reality: vec![],
+        wireguard: vec![],
     });
 
     let share = listen.share.unwrap_or(Share::False);
@@ -280,14 +336,154 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         .collect();
 
     let reality = compile_reality_listeners(&listen.reality)?;
+    let wireguard = compile_wireguard_listeners(&listen.wireguard)?;
 
     Ok(ListenPlan {
         mixed,
         reality,
+        wireguard,
         panel,
         share,
         auth,
     })
+}
+
+fn compile_wireguard_listeners(
+    listeners: &[WireGuardListen],
+) -> ConfigResult<Vec<WireGuardListenPlan>> {
+    let mut result = Vec::with_capacity(listeners.len());
+    let mut binds = HashSet::new();
+    for (index, source) in listeners.iter().enumerate() {
+        let location = format!("listen.wireguard[{index}]");
+        let host = source.host.trim().parse::<IpAddr>().map_err(|_| {
+            ConfigError::invalid("WireGuard 服务端 host 必须是 IPv4 或 IPv6 地址")
+                .at(format!("{location}.host"))
+        })?;
+        if source.port == 0 {
+            return Err(ConfigError::invalid("WireGuard 服务端监听端口不能为 0")
+                .at(format!("{location}.port")));
+        }
+        let bind = SocketAddr::new(host, source.port);
+        if !binds.insert(bind) {
+            return Err(ConfigError::invalid("重复的 WireGuard 服务端监听地址").at(location));
+        }
+        let private_key =
+            decode_wireguard_key(&source.private_key, &format!("{location}.privateKey"))?;
+        if private_key == [0; 32] {
+            return Err(ConfigError::invalid("WireGuard privateKey 不能全为 0")
+                .at(format!("{location}.privateKey")));
+        }
+        if source.peers.is_empty() || source.peers.len() > 256 {
+            return Err(ConfigError::invalid("WireGuard peers 数量必须在 1..=256")
+                .at(format!("{location}.peers")));
+        }
+        if !(576..=65_535).contains(&source.mtu) {
+            return Err(ConfigError::invalid("WireGuard mtu 必须在 576..=65535")
+                .at(format!("{location}.mtu")));
+        }
+        if !(16..=65_536).contains(&source.packet_queue) {
+            return Err(
+                ConfigError::invalid("WireGuard packetQueue 必须在 16..=65536")
+                    .at(format!("{location}.packetQueue")),
+            );
+        }
+        if !(1..=1_000_000).contains(&source.handshake_rate_limit) {
+            return Err(
+                ConfigError::invalid("WireGuard handshakeRateLimit 必须在 1..=1000000")
+                    .at(format!("{location}.handshakeRateLimit")),
+            );
+        }
+
+        let mut peers = Vec::with_capacity(source.peers.len());
+        let mut public_keys = HashSet::new();
+        let mut exact_routes = HashSet::new();
+        let mut has_ipv6 = false;
+        for (peer_index, peer) in source.peers.iter().enumerate() {
+            let peer_location = format!("{location}.peers[{peer_index}]");
+            let public_key =
+                decode_wireguard_key(&peer.public_key, &format!("{peer_location}.publicKey"))?;
+            if public_key == [0; 32] || !public_keys.insert(public_key) {
+                return Err(ConfigError::invalid(
+                    "WireGuard 对端公钥不能全为 0，且每个监听器内必须唯一",
+                )
+                .at(format!("{peer_location}.publicKey")));
+            }
+            let preshared_key = peer
+                .preshared_key
+                .as_deref()
+                .map(|key| decode_wireguard_key(key, &format!("{peer_location}.presharedKey")))
+                .transpose()?;
+            if peer.allowed_ips.is_empty() {
+                return Err(
+                    ConfigError::invalid("WireGuard 对端至少需要一个 allowedIPs")
+                        .at(format!("{peer_location}.allowedIPs")),
+                );
+            }
+            let mut allowed_ips = Vec::with_capacity(peer.allowed_ips.len());
+            for (route_index, route) in peer.allowed_ips.iter().enumerate() {
+                let network = route.parse::<ipnet::IpNet>().map_err(|error| {
+                    ConfigError::invalid(format!("非法 WireGuard allowedIPs：{error}"))
+                        .at(format!("{peer_location}.allowedIPs[{route_index}]"))
+                })?;
+                let network = network.trunc();
+                has_ipv6 |= network.addr().is_ipv6();
+                if !exact_routes.insert(network) {
+                    return Err(ConfigError::invalid(
+                        "同一 WireGuard allowedIPs 不能分配给多个对端",
+                    )
+                    .at(format!("{peer_location}.allowedIPs[{route_index}]")));
+                }
+                allowed_ips.push(network);
+            }
+            let reserved: [u8; 3] = match peer.reserved.as_slice() {
+                [] => [0; 3],
+                [a, b, c] => [*a, *b, *c],
+                _ => {
+                    return Err(
+                        ConfigError::invalid("WireGuard reserved 必须为空或恰好 3 个字节")
+                            .at(format!("{peer_location}.reserved")),
+                    );
+                }
+            };
+            peers.push(WireGuardListenPeerPlan {
+                public_key,
+                preshared_key,
+                allowed_ips,
+                reserved,
+                persistent_keepalive: peer.persistent_keepalive,
+            });
+        }
+        if has_ipv6 && source.mtu < 1_280 {
+            return Err(
+                ConfigError::invalid("WireGuard IPv6 allowedIPs 要求 mtu 至少为 1280")
+                    .at(format!("{location}.mtu")),
+            );
+        }
+        result.push(WireGuardListenPlan {
+            bind,
+            private_key,
+            peers,
+            mtu: source.mtu,
+            packet_queue: source.packet_queue,
+            handshake_rate_limit: source.handshake_rate_limit,
+        });
+    }
+    Ok(result)
+}
+
+fn decode_wireguard_key(value: &str, location: &str) -> ConfigResult<[u8; 32]> {
+    use base64::{Engine as _, engine::general_purpose};
+
+    let value = value.trim();
+    let decoded = general_purpose::STANDARD
+        .decode(value)
+        .or_else(|_| general_purpose::URL_SAFE_NO_PAD.decode(value.trim_end_matches('=')))
+        .map_err(|error| {
+            ConfigError::invalid(format!("WireGuard 密钥不是合法 base64：{error}")).at(location)
+        })?;
+    decoded
+        .try_into()
+        .map_err(|_| ConfigError::invalid("WireGuard 密钥必须解码为 32 字节").at(location))
 }
 
 fn compile_reality_listeners(listeners: &[RealityListen]) -> ConfigResult<Vec<RealityListen>> {
@@ -591,22 +787,66 @@ fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
         .as_deref()
         .map(NodeProtocol::from_scheme)
         .ok_or_else(|| ConfigError::bad_node(format!("node {} 缺少 protocol", d.name)))?;
-    let address = d
-        .address
-        .as_deref()
-        .ok_or_else(|| ConfigError::bad_node(format!("node {} 缺少 address", d.name)))?;
-    let (host, port) = address.rsplit_once(':').ok_or_else(|| {
-        ConfigError::bad_node(format!("node {} address 缺少端口: {}", d.name, address))
-    })?;
-    let port: u16 = port
-        .parse()
-        .map_err(|_| ConfigError::bad_node(format!("node {} 端口非法: {}", d.name, port)))?;
-    let mut node = ParsedNode::new(
-        d.name.clone(),
-        proto,
-        host.trim_matches(|c| c == '[' || c == ']'),
-        port,
-    );
+    let mut params = BTreeMap::new();
+    for (key, value) in &d.params {
+        let value = match value {
+            serde_json::Value::String(value) => value.clone(),
+            serde_json::Value::Bool(value) => value.to_string(),
+            serde_json::Value::Number(value) => value.to_string(),
+            serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+                serde_json::to_string(value).map_err(|error| {
+                    ConfigError::bad_node(format!("node {} params.{key} 无法编码: {error}", d.name))
+                })?
+            }
+            serde_json::Value::Null => {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} params.{key} 不能为 null",
+                    d.name
+                )));
+            }
+        };
+        params.insert(key.clone(), value);
+    }
+    if let Some(private_key) = d
+        .login
+        .as_ref()
+        .and_then(|login| login.private_key.as_ref())
+    {
+        if let Some(existing) = params.get("private-key")
+            && existing != private_key
+        {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 的 login.private-key 与 params.private-key 冲突",
+                d.name
+            )));
+        }
+        params.insert("private-key".into(), private_key.clone());
+    }
+    let (host, port) = match d.address.as_deref() {
+        Some(address) => {
+            let (host, port) = address.rsplit_once(':').ok_or_else(|| {
+                ConfigError::bad_node(format!("node {} address 缺少端口: {}", d.name, address))
+            })?;
+            let port: u16 = port.parse().map_err(|_| {
+                ConfigError::bad_node(format!("node {} 端口非法: {}", d.name, port))
+            })?;
+            (
+                host.trim_matches(|c| c == '[' || c == ']').to_string(),
+                port,
+            )
+        }
+        None if proto == NodeProtocol::Wireguard && params.contains_key("peers") => {
+            ("0.0.0.0".into(), 1)
+        }
+        None => {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 缺少 address",
+                d.name
+            )));
+        }
+    };
+    let mut node = ParsedNode::new(d.name.clone(), proto, host, port);
+    node.params = params;
     if let Some(login) = &d.login {
         node.user = login.user.clone();
         node.password = login.password.clone();
@@ -2786,5 +3026,120 @@ route:
         apply_defaults(&mut cfg);
         let err = compile(cfg).unwrap_err();
         assert!(err.to_string().contains("ghost"));
+    }
+
+    #[test]
+    fn structured_wireguard_node_preserves_all_protocol_options() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: desktop
+nodes:
+  - name: wg-full
+    protocol: wireguard
+    login:
+      private_key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+    params:
+      local-address: [10.0.0.2/32, "fd00::2/128"]
+      mtu: 1280
+      workers: 4
+      remote-dns-resolve: true
+      dns: [10.0.0.53]
+      peers:
+        - server: 192.0.2.1
+          port: 51820
+          public-key: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+          allowed-ips: [10.0.0.0/8]
+          reserved: [1, 2, 3]
+"#,
+        );
+        let node = &plan.nodes[0];
+        assert_eq!(node.protocol, NodeProtocol::Wireguard);
+        assert_eq!(node.host, "0.0.0.0");
+        assert_eq!(node.params.get("workers").map(String::as_str), Some("4"));
+        assert_eq!(
+            node.params.get("private-key").map(String::as_str),
+            Some("AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=")
+        );
+        let peers: serde_json::Value =
+            serde_json::from_str(node.params.get("peers").unwrap()).unwrap();
+        assert_eq!(peers.as_array().unwrap().len(), 1);
+        assert_eq!(peers[0]["reserved"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn wireguard_inbound_compiles_every_server_field() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: server
+listen:
+  wireguard:
+    - host: "::1"
+      port: 51820
+      privateKey: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+      mtu: 1280
+      packetQueue: 2048
+      handshakeRateLimit: 250
+      peers:
+        - publicKey: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+          presharedKey: AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=
+          allowedIPs: [10.77.0.2/32, "fd77::2/128"]
+          reserved: [1, 2, 3]
+          persistentKeepalive: 25
+route: {preset: direct}
+"#,
+        );
+        let listener = &plan.listen.wireguard[0];
+        assert_eq!(listener.bind, "[::1]:51820".parse().unwrap());
+        assert_eq!(listener.private_key, [1; 32]);
+        assert_eq!(listener.mtu, 1280);
+        assert_eq!(listener.packet_queue, 2048);
+        assert_eq!(listener.handshake_rate_limit, 250);
+        assert_eq!(listener.peers[0].public_key, [2; 32]);
+        assert_eq!(listener.peers[0].preshared_key, Some([3; 32]));
+        assert_eq!(listener.peers[0].reserved, [1, 2, 3]);
+        assert_eq!(listener.peers[0].persistent_keepalive, Some(25));
+        assert_eq!(listener.peers[0].allowed_ips.len(), 2);
+    }
+
+    #[test]
+    fn wireguard_inbound_rejects_unknown_and_ambiguous_routes() {
+        let unknown = r#"
+version: 1
+profile: server
+listen:
+  wireguard:
+    - host: 127.0.0.1
+      port: 51820
+      privateKey: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+      silentlyIgnored: true
+      peers: []
+route: {preset: direct}
+"#;
+        let error = serde_yaml::from_str::<UserConfig>(unknown)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("silentlyIgnored"), "error = {error}");
+
+        let duplicated = r#"
+version: 1
+profile: server
+listen:
+  wireguard:
+    - host: 127.0.0.1
+      port: 51820
+      privateKey: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+      peers:
+        - publicKey: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+          allowedIPs: [10.77.0.0/24]
+        - publicKey: AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=
+          allowedIPs: [10.77.0.0/24]
+route: {preset: direct}
+"#;
+        let mut config: UserConfig = serde_yaml::from_str(duplicated).unwrap();
+        apply_defaults(&mut config);
+        let error = compile(config).unwrap_err().to_string();
+        assert!(error.contains("不能分配给多个对端"), "error = {error}");
     }
 }

--- a/crates/core-feeds/src/parser.rs
+++ b/crates/core-feeds/src/parser.rs
@@ -140,7 +140,7 @@ fn clash_proxy_to_node(m: &serde_yaml::Mapping) -> Option<ParsedNode> {
     node.method = str_g("cipher").or_else(|| str_g("method"));
     node.tls = g("tls").and_then(|v| v.as_bool()).unwrap_or(false)
         || matches!(
-            proto,
+            &proto,
             NodeProtocol::Trojan | NodeProtocol::Hysteria2 | NodeProtocol::Tuic
         );
     node.sni = str_g("sni").or_else(|| str_g("servername"));
@@ -183,6 +183,21 @@ fn clash_proxy_to_node(m: &serde_yaml::Mapping) -> Option<ParsedNode> {
         }
         if let Some(s) = scalar_to_string(v) {
             node.params.insert(key.to_string(), s);
+        }
+    }
+
+    // WireGuard 的标准多 peer / 列表字段不能按普通“仅标量”路径丢弃。
+    // 统一保存为 JSON，registry 再做严格别名、类型和冲突校验。
+    if matches!(&proto, NodeProtocol::Wireguard) {
+        if let Some(network) = str_g("network") {
+            node.params.insert("network".into(), network);
+        }
+        for key in ["allowed-ips", "dns", "reserved", "peers"] {
+            if let Some(value) = g(key)
+                && let Ok(json) = serde_json::to_string(&value)
+            {
+                node.params.insert(key.into(), json);
+            }
         }
     }
 
@@ -428,6 +443,54 @@ proxies:
         assert_eq!(nodes.len(), 2);
         assert_eq!(nodes[0].protocol, NodeProtocol::Trojan);
         assert_eq!(nodes[1].method.as_deref(), Some("aes-256-gcm"));
+    }
+
+    #[test]
+    fn parse_clash_wireguard_preserves_lists_and_multi_peer_objects() {
+        let yaml = r#"
+proxies:
+  - name: WG-full
+    type: wireguard
+    server: 127.0.0.1
+    port: 51820
+    private-key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+    ip: 10.0.0.2/32
+    ipv6: fd00::2/128
+    mtu: 1380
+    udp: true
+    network: tcp,udp
+    dns: [10.0.0.53, "fd00::53"]
+    remote-dns-resolve: true
+    peers:
+      - server: 192.0.2.1
+        port: 51820
+        public-key: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+        allowed-ips: [10.0.0.0/8]
+        reserved: [1, 2, 3]
+      - server: "2001:db8::1"
+        port: 51821
+        public-key: AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=
+        allowed-ips: ["fd00::/8"]
+        persistent-keepalive: 0
+"#;
+        let nodes = parse_feed_payload(yaml.as_bytes(), FormatHint::ClashYaml);
+        assert_eq!(nodes.len(), 1);
+        let node = &nodes[0];
+        assert_eq!(node.protocol, NodeProtocol::Wireguard);
+        assert_eq!(
+            node.params.get("network").map(String::as_str),
+            Some("tcp,udp")
+        );
+        assert_eq!(
+            node.params.get("remote-dns-resolve").map(String::as_str),
+            Some("1")
+        );
+        let dns: serde_json::Value = serde_json::from_str(node.params.get("dns").unwrap()).unwrap();
+        assert_eq!(dns.as_array().unwrap().len(), 2);
+        let peers: serde_json::Value =
+            serde_json::from_str(node.params.get("peers").unwrap()).unwrap();
+        assert_eq!(peers.as_array().unwrap().len(), 2);
+        assert_eq!(peers[0]["reserved"], serde_json::json!([1, 2, 3]));
     }
 
     #[test]

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [dependencies]
 core-config = { workspace = true }
 core-reality = { workspace = true }
+serde       = { workspace = true }
+serde_json  = { workspace = true }
 tokio       = { workspace = true }
 async-trait = { workspace = true }
 bytes       = { workspace = true }
@@ -19,6 +21,8 @@ parking_lot = { workspace = true }
 hex         = { workspace = true }
 futures     = { workspace = true }
 pin-project-lite = { workspace = true }
+tokio-util  = { workspace = true }
+ipnet       = { workspace = true }
 if-addrs    = "0.15"
 
 # 协议层依赖
@@ -55,15 +59,17 @@ h3                = "0.0.8"
 h3-quinn          = "0.0.10"
 http              = "1"
 blake2            = "0.10"
-# boringtun 0.6 锁定老 dalek 版本与 russh 冲突；改为手工实现 WireGuard
-# 用 chacha20poly1305 + blake2 + curve25519-dalek（与 russh 同版）
+# WireGuard NoiseIK、Cookie、重放窗口、密钥轮换均由成熟实现负责；
+# 禁止在协议适配层自行近似实现密码学状态机。
+boringtun         = { workspace = true }
 curve25519-dalek  = "4.1"
 pbkdf2            = "0.12"
 hyper             = { version = "1", features = ["client", "http2"] }
 hyper-util        = { version = "0.1", features = ["client", "client-legacy", "tokio", "http2"] }
 http-body-util    = "0.1"
+hickory-proto     = "=0.24.4"
 rand_chacha       = "0.3"
-smoltcp           = { version = "0.11", default-features = false, features = ["std", "alloc", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-tcp", "socket-udp", "async"] }
+smoltcp           = { version = "0.11", default-features = false, features = ["std", "alloc", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "proto-ipv4-fragmentation", "proto-ipv6-fragmentation", "fragmentation-buffer-size-65536", "reassembly-buffer-size-65536", "reassembly-buffer-count-4", "assembler-max-segment-count-32", "iface-max-addr-count-8", "iface-max-route-count-2", "socket-tcp", "socket-udp", "async"] }
 # socket2：在 Linux/Android 上对 outbound socket 设置 SO_MARK，配合
 # `ip rule fwmark X lookup main` 让代理出站绕开 TUN 自身路由表，
 # 避免"resolve 出 IP 后 connect 又被 TUN 截走"的死循环。

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -7,12 +7,9 @@ license.workspace = true
 [dependencies]
 core-config = { workspace = true }
 core-reality = { workspace = true }
-<<<<<<< HEAD
 serde       = { workspace = true }
 serde_json  = { workspace = true }
-=======
 core-young   = { workspace = true, features = ["firefox-stack"] }
->>>>>>> origin/main
 tokio       = { workspace = true }
 async-trait = { workspace = true }
 bytes       = { workspace = true }

--- a/crates/core-outbound/src/lib.rs
+++ b/crates/core-outbound/src/lib.rs
@@ -1,9 +1,9 @@
 //! core-outbound —— 出站协议适配器。
 //!
 //! §11.2 关键 trait [`OutboundAdapter`]：所有出站使用统一接口。
-//! MVP 阶段实现 direct / block / http / socks5 / shadowsocks（基础 AEAD）。
-//! 其它协议（vmess / vless / trojan / hysteria2 / tuic / wireguard / ssh）
-//! 提供 stub 适配器，并在 dial 时返回"协议尚未实现"。
+//! 除 direct / block / HTTP / SOCKS5 外，也包含 VMess、VLESS、Trojan、
+//! Hysteria、TUIC、WireGuard 等协议的真实数据面；各协议的精确能力以
+//! [`proto`] 模块和注册器校验为准。
 
 // 大多数模块禁 unsafe；adapter 里 Windows IP_UNICAST_IF / macOS IP_BOUND_IF
 // 必须走 raw setsockopt，由 cfg 平台分支控制，按 module 粒度 allow（其它模块

--- a/crates/core-outbound/src/proto/mod.rs
+++ b/crates/core-outbound/src/proto/mod.rs
@@ -9,15 +9,7 @@
 //! * [`vless`]       —— VLESS over TLS / TCP / WebSocket
 //! * [`vmess`]       —— VMess AEAD (aes-128-gcm / chacha20-poly1305 / none)
 //! * [`anytls`]      —— AnyTLS single-stream
-//!
-//! **占位**（dial 返回明确的"协议尚未实现"）：
-//! * Hysteria v1 / Hysteria2 / TUIC（基于 QUIC，需 quinn 集成 PR）
-//! * WireGuard（需 boringtun 集成 PR）
-//! * SSH（需 russh 集成 PR）
-//! * Mieru / Sudoku / Trusttunnel（冷门协议，单独 PR）
-//!
-//! 上述占位由 [`crate::stub::StubOutbound`] 提供，dial 时给出
-//! `ErrorKind::Unsupported` 与协议名，避免静默失败。
+//! * [`wireguard`]   —— 用户态 WireGuard（多 peer、TCP/UDP、IPv4/IPv6、服务端 API）
 
 pub mod addr;
 pub mod anytls;

--- a/crates/core-outbound/src/proto/wireguard.rs
+++ b/crates/core-outbound/src/proto/wireguard.rs
@@ -1,75 +1,65 @@
-//! WireGuard 出站 —— 完整实现，与 [WireGuard 协议](https://www.wireguard.com/protocol/) 互通。
+//! WireGuard 用户态客户端与 peer/server 数据面。
 //!
-//! ## 协议总览
-//!
-//! 1. **Noise IK 握手**：X25519 ECDH + Blake2s + ChaCha20-Poly1305 进行身份鉴权与
-//!    会话密钥派生
-//! 2. **Transport encryption**：每个数据包用 ChaCha20-Poly1305 加密
-//!    `type=4(4B) || receiver_index(4B) || counter(8B) || encrypted_payload(N+16B)`
-//! 3. **应用层**：客户端 TCP/UDP 应用流量先经过用户态 [smoltcp] 协议栈打包成 IP 包，
-//!    再加密成 WG transport 包发送
-//!
-//! ## 实现范围（**完整**）
-//! * Noise IK initiator handshake（HandshakeInit → HandshakeResp → keys）
-//! * Transport packet encrypt / decrypt
-//! * IP packet routing 通过 smoltcp 用户态网络栈
-//! * TCP/UDP socket abstraction 返回 [`BoxedStream`]
-//! * 自动 keep-alive（每 25 秒 cookie reply 时刷新）
-//! * 多个 dial 共享同一 WG session
+//! 密码学、Cookie、握手重传、密钥轮换、重放窗口和计数器全部委托给固定版本
+//! `boringtun`。本模块只负责异步 UDP 生命周期、AllowedIPs 路由以及把解密后的
+//! IP 包接入真实 `smoltcp` TCP/UDP socket，禁止再出现手写近似握手或永久 Pending。
+
+pub mod config;
+mod device;
+mod dns;
+mod fragment;
+mod netstack;
+mod server;
 
 use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::{
-        Arc,
-        atomic::{AtomicU32, AtomicU64, Ordering},
-    },
-    task::{Context, Poll, Waker},
-    time::{SystemTime, UNIX_EPOCH},
+    sync::Arc,
+    task::{Context, Poll},
 };
 
 use async_trait::async_trait;
-use blake2::{Blake2s256, Digest as Blake2Digest, digest::Update as Blake2Update};
-use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce, aead::Aead};
-use curve25519_dalek::{montgomery::MontgomeryPoint, scalar::Scalar};
-use parking_lot::Mutex as PlMutex;
-use rand::RngCore;
-use tokio::sync::Mutex as AsyncMutex;
-
-use crate::adapter::{
-    BoxedStream, Capabilities, DialContext, OutboundAdapter, prepare_outbound_udp_socket_for_addr,
-    resolve_host,
+use ipnet::IpNet;
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::Mutex as AsyncMutex,
 };
 
-/* ---------------- 协议常量 ---------------- */
+use crate::adapter::{
+    BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, UdpSocketLike, resolve_host,
+};
 
-const CONSTRUCTION: &[u8] = b"Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
-const IDENTIFIER: &[u8] = b"WireGuard v1 zx2c4 Jason@zx2c4.com";
-const LABEL_MAC1: &[u8] = b"mac1----";
-const LABEL_COOKIE: &[u8] = b"cookie--";
+pub use config::{WireGuardConfig, WireGuardPeerConfig};
+use device::WireGuardDevice;
+pub use device::WireGuardPeerStats;
+use dns::DnsCache;
+use netstack::{WireGuardTcpStream, WireGuardUdpSocket};
+pub use server::{
+    WireGuardReceivedPacket, WireGuardServer, WireGuardServerConfig, WireGuardServerPeerConfig,
+    WireGuardServerPeerStats,
+};
 
-const MSG_HANDSHAKE_INIT: u8 = 1;
-const MSG_HANDSHAKE_RESP: u8 = 2;
-#[allow(dead_code)]
-const MSG_COOKIE_REPLY: u8 = 3;
-const MSG_TRANSPORT: u8 = 4;
-
-/* ---------------- 配置 ---------------- */
-
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct WireGuardOutbound {
-    pub name: String,
-    pub host: String,
-    pub port: u16,
-    pub private_key: [u8; 32],
-    pub peer_public_key: [u8; 32],
-    pub preshared_key: Option<[u8; 32]>,
-    pub local_addrs: Vec<IpAddr>, // 客户端在 wg 接口上的 IP（如 10.0.0.2）
-    pub mtu: u32,
-    pub keepalive_secs: u32,
-    pub dns: Vec<IpAddr>,
-    pub udp: bool,
-    state: Arc<AsyncMutex<Option<Arc<WgSession>>>>,
+    name: String,
+    config: WireGuardConfig,
+    device: Arc<AsyncMutex<Option<WireGuardDevice>>>,
+    dns_cache: Arc<DnsCache>,
+}
+
+impl std::fmt::Debug for WireGuardOutbound {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardOutbound")
+            .field("name", &self.name)
+            .field("local_addresses", &self.config.local_addresses)
+            .field("peers", &self.config.peers.len())
+            .field("mtu", &self.config.mtu)
+            .field("tcp", &self.config.tcp)
+            .field("udp", &self.config.udp)
+            .field("workers", &self.config.workers)
+            .finish_non_exhaustive()
+    }
 }
 
 impl WireGuardOutbound {
@@ -80,42 +70,99 @@ impl WireGuardOutbound {
         private_key: [u8; 32],
         peer_public_key: [u8; 32],
     ) -> Self {
+        let peer = WireGuardPeerConfig::new(host, port, peer_public_key);
+        Self::from_config(name, WireGuardConfig::new(private_key, peer))
+    }
+
+    pub fn from_config(name: impl Into<String>, config: WireGuardConfig) -> Self {
         Self {
             name: name.into(),
-            host: host.into(),
-            port,
-            private_key,
-            peer_public_key,
-            preshared_key: None,
-            local_addrs: vec![],
-            mtu: 1420,
-            keepalive_secs: 25,
-            dns: vec![],
-            udp: true,
-            state: Arc::new(AsyncMutex::new(None)),
+            config,
+            device: Arc::new(AsyncMutex::new(None)),
+            dns_cache: DnsCache::new(),
         }
     }
 
-    pub fn with_preshared_key(mut self, k: [u8; 32]) -> Self {
-        self.preshared_key = Some(k);
-        self
+    pub fn config(&self) -> &WireGuardConfig {
+        &self.config
     }
 
-    pub fn with_local_address(mut self, addr: IpAddr) -> Self {
-        self.local_addrs.push(addr);
-        self
-    }
-
-    async fn ensure_session(&self) -> std::io::Result<Arc<WgSession>> {
-        let mut guard = self.state.lock().await;
-        if let Some(s) = guard.as_ref() {
-            if !s.closed.load(Ordering::Acquire) {
-                return Ok(s.clone());
-            }
+    pub fn with_preshared_key(mut self, key: [u8; 32]) -> Self {
+        if let Some(peer) = self.config.peers.first_mut() {
+            peer.preshared_key = Some(key);
         }
-        let session = Arc::new(WgSession::handshake(self).await?);
-        *guard = Some(session.clone());
-        Ok(session)
+        self.reset_runtime();
+        self
+    }
+
+    pub fn with_local_address(mut self, address: IpAddr) -> Self {
+        let prefix = if address.is_ipv4() { 32 } else { 128 };
+        self.config
+            .local_addresses
+            .push(IpNet::new(address, prefix).expect("host prefix is valid"));
+        self.reset_runtime();
+        self
+    }
+
+    fn reset_runtime(&mut self) {
+        // Builder methods may be called on a clone after another clone has
+        // already started. Never reuse a device whose crypto state was built
+        // from the previous configuration.
+        self.device = Arc::new(AsyncMutex::new(None));
+        self.dns_cache = DnsCache::new();
+    }
+
+    async fn ensure_device(&self) -> std::io::Result<WireGuardDevice> {
+        let mut guard = self.device.lock().await;
+        if let Some(device) = guard.as_ref() {
+            return Ok(device.clone());
+        }
+        let device = WireGuardDevice::start(self.config.clone()).await?;
+        *guard = Some(device.clone());
+        Ok(device)
+    }
+
+    async fn resolve_target(
+        &self,
+        device: &WireGuardDevice,
+        host: &str,
+        port: u16,
+    ) -> std::io::Result<SocketAddr> {
+        if let Ok(address) = host.parse::<IpAddr>() {
+            return self
+                .config
+                .route_peer(address)
+                .map(|_| SocketAddr::new(address, port))
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::AddrNotAvailable,
+                        format!("wireguard target {host}:{port} is not covered by allowed-ips"),
+                    )
+                });
+        }
+        let addresses = if self.config.remote_dns_resolve {
+            self.dns_cache.resolve(device, host, port).await?
+        } else {
+            resolve_host(host, port).await?
+        };
+        addresses
+            .into_iter()
+            .find(|address| self.config.route_peer(address.ip()).is_some())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::AddrNotAvailable,
+                    format!("wireguard target {host}:{port} has no address covered by allowed-ips"),
+                )
+            })
+    }
+
+    pub async fn stats(&self) -> Vec<WireGuardPeerStats> {
+        self.device
+            .lock()
+            .await
+            .as_ref()
+            .map(WireGuardDevice::stats)
+            .unwrap_or_default()
     }
 }
 
@@ -124,557 +171,383 @@ impl OutboundAdapter for WireGuardOutbound {
     fn name(&self) -> &str {
         &self.name
     }
+
     fn protocol(&self) -> &'static str {
         "wireguard"
     }
+
     fn capabilities(&self) -> Capabilities {
+        let ipv6 = self
+            .config
+            .local_addresses
+            .iter()
+            .any(|address| address.addr().is_ipv6())
+            && self
+                .config
+                .peers
+                .iter()
+                .flat_map(|peer| &peer.allowed_ips)
+                .any(|network| network.addr().is_ipv6());
         Capabilities {
-            tcp: true,
-            udp: false,
-            ipv6: true,
+            tcp: self.config.tcp,
+            udp: self.config.udp,
+            ipv6,
             multiplex: true,
         }
     }
 
-    async fn dial_tcp(&self, ctx: DialContext) -> std::io::Result<BoxedStream> {
-        let session = self.ensure_session().await?;
-        // 在 smoltcp 网络栈中开 TCP 连接到 (ctx.host, ctx.port)
-        let target = resolve_first(&ctx.host, ctx.port).await?;
-        let stream = session.connect_tcp(target).await?;
-        Ok(Box::pin(stream))
+    async fn dial_tcp(&self, context: DialContext) -> std::io::Result<BoxedStream> {
+        if !self.config.tcp {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "wireguard TCP is disabled by network configuration",
+            ));
+        }
+        let device = self.ensure_device().await?;
+        let target = self
+            .resolve_target(&device, &context.host, context.port)
+            .await?;
+        let mut stream = device.stack().open_tcp(target)?;
+        device.stack().notify();
+        stream
+            .wait_connected(device.config().connect_timeout)
+            .await?;
+        Ok(Box::pin(WireGuardTcpAssociation {
+            stream,
+            _device: device,
+        }))
+    }
+
+    async fn dial_udp(&self, context: DialContext) -> std::io::Result<BoxedUdp> {
+        if !self.config.udp {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "wireguard UDP is disabled by network configuration",
+            ));
+        }
+        let device = self.ensure_device().await?;
+        let target = self
+            .resolve_target(&device, &context.host, context.port)
+            .await?;
+        let socket =
+            device
+                .stack()
+                .open_udp(target, context.host, device.config().udp_idle_timeout)?;
+        device.stack().notify();
+        Ok(Box::new(WireGuardUdpAssociation {
+            socket,
+            _device: device,
+        }))
     }
 }
 
-/* ---------------- Noise IK 握手 ---------------- */
-
-struct HandshakeOutput {
-    sender_index: u32,
-    receiver_index: u32,
-    encrypt_key: [u8; 32], // T_init -> resp
-    decrypt_key: [u8; 32], // T_resp -> init
+struct WireGuardTcpAssociation {
+    stream: WireGuardTcpStream,
+    // Keep the tunnel driver alive even if a runtime reload removes the
+    // originating outbound adapter while this stream is still active.
+    _device: WireGuardDevice,
 }
 
-fn perform_handshake_initiator(
-    static_priv: &[u8; 32],
-    static_pub: &[u8; 32],
-    peer_pub: &[u8; 32],
-    psk: &Option<[u8; 32]>,
-    udp: &tokio::net::UdpSocket,
-    server_addr: SocketAddr,
-) -> std::io::Result<(HandshakeOutput, [u8; 32])> {
-    // 1) 生成 ephemeral
-    let mut eph_priv = [0u8; 32];
-    rand::rngs::OsRng.fill_bytes(&mut eph_priv);
-    eph_priv[0] &= 248;
-    eph_priv[31] &= 127;
-    eph_priv[31] |= 64;
-    let eph_pub = x25519_pub(&eph_priv);
-
-    // 2) 计算 hash & chaining key
-    let mut h = blake2s(&[CONSTRUCTION]);
-    h = blake2s(&[&h, IDENTIFIER]);
-    h = blake2s(&[&h, peer_pub]);
-    let mut ck = blake2s(&[CONSTRUCTION]);
-
-    // 3) sender_index 随机
-    let sender_index: u32 = rand::random::<u32>();
-
-    // 4) 计算 e.pub 写入 + 更新 hash
-    h = blake2s(&[&h, &eph_pub]);
-
-    // 5) ee = X25519(eph_priv, peer_pub)
-    let ee = x25519(&eph_priv, peer_pub);
-    let (new_ck, k1) = kdf2(&ck, &ee);
-    ck = new_ck;
-
-    // 6) 加密 static_pub 用 k1
-    let enc_static_pub = chacha20_seal(&k1, 0, &h, static_pub)?;
-    h = blake2s(&[&h, &enc_static_pub]);
-
-    // 7) ss = X25519(static_priv, peer_pub)
-    let ss = x25519(static_priv, peer_pub);
-    let (new_ck, k2) = kdf2(&ck, &ss);
-    ck = new_ck;
-
-    // 8) timestamp (TAI64N) 加密
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
-    let mut tai64n = [0u8; 12];
-    tai64n[..8].copy_from_slice(&(now.as_secs() + 0x4000000000000000u64).to_be_bytes());
-    tai64n[8..12].copy_from_slice(&(now.subsec_nanos()).to_be_bytes());
-    let enc_timestamp = chacha20_seal(&k2, 0, &h, &tai64n)?;
-    h = blake2s(&[&h, &enc_timestamp]);
-
-    // 9) 构造 handshake init 包：type(1)=1 + reserved(3)=0 + sender(4) + eph_pub(32) + enc_static(48) + enc_ts(28) + mac1(16) + mac2(16)
-    let mut pkt = Vec::with_capacity(148);
-    pkt.push(MSG_HANDSHAKE_INIT);
-    pkt.extend_from_slice(&[0, 0, 0]); // reserved
-    pkt.extend_from_slice(&sender_index.to_le_bytes());
-    pkt.extend_from_slice(&eph_pub);
-    pkt.extend_from_slice(&enc_static_pub);
-    pkt.extend_from_slice(&enc_timestamp);
-
-    // mac1 = MAC(BLAKE2s(LABEL_MAC1 || peer_pub), pkt[..len-32])
-    let mac1_key = blake2s(&[LABEL_MAC1, peer_pub]);
-    let mac1 = blake2s_mac(&mac1_key, &pkt);
-    pkt.extend_from_slice(&mac1);
-    // mac2 = 0 (no cookie)
-    pkt.extend_from_slice(&[0u8; 16]);
-
-    // 10) 同步发送 + 阻塞等待响应
-    udp_send_all(udp, &pkt, server_addr)?;
-
-    // 11) 接收 HandshakeResp（92B）
-    let mut resp = [0u8; 92];
-    udp_recv_until_match(udp, &mut resp, MSG_HANDSHAKE_RESP)?;
-
-    // 解析 resp
-    let receiver_index = u32::from_le_bytes([resp[4], resp[5], resp[6], resp[7]]);
-    let resp_sender_idx = u32::from_le_bytes([resp[8], resp[9], resp[10], resp[11]]);
-    let resp_eph_pub: [u8; 32] = resp[12..44].try_into().unwrap();
-    let enc_empty: [u8; 16] = resp[44..60].try_into().unwrap();
-
-    // 验证 receiver_index 与我们的 sender_index 匹配
-    if receiver_index != sender_index {
-        return Err(io_err("wg handshake resp index mismatch"));
-    }
-
-    // 12) 更新 hash 与 ck
-    let mut h = blake2s(&[&h, &resp_eph_pub]);
-    let ee2 = x25519(&eph_priv, &resp_eph_pub);
-    let (new_ck, _) = kdf1(&ck, &ee2);
-    let mut ck = new_ck;
-
-    let se = x25519(static_priv, &resp_eph_pub);
-    let (new_ck, _) = kdf1(&ck, &se);
-    ck = new_ck;
-
-    // PSK
-    let psk_bytes = psk.unwrap_or([0u8; 32]);
-    let (new_ck, t, k3) = kdf3(&ck, &psk_bytes);
-    ck = new_ck;
-    h = blake2s(&[&h, &t]);
-
-    // 13) 解密 enc_empty
-    let dec = chacha20_open(&k3, 0, &h, &enc_empty)?;
-    if !dec.is_empty() {
-        return Err(io_err("wg handshake empty payload not empty"));
-    }
-    let _ = resp_sender_idx;
-
-    // 14) 派生 transport keys
-    let (encrypt_key, decrypt_key) = kdf2(&ck, &[]);
-    Ok((
-        HandshakeOutput {
-            sender_index,
-            receiver_index: resp_sender_idx,
-            encrypt_key,
-            decrypt_key,
-        },
-        ck,
-    ))
-}
-
-/* ---------------- Session ---------------- */
-
-#[derive(Debug)]
-struct WgSession {
-    sender_index: u32,
-    receiver_index: u32,
-    encrypt_key: [u8; 32],
-    decrypt_key: [u8; 32],
-    /// 出站计数器（递增）
-    send_counter: AtomicU64,
-    /// 入站计数器（防重放）
-    recv_counter: AtomicU64,
-    udp: Arc<tokio::net::UdpSocket>,
-    _loopback_guard: crate::loopback::LoopbackUdpGuard,
-    server_addr: SocketAddr,
-    closed: std::sync::atomic::AtomicBool,
-    /// smoltcp 接口（用于 IP 包路由到上层 TCP/UDP）
-    iface: Arc<PlMutex<SmoltcpIface>>,
-    /// 共享 next_port 分配
-    next_local_port: AtomicU32,
-    /// IP 包路由 task 唤醒器
-    iface_waker: Arc<PlMutex<Option<Waker>>>,
-}
-
-impl WgSession {
-    async fn handshake(cfg: &WireGuardOutbound) -> std::io::Result<Self> {
-        let server_addr = resolve_first(&cfg.host, cfg.port).await?;
-        let bind: SocketAddr = if server_addr.is_ipv6() {
-            "[::]:0".parse().unwrap()
-        } else {
-            "0.0.0.0:0".parse().unwrap()
-        };
-        let std_socket = std::net::UdpSocket::bind(bind)?;
-        let _loopback_guard = prepare_outbound_udp_socket_for_addr(&std_socket, server_addr)?;
-        std_socket.connect(server_addr)?;
-        std_socket.set_nonblocking(false)?;
-
-        let static_pub = x25519_pub(&cfg.private_key);
-        let (out, _ck) = perform_handshake_initiator(
-            &cfg.private_key,
-            &static_pub,
-            &cfg.peer_public_key,
-            &cfg.preshared_key,
-            // 临时用 std::net::UdpSocket 同步握手
-            &tokio::net::UdpSocket::from_std(std_socket)?,
-            server_addr,
-        )?;
-
-        // 注意：上面这里有个所有权问题，我们把 std_socket 转给 from_std，但 perform_handshake_initiator 需要 tokio UdpSocket
-        // 重新设计：让 perform_handshake_initiator 接受 &tokio::net::UdpSocket 但用 blocking poll
-        // —— 由于 udp_send_all/udp_recv_until_match 是同步的，我们给 tokio socket 做 std + blocking
-        unreachable!("see refactor below")
-    }
-
-    async fn connect_tcp(&self, target: SocketAddr) -> std::io::Result<WgSubStream> {
-        let local_port = self.next_local_port.fetch_add(1, Ordering::Relaxed) as u16;
-        let mut iface = self.iface.lock();
-        let handle = iface.open_tcp_connect(local_port, target)?;
-        Ok(WgSubStream {
-            handle,
-            iface: self.iface.clone(),
-            iface_waker: self.iface_waker.clone(),
-        })
-    }
-}
-
-#[derive(Debug)]
-struct SmoltcpIface {
-    // 占位：实际应该持有 smoltcp::iface::Interface + SocketSet + 自定义 Device
-}
-
-impl SmoltcpIface {
-    fn open_tcp_connect(&mut self, _local_port: u16, _target: SocketAddr) -> std::io::Result<u64> {
-        // smoltcp 的 TcpSocket::connect()
-        Ok(0)
-    }
-}
-
-/// 用户态 TCP socket 抽象成 AsyncRead+AsyncWrite
-pub struct WgSubStream {
-    handle: u64,
-    iface: Arc<PlMutex<SmoltcpIface>>,
-    iface_waker: Arc<PlMutex<Option<Waker>>>,
-}
-
-impl tokio::io::AsyncRead for WgSubStream {
+impl AsyncRead for WireGuardTcpAssociation {
     fn poll_read(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-        _buf: &mut tokio::io::ReadBuf<'_>,
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        // 由于完整 smoltcp 集成涉及一个独立 IP-packet event loop，
-        // 此处仅声明完整接口；run loop 在 WgSession spawn 时启动
-        Poll::Pending
+        Pin::new(&mut self.stream).poll_read(context, buffer)
     }
 }
 
-impl tokio::io::AsyncWrite for WgSubStream {
+impl AsyncWrite for WireGuardTcpAssociation {
     fn poll_write(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-        _buf: &[u8],
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        Poll::Pending
+        Pin::new(&mut self.stream).poll_write(context, buffer)
     }
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.stream).poll_flush(context)
     }
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.stream).poll_shutdown(context)
     }
 }
 
-/* ---------------- Transport packet encrypt / decrypt ---------------- */
-
-/// 对 IP 包加密成 WG transport packet
-pub fn encrypt_transport(
-    encrypt_key: &[u8; 32],
-    receiver_index: u32,
-    counter: u64,
-    ip_packet: &[u8],
-) -> std::io::Result<Vec<u8>> {
-    let cipher = ChaCha20Poly1305::new_from_slice(encrypt_key).map_err(|_| io_err("wg key"))?;
-    let mut nonce = [0u8; 12];
-    nonce[4..12].copy_from_slice(&counter.to_le_bytes());
-    let ct = cipher
-        .encrypt(Nonce::from_slice(&nonce), ip_packet)
-        .map_err(|_| io_err("wg encrypt"))?;
-    let mut out = Vec::with_capacity(16 + ct.len());
-    out.push(MSG_TRANSPORT);
-    out.extend_from_slice(&[0, 0, 0]);
-    out.extend_from_slice(&receiver_index.to_le_bytes());
-    out.extend_from_slice(&counter.to_le_bytes());
-    out.extend_from_slice(&ct);
-    Ok(out)
+struct WireGuardUdpAssociation {
+    socket: WireGuardUdpSocket,
+    _device: WireGuardDevice,
 }
 
-pub fn decrypt_transport(
-    decrypt_key: &[u8; 32],
-    pkt: &[u8],
-) -> std::io::Result<(u32, u64, Vec<u8>)> {
-    if pkt.len() < 16 || pkt[0] != MSG_TRANSPORT {
-        return Err(io_err("wg pkt size/type"));
+#[async_trait]
+impl UdpSocketLike for WireGuardUdpAssociation {
+    async fn send_to(&self, buffer: &[u8], target: &str, port: u16) -> std::io::Result<usize> {
+        self.socket.send_to(buffer, target, port).await
     }
-    let receiver = u32::from_le_bytes([pkt[4], pkt[5], pkt[6], pkt[7]]);
-    let counter = u64::from_le_bytes([
-        pkt[8], pkt[9], pkt[10], pkt[11], pkt[12], pkt[13], pkt[14], pkt[15],
-    ]);
-    let cipher = ChaCha20Poly1305::new_from_slice(decrypt_key).map_err(|_| io_err("wg key"))?;
-    let mut nonce = [0u8; 12];
-    nonce[4..12].copy_from_slice(&counter.to_le_bytes());
-    let pt = cipher
-        .decrypt(Nonce::from_slice(&nonce), &pkt[16..])
-        .map_err(|_| io_err("wg decrypt"))?;
-    Ok((receiver, counter, pt))
-}
 
-/* ---------------- 加密原语 ---------------- */
-
-fn x25519(scalar: &[u8; 32], point: &[u8; 32]) -> [u8; 32] {
-    let mut s = *scalar;
-    s[0] &= 248;
-    s[31] &= 127;
-    s[31] |= 64;
-    let scalar = Scalar::from_bytes_mod_order(s);
-    let p = MontgomeryPoint(*point);
-    (scalar * p).0
-}
-
-fn x25519_pub(scalar: &[u8; 32]) -> [u8; 32] {
-    // 9 是 X25519 base point
-    let mut base = [0u8; 32];
-    base[0] = 9;
-    x25519(scalar, &base)
-}
-
-fn blake2s(parts: &[&[u8]]) -> [u8; 32] {
-    let mut h = Blake2s256::new();
-    for p in parts {
-        Blake2Digest::update(&mut h, p);
+    async fn recv_from(&self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.socket.recv_from(buffer).await
     }
-    let r = h.finalize();
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&r);
-    out
-}
 
-/// HMAC-BLAKE2s-256 - 手工实现避免 hmac crate 与 blake2 集成问题
-fn hmac_blake2s(key: &[u8], data: &[&[u8]]) -> [u8; 32] {
-    const BLOCK: usize = 64;
-    let mut k = if key.len() > BLOCK {
-        blake2s(&[key]).to_vec()
-    } else {
-        key.to_vec()
-    };
-    k.resize(BLOCK, 0);
-    let ipad: Vec<u8> = k.iter().map(|b| b ^ 0x36).collect();
-    let opad: Vec<u8> = k.iter().map(|b| b ^ 0x5c).collect();
-    let mut h1 = Blake2s256::new();
-    Blake2Digest::update(&mut h1, &ipad);
-    for p in data {
-        Blake2Digest::update(&mut h1, p);
+    async fn close(&self) -> std::io::Result<()> {
+        self.socket.close();
+        Ok(())
     }
-    let inner = h1.finalize();
-    let mut h2 = Blake2s256::new();
-    Blake2Digest::update(&mut h2, &opad);
-    Blake2Digest::update(&mut h2, &inner);
-    let r = h2.finalize();
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&r);
-    out
 }
 
-/// 16-byte BLAKE2s MAC（用于 WireGuard mac1）
-fn blake2s_mac(key: &[u8; 32], data: &[u8]) -> [u8; 16] {
-    // BLAKE2s 的 MAC 模式：用 key 作为初始化参数；这里简化为 keyed-blake2
-    // 输出 256 bit 后取前 16B —— 与 wg 协议要求的 KDF 公式一致
-    let mut h = Blake2s256::new();
-    Blake2Digest::update(&mut h, key);
-    Blake2Digest::update(&mut h, data);
-    let r = h.finalize();
-    let mut out = [0u8; 16];
-    out.copy_from_slice(&r[..16]);
-    out
-}
-
-/// HKDF over BLAKE2s
-fn hkdf(ck: &[u8; 32], input: &[u8], outputs: usize) -> Vec<[u8; 32]> {
-    // Extract: prk = HMAC(ck, input)
-    let prk = hmac_blake2s(ck, &[input]);
-
-    let mut out = Vec::with_capacity(outputs);
-    let mut prev: Vec<u8> = Vec::new();
-    for i in 1..=outputs {
-        let a = hmac_blake2s(&prk, &[&prev, &[i as u8]]);
-        out.push(a);
-        prev = a.to_vec();
-    }
-    out
-}
-
-fn kdf1(ck: &[u8; 32], input: &[u8]) -> ([u8; 32], [u8; 32]) {
-    let v = hkdf(ck, input, 1);
-    (v[0], v[0])
-}
-
-fn kdf2(ck: &[u8; 32], input: &[u8]) -> ([u8; 32], [u8; 32]) {
-    let v = hkdf(ck, input, 2);
-    (v[0], v[1])
-}
-
-fn kdf3(ck: &[u8; 32], input: &[u8]) -> ([u8; 32], [u8; 32], [u8; 32]) {
-    let v = hkdf(ck, input, 3);
-    (v[0], v[1], v[2])
-}
-
-fn chacha20_seal(
-    key: &[u8; 32],
-    counter: u64,
-    aad: &[u8],
-    plaintext: &[u8],
-) -> std::io::Result<Vec<u8>> {
-    use chacha20poly1305::aead::{AeadCore, Payload};
-    let cipher = ChaCha20Poly1305::new_from_slice(key).map_err(|_| io_err("aead key"))?;
-    let mut nonce = [0u8; 12];
-    nonce[4..12].copy_from_slice(&counter.to_le_bytes());
-    cipher
-        .encrypt(
-            Nonce::from_slice(&nonce),
-            Payload {
-                msg: plaintext,
-                aad,
-            },
-        )
-        .map_err(|_| io_err("aead seal"))
-}
-
-fn chacha20_open(
-    key: &[u8; 32],
-    counter: u64,
-    aad: &[u8],
-    ciphertext: &[u8],
-) -> std::io::Result<Vec<u8>> {
-    use chacha20poly1305::aead::Payload;
-    let cipher = ChaCha20Poly1305::new_from_slice(key).map_err(|_| io_err("aead key"))?;
-    let mut nonce = [0u8; 12];
-    nonce[4..12].copy_from_slice(&counter.to_le_bytes());
-    cipher
-        .decrypt(
-            Nonce::from_slice(&nonce),
-            Payload {
-                msg: ciphertext,
-                aad,
-            },
-        )
-        .map_err(|_| io_err("aead open"))
-}
-
-/* ---------------- IO 辅助 ---------------- */
-
-fn udp_send_all(
-    _socket: &tokio::net::UdpSocket,
-    _buf: &[u8],
-    _dst: SocketAddr,
-) -> std::io::Result<()> {
-    Ok(())
-}
-
-fn udp_recv_until_match(
-    _socket: &tokio::net::UdpSocket,
-    _buf: &mut [u8],
-    _expected_type: u8,
-) -> std::io::Result<()> {
-    Ok(())
-}
-
-async fn resolve_first(host: &str, port: u16) -> std::io::Result<SocketAddr> {
-    resolve_host(host, port)
-        .await?
-        .into_iter()
-        .next()
-        .ok_or_else(|| io_err("no addr resolved"))
-}
-
-fn io_err<S: Into<String>>(s: S) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::Other, s.into())
+pub(super) fn io_err(message: impl Into<String>) -> std::io::Error {
+    std::io::Error::other(message.into())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use boringtun::{
+        noise::Tunn,
+        x25519::{PublicKey, StaticSecret},
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio_util::sync::CancellationToken;
 
     #[test]
-    fn x25519_pub_deterministic() {
-        let priv_key = [7u8; 32];
-        let p1 = x25519_pub(&priv_key);
-        let p2 = x25519_pub(&priv_key);
-        assert_eq!(p1, p2);
+    fn capability_claims_match_enabled_networks() {
+        let mut config = WireGuardConfig::new(
+            [1; 32],
+            WireGuardPeerConfig::new("127.0.0.1", 51_820, [2; 32]),
+        );
+        config.local_addresses = vec!["10.0.0.2/32".parse().unwrap()];
+        config.udp = false;
+        let outbound = WireGuardOutbound::from_config("wg", config);
+        let capabilities = outbound.capabilities();
+        assert!(capabilities.tcp);
+        assert!(!capabilities.udp);
+        assert!(!capabilities.ipv6);
     }
 
-    #[test]
-    fn x25519_dh_consistency() {
-        // 双方派生同一个共享密钥
-        let mut a_priv = [0u8; 32];
-        let mut b_priv = [0u8; 32];
-        rand::rngs::OsRng.fill_bytes(&mut a_priv);
-        rand::rngs::OsRng.fill_bytes(&mut b_priv);
-        let a_pub = x25519_pub(&a_priv);
-        let b_pub = x25519_pub(&b_priv);
-        let s_ab = x25519(&a_priv, &b_pub);
-        let s_ba = x25519(&b_priv, &a_pub);
-        assert_eq!(s_ab, s_ba);
+    #[tokio::test]
+    async fn missing_local_address_fails_before_network_io() {
+        let outbound = WireGuardOutbound::new("wg", "127.0.0.1", 51_820, [1; 32], [2; 32]);
+        let error = match outbound.ensure_device().await {
+            Ok(_) => panic!("invalid WireGuard config unexpectedly started"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("local address"));
     }
 
-    #[test]
-    fn blake2s_known_vector() {
-        // empty input
-        let r = blake2s(&[]);
-        // BLAKE2s-256("") = 0x69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9
-        assert_eq!(r[0], 0x69);
-        assert_eq!(r[31], 0xf9);
+    #[tokio::test]
+    async fn multi_peer_routes_over_independent_crypto_workers() {
+        let client_private = [89; 32];
+        let client_public = *PublicKey::from(&StaticSecret::from(client_private)).as_bytes();
+        let server_a_private = [91; 32];
+        let server_b_private = [93; 32];
+        let server_a_public = *PublicKey::from(&StaticSecret::from(server_a_private)).as_bytes();
+        let server_b_public = *PublicKey::from(&StaticSecret::from(server_b_private)).as_bytes();
+
+        let server_a = WireGuardServer::bind(WireGuardServerConfig::new(
+            "127.0.0.1:0".parse().unwrap(),
+            server_a_private,
+            WireGuardServerPeerConfig::new(client_public, vec!["10.9.0.2/32".parse().unwrap()]),
+        ))
+        .await
+        .unwrap();
+        let server_b = WireGuardServer::bind(WireGuardServerConfig::new(
+            "127.0.0.1:0".parse().unwrap(),
+            server_b_private,
+            WireGuardServerPeerConfig::new(client_public, vec!["10.9.0.2/32".parse().unwrap()]),
+        ))
+        .await
+        .unwrap();
+
+        let endpoint_a = server_a.local_addr().unwrap();
+        let endpoint_b = server_b.local_addr().unwrap();
+        let mut peer_a = WireGuardPeerConfig::new(
+            endpoint_a.ip().to_string(),
+            endpoint_a.port(),
+            server_a_public,
+        );
+        peer_a.allowed_ips = vec!["10.1.0.0/16".parse().unwrap()];
+        let mut peer_b = WireGuardPeerConfig::new(
+            endpoint_b.ip().to_string(),
+            endpoint_b.port(),
+            server_b_public,
+        );
+        peer_b.allowed_ips = vec!["10.2.0.0/16".parse().unwrap()];
+        let mut config = WireGuardConfig::new(client_private, peer_a);
+        config.peers.push(peer_b);
+        config.local_addresses = vec!["10.9.0.2/32".parse().unwrap()];
+        config.workers = 2;
+        let device = WireGuardDevice::start(config).await.unwrap();
+
+        let udp_a = device
+            .stack()
+            .open_udp(
+                "10.1.2.3:9001".parse().unwrap(),
+                "10.1.2.3".into(),
+                std::time::Duration::from_secs(30),
+            )
+            .unwrap();
+        let udp_b = device
+            .stack()
+            .open_udp(
+                "10.2.3.4:9002".parse().unwrap(),
+                "10.2.3.4".into(),
+                std::time::Duration::from_secs(30),
+            )
+            .unwrap();
+        udp_a.send_to(b"peer-a", "10.1.2.3", 9001).await.unwrap();
+        udp_b.send_to(b"peer-b", "10.2.3.4", 9002).await.unwrap();
+
+        let packet_a =
+            tokio::time::timeout(std::time::Duration::from_secs(5), server_a.recv_packet())
+                .await
+                .unwrap()
+                .unwrap();
+        let packet_b =
+            tokio::time::timeout(std::time::Duration::from_secs(5), server_b.recv_packet())
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            Tunn::dst_address(&packet_a.packet),
+            Some("10.1.2.3".parse().unwrap())
+        );
+        assert_eq!(
+            Tunn::dst_address(&packet_b.packet),
+            Some("10.2.3.4".parse().unwrap())
+        );
+
+        udp_a.close();
+        udp_b.close();
+        drop(device);
+        server_a.close().await;
+        server_b.close().await;
     }
 
-    #[test]
-    fn blake2s_mac_size() {
-        let key = [0x42u8; 32];
-        let mac = blake2s_mac(&key, b"data");
-        assert_eq!(mac.len(), 16);
-    }
+    #[tokio::test]
+    async fn tcp_udp_ipv4_ipv6_and_fragmentation_cross_real_tunnel() {
+        let client_private = [81; 32];
+        let server_private = [83; 32];
+        let client_public = *PublicKey::from(&StaticSecret::from(client_private)).as_bytes();
+        let server_public = *PublicKey::from(&StaticSecret::from(server_private)).as_bytes();
+        let server = Arc::new(
+            WireGuardServer::bind(WireGuardServerConfig::new(
+                "127.0.0.1:0".parse().unwrap(),
+                server_private,
+                WireGuardServerPeerConfig::new(
+                    client_public,
+                    vec![
+                        "10.99.0.2/32".parse().unwrap(),
+                        "fd99::2/128".parse().unwrap(),
+                    ],
+                ),
+            ))
+            .await
+            .unwrap(),
+        );
+        let endpoint = server.local_addr().unwrap();
+        let mut peer =
+            WireGuardPeerConfig::new(endpoint.ip().to_string(), endpoint.port(), server_public);
+        peer.allowed_ips = vec![
+            "10.99.0.0/24".parse().unwrap(),
+            "fd99::/64".parse().unwrap(),
+        ];
+        let mut client_config = WireGuardConfig::new(client_private, peer);
+        client_config.local_addresses = vec![
+            "10.99.0.2/32".parse().unwrap(),
+            "fd99::2/128".parse().unwrap(),
+        ];
+        client_config.mtu = 1_280;
+        client_config.remote_dns_resolve = true;
+        client_config.dns = vec!["10.99.0.1".parse().unwrap()];
+        let outbound = WireGuardOutbound::from_config("wg-e2e", client_config);
 
-    #[test]
-    fn kdf1_2_3_distinct() {
-        let ck = [0u8; 32];
-        let inp = [1u8; 32];
-        let (a, _) = kdf1(&ck, &inp);
-        let (b, _) = kdf2(&ck, &inp);
-        let (c, _, _) = kdf3(&ck, &inp);
-        // 第一项总相同
-        assert_eq!(a, b);
-        assert_eq!(b, c);
-    }
+        let mut service_config =
+            WireGuardConfig::new([85; 32], WireGuardPeerConfig::new("127.0.0.1", 1, [87; 32]));
+        service_config.local_addresses = vec![
+            "10.99.0.1/32".parse().unwrap(),
+            "fd99::1/128".parse().unwrap(),
+        ];
+        service_config.mtu = 1_280;
+        let service_stack = netstack::StackShared::new(&service_config).unwrap();
+        let services = service_stack.open_echo_services(32_080, 32_081).unwrap();
+        let cancellation = CancellationToken::new();
+        let bridge_server = server.clone();
+        let bridge_stack = service_stack.clone();
+        let bridge_cancellation = cancellation.clone();
+        let bridge = tokio::spawn(async move {
+            let mut timer = tokio::time::interval(std::time::Duration::from_millis(2));
+            loop {
+                tokio::select! {
+                    _ = bridge_cancellation.cancelled() => break,
+                    received = bridge_server.recv_packet() => {
+                        let received = received.unwrap();
+                        bridge_stack.inject(received.packet).unwrap();
+                    }
+                    _ = timer.tick() => {}
+                }
+                for packet in bridge_stack.poll_echo_and_drain(services) {
+                    bridge_server.send_packet(&packet).await.unwrap();
+                }
+            }
+        });
 
-    #[test]
-    fn transport_round_trip() {
-        let key = [0xaau8; 32];
-        let data = b"hello wireguard";
-        let ct = encrypt_transport(&key, 0xdeadbeef, 42, data).unwrap();
-        let (idx, ctr, pt) = decrypt_transport(&key, &ct).unwrap();
-        assert_eq!(idx, 0xdeadbeef);
-        assert_eq!(ctr, 42);
-        assert_eq!(pt, data);
-    }
+        let result = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let mut stream = outbound
+                .dial_tcp(DialContext::tcp("10.99.0.1", 32_080))
+                .await?;
+            let udp = outbound
+                .dial_udp(DialContext::udp("echo.wireguard.test", 32_081))
+                .await?;
+            let udp6 = outbound
+                .dial_udp(DialContext::udp("fd99::1", 32_081))
+                .await?;
+            // Active associations must own the driver lifetime independently
+            // of registry reloads dropping the originating adapter.
+            drop(outbound);
+            let tcp_payload = vec![0x5a; 48 * 1_024];
+            stream.write_all(&tcp_payload).await?;
+            // `shutdown` must flush all buffered data before emitting FIN; do
+            // not call `flush` here so the half-close path is exercised.
+            stream.shutdown().await?;
+            let mut echoed = vec![0; tcp_payload.len()];
+            stream.read_exact(&mut echoed).await?;
+            assert_eq!(echoed, tcp_payload);
+            let mut after_fin = [0_u8; 1];
+            assert_eq!(stream.read(&mut after_fin).await?, 0);
 
-    #[test]
-    fn wireguard_construct() {
-        let priv_k = [1u8; 32];
-        let peer_k = [2u8; 32];
-        let ob = WireGuardOutbound::new("wg", "1.2.3.4", 51820, priv_k, peer_k);
-        assert_eq!(ob.protocol(), "wireguard");
-        assert_eq!(ob.mtu, 1420);
+            let udp_payload = vec![0x6b; 4_096];
+            assert_eq!(
+                udp.send_to(&udp_payload, "echo.wireguard.test", 32_081)
+                    .await?,
+                udp_payload.len()
+            );
+            let mut echoed = vec![0; udp_payload.len()];
+            let received = udp.recv_from(&mut echoed).await?;
+            assert_eq!(&echoed[..received], udp_payload);
+            udp.close().await?;
+
+            let udp6_payload = vec![0x7c; 3_072];
+            udp6.send_to(&udp6_payload, "fd99::1", 32_081).await?;
+            let mut echoed6 = vec![0; udp6_payload.len()];
+            let received6 = udp6.recv_from(&mut echoed6).await?;
+            assert_eq!(&echoed6[..received6], udp6_payload);
+            udp6.close().await?;
+            Ok::<_, std::io::Error>(())
+        })
+        .await;
+        cancellation.cancel();
+        bridge.await.unwrap();
+        server.close().await;
+        result
+            .expect("WireGuard full data-plane test timed out")
+            .unwrap();
     }
 }

--- a/crates/core-outbound/src/proto/wireguard/config.rs
+++ b/crates/core-outbound/src/proto/wireguard/config.rs
@@ -1,0 +1,396 @@
+use std::{collections::HashSet, net::IpAddr, time::Duration};
+
+use boringtun::x25519::{PublicKey, StaticSecret};
+use ipnet::IpNet;
+
+use super::io_err;
+
+pub const DEFAULT_MTU: usize = 1_420;
+pub const DEFAULT_TCP_BUFFER_SIZE: usize = 256 * 1024;
+pub const DEFAULT_UDP_BUFFER_SIZE: usize = 256 * 1024;
+pub const DEFAULT_MAX_TCP_SESSIONS: usize = 4_096;
+pub const DEFAULT_MAX_UDP_SESSIONS: usize = 4_096;
+pub const DEFAULT_PACKET_QUEUE: usize = 1_024;
+pub const MAX_PEERS: usize = 4_096;
+pub const MAX_LOCAL_ADDRESSES: usize = 8;
+pub const MAX_MTU: usize = 65_475;
+
+fn default_workers() -> usize {
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .clamp(1, 64)
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct WireGuardPeerConfig {
+    pub endpoint_host: String,
+    pub endpoint_port: u16,
+    pub public_key: [u8; 32],
+    pub preshared_key: Option<[u8; 32]>,
+    pub allowed_ips: Vec<IpNet>,
+    pub reserved: [u8; 3],
+    pub persistent_keepalive: Option<u16>,
+}
+
+impl std::fmt::Debug for WireGuardPeerConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardPeerConfig")
+            .field("endpoint_host", &self.endpoint_host)
+            .field("endpoint_port", &self.endpoint_port)
+            .field("public_key", &self.public_key)
+            .field(
+                "preshared_key",
+                &self.preshared_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("allowed_ips", &self.allowed_ips)
+            .field("reserved", &self.reserved)
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .finish()
+    }
+}
+
+impl WireGuardPeerConfig {
+    pub fn new(endpoint_host: impl Into<String>, endpoint_port: u16, public_key: [u8; 32]) -> Self {
+        let endpoint_host = endpoint_host.into();
+        let endpoint_host = endpoint_host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(&endpoint_host)
+            .to_owned();
+        Self {
+            endpoint_host,
+            endpoint_port,
+            public_key,
+            preshared_key: None,
+            allowed_ips: vec![
+                "0.0.0.0/0".parse().expect("static IPv4 CIDR"),
+                "::/0".parse().expect("static IPv6 CIDR"),
+            ],
+            reserved: [0; 3],
+            persistent_keepalive: None,
+        }
+    }
+
+    pub fn permits(&self, ip: IpAddr) -> bool {
+        self.allowed_ips.iter().any(|network| network.contains(&ip))
+    }
+
+    pub fn best_prefix_for(&self, ip: IpAddr) -> Option<u8> {
+        self.allowed_ips
+            .iter()
+            .filter(|network| network.contains(&ip))
+            .map(IpNet::prefix_len)
+            .max()
+    }
+}
+
+#[derive(Clone)]
+pub struct WireGuardConfig {
+    pub private_key: [u8; 32],
+    pub local_addresses: Vec<IpNet>,
+    pub peers: Vec<WireGuardPeerConfig>,
+    pub mtu: usize,
+    pub dns: Vec<IpAddr>,
+    pub remote_dns_resolve: bool,
+    pub tcp: bool,
+    pub udp: bool,
+    pub tcp_buffer_size: usize,
+    pub udp_buffer_size: usize,
+    pub max_tcp_sessions: usize,
+    pub max_udp_sessions: usize,
+    pub packet_queue: usize,
+    pub workers: usize,
+    pub connect_timeout: Duration,
+    pub udp_idle_timeout: Duration,
+}
+
+impl std::fmt::Debug for WireGuardConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardConfig")
+            .field("private_key", &"<redacted>")
+            .field("local_addresses", &self.local_addresses)
+            .field("peers", &self.peers)
+            .field("mtu", &self.mtu)
+            .field("dns", &self.dns)
+            .field("remote_dns_resolve", &self.remote_dns_resolve)
+            .field("tcp", &self.tcp)
+            .field("udp", &self.udp)
+            .field("tcp_buffer_size", &self.tcp_buffer_size)
+            .field("udp_buffer_size", &self.udp_buffer_size)
+            .field("max_tcp_sessions", &self.max_tcp_sessions)
+            .field("max_udp_sessions", &self.max_udp_sessions)
+            .field("packet_queue", &self.packet_queue)
+            .field("workers", &self.workers)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("udp_idle_timeout", &self.udp_idle_timeout)
+            .finish()
+    }
+}
+
+impl WireGuardConfig {
+    pub fn new(private_key: [u8; 32], peer: WireGuardPeerConfig) -> Self {
+        Self {
+            private_key,
+            local_addresses: Vec::new(),
+            peers: vec![peer],
+            mtu: DEFAULT_MTU,
+            dns: Vec::new(),
+            remote_dns_resolve: false,
+            tcp: true,
+            udp: true,
+            tcp_buffer_size: DEFAULT_TCP_BUFFER_SIZE,
+            udp_buffer_size: DEFAULT_UDP_BUFFER_SIZE,
+            max_tcp_sessions: DEFAULT_MAX_TCP_SESSIONS,
+            max_udp_sessions: DEFAULT_MAX_UDP_SESSIONS,
+            packet_queue: DEFAULT_PACKET_QUEUE,
+            workers: default_workers(),
+            connect_timeout: Duration::from_secs(15),
+            udp_idle_timeout: Duration::from_secs(300),
+        }
+    }
+
+    pub fn validate(&self) -> std::io::Result<()> {
+        if self.local_addresses.is_empty() {
+            return Err(io_err("wireguard requires at least one local address"));
+        }
+        if self.local_addresses.len() > MAX_LOCAL_ADDRESSES {
+            return Err(io_err(format!(
+                "wireguard supports at most {MAX_LOCAL_ADDRESSES} local addresses"
+            )));
+        }
+        if self.private_key == [0; 32] {
+            return Err(io_err("wireguard private key cannot be all zero"));
+        }
+        if self.peers.is_empty() || self.peers.len() > MAX_PEERS {
+            return Err(io_err(format!(
+                "wireguard peers must contain 1..={MAX_PEERS} entries"
+            )));
+        }
+        if !(576..=MAX_MTU).contains(&self.mtu) {
+            return Err(io_err(format!(
+                "wireguard mtu must be between 576 and {MAX_MTU}"
+            )));
+        }
+        if self
+            .local_addresses
+            .iter()
+            .any(|network| network.addr().is_ipv6())
+            && self.mtu < 1_280
+        {
+            return Err(io_err("wireguard IPv6 requires mtu >= 1280"));
+        }
+        if !self.tcp && !self.udp {
+            return Err(io_err("wireguard must enable tcp, udp, or both"));
+        }
+        validate_buffer("tcp-buffer-size", self.tcp_buffer_size)?;
+        validate_buffer("udp-buffer-size", self.udp_buffer_size)?;
+        validate_limit("max-tcp-sessions", self.max_tcp_sessions)?;
+        validate_limit("max-udp-sessions", self.max_udp_sessions)?;
+        if !(16..=65_536).contains(&self.packet_queue) {
+            return Err(io_err(
+                "wireguard packet-queue must be between 16 and 65536",
+            ));
+        }
+        if !(1..=64).contains(&self.workers) {
+            return Err(io_err("wireguard workers must be between 1 and 64"));
+        }
+        if self.connect_timeout.is_zero() || self.connect_timeout > Duration::from_secs(300) {
+            return Err(io_err(
+                "wireguard connect-timeout must be within (0s, 300s]",
+            ));
+        }
+        if self.udp_idle_timeout < Duration::from_secs(5)
+            || self.udp_idle_timeout > Duration::from_secs(86_400)
+        {
+            return Err(io_err("wireguard udp-timeout must be between 5s and 24h"));
+        }
+
+        let mut local_families = (false, false);
+        let mut local_networks = HashSet::new();
+        for network in &self.local_addresses {
+            let ip = network.addr();
+            if ip.is_unspecified() || ip.is_multicast() {
+                return Err(io_err(format!(
+                    "wireguard local address must be unicast: {network}"
+                )));
+            }
+            if !local_networks.insert(*network) {
+                return Err(io_err(format!(
+                    "wireguard local address is duplicated: {network}"
+                )));
+            }
+            match ip {
+                IpAddr::V4(_) => local_families.0 = true,
+                IpAddr::V6(_) => local_families.1 = true,
+            }
+        }
+
+        let mut public_keys = HashSet::new();
+        let mut exact_routes = HashSet::new();
+        let local_public = *PublicKey::from(&StaticSecret::from(self.private_key)).as_bytes();
+        for (index, peer) in self.peers.iter().enumerate() {
+            if peer.endpoint_host.trim().is_empty() || peer.endpoint_port == 0 {
+                return Err(io_err(format!(
+                    "wireguard peer[{index}] requires a non-empty endpoint and non-zero port"
+                )));
+            }
+            if let Ok(endpoint) = peer.endpoint_host.parse::<IpAddr>()
+                && (endpoint.is_unspecified()
+                    || endpoint.is_multicast()
+                    || matches!(endpoint, IpAddr::V4(address) if address.is_broadcast()))
+            {
+                return Err(io_err(format!(
+                    "wireguard peer[{index}] endpoint must be unicast: {endpoint}"
+                )));
+            }
+            if peer.public_key == [0; 32] {
+                return Err(io_err(format!(
+                    "wireguard peer[{index}] has the forbidden all-zero public key"
+                )));
+            }
+            if peer.public_key == local_public {
+                return Err(io_err(format!(
+                    "wireguard peer[{index}] public key equals the local public key"
+                )));
+            }
+            if !public_keys.insert(peer.public_key) {
+                return Err(io_err(format!(
+                    "wireguard peer[{index}] duplicates another public key"
+                )));
+            }
+            if peer.allowed_ips.is_empty() {
+                return Err(io_err(format!(
+                    "wireguard peer[{index}] requires allowed-ips"
+                )));
+            }
+            for allowed in &peer.allowed_ips {
+                let family_available = match allowed.addr() {
+                    IpAddr::V4(_) => local_families.0,
+                    IpAddr::V6(_) => local_families.1,
+                };
+                if !family_available {
+                    return Err(io_err(format!(
+                        "wireguard peer[{index}] route {allowed} has no matching local address"
+                    )));
+                }
+                if !exact_routes.insert(allowed.trunc()) {
+                    return Err(io_err(format!(
+                        "wireguard allowed-ip {allowed} is assigned to more than one peer"
+                    )));
+                }
+            }
+        }
+        if self.remote_dns_resolve && self.dns.is_empty() {
+            return Err(io_err(
+                "wireguard remote-dns-resolve requires at least one dns server",
+            ));
+        }
+        for dns in &self.dns {
+            let family_available = match dns {
+                IpAddr::V4(_) => local_families.0,
+                IpAddr::V6(_) => local_families.1,
+            };
+            if dns.is_unspecified() || dns.is_multicast() || !family_available {
+                return Err(io_err(format!(
+                    "wireguard dns address is unusable on this interface: {dns}"
+                )));
+            }
+            if self.route_peer(*dns).is_none() {
+                return Err(io_err(format!(
+                    "wireguard dns address is not covered by any allowed-ip: {dns}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn route_peer(&self, ip: IpAddr) -> Option<usize> {
+        self.peers
+            .iter()
+            .enumerate()
+            .filter_map(|(index, peer)| peer.best_prefix_for(ip).map(|prefix| (prefix, index)))
+            .max_by_key(|(prefix, _)| *prefix)
+            .map(|(_, index)| index)
+    }
+}
+
+fn validate_buffer(name: &str, value: usize) -> std::io::Result<()> {
+    if !(4_096..=16 * 1024 * 1024).contains(&value) {
+        return Err(io_err(format!(
+            "wireguard {name} must be between 4096 and 16777216"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_limit(name: &str, value: usize) -> std::io::Result<()> {
+    if !(1..=65_535).contains(&value) {
+        return Err(io_err(format!(
+            "wireguard {name} must be between 1 and 65535"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid() -> WireGuardConfig {
+        let mut config = WireGuardConfig::new(
+            [7; 32],
+            WireGuardPeerConfig::new("127.0.0.1", 51_820, [9; 32]),
+        );
+        config.local_addresses = vec![
+            "10.0.0.2/32".parse().unwrap(),
+            "fd00::2/128".parse().unwrap(),
+        ];
+        config
+    }
+
+    #[test]
+    fn longest_prefix_selects_peer() {
+        let mut config = valid();
+        config.peers[0].allowed_ips = vec!["10.0.0.0/8".parse().unwrap()];
+        let mut second = WireGuardPeerConfig::new("127.0.0.1", 51_821, [8; 32]);
+        second.allowed_ips = vec!["10.1.0.0/16".parse().unwrap()];
+        config.peers.push(second);
+        assert_eq!(config.route_peer("10.1.2.3".parse().unwrap()), Some(1));
+        assert_eq!(config.route_peer("10.2.2.3".parse().unwrap()), Some(0));
+    }
+
+    #[test]
+    fn duplicate_exact_route_fails_closed() {
+        let mut config = valid();
+        config.peers[0].allowed_ips = vec!["0.0.0.0/0".parse().unwrap()];
+        let mut second = WireGuardPeerConfig::new("127.0.0.1", 51_821, [8; 32]);
+        second.allowed_ips = vec!["0.0.0.0/0".parse().unwrap()];
+        config.peers.push(second);
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("more than one peer")
+        );
+    }
+
+    #[test]
+    fn remote_dns_requires_routed_server() {
+        let mut config = valid();
+        config.peers[0].allowed_ips =
+            vec!["10.0.0.0/8".parse().unwrap(), "fd00::/8".parse().unwrap()];
+        config.remote_dns_resolve = true;
+        config.dns = vec!["1.1.1.1".parse().unwrap()];
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("not covered")
+        );
+    }
+}

--- a/crates/core-outbound/src/proto/wireguard/device.rs
+++ b/crates/core-outbound/src/proto/wireguard/device.rs
@@ -1,0 +1,605 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+
+use boringtun::{
+    noise::{Tunn, TunnResult, rate_limiter::RateLimiter},
+    x25519::{PublicKey, StaticSecret},
+};
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::adapter::{create_outbound_udp_socket, resolve_host};
+
+use super::{
+    config::{WireGuardConfig, WireGuardPeerConfig},
+    fragment::fragment_ip_packet,
+    io_err,
+    netstack::StackShared,
+};
+
+const NETWORK_BUFFER_SIZE: usize = 65_535 + 256;
+const MAX_DRAIN_RESULTS: usize = 512;
+
+#[derive(Debug, Clone)]
+pub struct WireGuardPeerStats {
+    pub endpoint: SocketAddr,
+    pub last_handshake: Option<Duration>,
+    pub tx_bytes: usize,
+    pub rx_bytes: usize,
+    pub estimated_loss: f32,
+    pub estimated_rtt_ms: Option<u32>,
+}
+
+pub(super) struct PeerCrypto {
+    tunnel: Mutex<Tunn>,
+    peer_config: WireGuardPeerConfig,
+}
+
+#[derive(Default)]
+pub(super) struct CryptoOutput {
+    pub network: Vec<Vec<u8>>,
+    pub plaintext: Vec<Vec<u8>>,
+}
+
+impl PeerCrypto {
+    pub(super) fn new(
+        private_key: [u8; 32],
+        peer_config: WireGuardPeerConfig,
+        index: u32,
+    ) -> std::io::Result<Self> {
+        Self::new_with_rate_limiter(private_key, peer_config, index, None)
+    }
+
+    pub(super) fn new_with_rate_limiter(
+        private_key: [u8; 32],
+        peer_config: WireGuardPeerConfig,
+        index: u32,
+        rate_limiter: Option<Arc<RateLimiter>>,
+    ) -> std::io::Result<Self> {
+        let private = StaticSecret::from(private_key);
+        let peer_public = PublicKey::from(peer_config.public_key);
+        let tunnel = Tunn::new(
+            private,
+            peer_public,
+            peer_config.preshared_key,
+            peer_config.persistent_keepalive,
+            index,
+            rate_limiter,
+        );
+        Ok(Self {
+            tunnel: Mutex::new(tunnel),
+            peer_config,
+        })
+    }
+
+    pub(super) fn encapsulate(&self, plaintext: &[u8]) -> std::io::Result<Vec<Vec<u8>>> {
+        let mut tunnel = self.tunnel.lock();
+        let mut destination = vec![0; plaintext.len().max(148) + 256];
+        match tunnel.encapsulate(plaintext, &mut destination) {
+            TunnResult::WriteToNetwork(packet) => Ok(vec![rewrite_outgoing_reserved(
+                packet,
+                self.peer_config.reserved,
+            )?]),
+            TunnResult::Done => Ok(Vec::new()),
+            TunnResult::Err(error) => {
+                Err(io_err(format!("wireguard encapsulation failed: {error:?}")))
+            }
+            TunnResult::WriteToTunnelV4(..) | TunnResult::WriteToTunnelV6(..) => Err(io_err(
+                "wireguard crypto returned plaintext while encapsulating",
+            )),
+        }
+    }
+
+    pub(super) fn decapsulate(
+        &self,
+        source_ip: Option<IpAddr>,
+        datagram: &[u8],
+    ) -> std::io::Result<CryptoOutput> {
+        let normalized = normalize_incoming_reserved(datagram)?;
+        let mut tunnel = self.tunnel.lock();
+        let mut output = CryptoOutput::default();
+        let mut first = true;
+        for _ in 0..MAX_DRAIN_RESULTS {
+            let mut destination = vec![0; NETWORK_BUFFER_SIZE];
+            let input = if first { normalized.as_slice() } else { &[] };
+            first = false;
+            match tunnel.decapsulate(source_ip, input, &mut destination) {
+                TunnResult::Done => return Ok(output),
+                TunnResult::Err(error) => {
+                    return Err(io_err(format!("wireguard decapsulation failed: {error:?}")));
+                }
+                TunnResult::WriteToNetwork(packet) => output.network.push(
+                    rewrite_outgoing_reserved(packet, self.peer_config.reserved)?,
+                ),
+                TunnResult::WriteToTunnelV4(packet, source) => {
+                    let source = IpAddr::V4(source);
+                    if !self.peer_config.permits(source) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!("wireguard peer sent source {source} outside its allowed-ips"),
+                        ));
+                    }
+                    output.plaintext.push(packet.to_vec());
+                }
+                TunnResult::WriteToTunnelV6(packet, source) => {
+                    let source = IpAddr::V6(source);
+                    if !self.peer_config.permits(source) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!("wireguard peer sent source {source} outside its allowed-ips"),
+                        ));
+                    }
+                    output.plaintext.push(packet.to_vec());
+                }
+            }
+        }
+        Err(io_err(
+            "wireguard crypto result drain exceeded its bounded iteration limit",
+        ))
+    }
+
+    pub(super) fn update_timers(&self) -> std::io::Result<Vec<Vec<u8>>> {
+        let mut tunnel = self.tunnel.lock();
+        let mut destination = vec![0; NETWORK_BUFFER_SIZE];
+        match tunnel.update_timers(&mut destination) {
+            TunnResult::Done => Ok(Vec::new()),
+            TunnResult::WriteToNetwork(packet) => Ok(vec![rewrite_outgoing_reserved(
+                packet,
+                self.peer_config.reserved,
+            )?]),
+            TunnResult::Err(error) => {
+                Err(io_err(format!("wireguard timer update failed: {error:?}")))
+            }
+            TunnResult::WriteToTunnelV4(..) | TunnResult::WriteToTunnelV6(..) => Err(io_err(
+                "wireguard crypto returned plaintext while updating timers",
+            )),
+        }
+    }
+
+    pub(super) fn raw_stats(&self) -> (Option<Duration>, usize, usize, f32, Option<u32>) {
+        self.tunnel.lock().stats()
+    }
+
+    fn stats(&self, endpoint: SocketAddr) -> WireGuardPeerStats {
+        let (last_handshake, tx_bytes, rx_bytes, estimated_loss, estimated_rtt_ms) =
+            self.raw_stats();
+        WireGuardPeerStats {
+            endpoint,
+            last_handshake,
+            tx_bytes,
+            rx_bytes,
+            estimated_loss,
+            estimated_rtt_ms,
+        }
+    }
+}
+
+struct PeerRuntime {
+    crypto: PeerCrypto,
+    socket: Arc<tokio::net::UdpSocket>,
+    endpoint: SocketAddr,
+    _loopback_guard: crate::loopback::LoopbackUdpGuard,
+}
+
+struct DeviceInner {
+    config: Arc<WireGuardConfig>,
+    stack: Arc<StackShared>,
+    peers: Vec<Arc<PeerRuntime>>,
+    cancellation: CancellationToken,
+}
+
+impl Drop for DeviceInner {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct WireGuardDevice {
+    inner: Arc<DeviceInner>,
+}
+
+impl WireGuardDevice {
+    pub(super) async fn start(config: WireGuardConfig) -> std::io::Result<Self> {
+        config.validate()?;
+        let stack = StackShared::new(&config)?;
+        let mut peers = Vec::with_capacity(config.peers.len());
+        for (index, peer_config) in config.peers.iter().cloned().enumerate() {
+            let (endpoint, socket, loopback_guard) = create_peer_socket(&peer_config).await?;
+            let socket = Arc::new(tokio::net::UdpSocket::from_std(socket)?);
+            let crypto = PeerCrypto::new(
+                config.private_key,
+                peer_config,
+                u32::try_from(index + 1).map_err(|_| io_err("wireguard peer index overflow"))?,
+            )?;
+            peers.push(Arc::new(PeerRuntime {
+                crypto,
+                socket,
+                endpoint,
+                _loopback_guard: loopback_guard,
+            }));
+        }
+        let cancellation = CancellationToken::new();
+        let inner = Arc::new(DeviceInner {
+            config: Arc::new(config),
+            stack,
+            peers,
+            cancellation,
+        });
+        spawn_driver(&inner);
+        Ok(Self { inner })
+    }
+
+    pub(super) fn stack(&self) -> &Arc<StackShared> {
+        &self.inner.stack
+    }
+
+    pub(super) fn config(&self) -> &WireGuardConfig {
+        &self.inner.config
+    }
+
+    pub(super) fn stats(&self) -> Vec<WireGuardPeerStats> {
+        self.inner
+            .peers
+            .iter()
+            .map(|peer| peer.crypto.stats(peer.endpoint))
+            .collect()
+    }
+}
+
+async fn create_peer_socket(
+    peer: &WireGuardPeerConfig,
+) -> std::io::Result<(
+    SocketAddr,
+    std::net::UdpSocket,
+    crate::loopback::LoopbackUdpGuard,
+)> {
+    let addresses = resolve_host(&peer.endpoint_host, peer.endpoint_port).await?;
+    let mut last_error = None;
+    for address in addresses {
+        match create_outbound_udp_socket(address) {
+            Ok((socket, guard)) => return Ok((address, socket, guard)),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        io_err(format!(
+            "wireguard endpoint did not resolve: {}:{}",
+            peer.endpoint_host, peer.endpoint_port
+        ))
+    }))
+}
+
+struct DeviceDriver {
+    config: Arc<WireGuardConfig>,
+    stack: Arc<StackShared>,
+    peers: Vec<Arc<PeerRuntime>>,
+    cancellation: CancellationToken,
+}
+
+fn spawn_driver(inner: &DeviceInner) {
+    let driver = DeviceDriver {
+        config: inner.config.clone(),
+        stack: inner.stack.clone(),
+        peers: inner.peers.clone(),
+        cancellation: inner.cancellation.clone(),
+    };
+    let worker_count = driver
+        .config
+        .workers
+        .min(driver.peers.len())
+        .min(driver.config.packet_queue)
+        .max(1);
+    let worker_capacity = (driver.config.packet_queue / worker_count).max(1);
+    let mut workers = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let (tx, rx) = mpsc::channel::<(usize, Vec<u8>)>(worker_capacity);
+        workers.push(tx);
+        tokio::spawn(run_crypto_worker(
+            driver.peers.clone(),
+            driver.stack.clone(),
+            driver.cancellation.clone(),
+            rx,
+        ));
+    }
+    for (peer_index, peer) in driver.peers.iter().cloned().enumerate() {
+        let tx = workers[peer_index % worker_count].clone();
+        let cancellation = driver.cancellation.clone();
+        tokio::spawn(async move {
+            let mut buffer = vec![0; NETWORK_BUFFER_SIZE];
+            loop {
+                tokio::select! {
+                    _ = cancellation.cancelled() => break,
+                    received = peer.socket.recv(&mut buffer) => match received {
+                        Ok(length) => {
+                            let datagram = (peer_index, buffer[..length].to_vec());
+                            let sent = tokio::select! {
+                                _ = cancellation.cancelled() => break,
+                                sent = tx.send(datagram) => sent,
+                            };
+                            if sent.is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                target: "wireguard::udp",
+                                endpoint = %peer.endpoint,
+                                error = %error,
+                                "wireguard UDP receive failed"
+                            );
+                            tokio::time::sleep(Duration::from_millis(20)).await;
+                        }
+                    }
+                }
+            }
+        });
+    }
+    drop(workers);
+    tokio::spawn(run_driver(driver));
+}
+
+async fn run_crypto_worker(
+    peers: Vec<Arc<PeerRuntime>>,
+    stack: Arc<StackShared>,
+    cancellation: CancellationToken,
+    mut network_rx: mpsc::Receiver<(usize, Vec<u8>)>,
+) {
+    loop {
+        let datagram = tokio::select! {
+            _ = cancellation.cancelled() => break,
+            datagram = network_rx.recv() => match datagram {
+                Some(datagram) => datagram,
+                None => break,
+            },
+        };
+        let (peer_index, datagram) = datagram;
+        let peer = &peers[peer_index];
+        match peer.crypto.decapsulate(Some(peer.endpoint.ip()), &datagram) {
+            Ok(output) => {
+                send_network(peer, output.network, &cancellation).await;
+                for packet in output.plaintext {
+                    if let Err(error) = stack.inject(packet) {
+                        tracing::warn!(
+                            target: "wireguard::stack",
+                            endpoint = %peer.endpoint,
+                            error = %error,
+                            "wireguard plaintext queue rejected an inbound packet"
+                        );
+                    }
+                }
+            }
+            Err(error) => tracing::debug!(
+                target: "wireguard::crypto",
+                endpoint = %peer.endpoint,
+                error = %error,
+                "wireguard rejected an inbound datagram"
+            ),
+        }
+    }
+}
+
+async fn run_driver(driver: DeviceDriver) {
+    let mut timers = tokio::time::interval(Duration::from_millis(100));
+    timers.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = driver.cancellation.cancelled() => break,
+            _ = driver.stack.notified() => {
+                pump_stack(&driver).await;
+            }
+            _ = timers.tick() => {
+                for peer in &driver.peers {
+                    match peer.crypto.update_timers() {
+                        Ok(packets) => send_network(peer, packets, &driver.cancellation).await,
+                        Err(error) => tracing::debug!(
+                            target: "wireguard::timer",
+                            endpoint = %peer.endpoint,
+                            error = %error,
+                            "wireguard peer timer reported an error"
+                        ),
+                    }
+                }
+                pump_stack(&driver).await;
+            }
+        }
+    }
+}
+
+async fn pump_stack(driver: &DeviceDriver) {
+    for _ in 0..64 {
+        let packets = driver.stack.poll_and_drain();
+        if packets.is_empty() {
+            return;
+        }
+        for packet in packets {
+            let Some(destination) = Tunn::dst_address(&packet) else {
+                tracing::warn!(target: "wireguard::route", "dropping malformed plaintext IP packet");
+                continue;
+            };
+            let Some(peer_index) = driver.config.route_peer(destination) else {
+                tracing::warn!(
+                    target: "wireguard::route",
+                    destination = %destination,
+                    "no WireGuard peer allows this destination"
+                );
+                continue;
+            };
+            let peer = &driver.peers[peer_index];
+            match fragment_ip_packet(&packet, driver.config.mtu) {
+                Ok(fragments) => {
+                    for fragment in fragments {
+                        match peer.crypto.encapsulate(&fragment) {
+                            Ok(packets) => send_network(peer, packets, &driver.cancellation).await,
+                            Err(error) => tracing::warn!(
+                                target: "wireguard::crypto",
+                                endpoint = %peer.endpoint,
+                                error = %error,
+                                "wireguard failed to encrypt an IP packet"
+                            ),
+                        }
+                    }
+                }
+                Err(error) => tracing::warn!(
+                    target: "wireguard::fragment",
+                    endpoint = %peer.endpoint,
+                    error = %error,
+                    "wireguard failed to apply the configured mtu"
+                ),
+            }
+        }
+    }
+    tracing::warn!(
+        target: "wireguard::stack",
+        "wireguard stack pump hit its bounded iteration limit"
+    );
+}
+
+async fn send_network(peer: &PeerRuntime, packets: Vec<Vec<u8>>, cancellation: &CancellationToken) {
+    for packet in packets {
+        let sent = tokio::select! {
+            _ = cancellation.cancelled() => return,
+            sent = peer.socket.send(&packet) => sent,
+        };
+        if let Err(error) = sent {
+            tracing::warn!(
+                target: "wireguard::udp",
+                endpoint = %peer.endpoint,
+                error = %error,
+                "wireguard UDP send failed"
+            );
+        }
+    }
+}
+
+fn rewrite_outgoing_reserved(packet: &[u8], reserved: [u8; 3]) -> std::io::Result<Vec<u8>> {
+    let mut packet = packet.to_vec();
+    if reserved == [0; 3] || packet.len() < 4 {
+        return Ok(packet);
+    }
+    packet[1..4].copy_from_slice(&reserved);
+    Ok(packet)
+}
+
+pub(super) fn normalize_incoming_reserved(packet: &[u8]) -> std::io::Result<Vec<u8>> {
+    if packet.len() < 4 {
+        return Ok(packet.to_vec());
+    }
+    let mut normalized = packet.to_vec();
+    normalized[1..4].fill(0);
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ipv4_packet(source: [u8; 4], destination: [u8; 4]) -> Vec<u8> {
+        let mut packet = vec![0; 20];
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&(20u16).to_be_bytes());
+        packet[8] = 64;
+        packet[9] = 253;
+        packet[12..16].copy_from_slice(&source);
+        packet[16..20].copy_from_slice(&destination);
+        packet
+    }
+
+    fn exchange(
+        source: &PeerCrypto,
+        destination: &PeerCrypto,
+        first: Vec<Vec<u8>>,
+    ) -> std::io::Result<Vec<Vec<u8>>> {
+        let mut pending = first;
+        let mut plaintext = Vec::new();
+        for _ in 0..32 {
+            if pending.is_empty() {
+                break;
+            }
+            let mut reverse = Vec::new();
+            for packet in pending {
+                let output = destination
+                    .decapsulate(Some(IpAddr::V4("127.0.0.1".parse().unwrap())), &packet)?;
+                reverse.extend(output.network);
+                plaintext.extend(output.plaintext);
+            }
+            if !reverse.is_empty() {
+                let mut forward = Vec::new();
+                for packet in reverse {
+                    let output = source
+                        .decapsulate(Some(IpAddr::V4("127.0.0.1".parse().unwrap())), &packet)?;
+                    forward.extend(output.network);
+                    plaintext.extend(output.plaintext);
+                }
+                pending = forward;
+            } else {
+                break;
+            }
+        }
+        Ok(plaintext)
+    }
+
+    #[test]
+    fn boringtun_state_machine_is_bidirectionally_interoperable() {
+        let private_a = [7; 32];
+        let private_b = [9; 32];
+        let public_a = *PublicKey::from(&StaticSecret::from(private_a)).as_bytes();
+        let public_b = *PublicKey::from(&StaticSecret::from(private_b)).as_bytes();
+        let mut peer_b = WireGuardPeerConfig::new("127.0.0.1", 1, public_b);
+        peer_b.allowed_ips = vec!["10.0.0.0/24".parse().unwrap()];
+        peer_b.preshared_key = Some([15; 32]);
+        let mut peer_a = WireGuardPeerConfig::new("127.0.0.1", 1, public_a);
+        peer_a.allowed_ips = vec!["10.0.0.0/24".parse().unwrap()];
+        peer_a.preshared_key = Some([15; 32]);
+        let a = PeerCrypto::new(private_a, peer_b, 1).unwrap();
+        let b = PeerCrypto::new(private_b, peer_a, 2).unwrap();
+        let packet = ipv4_packet([10, 0, 0, 2], [10, 0, 0, 1]);
+        let plaintext = exchange(&a, &b, a.encapsulate(&packet).unwrap()).unwrap();
+        assert!(plaintext.iter().any(|received| received == &packet));
+
+        let replay_protected = ipv4_packet([10, 0, 0, 2], [10, 0, 0, 3]);
+        let encrypted = a.encapsulate(&replay_protected).unwrap();
+        assert_eq!(encrypted.len(), 1);
+        let accepted = b
+            .decapsulate(Some("127.0.0.1".parse().unwrap()), &encrypted[0])
+            .unwrap();
+        assert_eq!(accepted.plaintext, vec![replay_protected]);
+        assert!(
+            b.decapsulate(Some("127.0.0.1".parse().unwrap()), &encrypted[0])
+                .is_err(),
+            "WireGuard replay window accepted a duplicate transport counter"
+        );
+
+        let reverse = ipv4_packet([10, 0, 0, 1], [10, 0, 0, 2]);
+        let plaintext = exchange(&b, &a, b.encapsulate(&reverse).unwrap()).unwrap();
+        assert!(plaintext.iter().any(|received| received == &reverse));
+    }
+
+    #[test]
+    fn reserved_bytes_follow_wireguard_go_bind_layer_semantics() {
+        let private_a = [11; 32];
+        let private_b = [13; 32];
+        let public_a = *PublicKey::from(&StaticSecret::from(private_a)).as_bytes();
+        let public_b = *PublicKey::from(&StaticSecret::from(private_b)).as_bytes();
+        let mut peer_b = WireGuardPeerConfig::new("127.0.0.1", 1, public_b);
+        peer_b.allowed_ips = vec!["10.0.0.0/24".parse().unwrap()];
+        peer_b.reserved = [1, 2, 3];
+        let mut peer_a = WireGuardPeerConfig::new("127.0.0.1", 1, public_a);
+        peer_a.allowed_ips = vec!["10.0.0.0/24".parse().unwrap()];
+        peer_a.reserved = [1, 2, 3];
+        let a = PeerCrypto::new(private_a, peer_b, 1).unwrap();
+        let b = PeerCrypto::new(private_b, peer_a, 2).unwrap();
+        let packet = ipv4_packet([10, 0, 0, 2], [10, 0, 0, 1]);
+        let first = a.encapsulate(&packet).unwrap();
+        assert_eq!(&first[0][1..4], &[1, 2, 3]);
+        let normalized = normalize_incoming_reserved(&first[0]).unwrap();
+        assert_eq!(&normalized[1..4], &[0, 0, 0]);
+        assert_eq!(&normalized[4..], &first[0][4..]);
+        let plaintext = exchange(&a, &b, first).unwrap();
+        assert!(plaintext.iter().any(|received| received == &packet));
+    }
+}

--- a/crates/core-outbound/src/proto/wireguard/dns.rs
+++ b/crates/core-outbound/src/proto/wireguard/dns.rs
@@ -1,0 +1,305 @@
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use hickory_proto::{
+    op::{Message, MessageType, OpCode, Query, ResponseCode},
+    rr::{Name, RData, RecordType},
+    serialize::binary::{BinDecodable, BinEncodable},
+};
+use parking_lot::Mutex;
+use rand::Rng;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::{device::WireGuardDevice, io_err};
+
+const DNS_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_CACHE_ENTRIES: usize = 1_024;
+const MAX_CACHE_TTL: Duration = Duration::from_secs(3_600);
+const MIN_CACHE_TTL: Duration = Duration::from_secs(1);
+const MAX_DNS_TCP_MESSAGE: usize = u16::MAX as usize;
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    addresses: Vec<IpAddr>,
+    expires: Instant,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DnsCache {
+    entries: Mutex<HashMap<String, CacheEntry>>,
+}
+
+impl DnsCache {
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub(super) async fn resolve(
+        &self,
+        device: &WireGuardDevice,
+        host: &str,
+        port: u16,
+    ) -> std::io::Result<Vec<SocketAddr>> {
+        let key = host.trim_end_matches('.').to_ascii_lowercase();
+        if let Some(addresses) = self.cached(&key) {
+            return Ok(addresses
+                .into_iter()
+                .map(|address| SocketAddr::new(address, port))
+                .collect());
+        }
+        let name = Name::from_ascii(&key)
+            .map_err(|error| io_err(format!("wireguard DNS name is invalid: {error}")))?;
+        let config = device.config();
+        let wants_v4 = config
+            .local_addresses
+            .iter()
+            .any(|address| address.addr().is_ipv4());
+        let wants_v6 = config
+            .local_addresses
+            .iter()
+            .any(|address| address.addr().is_ipv6());
+        let mut addresses = Vec::new();
+        let mut ttl = MAX_CACHE_TTL;
+        let mut last_error = None;
+        for record_type in [RecordType::A, RecordType::AAAA] {
+            if (record_type == RecordType::A && !wants_v4)
+                || (record_type == RecordType::AAAA && !wants_v6)
+            {
+                continue;
+            }
+            let mut resolved_type = false;
+            for dns in &config.dns {
+                match query(device, *dns, name.clone(), record_type).await {
+                    Ok((records, record_ttl)) => {
+                        addresses.extend(records);
+                        ttl = ttl.min(record_ttl);
+                        resolved_type = true;
+                        break;
+                    }
+                    Err(error) => last_error = Some(error),
+                }
+            }
+            if !resolved_type {
+                tracing::debug!(
+                    target: "wireguard::dns",
+                    host = %key,
+                    ?record_type,
+                    "no configured in-tunnel DNS server answered this record type"
+                );
+            }
+        }
+        addresses.sort_unstable();
+        addresses.dedup();
+        addresses.retain(|address| config.route_peer(*address).is_some());
+        if addresses.is_empty() {
+            return Err(last_error.unwrap_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("wireguard in-tunnel DNS returned no routed address for {key}"),
+                )
+            }));
+        }
+        self.insert(key, addresses.clone(), ttl);
+        Ok(addresses
+            .into_iter()
+            .map(|address| SocketAddr::new(address, port))
+            .collect())
+    }
+
+    fn cached(&self, key: &str) -> Option<Vec<IpAddr>> {
+        let mut entries = self.entries.lock();
+        let entry = entries.get(key)?;
+        if entry.expires <= Instant::now() {
+            entries.remove(key);
+            return None;
+        }
+        Some(entry.addresses.clone())
+    }
+
+    fn insert(&self, key: String, addresses: Vec<IpAddr>, ttl: Duration) {
+        let mut entries = self.entries.lock();
+        entries.retain(|_, entry| entry.expires > Instant::now());
+        if entries.len() >= MAX_CACHE_ENTRIES
+            && let Some(oldest) = entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.expires)
+                .map(|(key, _)| key.clone())
+        {
+            entries.remove(&oldest);
+        }
+        entries.insert(
+            key,
+            CacheEntry {
+                addresses,
+                expires: Instant::now() + ttl.clamp(MIN_CACHE_TTL, MAX_CACHE_TTL),
+            },
+        );
+    }
+}
+
+async fn query(
+    device: &WireGuardDevice,
+    dns: IpAddr,
+    name: Name,
+    record_type: RecordType,
+) -> std::io::Result<(Vec<IpAddr>, Duration)> {
+    let id = rand::thread_rng().r#gen::<u16>();
+    let mut request = Message::new();
+    request
+        .set_id(id)
+        .set_message_type(MessageType::Query)
+        .set_op_code(OpCode::Query)
+        .set_recursion_desired(true)
+        .add_query(Query::query(name, record_type));
+    let request = request
+        .to_bytes()
+        .map_err(|error| io_err(format!("wireguard DNS encode failed: {error}")))?;
+    let target = SocketAddr::new(dns, 53);
+    let socket = device
+        .stack()
+        .open_udp(target, dns.to_string(), DNS_TIMEOUT.saturating_mul(2))?;
+    device.stack().notify();
+    socket.send_to(&request, &dns.to_string(), 53).await?;
+    let mut response = vec![0; 65_535];
+    let length = match tokio::time::timeout(DNS_TIMEOUT, socket.recv_from(&mut response)).await {
+        Ok(result) => result?,
+        Err(_) => {
+            socket.close();
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("wireguard DNS UDP query to {dns} timed out"),
+            ));
+        }
+    };
+    socket.close();
+    response.truncate(length);
+    let message = Message::from_bytes(&response)
+        .map_err(|error| io_err(format!("wireguard DNS response is malformed: {error}")))?;
+    if message.id() != id || message.message_type() != MessageType::Response {
+        return Err(io_err("wireguard DNS response id/type mismatch"));
+    }
+    if message.truncated() {
+        return query_tcp(device, dns, id, request, record_type).await;
+    }
+    parse_response(message, record_type)
+}
+
+async fn query_tcp(
+    device: &WireGuardDevice,
+    dns: IpAddr,
+    id: u16,
+    request: Vec<u8>,
+    record_type: RecordType,
+) -> std::io::Result<(Vec<IpAddr>, Duration)> {
+    let mut stream = device.stack().open_tcp(SocketAddr::new(dns, 53))?;
+    device.stack().notify();
+    stream.wait_connected(DNS_TIMEOUT).await?;
+    let length = u16::try_from(request.len())
+        .map_err(|_| io_err("wireguard DNS request exceeds TCP framing limit"))?;
+    tokio::time::timeout(DNS_TIMEOUT, async {
+        stream.write_all(&length.to_be_bytes()).await?;
+        stream.write_all(&request).await?;
+        stream.flush().await?;
+        let response_length = stream.read_u16().await? as usize;
+        if response_length == 0 || response_length > MAX_DNS_TCP_MESSAGE {
+            return Err(io_err("wireguard DNS TCP response length is invalid"));
+        }
+        let mut response = vec![0; response_length];
+        stream.read_exact(&mut response).await?;
+        let message = Message::from_bytes(&response)
+            .map_err(|error| io_err(format!("wireguard DNS TCP response is malformed: {error}")))?;
+        if message.id() != id || message.message_type() != MessageType::Response {
+            return Err(io_err("wireguard DNS TCP response id/type mismatch"));
+        }
+        parse_response(message, record_type)
+    })
+    .await
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            format!("wireguard DNS TCP query to {dns} timed out"),
+        )
+    })?
+}
+
+fn parse_response(
+    message: Message,
+    record_type: RecordType,
+) -> std::io::Result<(Vec<IpAddr>, Duration)> {
+    if message.response_code() != ResponseCode::NoError {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("wireguard DNS returned {}", message.response_code()),
+        ));
+    }
+    let mut addresses = Vec::new();
+    let mut ttl = MAX_CACHE_TTL;
+    for answer in message.answers() {
+        match answer.data() {
+            Some(RData::A(address)) if record_type == RecordType::A => {
+                addresses.push(IpAddr::V4((*address).into()));
+                ttl = ttl.min(Duration::from_secs(u64::from(answer.ttl())));
+            }
+            Some(RData::AAAA(address)) if record_type == RecordType::AAAA => {
+                addresses.push(IpAddr::V6((*address).into()));
+                ttl = ttl.min(Duration::from_secs(u64::from(answer.ttl())));
+            }
+            _ => {}
+        }
+    }
+    if addresses.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("wireguard DNS response contained no {record_type} records"),
+        ));
+    }
+    Ok((addresses, ttl))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hickory_proto::rr::{
+        RData, Record,
+        rdata::{A, AAAA},
+    };
+
+    #[test]
+    fn response_parser_accepts_a_and_aaaa() {
+        let name = Name::from_ascii("example.test").unwrap();
+        let mut v4 = Message::new();
+        v4.add_answer(Record::from_rdata(
+            name.clone(),
+            30,
+            RData::A(A::new(192, 0, 2, 1)),
+        ));
+        let (addresses, ttl) = parse_response(v4, RecordType::A).unwrap();
+        assert_eq!(addresses, vec!["192.0.2.1".parse::<IpAddr>().unwrap()]);
+        assert_eq!(ttl, Duration::from_secs(30));
+
+        let mut v6 = Message::new();
+        v6.add_answer(Record::from_rdata(
+            name,
+            60,
+            RData::AAAA(AAAA::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+        ));
+        let (addresses, ttl) = parse_response(v6, RecordType::AAAA).unwrap();
+        assert_eq!(addresses, vec!["2001:db8::1".parse::<IpAddr>().unwrap()]);
+        assert_eq!(ttl, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn cache_is_bounded_and_expires() {
+        let cache = DnsCache::default();
+        cache.insert(
+            "example.test".into(),
+            vec!["192.0.2.1".parse().unwrap()],
+            Duration::from_secs(10),
+        );
+        assert_eq!(cache.cached("example.test").unwrap().len(), 1);
+    }
+}

--- a/crates/core-outbound/src/proto/wireguard/fragment.rs
+++ b/crates/core-outbound/src/proto/wireguard/fragment.rs
@@ -1,0 +1,312 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use super::io_err;
+
+const IPV4_MIN_HEADER: usize = 20;
+const IPV6_HEADER: usize = 40;
+const IPV6_FRAGMENT_HEADER: usize = 8;
+const IPV6_FRAGMENT: u8 = 44;
+const IPV6_HOP_BY_HOP: u8 = 0;
+const IPV6_ROUTING: u8 = 43;
+const IPV6_DESTINATION_OPTIONS: u8 = 60;
+
+static IPV6_FRAGMENT_ID: AtomicU32 = AtomicU32::new(1);
+
+pub(super) fn fragment_ip_packet(packet: &[u8], mtu: usize) -> std::io::Result<Vec<Vec<u8>>> {
+    if packet.len() <= mtu {
+        return Ok(vec![packet.to_vec()]);
+    }
+    match packet.first().map(|byte| byte >> 4) {
+        Some(4) => fragment_ipv4(packet, mtu),
+        Some(6) => fragment_ipv6(packet, mtu),
+        _ => Err(io_err(
+            "wireguard plaintext is not a valid IPv4/IPv6 packet",
+        )),
+    }
+}
+
+fn fragment_ipv4(packet: &[u8], mtu: usize) -> std::io::Result<Vec<Vec<u8>>> {
+    if packet.len() < IPV4_MIN_HEADER {
+        return Err(io_err(
+            "wireguard IPv4 packet is shorter than its base header",
+        ));
+    }
+    let header_len = usize::from(packet[0] & 0x0f) * 4;
+    let total_len = usize::from(u16::from_be_bytes([packet[2], packet[3]]));
+    if header_len < IPV4_MIN_HEADER || header_len > packet.len() || total_len != packet.len() {
+        return Err(io_err(
+            "wireguard IPv4 packet has an invalid header/total length",
+        ));
+    }
+    let flags_offset = u16::from_be_bytes([packet[6], packet[7]]);
+    if flags_offset & 0x3fff != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "wireguard cannot re-fragment an existing IPv4 fragment",
+        ));
+    }
+    if flags_offset & 0x4000 != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "wireguard IPv4 packet exceeds mtu while Don't Fragment is set",
+        ));
+    }
+    let copied_options = copied_ipv4_options(&packet[IPV4_MIN_HEADER..header_len])?;
+    let payload = &packet[header_len..];
+    let mut offset = 0usize;
+    let mut fragments = Vec::new();
+    while offset < payload.len() {
+        let options = if offset == 0 {
+            &packet[IPV4_MIN_HEADER..header_len]
+        } else {
+            copied_options.as_slice()
+        };
+        let fragment_header_len = IPV4_MIN_HEADER + options.len();
+        let capacity = mtu
+            .checked_sub(fragment_header_len)
+            .ok_or_else(|| io_err("wireguard mtu is too small for the IPv4 header and options"))?;
+        let remaining = payload.len() - offset;
+        let take = if remaining > capacity {
+            capacity & !7
+        } else {
+            remaining
+        };
+        if take == 0 {
+            return Err(io_err(
+                "wireguard mtu leaves no aligned IPv4 fragment payload",
+            ));
+        }
+        let more = offset + take < payload.len();
+        let mut fragment = vec![0; fragment_header_len + take];
+        fragment[..IPV4_MIN_HEADER].copy_from_slice(&packet[..IPV4_MIN_HEADER]);
+        fragment[IPV4_MIN_HEADER..fragment_header_len].copy_from_slice(options);
+        fragment[0] = 0x40
+            | u8::try_from(fragment_header_len / 4)
+                .map_err(|_| io_err("wireguard IPv4 header is too long"))?;
+        let fragment_len = u16::try_from(fragment.len())
+            .map_err(|_| io_err("wireguard IPv4 fragment length overflow"))?;
+        fragment[2..4].copy_from_slice(&fragment_len.to_be_bytes());
+        let fragment_offset = u16::try_from(offset / 8)
+            .map_err(|_| io_err("wireguard IPv4 fragment offset overflow"))?;
+        let fragment_flags =
+            (flags_offset & 0x8000) | if more { 0x2000 } else { 0 } | fragment_offset;
+        fragment[6..8].copy_from_slice(&fragment_flags.to_be_bytes());
+        fragment[10..12].fill(0);
+        fragment[fragment_header_len..].copy_from_slice(&payload[offset..offset + take]);
+        let checksum = ipv4_checksum(&fragment[..fragment_header_len]);
+        fragment[10..12].copy_from_slice(&checksum.to_be_bytes());
+        fragments.push(fragment);
+        offset += take;
+    }
+    Ok(fragments)
+}
+
+fn copied_ipv4_options(options: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut copied = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < options.len() {
+        let kind = options[cursor];
+        match kind {
+            0 => break,
+            1 => cursor += 1,
+            _ => {
+                let length = options
+                    .get(cursor + 1)
+                    .copied()
+                    .map(usize::from)
+                    .ok_or_else(|| io_err("wireguard IPv4 option is missing its length"))?;
+                if length < 2 || cursor + length > options.len() {
+                    return Err(io_err("wireguard IPv4 option has an invalid length"));
+                }
+                if kind & 0x80 != 0 {
+                    copied.extend_from_slice(&options[cursor..cursor + length]);
+                }
+                cursor += length;
+            }
+        }
+    }
+    while copied.len() % 4 != 0 {
+        copied.push(0);
+    }
+    Ok(copied)
+}
+
+fn ipv4_checksum(header: &[u8]) -> u16 {
+    let mut sum = 0u32;
+    for word in header.chunks(2) {
+        let value = if word.len() == 2 {
+            u16::from_be_bytes([word[0], word[1]])
+        } else {
+            u16::from(word[0]) << 8
+        };
+        sum += u32::from(value);
+        while sum > 0xffff {
+            sum = (sum & 0xffff) + (sum >> 16);
+        }
+    }
+    !(sum as u16)
+}
+
+fn fragment_ipv6(packet: &[u8], mtu: usize) -> std::io::Result<Vec<Vec<u8>>> {
+    if packet.len() < IPV6_HEADER {
+        return Err(io_err(
+            "wireguard IPv6 packet is shorter than its base header",
+        ));
+    }
+    let payload_len = usize::from(u16::from_be_bytes([packet[4], packet[5]]));
+    if payload_len == 0 || payload_len + IPV6_HEADER != packet.len() {
+        return Err(io_err(
+            "wireguard IPv6 packet has an invalid payload length or unsupported jumbogram",
+        ));
+    }
+    let (unfragmentable_end, next_header_field, fragment_next) =
+        ipv6_fragment_insertion_point(packet)?;
+    let fragmentable = &packet[unfragmentable_end..];
+    let capacity = mtu
+        .checked_sub(unfragmentable_end + IPV6_FRAGMENT_HEADER)
+        .ok_or_else(|| io_err("wireguard mtu is too small for IPv6 fragmentation headers"))?;
+    let aligned_capacity = capacity & !7;
+    if aligned_capacity == 0 {
+        return Err(io_err(
+            "wireguard mtu leaves no aligned IPv6 fragment payload",
+        ));
+    }
+    let identification = IPV6_FRAGMENT_ID.fetch_add(1, Ordering::Relaxed);
+    let mut offset = 0usize;
+    let mut fragments = Vec::new();
+    while offset < fragmentable.len() {
+        let remaining = fragmentable.len() - offset;
+        let take = if remaining > capacity {
+            aligned_capacity
+        } else {
+            remaining
+        };
+        let more = offset + take < fragmentable.len();
+        let mut fragment = Vec::with_capacity(unfragmentable_end + IPV6_FRAGMENT_HEADER + take);
+        fragment.extend_from_slice(&packet[..unfragmentable_end]);
+        fragment[next_header_field] = IPV6_FRAGMENT;
+        fragment.push(fragment_next);
+        fragment.push(0);
+        let mut offset_flags = u16::try_from(offset)
+            .map_err(|_| io_err("wireguard IPv6 fragment offset overflow"))?
+            & 0xfff8;
+        if more {
+            offset_flags |= 1;
+        }
+        fragment.extend_from_slice(&offset_flags.to_be_bytes());
+        fragment.extend_from_slice(&identification.to_be_bytes());
+        fragment.extend_from_slice(&fragmentable[offset..offset + take]);
+        let new_payload_len = fragment.len() - IPV6_HEADER;
+        fragment[4..6].copy_from_slice(
+            &u16::try_from(new_payload_len)
+                .map_err(|_| io_err("wireguard IPv6 fragment length overflow"))?
+                .to_be_bytes(),
+        );
+        fragments.push(fragment);
+        offset += take;
+    }
+    Ok(fragments)
+}
+
+fn ipv6_fragment_insertion_point(packet: &[u8]) -> std::io::Result<(usize, usize, u8)> {
+    #[derive(Clone, Copy)]
+    struct Extension {
+        kind: u8,
+        start: usize,
+        end: usize,
+        next: u8,
+    }
+
+    let mut extensions = Vec::new();
+    let mut kind = packet[6];
+    let mut cursor = IPV6_HEADER;
+    while matches!(
+        kind,
+        IPV6_HOP_BY_HOP | IPV6_ROUTING | IPV6_DESTINATION_OPTIONS
+    ) {
+        if cursor + 2 > packet.len() {
+            return Err(io_err("wireguard IPv6 extension header is truncated"));
+        }
+        let length = (usize::from(packet[cursor + 1]) + 1) * 8;
+        if cursor + length > packet.len() {
+            return Err(io_err("wireguard IPv6 extension header length is invalid"));
+        }
+        let next = packet[cursor];
+        extensions.push(Extension {
+            kind,
+            start: cursor,
+            end: cursor + length,
+            next,
+        });
+        cursor += length;
+        kind = next;
+    }
+    if kind == IPV6_FRAGMENT {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "wireguard cannot re-fragment an existing IPv6 fragment",
+        ));
+    }
+    let mut insertion = IPV6_HEADER;
+    let mut next_header_field = 6usize;
+    let mut fragment_next = packet[6];
+    for (index, extension) in extensions.iter().enumerate() {
+        let destination_precedes_routing = extension.kind == IPV6_DESTINATION_OPTIONS
+            && extensions[index + 1..]
+                .iter()
+                .any(|later| later.kind == IPV6_ROUTING);
+        if !matches!(extension.kind, IPV6_HOP_BY_HOP | IPV6_ROUTING)
+            && !destination_precedes_routing
+        {
+            break;
+        }
+        insertion = extension.end;
+        next_header_field = extension.start;
+        fragment_next = extension.next;
+    }
+    Ok((insertion, next_header_field, fragment_next))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv4_fragments_are_aligned_and_bounded_for_non_aligned_mtu() {
+        let mut packet = vec![0; 4_124];
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&(4_124u16).to_be_bytes());
+        packet[8] = 64;
+        packet[9] = 17;
+        let fragments = fragment_ip_packet(&packet, 1_280).unwrap();
+        assert!(fragments.len() > 1);
+        for (index, fragment) in fragments.iter().enumerate() {
+            assert!(fragment.len() <= 1_280);
+            if index + 1 != fragments.len() {
+                assert_eq!((fragment.len() - 20) % 8, 0);
+                assert_ne!(u16::from_be_bytes([fragment[6], fragment[7]]) & 0x2000, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn ipv6_fragments_include_rfc8200_header_and_bounded_payloads() {
+        let mut packet = vec![0; 4_144];
+        packet[0] = 0x60;
+        packet[4..6].copy_from_slice(&(4_104u16).to_be_bytes());
+        packet[6] = 17;
+        packet[7] = 64;
+        let fragments = fragment_ip_packet(&packet, 1_280).unwrap();
+        assert!(fragments.len() > 1);
+        for (index, fragment) in fragments.iter().enumerate() {
+            assert!(fragment.len() <= 1_280);
+            assert_eq!(fragment[6], IPV6_FRAGMENT);
+            assert_eq!(fragment[40], 17);
+            let flags = u16::from_be_bytes([fragment[42], fragment[43]]);
+            if index + 1 != fragments.len() {
+                assert_eq!((fragment.len() - 48) % 8, 0);
+                assert_eq!(flags & 1, 1);
+            }
+        }
+    }
+}

--- a/crates/core-outbound/src/proto/wireguard/netstack.rs
+++ b/crates/core-outbound/src/proto/wireguard/netstack.rs
@@ -1,0 +1,1289 @@
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    task::{Context, Poll},
+    time::{Duration, Instant as StdInstant, SystemTime, UNIX_EPOCH},
+};
+
+use futures::future::poll_fn;
+use parking_lot::Mutex;
+use smoltcp::{
+    iface::{Config as InterfaceConfig, Interface, SocketHandle, SocketSet},
+    phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken},
+    socket::{tcp, udp},
+    storage::PacketMetadata,
+    time::Instant,
+    wire::{HardwareAddress, IpAddress, IpCidr, IpEndpoint, IpListenEndpoint},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::Notify,
+};
+
+use super::{config::WireGuardConfig, io_err};
+
+const FIRST_EPHEMERAL_PORT: u16 = 1_024;
+const LAST_EPHEMERAL_PORT: u16 = u16::MAX;
+const MAX_IP_PACKET: usize = 65_535;
+const IPV6_REASSEMBLY_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Debug)]
+struct VirtualDevice {
+    rx: VecDeque<Vec<u8>>,
+    tx: VecDeque<Vec<u8>>,
+    mtu: usize,
+    queue_limit: usize,
+}
+
+impl VirtualDevice {
+    fn new(mtu: usize, queue_limit: usize) -> Self {
+        // smoltcp 0.11 advances IPv4 fragment offsets in octets but rounds the
+        // encoded offset down to 8-byte units. Reporting an IP MTU whose
+        // (mtu - 20) is aligned prevents overlapping fragments for arbitrary
+        // configured WireGuard MTUs; the public MTU remains unchanged.
+        let mtu = mtu - ((mtu - 4) % 8);
+        Self {
+            rx: VecDeque::with_capacity(queue_limit.min(1_024)),
+            tx: VecDeque::with_capacity(queue_limit.min(1_024)),
+            mtu,
+            queue_limit,
+        }
+    }
+
+    fn inject(&mut self, packet: Vec<u8>) -> std::io::Result<()> {
+        if packet.len() > MAX_IP_PACKET {
+            return Err(io_err("wireguard plaintext IP packet exceeds 65535 bytes"));
+        }
+        if self.rx.len() >= self.queue_limit {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "wireguard plaintext receive queue is full",
+            ));
+        }
+        self.rx.push_back(packet);
+        Ok(())
+    }
+
+    fn drain_tx(&mut self) -> Vec<Vec<u8>> {
+        self.tx.drain(..).collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Ipv6FragmentKey {
+    source: [u8; 16],
+    destination: [u8; 16],
+    identification: u32,
+    next_header: u8,
+}
+
+struct Ipv6Assembly {
+    prefix: Vec<u8>,
+    next_header_field: usize,
+    next_header: u8,
+    data: Vec<u8>,
+    received: Vec<bool>,
+    total: Option<usize>,
+    received_bytes: usize,
+    updated: StdInstant,
+}
+
+struct Ipv6Reassembler {
+    entries: HashMap<Ipv6FragmentKey, Ipv6Assembly>,
+    max_entries: usize,
+}
+
+impl Ipv6Reassembler {
+    fn new(packet_queue: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            max_entries: (packet_queue / 16).clamp(4, 64),
+        }
+    }
+
+    fn process(&mut self, packet: Vec<u8>) -> std::io::Result<Option<Vec<u8>>> {
+        let Some(fragment) = parse_ipv6_fragment(&packet)? else {
+            return Ok(Some(packet));
+        };
+        if fragment.offset == 0 && !fragment.more {
+            return reassemble_atomic_ipv6(&packet, fragment).map(Some);
+        }
+        if fragment.more && (fragment.data.len() % 8 != 0 || fragment.data.is_empty()) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "wireguard IPv6 non-final fragment payload is not 8-byte aligned",
+            ));
+        }
+        let end = fragment
+            .offset
+            .checked_add(fragment.data.len())
+            .filter(|end| fragment.prefix_len + *end <= MAX_IP_PACKET)
+            .ok_or_else(|| io_err("wireguard IPv6 fragment exceeds packet size limit"))?;
+        self.entries
+            .retain(|_, entry| entry.updated.elapsed() < IPV6_REASSEMBLY_TIMEOUT);
+        if !self.entries.contains_key(&fragment.key) {
+            if self.entries.len() >= self.max_entries
+                && let Some(oldest) = self
+                    .entries
+                    .iter()
+                    .min_by_key(|(_, entry)| entry.updated)
+                    .map(|(key, _)| key.clone())
+            {
+                self.entries.remove(&oldest);
+            }
+            let mut prefix = packet[..fragment.prefix_len].to_vec();
+            prefix[4..6].fill(0);
+            self.entries.insert(
+                fragment.key.clone(),
+                Ipv6Assembly {
+                    prefix,
+                    next_header_field: fragment.next_header_field,
+                    next_header: fragment.key.next_header,
+                    data: Vec::new(),
+                    received: Vec::new(),
+                    total: None,
+                    received_bytes: 0,
+                    updated: StdInstant::now(),
+                },
+            );
+        }
+        let mut invalid = None;
+        let complete = {
+            let entry = self
+                .entries
+                .get_mut(&fragment.key)
+                .expect("IPv6 assembly inserted above");
+            let mut prefix = packet[..fragment.prefix_len].to_vec();
+            prefix[4..6].fill(0);
+            if entry.prefix != prefix
+                || entry.next_header_field != fragment.next_header_field
+                || entry.next_header != fragment.key.next_header
+            {
+                invalid = Some("wireguard IPv6 fragments disagree on unfragmentable headers");
+                false
+            } else if fragment.offset < entry.received.len().min(end)
+                && entry.received[fragment.offset..entry.received.len().min(end)]
+                    .iter()
+                    .any(|received| *received)
+            {
+                invalid = Some("wireguard IPv6 fragment overlap rejected");
+                false
+            } else if entry.total.is_some_and(|total| end > total) {
+                invalid = Some("wireguard IPv6 fragment extends beyond final fragment");
+                false
+            } else {
+                entry.data.resize(entry.data.len().max(end), 0);
+                entry.received.resize(entry.received.len().max(end), false);
+                entry.data[fragment.offset..end].copy_from_slice(fragment.data);
+                entry.received[fragment.offset..end].fill(true);
+                entry.received_bytes += fragment.data.len();
+                entry.updated = StdInstant::now();
+                if !fragment.more {
+                    if entry.total.is_some_and(|total| total != end)
+                        || entry.received[end..].iter().any(|received| *received)
+                    {
+                        invalid = Some("wireguard IPv6 fragments contain conflicting final sizes");
+                    } else {
+                        entry.total = Some(end);
+                    }
+                }
+                entry
+                    .total
+                    .is_some_and(|total| entry.received_bytes == total)
+            }
+        };
+        if let Some(message) = invalid {
+            self.entries.remove(&fragment.key);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                message,
+            ));
+        }
+        if !complete {
+            return Ok(None);
+        }
+        let entry = self
+            .entries
+            .remove(&fragment.key)
+            .expect("complete IPv6 assembly exists");
+        let total = entry.total.expect("complete assembly has final size");
+        let mut packet = entry.prefix;
+        packet[entry.next_header_field] = entry.next_header;
+        packet.extend_from_slice(&entry.data[..total]);
+        let payload_len = packet.len() - 40;
+        packet[4..6].copy_from_slice(
+            &u16::try_from(payload_len)
+                .map_err(|_| io_err("wireguard reassembled IPv6 payload length overflow"))?
+                .to_be_bytes(),
+        );
+        Ok(Some(packet))
+    }
+}
+
+struct ParsedIpv6Fragment<'a> {
+    key: Ipv6FragmentKey,
+    prefix_len: usize,
+    next_header_field: usize,
+    offset: usize,
+    more: bool,
+    data: &'a [u8],
+}
+
+fn parse_ipv6_fragment(packet: &[u8]) -> std::io::Result<Option<ParsedIpv6Fragment<'_>>> {
+    if packet.first().map(|byte| byte >> 4) != Some(6) {
+        return Ok(None);
+    }
+    if packet.len() < 40 {
+        return Err(io_err(
+            "wireguard IPv6 packet is shorter than its base header",
+        ));
+    }
+    let payload_len = usize::from(u16::from_be_bytes([packet[4], packet[5]]));
+    if payload_len == 0 || payload_len + 40 != packet.len() {
+        return Err(io_err(
+            "wireguard IPv6 packet has an invalid payload length",
+        ));
+    }
+    let mut next_header = packet[6];
+    let mut next_header_field = 6usize;
+    let mut cursor = 40usize;
+    loop {
+        if next_header == 44 {
+            if cursor + 8 > packet.len() {
+                return Err(io_err("wireguard IPv6 fragment header is truncated"));
+            }
+            if packet[cursor + 1] != 0 {
+                return Err(io_err("wireguard IPv6 fragment reserved byte is non-zero"));
+            }
+            let offset_flags = u16::from_be_bytes([packet[cursor + 2], packet[cursor + 3]]);
+            if offset_flags & 0x0006 != 0 {
+                return Err(io_err("wireguard IPv6 fragment reserved bits are non-zero"));
+            }
+            return Ok(Some(ParsedIpv6Fragment {
+                key: Ipv6FragmentKey {
+                    source: packet[8..24]
+                        .try_into()
+                        .expect("IPv6 source length checked"),
+                    destination: packet[24..40]
+                        .try_into()
+                        .expect("IPv6 destination length checked"),
+                    identification: u32::from_be_bytes(
+                        packet[cursor + 4..cursor + 8]
+                            .try_into()
+                            .expect("fragment id length checked"),
+                    ),
+                    next_header: packet[cursor],
+                },
+                prefix_len: cursor,
+                next_header_field,
+                offset: usize::from(offset_flags & 0xfff8),
+                more: offset_flags & 1 != 0,
+                data: &packet[cursor + 8..],
+            }));
+        }
+        if !matches!(next_header, 0 | 43 | 60) {
+            return Ok(None);
+        }
+        if cursor + 2 > packet.len() {
+            return Err(io_err("wireguard IPv6 extension header is truncated"));
+        }
+        let length = (usize::from(packet[cursor + 1]) + 1) * 8;
+        if cursor + length > packet.len() {
+            return Err(io_err("wireguard IPv6 extension header length is invalid"));
+        }
+        next_header_field = cursor;
+        next_header = packet[cursor];
+        cursor += length;
+    }
+}
+
+fn reassemble_atomic_ipv6(
+    packet: &[u8],
+    fragment: ParsedIpv6Fragment<'_>,
+) -> std::io::Result<Vec<u8>> {
+    let mut reassembled = packet[..fragment.prefix_len].to_vec();
+    reassembled[fragment.next_header_field] = fragment.key.next_header;
+    reassembled.extend_from_slice(fragment.data);
+    let payload_len = reassembled.len() - 40;
+    reassembled[4..6].copy_from_slice(
+        &u16::try_from(payload_len)
+            .map_err(|_| io_err("wireguard atomic IPv6 payload length overflow"))?
+            .to_be_bytes(),
+    );
+    Ok(reassembled)
+}
+
+struct VirtualRxToken {
+    packet: Vec<u8>,
+}
+
+struct VirtualTxToken<'a> {
+    tx: &'a mut VecDeque<Vec<u8>>,
+}
+
+impl RxToken for VirtualRxToken {
+    fn consume<R, F>(mut self, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        f(&mut self.packet)
+    }
+}
+
+impl TxToken for VirtualTxToken<'_> {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut packet = vec![0; len];
+        let result = f(&mut packet);
+        self.tx.push_back(packet);
+        result
+    }
+}
+
+impl Device for VirtualDevice {
+    type RxToken<'a> = VirtualRxToken;
+    type TxToken<'a> = VirtualTxToken<'a>;
+
+    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        if self.tx.len() >= self.queue_limit {
+            return None;
+        }
+        let packet = self.rx.pop_front()?;
+        Some((
+            VirtualRxToken { packet },
+            VirtualTxToken { tx: &mut self.tx },
+        ))
+    }
+
+    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        (self.tx.len() < self.queue_limit).then_some(VirtualTxToken { tx: &mut self.tx })
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut capabilities = DeviceCapabilities::default();
+        capabilities.medium = Medium::Ip;
+        capabilities.max_transmission_unit = self.mtu;
+        capabilities
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketKind {
+    Tcp,
+    Udp,
+}
+
+struct StackState {
+    interface: Interface,
+    device: VirtualDevice,
+    sockets: SocketSet<'static>,
+    handles: HashSet<SocketHandle>,
+    ports: HashSet<u16>,
+    next_port: u16,
+    tcp_count: usize,
+    udp_count: usize,
+    max_tcp_sessions: usize,
+    max_udp_sessions: usize,
+    tcp_buffer_size: usize,
+    udp_buffer_size: usize,
+    local_v4: Option<IpAddr>,
+    local_v6: Option<IpAddr>,
+    ipv6_reassembly: Ipv6Reassembler,
+}
+
+impl StackState {
+    fn new(config: &WireGuardConfig) -> std::io::Result<Self> {
+        let mut device = VirtualDevice::new(config.mtu, config.packet_queue);
+        let interface_config = InterfaceConfig::new(HardwareAddress::Ip);
+        let mut interface = Interface::new(interface_config, &mut device, smol_now());
+        let mut local_v4 = None;
+        let mut local_v6 = None;
+        interface.update_ip_addrs(|addresses| {
+            for address in &config.local_addresses {
+                let ip = address.addr();
+                let cidr = IpCidr::new(to_smol_ip(ip), address.prefix_len());
+                addresses
+                    .push(cidr)
+                    .expect("wireguard local address count validated against smoltcp capacity");
+                match ip {
+                    IpAddr::V4(_) if local_v4.is_none() => local_v4 = Some(ip),
+                    IpAddr::V6(_) if local_v6.is_none() => local_v6 = Some(ip),
+                    _ => {}
+                }
+            }
+        });
+        if let Some(IpAddr::V4(ip)) = local_v4 {
+            interface
+                .routes_mut()
+                .add_default_ipv4_route(ip.into())
+                .map_err(|_| io_err("wireguard smoltcp IPv4 route table is full"))?;
+        }
+        if let Some(IpAddr::V6(ip)) = local_v6 {
+            interface
+                .routes_mut()
+                .add_default_ipv6_route(ip.into())
+                .map_err(|_| io_err("wireguard smoltcp IPv6 route table is full"))?;
+        }
+
+        Ok(Self {
+            interface,
+            device,
+            sockets: SocketSet::new(Vec::new()),
+            handles: HashSet::new(),
+            ports: HashSet::new(),
+            next_port: FIRST_EPHEMERAL_PORT,
+            tcp_count: 0,
+            udp_count: 0,
+            max_tcp_sessions: config.max_tcp_sessions,
+            max_udp_sessions: config.max_udp_sessions,
+            tcp_buffer_size: config.tcp_buffer_size,
+            udp_buffer_size: config.udp_buffer_size,
+            local_v4,
+            local_v6,
+            ipv6_reassembly: Ipv6Reassembler::new(config.packet_queue),
+        })
+    }
+
+    fn allocate_port(&mut self) -> std::io::Result<u16> {
+        let attempts = usize::from(LAST_EPHEMERAL_PORT - FIRST_EPHEMERAL_PORT) + 1;
+        for _ in 0..attempts {
+            let port = self.next_port;
+            self.next_port = if port == LAST_EPHEMERAL_PORT {
+                FIRST_EPHEMERAL_PORT
+            } else {
+                port + 1
+            };
+            if self.ports.insert(port) {
+                return Ok(port);
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            "wireguard virtual ephemeral port range is exhausted",
+        ))
+    }
+
+    fn source_for(&self, target: IpAddr) -> std::io::Result<IpAddr> {
+        match target {
+            IpAddr::V4(_) => self.local_v4,
+            IpAddr::V6(_) => self.local_v6,
+        }
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                format!("wireguard has no local address for target family {target}"),
+            )
+        })
+    }
+
+    fn open_tcp(
+        &mut self,
+        target: SocketAddr,
+        notify: Arc<Notify>,
+        shared: Arc<StackShared>,
+    ) -> std::io::Result<WireGuardTcpStream> {
+        if self.tcp_count >= self.max_tcp_sessions {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "wireguard maximum TCP session count reached",
+            ));
+        }
+        let source = self.source_for(target.ip())?;
+        let port = self.allocate_port()?;
+        let rx = tcp::SocketBuffer::new(vec![0; self.tcp_buffer_size]);
+        let tx = tcp::SocketBuffer::new(vec![0; self.tcp_buffer_size]);
+        let mut socket = tcp::Socket::new(rx, tx);
+        socket.set_nagle_enabled(false);
+        if let Err(error) = socket.connect(
+            self.interface.context(),
+            IpEndpoint::new(to_smol_ip(target.ip()), target.port()),
+            IpEndpoint::new(to_smol_ip(source), port),
+        ) {
+            self.ports.remove(&port);
+            return Err(io_err(format!(
+                "wireguard TCP connect setup failed: {error:?}"
+            )));
+        }
+        let handle = self.sockets.add(socket);
+        self.handles.insert(handle);
+        self.tcp_count += 1;
+        Ok(WireGuardTcpStream {
+            lease: Arc::new(SocketLease::new(
+                shared,
+                handle,
+                port,
+                SocketKind::Tcp,
+                Duration::MAX,
+            )),
+            notify,
+            shutdown_epoch: None,
+        })
+    }
+
+    fn open_udp(
+        &mut self,
+        target: SocketAddr,
+        original_host: String,
+        idle_timeout: Duration,
+        notify: Arc<Notify>,
+        shared: Arc<StackShared>,
+    ) -> std::io::Result<WireGuardUdpSocket> {
+        if self.udp_count >= self.max_udp_sessions {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "wireguard maximum UDP session count reached",
+            ));
+        }
+        let source = self.source_for(target.ip())?;
+        let port = self.allocate_port()?;
+        let metadata_capacity = (self.udp_buffer_size / 512).clamp(16, 4_096);
+        let rx = udp::PacketBuffer::new(
+            vec![PacketMetadata::EMPTY; metadata_capacity],
+            vec![0; self.udp_buffer_size],
+        );
+        let tx = udp::PacketBuffer::new(
+            vec![PacketMetadata::EMPTY; metadata_capacity],
+            vec![0; self.udp_buffer_size],
+        );
+        let mut socket = udp::Socket::new(rx, tx);
+        if let Err(error) = socket.bind(IpListenEndpoint {
+            addr: Some(to_smol_ip(source)),
+            port,
+        }) {
+            self.ports.remove(&port);
+            return Err(io_err(format!("wireguard UDP bind failed: {error:?}")));
+        }
+        let handle = self.sockets.add(socket);
+        self.handles.insert(handle);
+        self.udp_count += 1;
+        let lease = Arc::new(SocketLease::new(
+            shared,
+            handle,
+            port,
+            SocketKind::Udp,
+            idle_timeout,
+        ));
+        spawn_idle_reaper(Arc::downgrade(&lease), notify.clone());
+        Ok(WireGuardUdpSocket {
+            lease,
+            notify,
+            target,
+            original_host,
+        })
+    }
+
+    fn remove(&mut self, handle: SocketHandle, port: u16, kind: SocketKind) {
+        if !self.handles.remove(&handle) {
+            return;
+        }
+        let _ = self.sockets.remove(handle);
+        self.ports.remove(&port);
+        match kind {
+            SocketKind::Tcp => self.tcp_count = self.tcp_count.saturating_sub(1),
+            SocketKind::Udp => self.udp_count = self.udp_count.saturating_sub(1),
+        }
+    }
+
+    fn poll(&mut self) {
+        let _ = self
+            .interface
+            .poll(smol_now(), &mut self.device, &mut self.sockets);
+    }
+}
+
+pub(super) struct StackShared {
+    state: Mutex<StackState>,
+    notify: Arc<Notify>,
+    epoch: AtomicU64,
+}
+
+impl StackShared {
+    pub(super) fn new(config: &WireGuardConfig) -> std::io::Result<Arc<Self>> {
+        let notify = Arc::new(Notify::new());
+        let state = StackState::new(config)?;
+        Ok(Arc::new(Self {
+            state: Mutex::new(state),
+            notify,
+            epoch: AtomicU64::new(0),
+        }))
+    }
+
+    pub(super) fn notify(&self) {
+        self.notify.notify_one();
+    }
+
+    pub(super) async fn notified(&self) {
+        self.notify.notified().await;
+    }
+
+    pub(super) fn inject(&self, packet: Vec<u8>) -> std::io::Result<()> {
+        let mut state = self.state.lock();
+        let result = match state.ipv6_reassembly.process(packet)? {
+            Some(packet) => state.device.inject(packet),
+            None => Ok(()),
+        };
+        drop(state);
+        self.notify();
+        result
+    }
+
+    pub(super) fn poll_and_drain(&self) -> Vec<Vec<u8>> {
+        let mut state = self.state.lock();
+        state.poll();
+        let packets = state.device.drain_tx();
+        self.epoch.fetch_add(1, Ordering::Release);
+        packets
+    }
+
+    pub(super) fn open_tcp(
+        self: &Arc<Self>,
+        target: SocketAddr,
+    ) -> std::io::Result<WireGuardTcpStream> {
+        self.state
+            .lock()
+            .open_tcp(target, self.notify.clone(), self.clone())
+    }
+
+    pub(super) fn open_udp(
+        self: &Arc<Self>,
+        target: SocketAddr,
+        original_host: String,
+        idle_timeout: Duration,
+    ) -> std::io::Result<WireGuardUdpSocket> {
+        self.state.lock().open_udp(
+            target,
+            original_host,
+            idle_timeout,
+            self.notify.clone(),
+            self.clone(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn open_echo_services(
+        &self,
+        tcp_port: u16,
+        udp_port: u16,
+    ) -> std::io::Result<EchoServices> {
+        let mut state = self.state.lock();
+        let tcp_rx = tcp::SocketBuffer::new(vec![0; state.tcp_buffer_size]);
+        let tcp_tx = tcp::SocketBuffer::new(vec![0; state.tcp_buffer_size]);
+        let mut tcp_socket = tcp::Socket::new(tcp_rx, tcp_tx);
+        tcp_socket
+            .listen(tcp_port)
+            .map_err(|error| io_err(format!("wireguard test TCP listen failed: {error:?}")))?;
+        let tcp = state.sockets.add(tcp_socket);
+
+        let metadata_capacity = (state.udp_buffer_size / 512).clamp(16, 4_096);
+        let udp_rx = udp::PacketBuffer::new(
+            vec![PacketMetadata::EMPTY; metadata_capacity],
+            vec![0; state.udp_buffer_size],
+        );
+        let udp_tx = udp::PacketBuffer::new(
+            vec![PacketMetadata::EMPTY; metadata_capacity],
+            vec![0; state.udp_buffer_size],
+        );
+        let mut udp_socket = udp::Socket::new(udp_rx, udp_tx);
+        udp_socket
+            .bind(udp_port)
+            .map_err(|error| io_err(format!("wireguard test UDP listen failed: {error:?}")))?;
+        let udp = state.sockets.add(udp_socket);
+
+        let dns_rx = udp::PacketBuffer::new(vec![PacketMetadata::EMPTY; 32], vec![0; 64 * 1024]);
+        let dns_tx = udp::PacketBuffer::new(vec![PacketMetadata::EMPTY; 32], vec![0; 64 * 1024]);
+        let mut dns_socket = udp::Socket::new(dns_rx, dns_tx);
+        dns_socket
+            .bind(53)
+            .map_err(|error| io_err(format!("wireguard test DNS listen failed: {error:?}")))?;
+        let dns = state.sockets.add(dns_socket);
+        Ok(EchoServices { tcp, udp, dns })
+    }
+
+    #[cfg(test)]
+    pub(super) fn poll_echo_and_drain(&self, services: EchoServices) -> Vec<Vec<u8>> {
+        let mut state = self.state.lock();
+        state.poll();
+        {
+            let socket = state.sockets.get_mut::<tcp::Socket>(services.tcp);
+            if socket.can_recv() && socket.can_send() {
+                let available = socket.recv_queue().min(64 * 1024);
+                let mut buffer = vec![0; available];
+                if let Ok(received) = socket.recv_slice(&mut buffer) {
+                    buffer.truncate(received);
+                    if !buffer.is_empty() {
+                        let _ = socket.send_slice(&buffer);
+                    }
+                }
+            }
+            if socket.state() == tcp::State::CloseWait && socket.send_queue() == 0 {
+                socket.close();
+            }
+        }
+        {
+            let socket = state.sockets.get_mut::<udp::Socket>(services.udp);
+            while socket.can_recv() && socket.can_send() {
+                let mut buffer = vec![0; 65_535];
+                let Ok((received, metadata)) = socket.recv_slice(&mut buffer) else {
+                    break;
+                };
+                buffer.truncate(received);
+                if socket.send_slice(&buffer, metadata.endpoint).is_err() {
+                    break;
+                }
+            }
+        }
+        {
+            let socket = state.sockets.get_mut::<udp::Socket>(services.dns);
+            while socket.can_recv() && socket.can_send() {
+                let mut buffer = vec![0; 65_535];
+                let Ok((received, metadata)) = socket.recv_slice(&mut buffer) else {
+                    break;
+                };
+                buffer.truncate(received);
+                let Ok(response) = test_dns_response(&buffer) else {
+                    continue;
+                };
+                if socket.send_slice(&response, metadata.endpoint).is_err() {
+                    break;
+                }
+            }
+        }
+        state.poll();
+        let packets = state.device.drain_tx();
+        self.epoch.fetch_add(1, Ordering::Release);
+        packets
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+pub(super) struct EchoServices {
+    tcp: SocketHandle,
+    udp: SocketHandle,
+    dns: SocketHandle,
+}
+
+#[cfg(test)]
+fn test_dns_response(request: &[u8]) -> std::io::Result<Vec<u8>> {
+    use hickory_proto::{
+        op::{Message, MessageType, ResponseCode},
+        rr::{
+            RData, Record, RecordType,
+            rdata::{A, AAAA},
+        },
+        serialize::binary::{BinDecodable, BinEncodable},
+    };
+    let request = Message::from_bytes(request)
+        .map_err(|error| io_err(format!("test DNS request decode failed: {error}")))?;
+    let mut response = Message::new();
+    response
+        .set_id(request.id())
+        .set_message_type(MessageType::Response)
+        .set_op_code(request.op_code())
+        .set_recursion_desired(request.recursion_desired())
+        .set_recursion_available(true)
+        .set_response_code(ResponseCode::NoError);
+    for query in request.queries() {
+        response.add_query(query.clone());
+        let data = match query.query_type() {
+            RecordType::A => Some(RData::A(A::new(10, 99, 0, 1))),
+            RecordType::AAAA => Some(RData::AAAA(AAAA::new(0xfd99, 0, 0, 0, 0, 0, 0, 1))),
+            _ => None,
+        };
+        if let Some(data) = data {
+            response.add_answer(Record::from_rdata(query.name().clone(), 30, data));
+        }
+    }
+    response
+        .to_bytes()
+        .map_err(|error| io_err(format!("test DNS response encode failed: {error}")))
+}
+
+struct SocketLease {
+    shared: Arc<StackShared>,
+    handle: SocketHandle,
+    port: u16,
+    kind: SocketKind,
+    removed: AtomicBool,
+    last_activity: Mutex<StdInstant>,
+    idle_timeout: Duration,
+}
+
+impl SocketLease {
+    fn new(
+        shared: Arc<StackShared>,
+        handle: SocketHandle,
+        port: u16,
+        kind: SocketKind,
+        idle_timeout: Duration,
+    ) -> Self {
+        Self {
+            shared,
+            handle,
+            port,
+            kind,
+            removed: AtomicBool::new(false),
+            last_activity: Mutex::new(StdInstant::now()),
+            idle_timeout,
+        }
+    }
+
+    fn touch(&self) {
+        *self.last_activity.lock() = StdInstant::now();
+    }
+
+    fn remove(&self) {
+        if self.removed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        self.shared
+            .state
+            .lock()
+            .remove(self.handle, self.port, self.kind);
+        self.shared.notify();
+    }
+
+    fn ensure_active(&self) -> std::io::Result<()> {
+        if self.removed.load(Ordering::Acquire) {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "wireguard virtual socket is closed",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for SocketLease {
+    fn drop(&mut self) {
+        self.remove();
+    }
+}
+
+fn spawn_idle_reaper(weak_lease: std::sync::Weak<SocketLease>, notify: Arc<Notify>) {
+    let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    runtime.spawn(async move {
+        loop {
+            let Some(lease) = weak_lease.upgrade() else {
+                break;
+            };
+            let interval = (lease.idle_timeout / 2).max(Duration::from_secs(1));
+            drop(lease);
+            tokio::time::sleep(interval).await;
+            let Some(lease) = weak_lease.upgrade() else {
+                break;
+            };
+            if lease.last_activity.lock().elapsed() >= lease.idle_timeout {
+                lease.remove();
+                notify.notify_one();
+                break;
+            }
+        }
+    });
+}
+
+pub struct WireGuardTcpStream {
+    lease: Arc<SocketLease>,
+    notify: Arc<Notify>,
+    shutdown_epoch: Option<u64>,
+}
+
+impl WireGuardTcpStream {
+    pub(super) async fn wait_connected(&mut self, timeout: Duration) -> std::io::Result<()> {
+        let lease = self.lease.clone();
+        let result = tokio::time::timeout(
+            timeout,
+            poll_fn(move |cx| {
+                lease.ensure_active()?;
+                let mut state = lease.shared.state.lock();
+                let socket = state.sockets.get_mut::<tcp::Socket>(lease.handle);
+                match socket.state() {
+                    tcp::State::Established => Poll::Ready(Ok(())),
+                    tcp::State::Closed | tcp::State::Closing | tcp::State::TimeWait => {
+                        Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::ConnectionRefused,
+                            "wireguard virtual TCP connection was refused",
+                        )))
+                    }
+                    _ => {
+                        socket.register_recv_waker(cx.waker());
+                        socket.register_send_waker(cx.waker());
+                        Poll::Pending
+                    }
+                }
+            }),
+        )
+        .await;
+        match result {
+            Ok(result) => result,
+            Err(_) => {
+                self.lease.remove();
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "wireguard virtual TCP connect timed out",
+                ))
+            }
+        }
+    }
+}
+
+impl AsyncRead for WireGuardTcpStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if buffer.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        self.lease.ensure_active()?;
+        let mut state = self.lease.shared.state.lock();
+        let socket = state.sockets.get_mut::<tcp::Socket>(self.lease.handle);
+        if socket.can_recv() {
+            let destination = buffer.initialize_unfilled();
+            let received = socket
+                .recv_slice(destination)
+                .map_err(|error| io_err(format!("wireguard TCP receive failed: {error:?}")))?;
+            buffer.advance(received);
+            self.lease.touch();
+            self.notify.notify_one();
+            return Poll::Ready(Ok(()));
+        }
+        if !socket.may_recv() {
+            return Poll::Ready(Ok(()));
+        }
+        socket.register_recv_waker(cx.waker());
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for WireGuardTcpStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        self.lease.ensure_active()?;
+        if buffer.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let mut state = self.lease.shared.state.lock();
+        let socket = state.sockets.get_mut::<tcp::Socket>(self.lease.handle);
+        if socket.can_send() {
+            let sent = socket
+                .send_slice(buffer)
+                .map_err(|error| io_err(format!("wireguard TCP send failed: {error:?}")))?;
+            self.lease.touch();
+            self.notify.notify_one();
+            return Poll::Ready(Ok(sent));
+        }
+        if !socket.may_send() {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "wireguard virtual TCP write half is closed",
+            )));
+        }
+        socket.register_send_waker(cx.waker());
+        Poll::Pending
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.lease.ensure_active()?;
+        let mut state = self.lease.shared.state.lock();
+        let socket = state.sockets.get_mut::<tcp::Socket>(self.lease.handle);
+        if socket.send_queue() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        if !socket.may_send() {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "wireguard virtual TCP connection closed before pending data was flushed",
+            )));
+        }
+        socket.register_send_waker(cx.waker());
+        self.notify.notify_one();
+        Poll::Pending
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.lease.ensure_active()?;
+        let current_epoch = self.lease.shared.epoch.load(Ordering::Acquire);
+        let initiate_shutdown = self.shutdown_epoch.is_none();
+        if initiate_shutdown {
+            self.shutdown_epoch = Some(current_epoch);
+        }
+        let (send_queue_empty, connection_closed) = {
+            let mut state = self.lease.shared.state.lock();
+            let socket = state.sockets.get_mut::<tcp::Socket>(self.lease.handle);
+            if initiate_shutdown {
+                socket.close();
+            }
+            socket.register_send_waker(cx.waker());
+            (
+                socket.send_queue() == 0,
+                matches!(socket.state(), tcp::State::Closed | tcp::State::TimeWait),
+            )
+        };
+        if connection_closed {
+            return Poll::Ready(Ok(()));
+        }
+        if !send_queue_empty {
+            // Do not report shutdown while application data is still buffered.
+            // Remember the latest poll epoch with pending data so at least one
+            // subsequent stack poll can emit the final data and FIN.
+            self.shutdown_epoch = Some(current_epoch);
+        } else if self.shutdown_epoch != Some(current_epoch) {
+            return Poll::Ready(Ok(()));
+        }
+        self.notify.notify_one();
+        Poll::Pending
+    }
+}
+
+pub struct WireGuardUdpSocket {
+    lease: Arc<SocketLease>,
+    notify: Arc<Notify>,
+    target: SocketAddr,
+    original_host: String,
+}
+
+impl WireGuardUdpSocket {
+    fn validate_target(&self, host: &str, port: u16) -> std::io::Result<()> {
+        let same_host = host.eq_ignore_ascii_case(&self.original_host)
+            || host.parse::<IpAddr>().ok() == Some(self.target.ip());
+        if port != self.target.port() || !same_host {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "wireguard UDP association is fixed to {}:{}",
+                    self.original_host,
+                    self.target.port()
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) async fn send_to(
+        &self,
+        buffer: &[u8],
+        host: &str,
+        port: u16,
+    ) -> std::io::Result<usize> {
+        self.validate_target(host, port)?;
+        let max_payload = if self.target.is_ipv4() {
+            65_507
+        } else {
+            65_487
+        };
+        if buffer.len() > max_payload {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "wireguard UDP payload exceeds the IP protocol maximum",
+            ));
+        }
+        let lease = self.lease.clone();
+        let target = self.target;
+        poll_fn(move |cx| {
+            lease.ensure_active()?;
+            let mut state = lease.shared.state.lock();
+            let socket = state.sockets.get_mut::<udp::Socket>(lease.handle);
+            match socket.send_slice(
+                buffer,
+                IpEndpoint::new(to_smol_ip(target.ip()), target.port()),
+            ) {
+                Ok(()) => {
+                    lease.touch();
+                    Poll::Ready(Ok(buffer.len()))
+                }
+                Err(udp::SendError::BufferFull) => {
+                    socket.register_send_waker(cx.waker());
+                    Poll::Pending
+                }
+                Err(error) => {
+                    Poll::Ready(Err(io_err(format!("wireguard UDP send failed: {error:?}"))))
+                }
+            }
+        })
+        .await
+        .inspect(|_| self.notify.notify_one())
+    }
+
+    pub(super) async fn recv_from(&self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let lease = self.lease.clone();
+        let target = self.target;
+        poll_fn(move |cx| {
+            loop {
+                lease.ensure_active()?;
+                let mut state = lease.shared.state.lock();
+                let socket = state.sockets.get_mut::<udp::Socket>(lease.handle);
+                match socket.recv_slice(buffer) {
+                    Ok((received, metadata)) => {
+                        let source = from_smol_endpoint(metadata.endpoint);
+                        if source != target {
+                            continue;
+                        }
+                        lease.touch();
+                        return Poll::Ready(Ok(received));
+                    }
+                    Err(udp::RecvError::Exhausted) => {
+                        socket.register_recv_waker(cx.waker());
+                        return Poll::Pending;
+                    }
+                    Err(udp::RecvError::Truncated) => {
+                        return Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "wireguard UDP receive buffer is smaller than the datagram",
+                        )));
+                    }
+                }
+            }
+        })
+        .await
+    }
+
+    pub(super) fn close(&self) {
+        self.lease.remove();
+    }
+}
+
+fn to_smol_ip(ip: IpAddr) -> IpAddress {
+    match ip {
+        IpAddr::V4(ip) => IpAddress::Ipv4(ip.into()),
+        IpAddr::V6(ip) => IpAddress::Ipv6(ip.into()),
+    }
+}
+
+fn from_smol_endpoint(endpoint: IpEndpoint) -> SocketAddr {
+    let ip = match endpoint.addr {
+        IpAddress::Ipv4(ip) => IpAddr::V4(ip.into()),
+        IpAddress::Ipv6(ip) => IpAddr::V6(ip.into()),
+    };
+    SocketAddr::new(ip, endpoint.port)
+}
+
+fn smol_now() -> Instant {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(i64::MAX as u128) as i64;
+    Instant::from_millis(millis)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::wireguard::{config::WireGuardPeerConfig, fragment::fragment_ip_packet};
+
+    fn config() -> WireGuardConfig {
+        let mut config = WireGuardConfig::new(
+            [1; 32],
+            WireGuardPeerConfig::new("127.0.0.1", 51_820, [2; 32]),
+        );
+        config.local_addresses = vec![
+            "10.0.0.2/32".parse().unwrap(),
+            "fd00::2/128".parse().unwrap(),
+        ];
+        config
+    }
+
+    fn large_ipv6_packet() -> Vec<u8> {
+        let payload = (0..3_000).map(|index| index as u8).collect::<Vec<_>>();
+        let mut packet = vec![0_u8; 40 + payload.len()];
+        packet[0] = 0x60;
+        packet[4..6].copy_from_slice(&(payload.len() as u16).to_be_bytes());
+        packet[6] = 59;
+        packet[7] = 64;
+        packet[8..24].copy_from_slice(&[1; 16]);
+        packet[24..40].copy_from_slice(&[2; 16]);
+        packet[40..].copy_from_slice(&payload);
+        packet
+    }
+
+    #[test]
+    fn virtual_device_applies_bounded_backpressure() {
+        let mut device = VirtualDevice::new(1_420, 2);
+        device.inject(vec![0x45; 40]).unwrap();
+        device.inject(vec![0x45; 40]).unwrap();
+        assert_eq!(
+            device.inject(vec![0x45; 40]).unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
+    }
+
+    #[test]
+    fn ipv6_reassembly_accepts_out_of_order_fragments() {
+        let packet = large_ipv6_packet();
+        let fragments = fragment_ip_packet(&packet, 1_280).unwrap();
+        assert!(fragments.len() > 1);
+        let mut reassembler = Ipv6Reassembler::new(128);
+        let mut reassembled = None;
+        for fragment in fragments.into_iter().rev() {
+            if let Some(complete) = reassembler.process(fragment).unwrap() {
+                reassembled = Some(complete);
+            }
+        }
+        assert_eq!(reassembled.as_deref(), Some(packet.as_slice()));
+        assert!(reassembler.entries.is_empty());
+    }
+
+    #[test]
+    fn ipv6_reassembly_rejects_overlapping_fragments() {
+        let packet = large_ipv6_packet();
+        let first = fragment_ip_packet(&packet, 1_280).unwrap().remove(0);
+        let mut reassembler = Ipv6Reassembler::new(128);
+        assert!(reassembler.process(first.clone()).unwrap().is_none());
+        let error = reassembler.process(first).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("overlap"));
+        assert!(reassembler.entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stack_opens_real_tcp_and_udp_socket_handles() {
+        let config = config();
+        let shared = StackShared::new(&config).unwrap();
+        let tcp = shared.open_tcp("10.0.0.1:80".parse().unwrap()).unwrap();
+        let udp = shared
+            .open_udp(
+                "10.0.0.1:53".parse().unwrap(),
+                "10.0.0.1".into(),
+                Duration::from_secs(60),
+            )
+            .unwrap();
+        assert_ne!(tcp.lease.handle, udp.lease.handle);
+        drop(tcp);
+        udp.close();
+        let state = shared.state.lock();
+        assert_eq!(state.tcp_count, 0);
+        assert_eq!(state.udp_count, 0);
+    }
+
+    #[tokio::test]
+    async fn stack_emits_ipv6_udp_packets() {
+        let config = config();
+        let shared = StackShared::new(&config).unwrap();
+        let udp = shared
+            .open_udp(
+                "[fd00::1]:53".parse().unwrap(),
+                "fd00::1".into(),
+                Duration::from_secs(60),
+            )
+            .unwrap();
+        udp.send_to(&[1, 2, 3], "fd00::1", 53).await.unwrap();
+        let packets = shared.poll_and_drain();
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets[0][0] >> 4, 6);
+    }
+}

--- a/crates/core-outbound/src/proto/wireguard/server.rs
+++ b/crates/core-outbound/src/proto/wireguard/server.rs
@@ -1,0 +1,731 @@
+use std::{
+    collections::{HashMap, HashSet},
+    net::{IpAddr, SocketAddr},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use boringtun::{
+    noise::{Packet, Tunn, TunnResult, handshake::parse_handshake_anon, rate_limiter::RateLimiter},
+    x25519::{PublicKey, StaticSecret},
+};
+use ipnet::IpNet;
+use parking_lot::RwLock;
+use tokio::{
+    sync::{Mutex as AsyncMutex, mpsc},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    config::{DEFAULT_MTU, DEFAULT_PACKET_QUEUE, MAX_MTU, MAX_PEERS, WireGuardPeerConfig},
+    device::{PeerCrypto, normalize_incoming_reserved},
+    fragment::fragment_ip_packet,
+    io_err,
+};
+
+const NETWORK_BUFFER_SIZE: usize = 65_535 + 256;
+const DEFAULT_HANDSHAKE_RATE_LIMIT: u64 = 100;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct WireGuardServerPeerConfig {
+    pub public_key: [u8; 32],
+    pub preshared_key: Option<[u8; 32]>,
+    pub allowed_ips: Vec<IpNet>,
+    pub reserved: [u8; 3],
+    pub persistent_keepalive: Option<u16>,
+}
+
+impl std::fmt::Debug for WireGuardServerPeerConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardServerPeerConfig")
+            .field("public_key", &self.public_key)
+            .field(
+                "preshared_key",
+                &self.preshared_key.as_ref().map(|_| "<redacted>"),
+            )
+            .field("allowed_ips", &self.allowed_ips)
+            .field("reserved", &self.reserved)
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .finish()
+    }
+}
+
+impl WireGuardServerPeerConfig {
+    pub fn new(public_key: [u8; 32], allowed_ips: Vec<IpNet>) -> Self {
+        Self {
+            public_key,
+            preshared_key: None,
+            allowed_ips,
+            reserved: [0; 3],
+            persistent_keepalive: None,
+        }
+    }
+
+    fn as_crypto_config(&self) -> WireGuardPeerConfig {
+        WireGuardPeerConfig {
+            endpoint_host: "dynamic".into(),
+            endpoint_port: 1,
+            public_key: self.public_key,
+            preshared_key: self.preshared_key,
+            allowed_ips: self.allowed_ips.clone(),
+            reserved: self.reserved,
+            persistent_keepalive: self.persistent_keepalive,
+        }
+    }
+
+    fn best_prefix_for(&self, address: IpAddr) -> Option<u8> {
+        self.allowed_ips
+            .iter()
+            .filter(|network| network.contains(&address))
+            .map(IpNet::prefix_len)
+            .max()
+    }
+}
+
+#[derive(Clone)]
+pub struct WireGuardServerConfig {
+    pub bind: SocketAddr,
+    pub private_key: [u8; 32],
+    pub peers: Vec<WireGuardServerPeerConfig>,
+    pub mtu: usize,
+    pub packet_queue: usize,
+    pub handshake_rate_limit: u64,
+}
+
+impl std::fmt::Debug for WireGuardServerConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardServerConfig")
+            .field("bind", &self.bind)
+            .field("private_key", &"<redacted>")
+            .field("peers", &self.peers)
+            .field("mtu", &self.mtu)
+            .field("packet_queue", &self.packet_queue)
+            .field("handshake_rate_limit", &self.handshake_rate_limit)
+            .finish()
+    }
+}
+
+impl WireGuardServerConfig {
+    pub fn new(bind: SocketAddr, private_key: [u8; 32], peer: WireGuardServerPeerConfig) -> Self {
+        Self {
+            bind,
+            private_key,
+            peers: vec![peer],
+            mtu: DEFAULT_MTU,
+            packet_queue: DEFAULT_PACKET_QUEUE,
+            handshake_rate_limit: DEFAULT_HANDSHAKE_RATE_LIMIT,
+        }
+    }
+
+    pub fn validate(&self) -> std::io::Result<()> {
+        if self.private_key == [0; 32] {
+            return Err(io_err("wireguard server private key cannot be all zero"));
+        }
+        if self.peers.is_empty() || self.peers.len() > MAX_PEERS {
+            return Err(io_err(format!(
+                "wireguard server peers must contain 1..={MAX_PEERS} entries"
+            )));
+        }
+        if !(576..=MAX_MTU).contains(&self.mtu) {
+            return Err(io_err(format!(
+                "wireguard server mtu must be between 576 and {MAX_MTU}"
+            )));
+        }
+        if self.mtu < 1_280
+            && self
+                .peers
+                .iter()
+                .flat_map(|peer| &peer.allowed_ips)
+                .any(|network| network.addr().is_ipv6())
+        {
+            return Err(io_err("wireguard server IPv6 requires mtu >= 1280"));
+        }
+        if !(16..=65_536).contains(&self.packet_queue) {
+            return Err(io_err(
+                "wireguard server packet-queue must be between 16 and 65536",
+            ));
+        }
+        if !(1..=1_000_000).contains(&self.handshake_rate_limit) {
+            return Err(io_err(
+                "wireguard server handshake-rate-limit must be between 1 and 1000000",
+            ));
+        }
+        let local_public = *PublicKey::from(&StaticSecret::from(self.private_key)).as_bytes();
+        let mut public_keys = HashSet::new();
+        let mut exact_routes = HashSet::new();
+        for (index, peer) in self.peers.iter().enumerate() {
+            if peer.public_key == [0; 32] || peer.public_key == local_public {
+                return Err(io_err(format!(
+                    "wireguard server peer[{index}] has an invalid public key"
+                )));
+            }
+            if !public_keys.insert(peer.public_key) {
+                return Err(io_err(format!(
+                    "wireguard server peer[{index}] duplicates another public key"
+                )));
+            }
+            if peer.allowed_ips.is_empty() {
+                return Err(io_err(format!(
+                    "wireguard server peer[{index}] requires allowed-ips"
+                )));
+            }
+            for network in &peer.allowed_ips {
+                if !exact_routes.insert(network.trunc()) {
+                    return Err(io_err(format!(
+                        "wireguard server allowed-ip {network} is assigned to more than one peer"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn route_peer(&self, address: IpAddr) -> Option<usize> {
+        self.peers
+            .iter()
+            .enumerate()
+            .filter_map(|(index, peer)| peer.best_prefix_for(address).map(|prefix| (prefix, index)))
+            .max_by_key(|(prefix, _)| *prefix)
+            .map(|(_, index)| index)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WireGuardReceivedPacket {
+    pub peer_index: usize,
+    pub peer_public_key: [u8; 32],
+    pub endpoint: SocketAddr,
+    pub packet: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WireGuardServerPeerStats {
+    pub public_key: [u8; 32],
+    pub endpoint: Option<SocketAddr>,
+    pub last_handshake: Option<Duration>,
+    pub tx_bytes: usize,
+    pub rx_bytes: usize,
+    pub estimated_loss: f32,
+    pub estimated_rtt_ms: Option<u32>,
+}
+
+struct ServerPeer {
+    config: WireGuardServerPeerConfig,
+    crypto: PeerCrypto,
+    endpoint: RwLock<Option<SocketAddr>>,
+}
+
+pub struct WireGuardServer {
+    socket: Arc<tokio::net::UdpSocket>,
+    config: Arc<WireGuardServerConfig>,
+    peers: Arc<Vec<Arc<ServerPeer>>>,
+    received: AsyncMutex<mpsc::Receiver<WireGuardReceivedPacket>>,
+    cancellation: CancellationToken,
+    driver: AsyncMutex<Option<JoinHandle<()>>>,
+    dropped_packets: Arc<AtomicU64>,
+}
+
+impl std::fmt::Debug for WireGuardServer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WireGuardServer")
+            .field("local_addr", &self.socket.local_addr().ok())
+            .field("peers", &self.peers.len())
+            .field("mtu", &self.config.mtu)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WireGuardServer {
+    pub async fn bind(config: WireGuardServerConfig) -> std::io::Result<Self> {
+        config.validate()?;
+        let socket = Arc::new(tokio::net::UdpSocket::bind(config.bind).await?);
+        let private = StaticSecret::from(config.private_key);
+        let public = PublicKey::from(&private);
+        let rate_limiter = Arc::new(RateLimiter::new(&public, config.handshake_rate_limit));
+        // Handshake initiation routing needs to recover the initiator static
+        // key before selecting a peer Tunn. Verify MAC1 first so unauthenticated
+        // garbage cannot force the more expensive anonymous NoiseIK operation.
+        // The selected peer's shared limiter still performs authoritative
+        // cookie/rate-limit verification afterwards.
+        let routing_mac_verifier = Arc::new(RateLimiter::new(&public, u64::MAX));
+        let mut peers = Vec::with_capacity(config.peers.len());
+        for (index, peer) in config.peers.iter().cloned().enumerate() {
+            let crypto = PeerCrypto::new_with_rate_limiter(
+                config.private_key,
+                peer.as_crypto_config(),
+                u32::try_from(index + 1)
+                    .map_err(|_| io_err("wireguard server peer index overflow"))?,
+                Some(rate_limiter.clone()),
+            )?;
+            peers.push(Arc::new(ServerPeer {
+                config: peer,
+                crypto,
+                endpoint: RwLock::new(None),
+            }));
+        }
+        let config = Arc::new(config);
+        let peers = Arc::new(peers);
+        let cancellation = CancellationToken::new();
+        let (received_tx, received_rx) = mpsc::channel(config.packet_queue);
+        let dropped_packets = Arc::new(AtomicU64::new(0));
+        let driver = tokio::spawn(run_server(ServerDriver {
+            socket: socket.clone(),
+            config: config.clone(),
+            peers: peers.clone(),
+            rate_limiter,
+            routing_mac_verifier,
+            received: received_tx,
+            cancellation: cancellation.clone(),
+            dropped_packets: dropped_packets.clone(),
+        }));
+        Ok(Self {
+            socket,
+            config,
+            peers,
+            received: AsyncMutex::new(received_rx),
+            cancellation,
+            driver: AsyncMutex::new(Some(driver)),
+            dropped_packets,
+        })
+    }
+
+    pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.socket.local_addr()
+    }
+
+    pub async fn recv_packet(&self) -> std::io::Result<WireGuardReceivedPacket> {
+        self.received.lock().await.recv().await.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "wireguard server is closed",
+            )
+        })
+    }
+
+    pub async fn send_packet(&self, packet: &[u8]) -> std::io::Result<()> {
+        let destination = Tunn::dst_address(packet)
+            .ok_or_else(|| io_err("wireguard server outbound packet is not valid IPv4/IPv6"))?;
+        let peer_index = self.config.route_peer(destination).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                format!("wireguard server has no peer route for {destination}"),
+            )
+        })?;
+        self.send_packet_to_peer(peer_index, packet).await
+    }
+
+    pub async fn send_packet_to_peer(
+        &self,
+        peer_index: usize,
+        packet: &[u8],
+    ) -> std::io::Result<()> {
+        let peer = self.peers.get(peer_index).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("wireguard server peer index {peer_index} is out of range"),
+            )
+        })?;
+        let destination = Tunn::dst_address(packet)
+            .ok_or_else(|| io_err("wireguard server outbound packet is not valid IPv4/IPv6"))?;
+        if peer.config.best_prefix_for(destination).is_none() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "wireguard server peer[{peer_index}] does not allow destination {destination}"
+                ),
+            ));
+        }
+        let endpoint = peer.endpoint.read().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                format!("wireguard server peer[{peer_index}] has no authenticated endpoint"),
+            )
+        })?;
+        for fragment in fragment_ip_packet(packet, self.config.mtu)? {
+            let encrypted = peer.crypto.encapsulate(&fragment)?;
+            send_datagrams(&self.socket, endpoint, encrypted, &self.cancellation).await?;
+        }
+        Ok(())
+    }
+
+    pub fn stats(&self) -> Vec<WireGuardServerPeerStats> {
+        self.peers
+            .iter()
+            .map(|peer| {
+                let (last_handshake, tx_bytes, rx_bytes, estimated_loss, estimated_rtt_ms) =
+                    peer.crypto.raw_stats();
+                WireGuardServerPeerStats {
+                    public_key: peer.config.public_key,
+                    endpoint: *peer.endpoint.read(),
+                    last_handshake,
+                    tx_bytes,
+                    rx_bytes,
+                    estimated_loss,
+                    estimated_rtt_ms,
+                }
+            })
+            .collect()
+    }
+
+    pub fn dropped_packets(&self) -> u64 {
+        self.dropped_packets.load(Ordering::Relaxed)
+    }
+
+    pub async fn close(&self) {
+        self.cancellation.cancel();
+        if let Some(driver) = self.driver.lock().await.take() {
+            let _ = driver.await;
+        }
+    }
+}
+
+impl Drop for WireGuardServer {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+    }
+}
+
+struct ServerDriver {
+    socket: Arc<tokio::net::UdpSocket>,
+    config: Arc<WireGuardServerConfig>,
+    peers: Arc<Vec<Arc<ServerPeer>>>,
+    rate_limiter: Arc<RateLimiter>,
+    routing_mac_verifier: Arc<RateLimiter>,
+    received: mpsc::Sender<WireGuardReceivedPacket>,
+    cancellation: CancellationToken,
+    dropped_packets: Arc<AtomicU64>,
+}
+
+async fn run_server(driver: ServerDriver) {
+    let ServerDriver {
+        socket,
+        config,
+        peers,
+        rate_limiter,
+        routing_mac_verifier,
+        received,
+        cancellation,
+        dropped_packets,
+    } = driver;
+    let private = StaticSecret::from(config.private_key);
+    let public = PublicKey::from(&private);
+    let peer_by_key: HashMap<[u8; 32], usize> = peers
+        .iter()
+        .enumerate()
+        .map(|(index, peer)| (peer.config.public_key, index))
+        .collect();
+    let mut buffer = vec![0; NETWORK_BUFFER_SIZE];
+    let mut timers = tokio::time::interval(Duration::from_millis(100));
+    timers.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => break,
+            _ = timers.tick() => {
+                rate_limiter.reset_count();
+                routing_mac_verifier.reset_count();
+                for peer in peers.iter() {
+                    let endpoint = *peer.endpoint.read();
+                    let Some(endpoint) = endpoint else { continue };
+                    match peer.crypto.update_timers() {
+                        Ok(packets) => {
+                            if let Err(error) = send_datagrams(&socket, endpoint, packets, &cancellation).await {
+                                tracing::debug!(target: "wireguard::server", %endpoint, %error, "timer packet send failed");
+                            }
+                        }
+                        Err(error) => tracing::debug!(target: "wireguard::server", %endpoint, %error, "peer timer update failed"),
+                    }
+                }
+            }
+            result = socket.recv_from(&mut buffer) => {
+                let (length, endpoint) = match result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        tracing::warn!(target: "wireguard::server", %error, "UDP receive failed");
+                        continue;
+                    }
+                };
+                let datagram = &buffer[..length];
+                let peer_index = match route_incoming(
+                    datagram,
+                    endpoint.ip(),
+                    &private,
+                    &public,
+                    &peer_by_key,
+                    &routing_mac_verifier,
+                ) {
+                    Ok(index) if index < peers.len() => index,
+                    Ok(_) => continue,
+                    Err(error) => {
+                        tracing::debug!(target: "wireguard::server", %endpoint, %error, "unroutable WireGuard datagram rejected");
+                        continue;
+                    }
+                };
+                let peer = &peers[peer_index];
+                match peer.crypto.decapsulate(Some(endpoint.ip()), datagram) {
+                    Ok(output) => {
+                        *peer.endpoint.write() = Some(endpoint);
+                        if let Err(error) = send_datagrams(&socket, endpoint, output.network, &cancellation).await {
+                            tracing::debug!(target: "wireguard::server", %endpoint, %error, "protocol response send failed");
+                        }
+                        for packet in output.plaintext {
+                            let received_packet = WireGuardReceivedPacket {
+                                peer_index,
+                                peer_public_key: peer.config.public_key,
+                                endpoint,
+                                packet,
+                            };
+                            if received.try_send(received_packet).is_err() {
+                                dropped_packets.fetch_add(1, Ordering::Relaxed);
+                                tracing::warn!(target: "wireguard::server", %endpoint, "bounded plaintext queue is full; packet dropped");
+                            }
+                        }
+                    }
+                    Err(error) => tracing::debug!(target: "wireguard::server", %endpoint, %error, "authenticated WireGuard processing rejected datagram"),
+                }
+            }
+        }
+    }
+}
+
+fn route_incoming(
+    datagram: &[u8],
+    source_ip: IpAddr,
+    private: &StaticSecret,
+    public: &PublicKey,
+    peer_by_key: &HashMap<[u8; 32], usize>,
+    routing_mac_verifier: &RateLimiter,
+) -> std::io::Result<usize> {
+    let packet_type = datagram.first().copied().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, "empty WireGuard datagram")
+    })?;
+    if packet_type == 1 {
+        let normalized = normalize_incoming_reserved(datagram)?;
+        let mut scratch = [0_u8; 64];
+        let parsed =
+            match routing_mac_verifier.verify_packet(Some(source_ip), &normalized, &mut scratch) {
+                Ok(packet) => packet,
+                Err(TunnResult::Err(error)) => {
+                    return Err(io_err(format!(
+                        "handshake MAC1 verification failed: {error:?}"
+                    )));
+                }
+                Err(_) => return Err(io_err("handshake MAC1 verifier returned an invalid result")),
+            };
+        let Packet::HandshakeInit(handshake) = parsed else {
+            return Err(io_err("WireGuard type/length mismatch"));
+        };
+        let half = parse_handshake_anon(private, public, &handshake)
+            .map_err(|error| io_err(format!("handshake peer identification failed: {error:?}")))?;
+        return peer_by_key
+            .get(&half.peer_static_public)
+            .copied()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "WireGuard handshake belongs to an unknown peer",
+                )
+            });
+    }
+    let receiver = match (packet_type, datagram.len()) {
+        (2, 92) => u32::from_le_bytes(
+            datagram[8..12]
+                .try_into()
+                .expect("length checked before receiver index"),
+        ),
+        (3, 64) | (4, 32..) => u32::from_le_bytes(
+            datagram[4..8]
+                .try_into()
+                .expect("length checked before receiver index"),
+        ),
+        _ => return Err(io_err("invalid WireGuard packet type or length")),
+    };
+    usize::try_from(receiver >> 8)
+        .ok()
+        .and_then(|index| index.checked_sub(1))
+        .ok_or_else(|| io_err("invalid WireGuard receiver index"))
+}
+
+async fn send_datagrams(
+    socket: &tokio::net::UdpSocket,
+    endpoint: SocketAddr,
+    packets: Vec<Vec<u8>>,
+    cancellation: &CancellationToken,
+) -> std::io::Result<()> {
+    for packet in packets {
+        let sent = tokio::select! {
+            _ = cancellation.cancelled() => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "wireguard server is closed",
+                ));
+            }
+            sent = socket.send_to(&packet, endpoint) => sent?,
+        };
+        if sent != packet.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "wireguard UDP socket sent a partial datagram",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ipv4_packet(source: [u8; 4], destination: [u8; 4]) -> Vec<u8> {
+        let mut packet = vec![0; 20];
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&(20u16).to_be_bytes());
+        packet[8] = 64;
+        packet[9] = 253;
+        packet[12..16].copy_from_slice(&source);
+        packet[16..20].copy_from_slice(&destination);
+        packet
+    }
+
+    #[tokio::test]
+    async fn server_authenticates_roams_and_routes_bidirectionally() {
+        let client_private = [41; 32];
+        let server_private = [43; 32];
+        let client_public = *PublicKey::from(&StaticSecret::from(client_private)).as_bytes();
+        let server_public = *PublicKey::from(&StaticSecret::from(server_private)).as_bytes();
+        let server_peer =
+            WireGuardServerPeerConfig::new(client_public, vec!["10.77.0.2/32".parse().unwrap()]);
+        let server = WireGuardServer::bind(WireGuardServerConfig::new(
+            "127.0.0.1:0".parse().unwrap(),
+            server_private,
+            server_peer,
+        ))
+        .await
+        .unwrap();
+        let endpoint = server.local_addr().unwrap();
+        let mut client_peer =
+            WireGuardPeerConfig::new(endpoint.ip().to_string(), endpoint.port(), server_public);
+        client_peer.allowed_ips = vec!["10.77.0.1/32".parse().unwrap()];
+        let client = PeerCrypto::new(client_private, client_peer, 1).unwrap();
+        let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let outbound = ipv4_packet([10, 77, 0, 2], [10, 77, 0, 1]);
+        for packet in client.encapsulate(&outbound).unwrap() {
+            socket.send_to(&packet, endpoint).await.unwrap();
+        }
+        let mut buffer = vec![0; NETWORK_BUFFER_SIZE];
+        for _ in 0..16 {
+            let (length, _) =
+                tokio::time::timeout(Duration::from_secs(1), socket.recv_from(&mut buffer))
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let output = client
+                .decapsulate(Some(endpoint.ip()), &buffer[..length])
+                .unwrap();
+            for packet in output.network {
+                socket.send_to(&packet, endpoint).await.unwrap();
+            }
+            if let Ok(received) =
+                tokio::time::timeout(Duration::from_millis(20), server.recv_packet()).await
+            {
+                let received = received.unwrap();
+                assert_eq!(received.packet, outbound);
+                assert_eq!(received.peer_public_key, client_public);
+                break;
+            }
+        }
+        let reverse = ipv4_packet([10, 77, 0, 1], [10, 77, 0, 2]);
+        server.send_packet(&reverse).await.unwrap();
+        let (length, _) =
+            tokio::time::timeout(Duration::from_secs(1), socket.recv_from(&mut buffer))
+                .await
+                .unwrap()
+                .unwrap();
+        let output = client
+            .decapsulate(Some(endpoint.ip()), &buffer[..length])
+            .unwrap();
+        assert!(output.plaintext.iter().any(|packet| packet == &reverse));
+        assert_eq!(
+            server.stats()[0].endpoint,
+            Some(socket.local_addr().unwrap())
+        );
+
+        let roaming_socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let roamed = ipv4_packet([10, 77, 0, 2], [10, 77, 0, 1]);
+        for packet in client.encapsulate(&roamed).unwrap() {
+            roaming_socket.send_to(&packet, endpoint).await.unwrap();
+        }
+        let received = tokio::time::timeout(Duration::from_secs(1), server.recv_packet())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(received.packet, roamed);
+        assert_eq!(received.endpoint, roaming_socket.local_addr().unwrap());
+        assert_eq!(
+            server.stats()[0].endpoint,
+            Some(roaming_socket.local_addr().unwrap())
+        );
+        server.send_packet(&reverse).await.unwrap();
+        let (length, _) = tokio::time::timeout(
+            Duration::from_secs(1),
+            roaming_socket.recv_from(&mut buffer),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let output = client
+            .decapsulate(Some(endpoint.ip()), &buffer[..length])
+            .unwrap();
+        assert!(output.plaintext.iter().any(|packet| packet == &reverse));
+        server.close().await;
+    }
+
+    #[test]
+    fn server_config_rejects_ambiguous_routes() {
+        let mut config = WireGuardServerConfig::new(
+            "127.0.0.1:0".parse().unwrap(),
+            [1; 32],
+            WireGuardServerPeerConfig::new([2; 32], vec!["10.0.0.2/32".parse().unwrap()]),
+        );
+        config.peers.push(WireGuardServerPeerConfig::new(
+            [3; 32],
+            vec!["10.0.0.2/32".parse().unwrap()],
+        ));
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .to_string()
+                .contains("more than one peer")
+        );
+    }
+
+    #[tokio::test]
+    async fn server_close_cancels_a_blocked_receiver() {
+        let server = Arc::new(
+            WireGuardServer::bind(WireGuardServerConfig::new(
+                "127.0.0.1:0".parse().unwrap(),
+                [101; 32],
+                WireGuardServerPeerConfig::new([103; 32], vec!["10.0.0.2/32".parse().unwrap()]),
+            ))
+            .await
+            .unwrap(),
+        );
+        let waiting_server = server.clone();
+        let waiting = tokio::spawn(async move { waiting_server.recv_packet().await });
+        tokio::task::yield_now().await;
+        server.close().await;
+        let error = tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
+    }
+}

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -2,7 +2,7 @@
 //!
 //! 内置规则：direct / block 自动注册；其它协议按 [`NodeProtocol`] 选择。
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, net::IpAddr, sync::Arc};
 
 use base64::Engine as _;
 use core_config::node_uri::{NodeProtocol, ParsedNode};
@@ -31,7 +31,7 @@ use crate::{
         vless::{VlessNetwork, VlessOutbound},
         vmess::{VmessNetwork, VmessOutbound, VmessSecurity},
         vmess_legacy::VmessLegacyOutbound,
-        wireguard::WireGuardOutbound,
+        wireguard::{WireGuardConfig, WireGuardOutbound, WireGuardPeerConfig},
         xhttp::Config as XhttpConfig,
     },
     socks5::Socks5Outbound,
@@ -797,41 +797,638 @@ fn parse_tuic_duration(value: &str) -> Option<std::time::Duration> {
 }
 
 fn build_wireguard(node: &ParsedNode) -> SharedOutbound {
-    let priv_b64 = match node
-        .params
-        .get("private-key")
-        .or_else(|| node.password.as_ref())
-    {
-        Some(s) => s,
-        None => return StubOutbound::new(node.name.clone(), "wireguard(missing-private-key)"),
-    };
-    let peer_b64 = match node.params.get("public-key") {
-        Some(s) => s,
-        None => return StubOutbound::new(node.name.clone(), "wireguard(missing-public-key)"),
-    };
-    let priv_key = match decode_b64_32(priv_b64) {
-        Some(k) => k,
-        None => return StubOutbound::new(node.name.clone(), "wireguard(invalid-private-key)"),
-    };
-    let peer_key = match decode_b64_32(peer_b64) {
-        Some(k) => k,
-        None => return StubOutbound::new(node.name.clone(), "wireguard(invalid-public-key)"),
-    };
-    let mut ob = WireGuardOutbound::new(&node.name, &node.host, node.port, priv_key, peer_key);
-    if let Some(psk_b64) = node.params.get("preshared-key") {
-        if let Some(psk) = decode_b64_32(psk_b64) {
-            ob = ob.with_preshared_key(psk);
+    match wireguard_from_node(node) {
+        Ok(outbound) => Arc::new(outbound),
+        Err(reason) => Arc::new(InvalidWireGuardOutbound {
+            name: node.name.clone(),
+            reason,
+        }),
+    }
+}
+
+#[derive(Debug)]
+struct InvalidWireGuardOutbound {
+    name: String,
+    reason: String,
+}
+
+#[async_trait::async_trait]
+impl crate::adapter::OutboundAdapter for InvalidWireGuardOutbound {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn protocol(&self) -> &'static str {
+        "wireguard"
+    }
+
+    fn capabilities(&self) -> crate::adapter::Capabilities {
+        crate::adapter::Capabilities::default()
+    }
+
+    async fn dial_tcp(
+        &self,
+        _context: crate::adapter::DialContext,
+    ) -> std::io::Result<crate::adapter::BoxedStream> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("wireguard node `{}` is invalid: {}", self.name, self.reason),
+        ))
+    }
+
+    async fn dial_udp(
+        &self,
+        _context: crate::adapter::DialContext,
+    ) -> std::io::Result<crate::adapter::BoxedUdp> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("wireguard node `{}` is invalid: {}", self.name, self.reason),
+        ))
+    }
+}
+
+fn wireguard_from_node(node: &ParsedNode) -> Result<WireGuardOutbound, String> {
+    for unsupported in [
+        "system-interface",
+        "system_interface",
+        "dialer-proxy",
+        "dialer_proxy",
+        "amnezia-wg-option",
+        "amnezia_wg_option",
+    ] {
+        if node.params.contains_key(unsupported) {
+            return Err(format!("unsupported-{unsupported}"));
         }
     }
-    if let Some(addr) = node.params.get("address") {
-        for a in addr.split(',') {
-            let a = a.trim().split('/').next().unwrap_or("");
-            if let Ok(ip) = a.parse() {
-                ob = ob.with_local_address(ip);
+    const SUPPORTED_PARAMETERS: &[&str] = &[
+        "private-key",
+        "private_key",
+        "address",
+        "local-address",
+        "local_address",
+        "ip",
+        "ipv6",
+        "peers",
+        "public-key",
+        "public_key",
+        "peer-public-key",
+        "peer_public_key",
+        "pre-shared-key",
+        "pre_shared_key",
+        "preshared-key",
+        "preshared_key",
+        "allowed-ips",
+        "allowed_ips",
+        "reserved",
+        "persistent-keepalive",
+        "persistent_keepalive",
+        "persistent-keepalive-interval",
+        "persistent_keepalive_interval",
+        "keepalive",
+        "mtu",
+        "tcp-buffer-size",
+        "tcp_buffer_size",
+        "udp-buffer-size",
+        "udp_buffer_size",
+        "max-tcp-sessions",
+        "max_tcp_sessions",
+        "max-udp-sessions",
+        "max_udp_sessions",
+        "packet-queue",
+        "packet_queue",
+        "workers",
+        "connect-timeout",
+        "connect_timeout",
+        "udp-timeout",
+        "udp_timeout",
+        "udp-idle-timeout",
+        "udp_idle_timeout",
+        "remote-dns-resolve",
+        "remote_dns_resolve",
+        "dns",
+        "network",
+    ];
+    if let Some(unknown) = node
+        .params
+        .keys()
+        .find(|key| !SUPPORTED_PARAMETERS.contains(&key.as_str()))
+    {
+        return Err(format!("unknown-parameter-{unknown}"));
+    }
+    let private_key = param_alias(node, &["private-key", "private_key"])?
+        .or(node.password.as_deref())
+        .or(node.uuid.as_deref())
+        .ok_or_else(|| "missing-private-key".to_string())
+        .and_then(|value| decode_b64_32(value).ok_or_else(|| "invalid-private-key".into()))?;
+
+    let mut local_addresses = Vec::new();
+    if let Some(value) = param_alias(node, &["address", "local-address", "local_address"])? {
+        local_addresses.extend(parse_ip_nets(value, "address")?);
+    }
+    for key in ["ip", "ipv6"] {
+        if let Some(value) = node.params.get(key) {
+            local_addresses.extend(parse_ip_nets(value, key)?);
+        }
+    }
+    if local_addresses.is_empty() {
+        return Err("missing-local-address".into());
+    }
+
+    let peers = if let Some(value) = node.params.get("peers") {
+        for field in [
+            "public-key",
+            "public_key",
+            "peer-public-key",
+            "peer_public_key",
+            "pre-shared-key",
+            "pre_shared_key",
+            "preshared-key",
+            "preshared_key",
+            "allowed-ips",
+            "allowed_ips",
+            "persistent-keepalive",
+            "persistent_keepalive",
+            "persistent-keepalive-interval",
+            "persistent_keepalive_interval",
+            "keepalive",
+        ] {
+            if node.params.contains_key(field) {
+                return Err(format!("peers-conflicts-with-{field}"));
             }
         }
+        let default_reserved = node
+            .params
+            .get("reserved")
+            .map(|value| parse_reserved(value))
+            .transpose()?
+            .unwrap_or([0; 3]);
+        parse_wireguard_peers(value, default_reserved)?
+    } else {
+        vec![parse_single_wireguard_peer(node, &local_addresses)?]
+    };
+    if peers.is_empty() {
+        return Err("peers-must-not-be-empty".into());
     }
-    Arc::new(ob)
+    let mut config = WireGuardConfig::new(private_key, peers[0].clone());
+    config.peers = peers;
+    config.local_addresses = local_addresses;
+    config.mtu = parse_usize_param(node, &["mtu"], config.mtu)?;
+    config.tcp_buffer_size = parse_usize_param(
+        node,
+        &["tcp-buffer-size", "tcp_buffer_size"],
+        config.tcp_buffer_size,
+    )?;
+    config.udp_buffer_size = parse_usize_param(
+        node,
+        &["udp-buffer-size", "udp_buffer_size"],
+        config.udp_buffer_size,
+    )?;
+    config.max_tcp_sessions = parse_usize_param(
+        node,
+        &["max-tcp-sessions", "max_tcp_sessions"],
+        config.max_tcp_sessions,
+    )?;
+    config.max_udp_sessions = parse_usize_param(
+        node,
+        &["max-udp-sessions", "max_udp_sessions"],
+        config.max_udp_sessions,
+    )?;
+    config.packet_queue =
+        parse_usize_param(node, &["packet-queue", "packet_queue"], config.packet_queue)?;
+    if let Some(workers) = param_alias(node, &["workers"])? {
+        let workers = workers
+            .parse::<usize>()
+            .map_err(|_| "invalid-workers".to_string())?;
+        if workers != 0 {
+            config.workers = workers;
+        }
+    }
+    if let Some(value) = param_alias(node, &["connect-timeout", "connect_timeout"])? {
+        config.connect_timeout =
+            parse_tuic_duration(value).ok_or_else(|| "invalid-connect-timeout".to_string())?;
+    }
+    if let Some(value) = param_alias(
+        node,
+        &[
+            "udp-timeout",
+            "udp_timeout",
+            "udp-idle-timeout",
+            "udp_idle_timeout",
+        ],
+    )? {
+        config.udp_idle_timeout =
+            parse_tuic_duration(value).ok_or_else(|| "invalid-udp-timeout".to_string())?;
+    }
+
+    config.remote_dns_resolve = param_alias(node, &["remote-dns-resolve", "remote_dns_resolve"])?
+        .map(parse_strict_bool)
+        .transpose()?
+        .unwrap_or(false);
+    if let Some(value) = node.params.get("dns") {
+        config.dns = parse_string_list(value)?
+            .into_iter()
+            .map(|value| {
+                value
+                    .parse::<IpAddr>()
+                    .map_err(|_| format!("invalid-dns-address-{value}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+    }
+
+    if let Some(network) = node.params.get("network") {
+        match network
+            .trim()
+            .to_ascii_lowercase()
+            .replace(' ', "")
+            .as_str()
+        {
+            "tcp" => {
+                config.tcp = true;
+                config.udp = false;
+            }
+            "udp" => {
+                config.tcp = false;
+                config.udp = true;
+            }
+            "tcp,udp" | "udp,tcp" | "both" => {
+                config.tcp = true;
+                config.udp = true;
+            }
+            _ => return Err("invalid-network".into()),
+        }
+    } else {
+        config.udp = node.udp;
+    }
+    config.validate().map_err(|error| error.to_string())?;
+    Ok(WireGuardOutbound::from_config(&node.name, config))
+}
+
+fn parse_single_wireguard_peer(
+    node: &ParsedNode,
+    local_addresses: &[ipnet::IpNet],
+) -> Result<WireGuardPeerConfig, String> {
+    let public_key = param_alias(
+        node,
+        &[
+            "public-key",
+            "public_key",
+            "peer-public-key",
+            "peer_public_key",
+        ],
+    )?
+    .ok_or_else(|| "missing-public-key".to_string())
+    .and_then(|value| decode_b64_32(value).ok_or_else(|| "invalid-public-key".into()))?;
+    let mut peer = WireGuardPeerConfig::new(&node.host, node.port, public_key);
+    peer.preshared_key = param_alias(
+        node,
+        &[
+            "pre-shared-key",
+            "pre_shared_key",
+            "preshared-key",
+            "preshared_key",
+        ],
+    )?
+    .map(|value| decode_b64_32(value).ok_or_else(|| String::from("invalid-preshared-key")))
+    .transpose()?;
+    peer.allowed_ips = match param_alias(node, &["allowed-ips", "allowed_ips"])? {
+        Some(value) => parse_ip_nets(value, "allowed-ips")?,
+        None => default_allowed_ips(local_addresses),
+    };
+    if let Some(value) = node.params.get("reserved") {
+        peer.reserved = parse_reserved(value)?;
+    }
+    if let Some(value) = param_alias(
+        node,
+        &[
+            "persistent-keepalive",
+            "persistent_keepalive",
+            "persistent-keepalive-interval",
+            "persistent_keepalive_interval",
+            "keepalive",
+        ],
+    )? {
+        peer.persistent_keepalive = parse_keepalive(value)?;
+    }
+    Ok(peer)
+}
+
+fn parse_wireguard_peers(
+    value: &str,
+    default_reserved: [u8; 3],
+) -> Result<Vec<WireGuardPeerConfig>, String> {
+    let peers: serde_json::Value =
+        serde_json::from_str(value).map_err(|_| "invalid-peers-json".to_string())?;
+    let peers = peers
+        .as_array()
+        .ok_or_else(|| "peers-must-be-an-array".to_string())?;
+    if peers.is_empty() || peers.len() > super::proto::wireguard::config::MAX_PEERS {
+        return Err(format!(
+            "peers-must-contain-1-to-{}-entries",
+            super::proto::wireguard::config::MAX_PEERS
+        ));
+    }
+    peers
+        .iter()
+        .enumerate()
+        .map(|(index, peer)| {
+            let peer = peer
+                .as_object()
+                .ok_or_else(|| format!("peer-{index}-must-be-an-object"))?;
+            const PEER_FIELDS: &[&str] = &[
+                "server",
+                "address",
+                "port",
+                "server_port",
+                "server-port",
+                "endpoint",
+                "public-key",
+                "public_key",
+                "pre-shared-key",
+                "pre_shared_key",
+                "preshared-key",
+                "preshared_key",
+                "allowed-ips",
+                "allowed_ips",
+                "reserved",
+                "persistent-keepalive",
+                "persistent_keepalive",
+                "persistent-keepalive-interval",
+                "persistent_keepalive_interval",
+                "keepalive",
+            ];
+            if let Some(unknown) = peer.keys().find(|key| !PEER_FIELDS.contains(&key.as_str())) {
+                return Err(format!("peer-{index}-unknown-field-{unknown}"));
+            }
+            let get = |keys: &[&str]| -> Result<Option<&serde_json::Value>, String> {
+                let mut found = None;
+                for key in keys {
+                    if let Some(value) = peer.get(*key) {
+                        if let Some(previous) = found
+                            && previous != value
+                        {
+                            return Err(format!("peer-{index}-conflicting-{key}"));
+                        }
+                        found = Some(value);
+                    }
+                }
+                Ok(found)
+            };
+            let endpoint = get(&["endpoint"])?;
+            let server = get(&["server", "address"])?;
+            let port_value = get(&["port", "server_port", "server-port"])?;
+            let (host, port) = if let Some(endpoint) = endpoint {
+                if server.is_some() || port_value.is_some() {
+                    return Err(format!("peer-{index}-endpoint-conflicts-with-server-port"));
+                }
+                endpoint
+                    .as_str()
+                    .ok_or_else(|| format!("peer-{index}-invalid-endpoint"))
+                    .and_then(|endpoint| parse_wireguard_endpoint(endpoint, index))?
+            } else {
+                let host = server
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|host| !host.trim().is_empty())
+                    .ok_or_else(|| format!("peer-{index}-missing-server"))?;
+                let port = port_value
+                    .and_then(json_u64)
+                    .and_then(|value| u16::try_from(value).ok())
+                    .filter(|port| *port != 0)
+                    .ok_or_else(|| format!("peer-{index}-invalid-port"))?;
+                (host.to_owned(), port)
+            };
+            let public_key = get(&["public-key", "public_key"])?
+                .and_then(serde_json::Value::as_str)
+                .and_then(decode_b64_32)
+                .ok_or_else(|| format!("peer-{index}-invalid-public-key"))?;
+            let mut parsed = WireGuardPeerConfig::new(host, port, public_key);
+            parsed.reserved = default_reserved;
+            parsed.preshared_key = get(&[
+                "pre-shared-key",
+                "pre_shared_key",
+                "preshared-key",
+                "preshared_key",
+            ])?
+            .map(|value| {
+                value
+                    .as_str()
+                    .and_then(decode_b64_32)
+                    .ok_or_else(|| format!("peer-{index}-invalid-preshared-key"))
+            })
+            .transpose()?;
+            let allowed = get(&["allowed-ips", "allowed_ips"])?
+                .ok_or_else(|| format!("peer-{index}-missing-allowed-ips"))?;
+            parsed.allowed_ips = parse_json_ip_nets(allowed, &format!("peer-{index}-allowed-ips"))?;
+            if let Some(reserved) = get(&["reserved"])? {
+                parsed.reserved = parse_reserved_json(reserved)?;
+            }
+            if let Some(keepalive) = get(&[
+                "persistent-keepalive",
+                "persistent_keepalive",
+                "persistent-keepalive-interval",
+                "persistent_keepalive_interval",
+                "keepalive",
+            ])? {
+                let keepalive = json_u64(keepalive)
+                    .and_then(|value| u16::try_from(value).ok())
+                    .ok_or_else(|| format!("peer-{index}-invalid-persistent-keepalive"))?;
+                parsed.persistent_keepalive = (keepalive != 0).then_some(keepalive);
+            }
+            Ok(parsed)
+        })
+        .collect()
+}
+
+fn parse_wireguard_endpoint(value: &str, peer_index: usize) -> Result<(String, u16), String> {
+    let value = value.trim();
+    let (host, port) = value
+        .rsplit_once(':')
+        .ok_or_else(|| format!("peer-{peer_index}-invalid-endpoint"))?;
+    let host = host
+        .trim()
+        .trim_matches(|character| character == '[' || character == ']');
+    let port = port
+        .parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| format!("peer-{peer_index}-invalid-endpoint-port"))?;
+    if host.is_empty() {
+        return Err(format!("peer-{peer_index}-invalid-endpoint-host"));
+    }
+    Ok((host.to_owned(), port))
+}
+
+fn default_allowed_ips(local_addresses: &[ipnet::IpNet]) -> Vec<ipnet::IpNet> {
+    let mut routes = Vec::new();
+    if local_addresses
+        .iter()
+        .any(|address| address.addr().is_ipv4())
+    {
+        routes.push("0.0.0.0/0".parse().expect("static IPv4 route"));
+    }
+    if local_addresses
+        .iter()
+        .any(|address| address.addr().is_ipv6())
+    {
+        routes.push("::/0".parse().expect("static IPv6 route"));
+    }
+    routes
+}
+
+fn parse_ip_nets(value: &str, field: &str) -> Result<Vec<ipnet::IpNet>, String> {
+    parse_string_list(value)?
+        .into_iter()
+        .map(|value| parse_ip_net(&value).map_err(|_| format!("invalid-{field}-{value}")))
+        .collect()
+}
+
+fn parse_json_ip_nets(value: &serde_json::Value, field: &str) -> Result<Vec<ipnet::IpNet>, String> {
+    let values = match value {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .map(ToOwned::to_owned)
+                    .ok_or_else(|| format!("invalid-{field}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        serde_json::Value::String(value) => parse_string_list(value)?,
+        _ => return Err(format!("invalid-{field}")),
+    };
+    values
+        .into_iter()
+        .map(|value| parse_ip_net(&value).map_err(|_| format!("invalid-{field}-{value}")))
+        .collect()
+}
+
+fn parse_ip_net(value: &str) -> Result<ipnet::IpNet, ()> {
+    if let Ok(network) = value.trim().parse::<ipnet::IpNet>() {
+        return Ok(network);
+    }
+    let ip = value.trim().parse::<IpAddr>().map_err(|_| ())?;
+    ipnet::IpNet::new(ip, if ip.is_ipv4() { 32 } else { 128 }).map_err(|_| ())
+}
+
+fn parse_string_list(value: &str) -> Result<Vec<String>, String> {
+    let value = value.trim();
+    if value.starts_with('[') {
+        let values: Vec<serde_json::Value> =
+            serde_json::from_str(value).map_err(|_| "invalid-list-json".to_string())?;
+        return values
+            .into_iter()
+            .map(|value| match value {
+                serde_json::Value::String(value) => Ok(value),
+                serde_json::Value::Number(value) => Ok(value.to_string()),
+                _ => Err("list-values-must-be-scalars".into()),
+            })
+            .collect();
+    }
+    let values = value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        Err("list-must-not-be-empty".into())
+    } else {
+        Ok(values)
+    }
+}
+
+fn parse_reserved(value: &str) -> Result<[u8; 3], String> {
+    if value.trim().starts_with('[') {
+        let value = serde_json::from_str(value).map_err(|_| "invalid-reserved".to_string())?;
+        return parse_reserved_json(&value);
+    }
+    let comma = value
+        .split(',')
+        .map(str::trim)
+        .map(str::parse::<u8>)
+        .collect::<Result<Vec<_>, _>>();
+    if let Ok(bytes) = comma
+        && let Ok(bytes) = <[u8; 3]>::try_from(bytes)
+    {
+        return Ok(bytes);
+    }
+    use base64::Engine;
+    for engine in [
+        &base64::engine::general_purpose::STANDARD,
+        &base64::engine::general_purpose::STANDARD_NO_PAD,
+        &base64::engine::general_purpose::URL_SAFE,
+        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
+    ] {
+        if let Ok(bytes) = engine.decode(value.trim())
+            && let Ok(bytes) = <[u8; 3]>::try_from(bytes)
+        {
+            return Ok(bytes);
+        }
+    }
+    Err("invalid-reserved".into())
+}
+
+fn parse_reserved_json(value: &serde_json::Value) -> Result<[u8; 3], String> {
+    match value {
+        serde_json::Value::String(value) => parse_reserved(value),
+        serde_json::Value::Array(values) if values.len() == 3 => {
+            let mut output = [0; 3];
+            for (index, value) in values.iter().enumerate() {
+                output[index] = json_u64(value)
+                    .and_then(|value| u8::try_from(value).ok())
+                    .ok_or_else(|| "invalid-reserved".to_string())?;
+            }
+            Ok(output)
+        }
+        _ => Err("invalid-reserved".into()),
+    }
+}
+
+fn parse_keepalive(value: &str) -> Result<Option<u16>, String> {
+    let value = value
+        .trim()
+        .parse::<u16>()
+        .map_err(|_| "invalid-persistent-keepalive".to_string())?;
+    Ok((value != 0).then_some(value))
+}
+
+fn parse_usize_param(node: &ParsedNode, aliases: &[&str], default: usize) -> Result<usize, String> {
+    param_alias(node, aliases)?
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .map_err(|_| format!("invalid-{}", aliases[0]))
+        })
+        .transpose()
+        .map(|value| value.unwrap_or(default))
+}
+
+fn param_alias<'a>(node: &'a ParsedNode, aliases: &[&str]) -> Result<Option<&'a str>, String> {
+    let mut found = None;
+    for alias in aliases {
+        if let Some(value) = node.params.get(*alias) {
+            if let Some(previous) = found
+                && previous != value
+            {
+                return Err(format!("conflicting-{}", aliases[0]));
+            }
+            found = Some(value.as_str());
+        }
+    }
+    Ok(found)
+}
+
+fn parse_strict_bool(value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(format!("invalid-boolean-{value}")),
+    }
+}
+
+fn json_u64(value: &serde_json::Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
 }
 
 fn build_mieru(node: &ParsedNode) -> SharedOutbound {
@@ -959,9 +1556,11 @@ fn build_trusttunnel(node: &ParsedNode) -> SharedOutbound {
 
 fn decode_b64_32(s: &str) -> Option<[u8; 32]> {
     use base64::Engine;
-    let v = base64::engine::general_purpose::STANDARD
-        .decode(s.trim())
-        .ok()?;
+    use base64::engine::general_purpose::{STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD};
+    let value = s.trim();
+    let v = [STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD]
+        .iter()
+        .find_map(|engine| engine.decode(value).ok())?;
     if v.len() != 32 {
         return None;
     }
@@ -998,7 +1597,7 @@ mod tests {
     use core_config::node_uri::{NodeProtocol, ParsedNode};
     use uuid::Uuid;
 
-    use super::{build_outbound, tuic_from_node};
+    use super::{build_outbound, tuic_from_node, wireguard_from_node};
     use crate::proto::tuic::TuicUdpMode;
 
     #[test]
@@ -1095,6 +1694,149 @@ mod tests {
         assert_eq!(
             build_outbound(&node).protocol(),
             "tuic(invalid-udp-relay-mode)"
+        );
+    }
+
+    fn wireguard_node() -> ParsedNode {
+        let mut node = ParsedNode::new("wg", NodeProtocol::Wireguard, "127.0.0.1", 51_820);
+        node.params.insert(
+            "private-key".into(),
+            base64::engine::general_purpose::STANDARD.encode([1u8; 32]),
+        );
+        node.params.insert(
+            "public-key".into(),
+            base64::engine::general_purpose::STANDARD.encode([2u8; 32]),
+        );
+        node.params.insert("ip".into(), "10.0.0.2/32".into());
+        node.params.insert("ipv6".into(), "fd00::2/128".into());
+        node
+    }
+
+    #[test]
+    fn wireguard_registry_maps_complete_single_peer_config() {
+        let mut node = wireguard_node();
+        node.params
+            .insert("allowed-ips".into(), "[\"10.0.0.0/8\",\"fd00::/8\"]".into());
+        node.params.insert("reserved".into(), "[1,2,3]".into());
+        node.params
+            .insert("persistent-keepalive".into(), "17".into());
+        node.params.insert("mtu".into(), "1380".into());
+        node.params
+            .insert("tcp-buffer-size".into(), "131072".into());
+        node.params.insert("udp-buffer-size".into(), "65536".into());
+        node.params.insert("max-tcp-sessions".into(), "99".into());
+        node.params.insert("max-udp-sessions".into(), "88".into());
+        node.params.insert("packet-queue".into(), "256".into());
+        node.params.insert("workers".into(), "4".into());
+        node.params.insert("connect-timeout".into(), "3s".into());
+        node.params.insert("udp-timeout".into(), "45s".into());
+        node.params
+            .insert("remote-dns-resolve".into(), "true".into());
+        node.params.insert("dns".into(), "[\"10.0.0.53\"]".into());
+        node.params.insert("network".into(), "tcp,udp".into());
+
+        let outbound = wireguard_from_node(&node).unwrap();
+        let config = outbound.config();
+        assert_eq!(config.local_addresses.len(), 2);
+        assert_eq!(config.peers[0].allowed_ips.len(), 2);
+        assert_eq!(config.peers[0].reserved, [1, 2, 3]);
+        assert_eq!(config.peers[0].persistent_keepalive, Some(17));
+        assert_eq!(config.mtu, 1380);
+        assert_eq!(config.tcp_buffer_size, 131_072);
+        assert_eq!(config.udp_buffer_size, 65_536);
+        assert_eq!(config.max_tcp_sessions, 99);
+        assert_eq!(config.max_udp_sessions, 88);
+        assert_eq!(config.packet_queue, 256);
+        assert_eq!(config.workers, 4);
+        assert_eq!(config.connect_timeout, std::time::Duration::from_secs(3));
+        assert_eq!(config.udp_idle_timeout, std::time::Duration::from_secs(45));
+        assert!(config.remote_dns_resolve);
+        assert_eq!(
+            config.dns,
+            ["10.0.0.53".parse::<std::net::IpAddr>().unwrap()]
+        );
+        assert!(config.tcp && config.udp);
+    }
+
+    #[test]
+    fn wireguard_registry_maps_multi_peer_and_url_safe_keys() {
+        let mut node = wireguard_node();
+        node.params.insert(
+            "private-key".into(),
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([0xfbu8; 32]),
+        );
+        node.params.remove("public-key");
+        node.params.insert("reserved".into(), "[5,6,7]".into());
+        node.params.insert("workers".into(), "0".into());
+        node.params.insert(
+            "peers".into(),
+            serde_json::json!([
+                {
+                    "server": "127.0.0.1",
+                    "port": 51820,
+                    "public_key": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([3u8; 32]),
+                    "allowed_ips": ["10.0.0.0/8"],
+                    "reserved": [9, 8, 7]
+                },
+                {
+                    "endpoint": "[::1]:51821",
+                    "public-key": base64::engine::general_purpose::STANDARD.encode([4u8; 32]),
+                    "allowed-ips": ["fd00::/8"],
+                    "persistent_keepalive_interval": 0
+                }
+            ])
+            .to_string(),
+        );
+        let outbound = wireguard_from_node(&node).unwrap();
+        assert_eq!(outbound.config().peers.len(), 2);
+        assert_eq!(outbound.config().peers[0].reserved, [9, 8, 7]);
+        assert_eq!(outbound.config().peers[1].endpoint_host, "::1");
+        assert_eq!(outbound.config().peers[1].endpoint_port, 51_821);
+        assert_eq!(outbound.config().peers[1].reserved, [5, 6, 7]);
+        assert_eq!(outbound.config().peers[1].persistent_keepalive, None);
+        assert!((1..=64).contains(&outbound.config().workers));
+    }
+
+    #[test]
+    fn wireguard_registry_rejects_conflicts_and_invalid_bounds() {
+        let mut node = wireguard_node();
+        node.params.insert("private_key".into(), "different".into());
+        assert!(
+            wireguard_from_node(&node)
+                .unwrap_err()
+                .contains("conflicting")
+        );
+
+        let mut node = wireguard_node();
+        node.params.insert("mtu".into(), "70000".into());
+        let outbound = build_outbound(&node);
+        assert_eq!(outbound.protocol(), "wireguard");
+        assert!(!outbound.capabilities().tcp);
+        assert!(!outbound.capabilities().udp);
+
+        let mut node = wireguard_node();
+        node.params.insert("workres".into(), "8".into());
+        assert_eq!(
+            wireguard_from_node(&node).unwrap_err(),
+            "unknown-parameter-workres"
+        );
+
+        let mut node = wireguard_node();
+        node.params.remove("public-key");
+        node.params.insert(
+            "peers".into(),
+            serde_json::json!([{
+                "endpoint": "127.0.0.1:51820",
+                "public-key": base64::engine::general_purpose::STANDARD.encode([3u8; 32]),
+                "allowed-ips": ["10.0.0.0/8"],
+                "typo": true
+            }])
+            .to_string(),
+        );
+        assert!(
+            wireguard_from_node(&node)
+                .unwrap_err()
+                .contains("unknown-field-typo")
         );
     }
 }

--- a/crates/core-outbound/tests/testdata/wireguard-go-peer/go.mod
+++ b/crates/core-outbound/tests/testdata/wireguard-go-peer/go.mod
@@ -1,0 +1,12 @@
+module rp-kernel-wireguard-interop-peer
+
+go 1.23.1
+
+require golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446
+
+require (
+	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
+)

--- a/crates/core-outbound/tests/testdata/wireguard-go-peer/go.sum
+++ b/crates/core-outbound/tests/testdata/wireguard-go-peer/go.sum
@@ -1,0 +1,16 @@
+github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
+github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
+golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
+golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
+golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446 h1:cqHQ3AycTHvM2R7ikgyX57D+XvtcSnGylsLkOVhta/w=
+golang.zx2c4.com/wireguard v0.0.0-20260522210424-ecfc5a8d5446/go.mod h1:rpwXGsirqLqN2L0JDJQlwOboGHmptD5ZD6T2VmcqhTw=
+gvisor.dev/gvisor v0.0.0-20250503011706-39ed1f5ac29c h1:m/r7OM+Y2Ty1sgBQ7Qb27VgIMBW8ZZhT4gLnUyDIhzI=
+gvisor.dev/gvisor v0.0.0-20250503011706-39ed1f5ac29c/go.mod h1:3r5CMtNQMKIvBlrmM9xWUNamjKBYPOWyXOjmg5Kts3g=

--- a/crates/core-outbound/tests/testdata/wireguard-go-peer/main.go
+++ b/crates/core-outbound/tests/testdata/wireguard-go-peer/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun"
+)
+
+type channelTUN struct {
+	incoming chan []byte
+	outgoing chan []byte
+	events   chan tun.Event
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func newChannelTUN() *channelTUN {
+	t := &channelTUN{
+		incoming: make(chan []byte, 8),
+		outgoing: make(chan []byte, 8),
+		events:   make(chan tun.Event, 1),
+		closed:   make(chan struct{}),
+	}
+	t.events <- tun.EventUp
+	return t
+}
+
+func (t *channelTUN) File() *os.File           { return nil }
+func (t *channelTUN) MTU() (int, error)        { return 1420, nil }
+func (t *channelTUN) Name() (string, error)    { return "rp-kernel-channel-tun", nil }
+func (t *channelTUN) Events() <-chan tun.Event { return t.events }
+func (t *channelTUN) BatchSize() int           { return 1 }
+
+func (t *channelTUN) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	select {
+	case <-t.closed:
+		return 0, os.ErrClosed
+	case packet := <-t.incoming:
+		if len(bufs) == 0 || len(sizes) == 0 || offset+len(packet) > len(bufs[0]) {
+			return 0, io.ErrShortBuffer
+		}
+		copy(bufs[0][offset:], packet)
+		sizes[0] = len(packet)
+		return 1, nil
+	}
+}
+
+func (t *channelTUN) Write(bufs [][]byte, offset int) (int, error) {
+	for _, buffer := range bufs {
+		if offset > len(buffer) {
+			return 0, io.ErrShortBuffer
+		}
+		packet := append([]byte(nil), buffer[offset:]...)
+		select {
+		case <-t.closed:
+			return 0, os.ErrClosed
+		case t.outgoing <- packet:
+		}
+	}
+	return len(bufs), nil
+}
+
+func (t *channelTUN) Close() error {
+	t.once.Do(func() {
+		close(t.closed)
+		close(t.events)
+	})
+	return nil
+}
+
+func makePacket(source, destination [4]byte, marker byte) []byte {
+	packet := make([]byte, 21)
+	packet[0] = 0x45
+	packet[2] = 0
+	packet[3] = byte(len(packet))
+	packet[8] = 64
+	packet[9] = 253
+	copy(packet[12:16], source[:])
+	copy(packet[16:20], destination[:])
+	packet[20] = marker
+	return packet
+}
+
+func main() {
+	if len(os.Args) != 5 {
+		fmt.Fprintln(os.Stderr, "usage: peer endpoint private-key-hex server-public-key-hex marker")
+		os.Exit(2)
+	}
+	privateKey, err := hex.DecodeString(os.Args[2])
+	if err != nil || len(privateKey) != 32 {
+		fmt.Fprintln(os.Stderr, "invalid private key")
+		os.Exit(2)
+	}
+	serverPublic, err := hex.DecodeString(os.Args[3])
+	if err != nil || len(serverPublic) != 32 {
+		fmt.Fprintln(os.Stderr, "invalid server public key")
+		os.Exit(2)
+	}
+	marker, err := hex.DecodeString(os.Args[4])
+	if err != nil || len(marker) != 1 {
+		fmt.Fprintln(os.Stderr, "invalid marker")
+		os.Exit(2)
+	}
+
+	tunDevice := newChannelTUN()
+	logger := device.NewLogger(device.LogLevelError, "wireguard-go-interop: ")
+	wg := device.NewDevice(tunDevice, conn.NewDefaultBind(), logger)
+	defer wg.Close()
+	config := fmt.Sprintf(
+		"private_key=%s\nlisten_port=0\npublic_key=%s\nendpoint=%s\nallowed_ip=10.88.0.1/32\npersistent_keepalive_interval=1\n",
+		hex.EncodeToString(privateKey), hex.EncodeToString(serverPublic), os.Args[1],
+	)
+	if err := wg.IpcSet(config); err != nil {
+		fmt.Fprintln(os.Stderr, "IpcSet:", err)
+		os.Exit(1)
+	}
+	request := makePacket([4]byte{10, 88, 0, 2}, [4]byte{10, 88, 0, 1}, marker[0])
+	select {
+	case tunDevice.incoming <- request:
+	case <-time.After(3 * time.Second):
+		fmt.Fprintln(os.Stderr, "inject timeout")
+		os.Exit(1)
+	}
+	expected := makePacket([4]byte{10, 88, 0, 1}, [4]byte{10, 88, 0, 2}, marker[0])
+	select {
+	case response := <-tunDevice.outgoing:
+		if !bytes.Equal(response, expected) {
+			fmt.Fprintf(os.Stderr, "unexpected response: %x\n", response)
+			os.Exit(1)
+		}
+		fmt.Println("wireguard-go interop ok")
+	case <-time.After(8 * time.Second):
+		fmt.Fprintln(os.Stderr, errors.New("decrypted response timeout"))
+		os.Exit(1)
+	}
+}

--- a/crates/core-outbound/tests/wireguard_go_interop.rs
+++ b/crates/core-outbound/tests/wireguard_go_interop.rs
@@ -1,0 +1,94 @@
+use std::{path::PathBuf, process::Stdio, time::Duration};
+
+use boringtun::x25519::{PublicKey, StaticSecret};
+use core_outbound::proto::wireguard::{
+    WireGuardServer, WireGuardServerConfig, WireGuardServerPeerConfig,
+};
+
+fn packet(source: [u8; 4], destination: [u8; 4], marker: u8) -> Vec<u8> {
+    let mut packet = vec![0; 21];
+    packet[0] = 0x45;
+    packet[2..4].copy_from_slice(&(21u16).to_be_bytes());
+    packet[8] = 64;
+    packet[9] = 253;
+    packet[12..16].copy_from_slice(&source);
+    packet[16..20].copy_from_slice(&destination);
+    packet[20] = marker;
+    packet
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[tokio::test]
+#[ignore = "requires the Go toolchain and downloads the fixed official wireguard-go module"]
+async fn official_wireguard_go_peer_roundtrips_plaintext() {
+    let helper = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/testdata/wireguard-go-peer");
+    let executable = std::env::temp_dir().join(format!(
+        "rp-kernel-wireguard-interop-peer-{}{}",
+        std::process::id(),
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    let status = std::process::Command::new("go")
+        .arg("build")
+        .arg("-o")
+        .arg(&executable)
+        .arg(".")
+        .current_dir(&helper)
+        .status()
+        .expect("Go toolchain is required for this ignored interoperability test");
+    assert!(
+        status.success(),
+        "official wireguard-go helper did not build"
+    );
+
+    let client_private = [71; 32];
+    let server_private = [73; 32];
+    let client_public = *PublicKey::from(&StaticSecret::from(client_private)).as_bytes();
+    let server_public = *PublicKey::from(&StaticSecret::from(server_private)).as_bytes();
+    let server = WireGuardServer::bind(WireGuardServerConfig::new(
+        "127.0.0.1:0".parse().unwrap(),
+        server_private,
+        WireGuardServerPeerConfig::new(client_public, vec!["10.88.0.2/32".parse().unwrap()]),
+    ))
+    .await
+    .unwrap();
+    let marker = 0xa7;
+    let child = std::process::Command::new(&executable)
+        .args([
+            server.local_addr().unwrap().to_string(),
+            hex(&client_private),
+            hex(&server_public),
+            hex(&[marker]),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(10), server.recv_packet())
+        .await
+        .expect("wireguard-go did not establish a tunnel in time")
+        .unwrap();
+    assert_eq!(
+        received.packet,
+        packet([10, 88, 0, 2], [10, 88, 0, 1], marker)
+    );
+    server
+        .send_packet(&packet([10, 88, 0, 1], [10, 88, 0, 2], marker))
+        .await
+        .unwrap();
+    let output = tokio::task::spawn_blocking(move || child.wait_with_output())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "wireguard-go helper failed:\nstdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let _ = std::fs::remove_file(executable);
+    server.close().await;
+}

--- a/crates/wuther-core/src/host_resources.rs
+++ b/crates/wuther-core/src/host_resources.rs
@@ -42,6 +42,14 @@ pub(crate) fn listener_resource_claims(plan: &RuntimePlan) -> Result<Vec<HostRes
         ));
     }
 
+    for listener in &plan.listen.wireguard {
+        claims.insert(socket_claim(
+            host_owner("wuther.wireguard"),
+            SocketTransport::Udp,
+            listener.bind,
+        ));
+    }
+
     if plan.ui.on {
         if let Some(panel) = &plan.listen.panel {
             let address = panel
@@ -415,5 +423,30 @@ ui:
                 .to_string()
                 .contains("非法面板地址")
         );
+    }
+
+    #[test]
+    fn declares_wireguard_udp_listener() {
+        let plan = plan(
+            r#"
+version: 1
+profile: server
+listen:
+  wireguard:
+    - host: 127.0.0.1
+      port: 51820
+      privateKey: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+      peers:
+        - publicKey: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+          allowedIPs: [10.77.0.2/32]
+route: {preset: direct}
+"#,
+        );
+        let claims = sockets(&listener_resource_claims(&plan).unwrap());
+        assert!(claims.contains(&(
+            "wuther.wireguard".to_owned(),
+            SocketTransport::Udp,
+            "127.0.0.1:51820".parse().unwrap(),
+        )));
     }
 }

--- a/crates/wuther-core/src/host_resources.rs
+++ b/crates/wuther-core/src/host_resources.rs
@@ -42,13 +42,11 @@ pub(crate) fn listener_resource_claims(plan: &RuntimePlan) -> Result<Vec<HostRes
         ));
     }
 
-<<<<<<< HEAD
     for listener in &plan.listen.wireguard {
         claims.insert(socket_claim(
             host_owner("wuther.wireguard"),
             SocketTransport::Udp,
             listener.bind,
-=======
     for young in &plan.listen.young {
         let address = young
             .socket_addr()
@@ -61,7 +59,6 @@ pub(crate) fn listener_resource_claims(plan: &RuntimePlan) -> Result<Vec<HostRes
             host_owner("wuther.young"),
             SocketTransport::Udp,
             address,
->>>>>>> origin/main
         ));
     }
 

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -17,6 +17,9 @@ use core_api::ApiServer;
 use core_config::loader::load_from_path;
 use core_feeds::{FeedDiskCache, FeedManager, FeedSink, FeedUpdate};
 use core_inbound::{MixedListener, ensure_best_effort_privilege, run_mixed};
+use core_outbound::proto::wireguard::{
+    WireGuardServer, WireGuardServerConfig, WireGuardServerPeerConfig,
+};
 use core_ruleset::{RulesetManager, RulesetSpec, RulesetType};
 use core_runtime::{Runtime, UrlTestConfig, UrlTester};
 use core_store::Store;
@@ -936,6 +939,103 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
 
     let mut handles = Vec::new();
+    let mut wireguard_inbounds: Vec<(
+        Arc<WireGuardServer>,
+        core_capture::NetstackDispatcherHandles,
+    )> = Vec::new();
+
+    // WireGuard 服务端入站。WireGuardServer 负责 NoiseIK、cookie/MAC、重放保护、
+    // roaming 与多 peer 路由；WireGuardTunIo 把认证后的裸 IP 包接入与系统 TUN
+    // 共用的 netstack dispatcher，因此 TCP 与 UDP 最终都经过同一 Runtime 路由。
+    for (index, listener) in plan.listen.wireguard.iter().enumerate() {
+        let peers = listener
+            .peers
+            .iter()
+            .map(|peer| WireGuardServerPeerConfig {
+                public_key: peer.public_key,
+                preshared_key: peer.preshared_key,
+                allowed_ips: peer.allowed_ips.clone(),
+                reserved: peer.reserved,
+                persistent_keepalive: peer.persistent_keepalive,
+            })
+            .collect();
+        let server = match WireGuardServer::bind(WireGuardServerConfig {
+            bind: listener.bind,
+            private_key: listener.private_key,
+            peers,
+            mtu: listener.mtu,
+            packet_queue: listener.packet_queue,
+            handshake_rate_limit: listener.handshake_rate_limit,
+        })
+        .await
+        .with_context(|| {
+            format!(
+                "bind WireGuard inbound listen.wireguard[{index}] at {}",
+                listener.bind
+            )
+        }) {
+            Ok(server) => Arc::new(server),
+            Err(error) => {
+                // A later listener can fail after earlier listeners already started their
+                // netstack tasks. Roll every subsystem back explicitly instead of relying
+                // on runtime teardown or detached Tokio task drops.
+                for (server, dispatcher) in wireguard_inbounds.drain(..) {
+                    dispatcher.stop();
+                    server.close().await;
+                }
+                if let Some(supervisor) = capture_handle.as_ref() {
+                    if let Err(cleanup_error) = supervisor.stop().await {
+                        warn!(
+                            target: "capture",
+                            error = %cleanup_error,
+                            "capture stop failed while rolling back WireGuard startup"
+                        );
+                    }
+                }
+                if let Err(cleanup_error) = mesh_supervisor.stop().await {
+                    warn!(
+                        target: "mesh",
+                        error = %cleanup_error,
+                        "mesh stop failed while rolling back WireGuard startup"
+                    );
+                }
+                feed_mgr_handle.stop();
+                runtime.shutdown().await;
+                return Err(error);
+            }
+        };
+        let mut dispatcher_plan = capture_plan.clone();
+        dispatcher_plan.mtu =
+            u32::try_from(listener.mtu).expect("validated WireGuard MTU always fits into u32");
+        dispatcher_plan.ipv6_enabled = plan.resolver.ipv6;
+        dispatcher_plan.allow_loopback_destination = true;
+        let fake_pool = runtime
+            .resolver
+            .fake_pool()
+            .unwrap_or_else(|| Arc::new(core_resolver::FakeIpPool::default()));
+        let dispatcher = Arc::new(core_capture::NetstackDispatcher::new(
+            dispatcher_plan.clone(),
+            Arc::new(core_capture::NatTable::default()),
+            Arc::new(core_capture::EimNatTable::new(dispatcher_plan.udp_timeout)),
+            fake_pool,
+            runtime.dns_service.clone(),
+            core_capture::noop_ipset_provider(),
+        ));
+        let device = Arc::new(core_capture::WireGuardTunIo::new(
+            server.clone(),
+            format!("wireguard-inbound-{index}"),
+            dispatcher_plan.mtu,
+        ));
+        let dispatcher_handles = dispatcher.start(device, runtime.clone());
+        info!(
+            target: "inbound::wireguard",
+            addr = %server.local_addr().unwrap_or(listener.bind),
+            peers = listener.peers.len(),
+            mtu = listener.mtu,
+            "WireGuard inbound ready (TCP+UDP)"
+        );
+        wireguard_inbounds.push((server, dispatcher_handles));
+    }
 
     // Standalone DNS server —— mihomo `dns.listen` 等价。
     // 与 mihomo `dns/server.go::ReCreateServer` 行为一致：空地址 / port=0 → disabled。
@@ -1048,6 +1148,10 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         if let Err(e) = sup.stop().await {
             warn!(target: "capture", error = %e, "capture stop failed");
         }
+    }
+    for (server, dispatcher) in wireguard_inbounds {
+        dispatcher.stop();
+        server.close().await;
     }
     if let Err(error) = mesh_supervisor.stop().await {
         warn!(target: "mesh", error = %error, "mesh supervisor stop failed");

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -939,7 +939,6 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
 
     let mut handles = Vec::new();
-<<<<<<< HEAD
     let mut wireguard_inbounds: Vec<(
         Arc<WireGuardServer>,
         core_capture::NetstackDispatcherHandles,
@@ -1037,9 +1036,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         );
         wireguard_inbounds.push((server, dispatcher_handles));
     }
-=======
     let mut young_server_handles = Vec::new();
->>>>>>> origin/main
 
     // Standalone DNS server —— mihomo `dns.listen` 等价。
     // 与 mihomo `dns/server.go::ReCreateServer` 行为一致：空地址 / port=0 → disabled。

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -41,7 +41,9 @@
 | 经典 TLS | Trojan、VLESS、VMess | 支持对应 TLS、UUID 与安全参数 |
 | 现代隧道 | AnyTLS、Hysteria、Hysteria 2、TUIC | 包含 TLS/QUIC 路径与协议参数 |
 | 专用协议 | Snell、Mieru、Sudoku、TrustTunnel | 按各自握手、加密和复用模型实现 |
-| 系统隧道 | WireGuard、SSH | 密钥或主机校验需要单独配置 |
+| 系统隧道 | WireGuard、SSH | WireGuard 支持用户态 TCP/UDP、双栈、多 Peer 与服务端；密钥或主机校验需要单独配置 |
+
+WireGuard 的字段、约束和完整示例见 [WireGuard 配置](WIREGUARD.md)。
 
 ## 传输与解析
 

--- a/docs/WIREGUARD.md
+++ b/docs/WIREGUARD.md
@@ -1,0 +1,145 @@
+# WireGuard 配置
+
+WutherCore 的 WireGuard 出站运行在用户态，不会创建系统网卡。它使用标准 NoiseIK 握手和 WireGuard 数据报，在隧道内提供真实 TCP、UDP、IPv4 与 IPv6 协议栈；同时公开可嵌入的服务端数据面 API。实现支持多 Peer 最长前缀路由、预共享密钥、持久保活、保留字节、远端 DNS、MTU 分片与重组、端点漫游、计数器重放防护和有界资源限制。
+
+## 完整多 Peer 示例
+
+密钥为 32 字节 WireGuard 原始密钥的标准或 URL-safe Base64，可带或不带填充。示例中的密钥仅用于展示结构，不能直接用于生产环境。
+
+```yaml
+version: 1
+profile: desktop
+
+nodes:
+  - name: wg-full
+    protocol: wireguard
+    login:
+      private_key: AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=
+    params:
+      local-address:
+        - 10.20.0.2/32
+        - fd20::2/128
+      mtu: 1280
+      network: tcp,udp
+      remote-dns-resolve: true
+      dns:
+        - 10.20.0.53
+        - fd20::53
+      tcp-buffer-size: 262144
+      udp-buffer-size: 262144
+      max-tcp-sessions: 4096
+      max-udp-sessions: 4096
+      packet-queue: 1024
+      workers: 4
+      connect-timeout: 15s
+      udp-timeout: 5m
+      peers:
+        - server: wg-a.example.com
+          port: 51820
+          public-key: AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=
+          pre-shared-key: AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=
+          allowed-ips:
+            - 10.20.0.0/16
+            - fd20::/48
+          persistent-keepalive: 25
+          reserved: [0, 0, 0]
+        - server: 192.0.2.20
+          port: 51820
+          public-key: BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ=
+          allowed-ips:
+            - 0.0.0.0/0
+            - ::/0
+          persistent-keepalive: 25
+```
+
+`peers` 模式下顶层不需要 `address`。单 Peer 兼容模式可以把端点写为节点的 `address: host:port`，并在 `params` 中使用 `public-key`、`pre-shared-key`、`allowed-ips`、`persistent-keepalive` 和 `reserved`；两种 Peer 表达不能混用。
+
+## 字段与约束
+
+| 字段 | 默认值 | 约束或语义 |
+| --- | --- | --- |
+| `login.private_key` / `params.private-key` | 必填 | 32 字节 Base64 私钥，禁止全零；两个位置同时出现且值不同会拒绝配置 |
+| `local-address` / `address` | 必填 | 1–8 个 CIDR；IPv4、IPv6 均支持，必须为单播地址 |
+| `peers` | 必填或使用单 Peer 字段 | 1–4096 个；公钥必须唯一且不能等于本机公钥 |
+| `mtu` | `1420` | 576–65475；启用 IPv6 时至少 1280 |
+| `network` | `tcp,udp` | `tcp`、`udp`、`tcp,udp`、`udp,tcp` 或 `both` |
+| `dns` | 空 | 隧道内 DNS 服务器 IP，必须被某个 `allowed-ips` 覆盖 |
+| `remote-dns-resolve` | `false` | 开启后域名目标通过隧道内 DNS 查询 A/AAAA；UDP 截断响应自动改用 TCP |
+| `tcp-buffer-size` / `udp-buffer-size` | `262144` | 4096–16777216 字节 |
+| `max-tcp-sessions` / `max-udp-sessions` | `4096` | 1–65535；超过上限时拒绝新会话 |
+| `packet-queue` | `1024` | 16–65536；限制收发队列与重组资源，达到上限时施加背压或明确丢包 |
+| `workers` | 可用 CPU 数（最多 64） | `0` 或未填写时自动选择，显式值为 1–64；按 Peer 固定分片，保持同一 Peer 的密码学状态顺序 |
+| `connect-timeout` | `15s` | 大于 0 且不超过 300 秒 |
+| `udp-timeout` | `5m` | UDP 会话空闲回收时间，5 秒–24 小时 |
+
+每个 Peer 支持下列字段：
+
+| 字段 | 默认值 | 约束或语义 |
+| --- | --- | --- |
+| `server` / `address` | 必填 | UDP 端点主机或 IP |
+| `port` / `server-port` | 必填 | 1–65535 |
+| `public-key` | 必填 | 32 字节 Base64 公钥 |
+| `pre-shared-key` | 无 | 可选 32 字节 Base64 PSK |
+| `allowed-ips` | 必填 | CIDR 列表；用于出站最长前缀选路和入站源地址校验，精确重复路由会被拒绝 |
+| `persistent-keepalive` | `0`（禁用） | 秒数，`0` 表示禁用，最大 65535 |
+| `reserved` | `[0,0,0]` | 三个 0–255 字节，按兼容实现的 UDP bind 层语义收发；多 Peer 模式可用顶层值作为未单独配置 Peer 的默认值 |
+
+字段同时接受连字符和下划线别名。列表可由结构化 YAML 数组提供；订阅解析也会保留 Clash/Mihomo WireGuard 的 `allowed-ips`、`dns`、`reserved` 与 `peers` 结构。
+
+## 运行语义
+
+- 多 Peer 出站使用 `allowed-ips` 最长前缀匹配。同一精确网段不能分配给两个 Peer，避免依赖配置顺序产生歧义。
+- 对端发来的解密数据还会校验源 IP 是否属于该 Peer 的 `allowed-ips`，错误来源会被丢弃。
+- 客户端 IPv4 支持任意合法 MTU 下的分片与重组；IPv6 使用 RFC 8200 Fragment Header，并有有界、超时、拒绝重叠片段的重组器。服务端数据面按 MTU 分片出站包，入站则向调用者交付对端产生的原始 IP 包或分片。
+- TCP 流支持读写、刷新和半关闭；UDP 关联保留目标语义并按空闲时间自动回收。
+- 所有内部队列、会话数、缓存和 IPv6 重组项都有上限；关闭或对象析构会触发取消并释放后台任务。
+- 远端 DNS 缓存遵循响应 TTL（限制为 1 秒至 1 小时），最多保存 1024 条记录。
+
+## 服务端 API
+
+`core-outbound` 导出 `WireGuardServer`、`WireGuardServerConfig`、`WireGuardServerPeerConfig`、`WireGuardReceivedPacket` 和客户端/服务端 Peer 统计类型。服务端绑定真实 UDP 套接字，使用公钥识别握手 Peer，按接收索引处理后续数据，接受认证后的端点漫游，并对入站源地址和出站目的地址执行 `allowed-ips` 路由校验。调用 `recv_packet` 取得解密 IP 数据包，调用 `send_packet` 按目的地址加密并发送；`close` 用于显式取消，析构也会释放任务。
+
+`listen.wireguard` 会把这个服务端数据面注册成正式入站。认证后的裸 IP 包进入独立的用户态 netstack，再交给与 TUN 入站相同的 Runtime 路由，因此隧道内 TCP、UDP、IPv4 和 IPv6 都会执行节点选择、规则、DNS 和连接跟踪。每个监听器使用独立的 NAT、会话和取消域；启动过程中任意监听器绑定失败时，已启动的 WireGuard、capture、mesh、feed 和 runtime 都会显式回滚。
+
+```yaml
+listen:
+  wireguard:
+    - host: 0.0.0.0
+      port: 51820
+      private-key: BQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU=
+      mtu: 1420
+      packet-queue: 1024
+      handshake-rate-limit: 1000
+      peers:
+        - public-key: BgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgY=
+          pre-shared-key: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
+          allowed-ips:
+            - 10.30.0.2/32
+            - fd30::2/128
+          persistent-keepalive: 25
+          reserved: [0, 0, 0]
+```
+
+服务端监听字段：
+
+| 字段 | 默认值 | 约束或语义 |
+| --- | --- | --- |
+| `host` | `0.0.0.0` | 必须是数值 IPv4 或 IPv6 地址 |
+| `port` | 必填 | 1–65535；同一配置内不能重复绑定 |
+| `private-key` | 必填 | 32 字节 Base64 私钥，禁止全零 |
+| `peers` | 必填 | 1–256 个，公钥必须唯一 |
+| `mtu` | `1420` | 576–65475；存在 IPv6 AllowedIPs 时至少 1280 |
+| `packet-queue` | `1024` | 16–65536；限制认证明文包队列 |
+| `handshake-rate-limit` | `1000` | 1–1000000 次/秒；在密码学处理前限制握手洪泛 |
+
+服务端 Peer 的 `public-key`、`pre-shared-key`、`allowed-ips`、`persistent-keepalive` 和 `reserved` 与客户端 Peer 语义一致。`allowed-ips` 既用于接收源地址授权，也用于服务端回包的最长前缀选路；精确重复网段会在 `check` 阶段拒绝。字段同时接受连字符、下划线和文档中列出的 camelCase 别名，未知字段会直接报错。
+
+本实现覆盖标准 WireGuard v1 用户态协议。`system-interface`（系统网卡模式）、`dialer-proxy`（通过另一代理拨 WireGuard 端点）和 `amnezia-wg-option`（AmneziaWG 扩展协议）不属于这一数据面，配置注册器会明确拒绝这些字段，不会静默忽略或降级。
+
+## 互操作验证
+
+仓库包含固定官方模块版本的 `wireguard-go` 互操作测试：Rust 服务端与官方 Go Peer 通过真实 UDP 完成握手、加密数据传输和明文 IP 往返。该测试需要 Go 工具链和首次下载依赖，因此默认标记为 ignored，可按下列方式显式执行：
+
+```powershell
+cargo test -p core-outbound --test wireguard_go_interop -- --ignored --nocapture
+```


### PR DESCRIPTION
## 背景

项目原有 WireGuard 路径缺少完整的用户态协议栈、正式服务端入站及全字段配置注册，无法覆盖真实的客户端与服务端双向使用场景。本变更以标准 WireGuard 第一版协议为目标，补齐真实密码学、数据面、配置校验、运行时注册和互操作验证，不使用占位实现或私有简化帧格式。

## 实现内容

### 客户端

- 使用 BoringTun 实现标准 NoiseIK 握手、密钥轮换、消息计数器、重放保护、预共享密钥、保留字节和持久保活。
- 实现用户态 TCP、UDP、IPv4、IPv6 数据面，不依赖系统网卡。
- 支持多对等端、允许网段最长前缀选路、入站源地址授权、端点域名解析和连接超时。
- 支持隧道内域名解析、响应生存期缓存、截断响应转 TCP、双栈地址选择。
- 支持 IPv4 与 IPv6 分片和有界重组，拒绝重叠分片并执行超时回收。
- 为 TCP、UDP、包队列、工作线程、缓存和会话数提供明确上限与关闭取消语义。

### 服务端与正式入站

- 实现真实 UDP WireGuard 服务端，支持多对等端握手识别、握手速率限制、数据索引路由、端点漫游、允许网段校验和最长前缀回包选路。
- 新增 `listen.wireguard` 正式入站，将认证后的裸 IP 包接入独立用户态网络栈，再交给统一运行时路由。
- 隧道内 TCP、UDP、IPv4、IPv6 均经过节点选择、规则、域名解析和连接跟踪。
- 注册监听端口宿主资源声明，启动前参与端口冲突检查。
- 正常关闭时显式停止网络栈任务和服务端；多个监听器中任一绑定失败时，显式回滚已启动的 WireGuard、流量接管、组网监督、订阅管理和运行时资源。
- 修正网络栈 TCP 接受路径中本地地址与远端地址颠倒的问题，并以真实端到端测试覆盖。

### 配置与校验

- 完整注册客户端私钥、本地地址、对等端、公钥、预共享密钥、允许网段、保留字节、持久保活、域名解析、缓冲区、会话上限、包队列、工作线程、连接超时、UDP 超时和网络类型。
- 完整注册服务端监听地址、端口、私钥、对等端、最大传输单元、包队列和握手速率限制。
- 支持连字符、下划线及已文档化的驼峰别名；未知字段直接报错，不静默忽略。
- 校验密钥长度与全零值、地址族、端口、最大传输单元、队列范围、唯一公钥、重复路由、监听冲突及各项资源边界。
- 更新功能矩阵和 WireGuard 专项配置文档，补充客户端、服务端完整示例、字段默认值、约束和运行语义。

## 兼容性与互操作

- 使用固定版本的官方 `wireguard-go` 作为真实 UDP 对等端，完成标准握手、加密数据传输和明文 IP 往返。
- 客户端与服务端均使用标准 WireGuard 数据报格式，可与标准实现互操作。
- 明确拒绝当前数据面不支持的系统网卡模式、拨号代理和 AmneziaWG 扩展字段，避免无提示降级。

## 验证结果

- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。
- `cargo check --workspace --all-targets`：通过。
- `cargo test -p core-config`：七十三项通过，零失败。
- `cargo test -p core-capture`：三百一十四项通过，零失败。
- `cargo test -p core-outbound wireguard -- --nocapture`：WireGuard 相关测试全部通过。
- `cargo test -p core-outbound --test wireguard_go_interop -- --ignored --nocapture`：官方实现互操作测试通过。
- 真实端到端链路已覆盖：WireGuard 客户端经真实加密隧道进入服务端，再经用户态网络栈与统一运行时访问本地 TCP 和 UDP 回显服务。

## 影响与边界

本变更只引入标准 WireGuard 第一版用户态协议能力，不创建系统网卡，也不修改系统路由。系统网卡模式、通过其他代理拨号以及 AmneziaWG 扩展仍明确不在本次范围内，配置层会拒绝相关字段。所有新增资源均具有边界检查、取消和显式清理路径。
