### PR TITLE
实现完整 gRPC 客户端、服务端与 Xray 互操作

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1111,6 +1111,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-grpc"
+version = "0.3.1-rc.5"
+dependencies = [
+ "bytes",
+ "futures",
+ "http 1.4.2",
+ "hyper",
+ "hyper-util",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "core-inbound"
 version = "0.3.1-rc.5"
 dependencies = [
@@ -1122,6 +1140,7 @@ dependencies = [
  "bytes",
  "chrono",
  "core-config",
+ "core-grpc",
  "core-observe",
  "core-outbound",
  "core-reality",
@@ -1227,6 +1246,7 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "core-config",
+ "core-grpc",
  "core-reality",
  "core-young",
  "crc32fast",
@@ -2980,6 +3000,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,6 +3867,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3987,6 +4036,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4211,7 +4283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f121c276d3f2fba8caabc870288de3f81abdb0bb94d5510651e58e1e00a7b9e7"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5402,11 +5474,15 @@ dependencies = [
 name = "tests-e2e"
 version = "0.3.1-rc.5"
 dependencies = [
+ "base64 0.22.1",
  "core-config",
+ "core-grpc",
  "core-inbound",
  "core-outbound",
+ "core-reality",
  "core-runtime",
  "core-smart",
+ "futures",
  "hex",
  "quinn",
  "rcgen 0.13.2",
@@ -5416,6 +5492,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5583,9 +5660,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.19"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5652,6 +5729,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.4",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.4.2",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/core-runtime",
     "crates/core-inbound",
     "crates/core-outbound",
+    "crates/core-grpc",
     "crates/core-feeds",
     "crates/core-store",
     "crates/core-ruleset",
@@ -93,6 +94,9 @@ hyper            = { version = "1", features = ["client", "http1", "http2"] }
 hyper-util       = { version = "0.1", features = ["client", "client-legacy", "tokio"] }
 http             = "1"
 http-body-util   = "0.1"
+prost            = "=0.13.5"
+tonic            = { version = "=0.13.1", default-features = false, features = ["prost"] }
+tokio-stream     = { version = "=0.1.18", features = ["sync"] }
 flate2           = "1"
 brotli           = "7"
 redb = "2.2"
@@ -156,6 +160,7 @@ core-fetch    = { path = "crates/core-fetch" }
 core-runtime  = { path = "crates/core-runtime" }
 core-inbound  = { path = "crates/core-inbound" }
 core-outbound = { path = "crates/core-outbound" }
+core-grpc     = { path = "crates/core-grpc" }
 core-feeds    = { path = "crates/core-feeds" }
 core-store    = { path = "crates/core-store" }
 core-ruleset  = { path = "crates/core-ruleset" }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,5 +1,23 @@
 # 第三方组件声明
 
+## tonic 0.13.1
+
+- 上游：`https://github.com/hyperium/tonic`
+- 用途：gRPC 客户端/服务端 codec、状态码与双向流语义。
+- 许可证：MIT。
+
+## prost 0.13.5
+
+- 上游：`https://github.com/tokio-rs/prost`
+- 用途：Xray `Hunk` / `MultiHunk` protobuf 消息编解码。
+- 许可证：Apache-2.0。
+
+## tokio-stream 0.1.18
+
+- 上游：`https://github.com/tokio-rs/tokio`
+- 用途：有界异步消息通道的 `Stream` 适配。
+- 许可证：MIT。
+
 ## shaped-rustls
 
 - 上游：`https://github.com/aimalygin/shaped-rustls`

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -227,6 +227,23 @@ pub struct Listen {
     /// Young 原生入站。传输层是 Firefox 使用的 Mozilla Neqo HTTP/3/WebTransport。
     #[serde(default, alias = "young-inbounds", alias = "young_inbounds")]
     pub young: Vec<YoungListen>,
+    /// Xray gRPC (`gun`) 入站。每个条目独立监听，并把 Tun/TunMulti
+    /// 双向流交给 `protocol` 指定的内层代理协议。
+    #[serde(default, alias = "grpc-inbounds", alias = "grpc_inbounds")]
+    pub grpc: Vec<GrpcListen>,
+}
+
+/// 完整的 Xray gRPC 服务端监听配置。
+///
+/// `grpcSettings` 沿用 Xray 字段名；本地资源上限单独注册，所有未知字段
+/// 均拒绝，避免拼写错误导致无界队列或静默使用默认值。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GrpcListenSecurity {
+    #[default]
+    None,
+    Tls,
+    Reality,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -412,6 +429,126 @@ impl std::fmt::Debug for YoungListen {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GrpcListen {
+    #[serde(default = "default_grpc_listen_host")]
+    pub host: String,
+    pub port: u16,
+    #[serde(default = "default_grpc_inner_protocol")]
+    pub protocol: String,
+    #[serde(default)]
+    pub users: Vec<String>,
+    #[serde(
+        default,
+        rename = "grpcSettings",
+        alias = "grpc",
+        alias = "grpc_settings",
+        alias = "grpc-settings"
+    )]
+    pub grpc_settings: GrpcTransportSettings,
+    /// 底层安全载波。省略时是明文 h2c；TLS 与 REALITY 必须显式选择，
+    /// 防止密钥配置存在但因拼写或遗漏而静默降级。
+    #[serde(default)]
+    pub security: GrpcListenSecurity,
+    /// 与 Xray `tlsSettings` 同构的完整 TLS 对象。gRPC 会强制协商 h2，
+    /// 其余证书、ECH、mTLS、版本、密码套件与曲线字段不做裁剪。
+    #[serde(
+        default,
+        rename = "tlsSettings",
+        alias = "tls_settings",
+        alias = "tls-settings"
+    )]
+    pub tls_settings: Option<XhttpDownloadTlsSettings>,
+    #[serde(
+        default,
+        rename = "requireClientCertificate",
+        alias = "require_client_certificate",
+        alias = "require-client-certificate"
+    )]
+    pub require_client_certificate: bool,
+    /// REALITY 服务端设置复用完整的监听模型。嵌套对象的 host、port、
+    /// protocol 与 users 由外层 gRPC 监听统一覆盖，避免重复配置冲突。
+    #[serde(
+        default,
+        rename = "realitySettings",
+        alias = "reality_settings",
+        alias = "reality-settings"
+    )]
+    pub reality_settings: Option<Box<RealityListen>>,
+    #[serde(
+        default = "default_grpc_vless_handshake_timeout",
+        with = "humantime_serde",
+        rename = "handshakeTimeout",
+        alias = "handshake_timeout",
+        alias = "handshake-timeout"
+    )]
+    pub handshake_timeout: Duration,
+    #[serde(
+        default = "default_grpc_max_mux_sessions",
+        rename = "maxMuxSessions",
+        alias = "max_mux_sessions",
+        alias = "max-mux-sessions"
+    )]
+    pub max_mux_sessions: usize,
+    #[serde(
+        default = "default_grpc_max_connections",
+        rename = "maxConnections",
+        alias = "max_connections",
+        alias = "max-connections"
+    )]
+    pub max_connections: usize,
+    #[serde(
+        default = "default_grpc_max_concurrent_streams",
+        rename = "maxConcurrentStreams",
+        alias = "max_concurrent_streams",
+        alias = "max-concurrent-streams"
+    )]
+    pub max_concurrent_streams: u32,
+    #[serde(
+        default = "default_grpc_max_header_list_size",
+        rename = "maxHeaderListSize",
+        alias = "max_header_list_size",
+        alias = "max-header-list-size"
+    )]
+    pub max_header_list_size: u32,
+    /// 与 Xray 一致：这里存放“信任标记请求头”的名称；仅当请求中至少
+    /// 存在一个标记头时，才采用 X-Forwarded-For 的第一个地址。
+    #[serde(
+        default,
+        rename = "trustedXForwardedFor",
+        alias = "trusted_x_forwarded_for",
+        alias = "trusted-x-forwarded-for"
+    )]
+    pub trusted_x_forwarded_for: Vec<String>,
+}
+
+impl std::fmt::Debug for GrpcListen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GrpcListen")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("protocol", &self.protocol)
+            .field("user_count", &self.users.len())
+            .field("grpc_settings", &self.grpc_settings)
+            .field("security", &self.security)
+            .field("has_tls_settings", &self.tls_settings.is_some())
+            .field(
+                "require_client_certificate",
+                &self.require_client_certificate,
+            )
+            .field("reality_settings", &self.reality_settings)
+            .field("handshake_timeout", &self.handshake_timeout)
+            .field("max_mux_sessions", &self.max_mux_sessions)
+            .field("max_connections", &self.max_connections)
+            .field("max_concurrent_streams", &self.max_concurrent_streams)
+            .field("max_header_list_size", &self.max_header_list_size)
+            .field("trusted_x_forwarded_for", &self.trusted_x_forwarded_for)
+            .finish()
+    }
+}
+
 /// Xray REALITY 服务端监听配置。
 ///
 /// 字段名同时接受 Xray 的 camelCase 与本项目常用的 snake/kebab 写法；
@@ -421,6 +558,7 @@ impl std::fmt::Debug for YoungListen {
 pub struct RealityListen {
     #[serde(default = "default_reality_listen_host")]
     pub host: String,
+    #[serde(default)]
     pub port: u16,
     #[serde(default = "default_reality_inner_protocol")]
     pub protocol: String,
@@ -1162,6 +1300,93 @@ pub struct NodeTransport {
         alias = "splithttp-settings"
     )]
     pub xhttp: Option<XhttpConfig>,
+    /// Xray-compatible gRPC transport settings. Keeping these settings typed
+    /// prevents misspelled fields from being silently discarded before the
+    /// runtime plan is built.
+    #[serde(
+        default,
+        rename = "grpcSettings",
+        alias = "grpc",
+        alias = "grpc_settings",
+        alias = "grpc-settings"
+    )]
+    pub grpc_settings: Option<GrpcTransportSettings>,
+}
+
+/// Complete Xray gRPC (`gun`) stream settings plus bounded local resources.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct GrpcTransportSettings {
+    #[serde(default)]
+    pub authority: Option<String>,
+    #[serde(
+        default,
+        rename = "serviceName",
+        alias = "service_name",
+        alias = "service-name"
+    )]
+    pub service_name: Option<String>,
+    #[serde(
+        default,
+        rename = "multiMode",
+        alias = "multi_mode",
+        alias = "multi-mode"
+    )]
+    pub multi_mode: Option<bool>,
+    #[serde(
+        default,
+        rename = "idle_timeout",
+        alias = "idleTimeout",
+        alias = "idle-timeout"
+    )]
+    pub idle_timeout: Option<CompatDuration>,
+    #[serde(
+        default,
+        rename = "health_check_timeout",
+        alias = "healthCheckTimeout",
+        alias = "health-check-timeout"
+    )]
+    pub health_check_timeout: Option<CompatDuration>,
+    #[serde(
+        default,
+        rename = "permit_without_stream",
+        alias = "permitWithoutStream",
+        alias = "permit-without-stream"
+    )]
+    pub permit_without_stream: Option<bool>,
+    #[serde(
+        default,
+        rename = "initial_windows_size",
+        alias = "initialWindowSize",
+        alias = "initial_window_size",
+        alias = "initial-window-size",
+        alias = "initial-windows-size"
+    )]
+    pub initial_window_size: Option<u32>,
+    #[serde(
+        default,
+        rename = "user_agent",
+        alias = "userAgent",
+        alias = "user-agent"
+    )]
+    pub user_agent: Option<String>,
+    /// Local defensive limit for the encoded protobuf message;
+    /// Xray/grpc-go defaults to four MiB.
+    #[serde(
+        default,
+        rename = "max_message_size",
+        alias = "maxMessageSize",
+        alias = "max-message-size"
+    )]
+    pub max_message_size: Option<usize>,
+    /// Number of protobuf messages allowed to wait for transport backpressure.
+    #[serde(
+        default,
+        rename = "queue_capacity",
+        alias = "queueCapacity",
+        alias = "queue-capacity"
+    )]
+    pub queue_capacity: Option<usize>,
 }
 
 /// Xray `Int32Range` 的无损配置表示。
@@ -3878,7 +4103,7 @@ pub struct MihomoRuleProviderSpec {
 }
 
 /// 上游刷新周期兼容表示：Mihomo 使用整数秒，sing-box 使用 duration 字符串。
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CompatDuration {
     Seconds(u64),
@@ -4783,6 +5008,27 @@ pub struct TailscaleUserspaceProxy {
 
 fn default_localhost() -> String {
     "127.0.0.1".into()
+}
+fn default_grpc_listen_host() -> String {
+    "0.0.0.0".into()
+}
+fn default_grpc_inner_protocol() -> String {
+    "vless".into()
+}
+fn default_grpc_vless_handshake_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+fn default_grpc_max_mux_sessions() -> usize {
+    1024
+}
+fn default_grpc_max_connections() -> usize {
+    4096
+}
+fn default_grpc_max_concurrent_streams() -> u32 {
+    1024
+}
+fn default_grpc_max_header_list_size() -> u32 {
+    64 * 1024
 }
 fn default_reality_listen_host() -> String {
     "0.0.0.0".into()

--- a/crates/core-config/src/profile.rs
+++ b/crates/core-config/src/profile.rs
@@ -18,6 +18,7 @@ pub fn apply_defaults(cfg: &mut UserConfig) {
         reality: vec![],
         wireguard: vec![],
         young: vec![],
+        grpc: vec![],
     });
     if listen.local.is_none() {
         listen.local = match profile {

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -48,6 +48,7 @@ pub struct ListenPlan {
     #[serde(default)]
     pub wireguard: Vec<WireGuardListenPlan>,
     pub young: Vec<YoungListen>,
+    pub grpc: Vec<GrpcListen>,
     pub panel: Option<PanelListen>,
     pub xhttp: Vec<XhttpListenPlan>,
     pub share: Share,
@@ -343,6 +344,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         reality: vec![],
         wireguard: vec![],
         young: vec![],
+        grpc: vec![],
     });
 
     let share = listen.share.unwrap_or(Share::False);
@@ -421,12 +423,14 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
     let reality = compile_reality_listeners(&listen.reality)?;
     let wireguard = compile_wireguard_listeners(&listen.wireguard)?;
     let young = compile_young_listeners(&listen.young)?;
+    let grpc = compile_grpc_listeners(&listen.grpc)?;
 
     Ok(ListenPlan {
         mixed,
         reality,
         wireguard,
         young,
+        grpc,
         panel,
         xhttp,
         share,
@@ -657,6 +661,244 @@ fn compile_young_listeners(listeners: &[YoungListen]) -> ConfigResult<Vec<YoungL
         output.push(listener.clone());
     }
     Ok(output)
+}
+
+fn compile_grpc_listeners(listeners: &[GrpcListen]) -> ConfigResult<Vec<GrpcListen>> {
+    const MIN_MESSAGE_SIZE: usize = 3;
+    const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+    const MAX_QUEUE_CAPACITY: usize = 1024;
+
+    let mut out = Vec::with_capacity(listeners.len());
+    let mut bound = HashSet::new();
+    for (index, source) in listeners.iter().enumerate() {
+        let location = format!("listen.grpc[{index}]");
+        if source.port == 0 {
+            return Err(ConfigError::invalid("gRPC 监听端口不能为 0").at(location));
+        }
+        let host = source.host.trim();
+        if host.is_empty() {
+            return Err(ConfigError::invalid("gRPC 监听地址不能为空").at(location));
+        }
+        let address = parse_listener_address(host, source.port).map_err(|error| {
+            ConfigError::invalid(format!("非法 gRPC 监听地址 `{host}`: {error}"))
+                .at(format!("{location}.host"))
+        })?;
+        if !bound.insert(address) {
+            return Err(ConfigError::invalid("重复的 gRPC 监听地址").at(location));
+        }
+        if !source.protocol.eq_ignore_ascii_case("vless") {
+            return Err(ConfigError::invalid(format!(
+                "gRPC 入站目前只接受完整实现的 VLESS 内层协议，收到 `{}`",
+                source.protocol
+            ))
+            .at(format!("{location}.protocol")));
+        }
+        if source.users.is_empty() {
+            return Err(
+                ConfigError::invalid("gRPC VLESS 入站至少需要一个 users UUID").at(location),
+            );
+        }
+        let mut users = HashSet::with_capacity(source.users.len());
+        for (user_index, user) in source.users.iter().enumerate() {
+            let parsed = uuid::Uuid::parse_str(user).map_err(|error| {
+                ConfigError::invalid(format!("非法 VLESS UUID: {error}"))
+                    .at(format!("{location}.users[{user_index}]"))
+            })?;
+            if !users.insert(parsed) {
+                return Err(ConfigError::invalid("gRPC VLESS users 中存在重复 UUID")
+                    .at(format!("{location}.users[{user_index}]")));
+            }
+        }
+        if source.handshake_timeout.is_zero() {
+            return Err(ConfigError::invalid("handshakeTimeout 必须大于 0")
+                .at(format!("{location}.handshakeTimeout")));
+        }
+        if source.max_mux_sessions == 0 || source.max_mux_sessions > u16::MAX as usize {
+            return Err(ConfigError::invalid("maxMuxSessions 必须在 1..=65535")
+                .at(format!("{location}.maxMuxSessions")));
+        }
+        if source.max_connections == 0 || source.max_connections > u16::MAX as usize {
+            return Err(ConfigError::invalid("maxConnections 必须在 1..=65535")
+                .at(format!("{location}.maxConnections")));
+        }
+        if source.max_concurrent_streams == 0 {
+            return Err(ConfigError::invalid("maxConcurrentStreams 必须大于 0")
+                .at(format!("{location}.maxConcurrentStreams")));
+        }
+        if source.max_header_list_size == 0 {
+            return Err(ConfigError::invalid("maxHeaderListSize 必须大于 0")
+                .at(format!("{location}.maxHeaderListSize")));
+        }
+
+        let settings = &source.grpc_settings;
+        for (name, value) in [
+            ("idle_timeout", settings.idle_timeout.as_ref()),
+            (
+                "health_check_timeout",
+                settings.health_check_timeout.as_ref(),
+            ),
+        ] {
+            if let Some(value) = value {
+                let duration = value.duration();
+                if duration.subsec_nanos() != 0 || duration.as_secs() > i32::MAX as u64 {
+                    return Err(ConfigError::invalid(format!(
+                        "{name} 必须是 0..={} 范围内的整数秒",
+                        i32::MAX
+                    ))
+                    .at(format!("{location}.grpcSettings.{name}")));
+                }
+            }
+        }
+        if settings
+            .initial_window_size
+            .is_some_and(|value| value > i32::MAX as u32)
+        {
+            return Err(
+                ConfigError::invalid("initial_windows_size 超出 Xray int32 范围")
+                    .at(format!("{location}.grpcSettings.initial_windows_size")),
+            );
+        }
+        if let Some(value) = settings.max_message_size
+            && !(MIN_MESSAGE_SIZE..=MAX_MESSAGE_SIZE).contains(&value)
+        {
+            return Err(ConfigError::invalid(format!(
+                "max_message_size 必须在 {MIN_MESSAGE_SIZE}..={MAX_MESSAGE_SIZE}"
+            ))
+            .at(format!("{location}.grpcSettings.max_message_size")));
+        }
+        if let Some(value) = settings.queue_capacity
+            && (value == 0 || value > MAX_QUEUE_CAPACITY)
+        {
+            return Err(ConfigError::invalid(format!(
+                "queue_capacity 必须在 1..={MAX_QUEUE_CAPACITY}"
+            ))
+            .at(format!("{location}.grpcSettings.queue_capacity")));
+        }
+        if settings
+            .authority
+            .as_deref()
+            .is_some_and(|value| has_header_injection(value))
+        {
+            return Err(ConfigError::invalid("authority 含非法控制字符")
+                .at(format!("{location}.grpcSettings.authority")));
+        }
+        if settings
+            .user_agent
+            .as_deref()
+            .is_some_and(has_header_injection)
+        {
+            return Err(ConfigError::invalid("user_agent 含非法控制字符")
+                .at(format!("{location}.grpcSettings.user_agent")));
+        }
+        for (header_index, header) in source.trusted_x_forwarded_for.iter().enumerate() {
+            if !is_http_header_name(header) {
+                return Err(
+                    ConfigError::invalid("trustedXForwardedFor 含非法 HTTP 头名称")
+                        .at(format!("{location}.trustedXForwardedFor[{header_index}]")),
+                );
+            }
+        }
+
+        let mut normalized = source.clone();
+        normalized.host = host.to_owned();
+        normalized.protocol = "vless".into();
+        match source.security {
+            GrpcListenSecurity::None => {
+                if source.tls_settings.is_some()
+                    || source.reality_settings.is_some()
+                    || source.require_client_certificate
+                {
+                    return Err(ConfigError::invalid(
+                        "security=none 不能同时配置 tlsSettings、realitySettings 或 requireClientCertificate",
+                    )
+                    .at(format!("{location}.security")));
+                }
+            }
+            GrpcListenSecurity::Tls => {
+                if source.reality_settings.is_some() {
+                    return Err(
+                        ConfigError::invalid("security=tls 不能同时配置 realitySettings")
+                            .at(format!("{location}.realitySettings")),
+                    );
+                }
+                let mut tls = source.tls_settings.clone().ok_or_else(|| {
+                    ConfigError::invalid("security=tls 必须配置 tlsSettings")
+                        .at(format!("{location}.tlsSettings"))
+                })?;
+                match tls.alpn.as_mut() {
+                    None => tls.alpn = Some(vec!["h2".into()]),
+                    Some(alpn) if !alpn.iter().any(|value| value == "h2") => {
+                        return Err(ConfigError::invalid(
+                            "gRPC TLS 的 alpn 必须包含 h2，禁止静默回退到 HTTP/1.1",
+                        )
+                        .at(format!("{location}.tlsSettings.alpn")));
+                    }
+                    Some(_) => {}
+                }
+                tls.validate().map_err(|error| {
+                    ConfigError::invalid(format!("gRPC TLS 配置非法：{error}"))
+                        .at(format!("{location}.tlsSettings"))
+                })?;
+                normalized.tls_settings = Some(tls);
+            }
+            GrpcListenSecurity::Reality => {
+                if source.tls_settings.is_some() || source.require_client_certificate {
+                    return Err(ConfigError::invalid(
+                        "security=reality 不能同时配置 tlsSettings 或 requireClientCertificate",
+                    )
+                    .at(format!("{location}.security")));
+                }
+                let mut reality = source.reality_settings.as_deref().cloned().ok_or_else(|| {
+                    ConfigError::invalid("security=reality 必须配置 realitySettings")
+                        .at(format!("{location}.realitySettings"))
+                })?;
+                reality.host = normalized.host.clone();
+                reality.port = normalized.port;
+                reality.protocol = "vless".into();
+                reality.users = normalized.users.clone();
+                let mut validated = compile_reality_listeners(&[reality])?;
+                normalized.reality_settings = Some(Box::new(validated.remove(0)));
+            }
+        }
+        out.push(normalized);
+    }
+    Ok(out)
+}
+
+fn parse_listener_address(host: &str, port: u16) -> Result<SocketAddr, std::net::AddrParseError> {
+    host.trim_matches(['[', ']'])
+        .parse::<IpAddr>()
+        .map(|ip| SocketAddr::new(ip, port))
+}
+
+fn has_header_injection(value: &str) -> bool {
+    value
+        .bytes()
+        .any(|byte| byte == b'\r' || byte == b'\n' || byte == 0)
+}
+
+fn is_http_header_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
 }
 
 fn compile_reality_listeners(listeners: &[RealityListen]) -> ConfigResult<Vec<RealityListen>> {
@@ -1404,7 +1646,19 @@ fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
                 d.name
             )));
         }
-        let explicit_tls = secure.tls.unwrap_or(false);
+        let tls_material = !reality_enabled
+            && (secure.tls_settings.is_some()
+                || secure.sni.is_some()
+                || secure.fingerprint.is_some()
+                || secure.utls.is_some()
+                || secure.ech == Some(true));
+        if secure.tls == Some(false) && tls_material {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 显式禁用 TLS，但仍提供了 TLS/ECH 配置",
+                d.name
+            )));
+        }
+        let explicit_tls = secure.tls.unwrap_or(tls_material);
         if explicit_tls && reality_enabled {
             return Err(ConfigError::bad_node(format!(
                 "node {} 不能同时启用普通 TLS 与 REALITY",
@@ -1474,7 +1728,27 @@ fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
             node.params.insert("utls".into(), utls.clone());
         }
         if let Some(ech) = secure.ech {
-            node.params.insert("ech".into(), ech.to_string());
+            if ech && reality_enabled {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 不能同时启用 ECH 与 REALITY",
+                    d.name
+                )));
+            }
+            if ech && tls_settings.ech_config_list.is_none() {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 的 secure.ech=true 必须同时提供 tlsSettings.echConfigList",
+                    d.name
+                )));
+            }
+            if !ech && tls_settings.ech_config_list.is_some() {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 的 secure.ech=false 与 tlsSettings.echConfigList 冲突",
+                    d.name
+                )));
+            }
+            if ech {
+                node.params.insert("ech".into(), "true".into());
+            }
         }
 
         if reality_enabled {
@@ -1588,6 +1862,87 @@ fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
             node.xhttp = Some(xhttp.clone());
             node.transport = "xhttp".into();
         }
+        if let Some(grpc) = transport.grpc_settings.as_ref() {
+            if transport.kind.as_deref().is_some_and(|kind| {
+                !kind.eq_ignore_ascii_case("grpc") && !kind.eq_ignore_ascii_case("gun")
+            }) {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 配置了 grpcSettings，但 transport.kind 不是 grpc/gun",
+                    d.name
+                )));
+            }
+            if transport.xhttp.is_some() {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 不能同时配置 XHTTP 与 gRPC 传输",
+                    d.name
+                )));
+            }
+            node.transport = "grpc".into();
+            insert_optional_param(&mut node, "authority", grpc.authority.as_ref())?;
+            insert_optional_param(&mut node, "serviceName", grpc.service_name.as_ref())?;
+            insert_optional_param(
+                &mut node,
+                "multiMode",
+                grpc.multi_mode.as_ref().map(bool::to_string).as_ref(),
+            )?;
+            insert_grpc_duration_param(&mut node, "idle_timeout", grpc.idle_timeout.as_ref())?;
+            insert_grpc_duration_param(
+                &mut node,
+                "health_check_timeout",
+                grpc.health_check_timeout.as_ref(),
+            )?;
+            insert_optional_param(
+                &mut node,
+                "permit_without_stream",
+                grpc.permit_without_stream
+                    .as_ref()
+                    .map(bool::to_string)
+                    .as_ref(),
+            )?;
+            insert_optional_param(
+                &mut node,
+                "initial_windows_size",
+                grpc.initial_window_size
+                    .as_ref()
+                    .map(u32::to_string)
+                    .as_ref(),
+            )?;
+            if grpc
+                .initial_window_size
+                .is_some_and(|value| value > i32::MAX as u32)
+            {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 的 gRPC initial_windows_size 超出 int32 范围",
+                    d.name
+                )));
+            }
+            insert_optional_param(&mut node, "user_agent", grpc.user_agent.as_ref())?;
+            if grpc
+                .max_message_size
+                .is_some_and(|value| !(3..=64 * 1024 * 1024).contains(&value))
+                || grpc
+                    .queue_capacity
+                    .is_some_and(|value| value == 0 || value > 1024)
+            {
+                return Err(ConfigError::bad_node(format!(
+                    "node {} 的 gRPC 资源上限非法",
+                    d.name
+                )));
+            }
+            insert_optional_param(
+                &mut node,
+                "max_message_size",
+                grpc.max_message_size
+                    .as_ref()
+                    .map(usize::to_string)
+                    .as_ref(),
+            )?;
+            insert_optional_param(
+                &mut node,
+                "queue_capacity",
+                grpc.queue_capacity.as_ref().map(usize::to_string).as_ref(),
+            )?;
+        }
     }
     if let Some(network) = &d.network {
         if let Some(udp) = network.udp {
@@ -1635,6 +1990,43 @@ fn parse_node_address(name: &str, address: &str) -> ConfigResult<(String, u16)> 
         host.trim_matches(|c| c == '[' || c == ']').to_string(),
         port,
     ))
+}
+
+fn insert_optional_param(
+    node: &mut ParsedNode,
+    key: &str,
+    value: Option<&String>,
+) -> ConfigResult<()> {
+    if let Some(value) = value {
+        if let Some(existing) = node.params.get(key)
+            && existing != value
+        {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 的 transport.{key} 配置冲突：`{existing}` 与 `{value}`",
+                node.name
+            )));
+        }
+        node.params.insert(key.to_string(), value.clone());
+    }
+    Ok(())
+}
+
+fn insert_grpc_duration_param(
+    node: &mut ParsedNode,
+    key: &str,
+    value: Option<&CompatDuration>,
+) -> ConfigResult<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let duration = value.duration();
+    if duration.subsec_nanos() != 0 || duration.as_secs() > i32::MAX as u64 {
+        return Err(ConfigError::bad_node(format!(
+            "node {} 的 gRPC {key} 必须是 int32 范围内的整秒数",
+            node.name
+        )));
+    }
+    insert_optional_param(node, key, Some(&duration.as_secs().to_string()))
 }
 
 fn compile_groups(
@@ -2522,6 +2914,9 @@ mod tests {
     use super::*;
     use crate::profile::apply_defaults;
 
+    const TEST_ECH_CONFIG_LIST: &str =
+        "AD7+DQA6AAAgACC7Lynj4wV+BBnVL8X0QRh3b422HOpP33YHm5NgbFpiSAAIAAEAAQABAAMAB2VjaC5jb20AAA==";
+
     fn base64url_bytes(byte: u8, len: usize) -> String {
         use base64::Engine as _;
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vec![byte; len])
@@ -3014,7 +3409,7 @@ master_key_log: none
 
     #[test]
     fn structured_xhttp_is_preserved_without_string_map_loss() {
-        let plan = compile_cfg(
+        let plan = compile_cfg(&format!(
             r#"
 version: 1
 profile: desktop
@@ -3029,6 +3424,7 @@ nodes:
       tls: true
       sni: sni.example.com
       fingerprint: chrome
+      ech: true
       tls-settings:
         enable-session-resumption: true
         pinned-peer-cert-sha256: "11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11"
@@ -3053,8 +3449,8 @@ nodes:
       mptcp: true
       mark: 123
       ip_family: ipv4
-"#,
-        );
+"#
+        ));
         let node = &plan.nodes[0];
         assert_eq!(node.transport, "xhttp");
         assert_eq!(node.transport_host.as_deref(), Some("cdn.example.com"));
@@ -3097,6 +3493,32 @@ nodes:
     }
 
     #[test]
+    fn structured_ech_toggle_requires_executable_settings_and_rejects_conflicts() {
+        let mut detail = NodeDetail {
+            name: "ech-client".into(),
+            protocol: Some("vless".into()),
+            address: Some("127.0.0.1:443".into()),
+            secure: Some(NodeSecure {
+                tls: Some(true),
+                ech: Some(true),
+                ..NodeSecure::default()
+            }),
+            ..NodeDetail::default()
+        };
+        assert!(detail_to_parsed(&detail).is_err());
+
+        let secure = detail.secure.as_mut().unwrap();
+        secure.tls_settings = Some(XhttpDownloadTlsSettings {
+            ech_config_list: Some(TEST_ECH_CONFIG_LIST.into()),
+            ..XhttpDownloadTlsSettings::default()
+        });
+        assert!(detail_to_parsed(&detail).is_ok());
+
+        detail.secure.as_mut().unwrap().ech = Some(false);
+        assert!(detail_to_parsed(&detail).is_err());
+    }
+
+    #[test]
     fn structured_fields_explicitly_override_link() {
         let plan = compile_cfg(
             r#"
@@ -3111,7 +3533,6 @@ nodes:
       uuid: 22222222-2222-2222-2222-222222222222
     secure:
       tls: false
-      sni: new-sni.example.com
     transport:
       kind: xhttp
       host: new-cdn.example.com
@@ -3132,7 +3553,7 @@ nodes:
             Some("22222222-2222-2222-2222-222222222222")
         );
         assert!(!node.tls);
-        assert_eq!(node.sni.as_deref(), Some("new-sni.example.com"));
+        assert!(node.sni.is_none());
         assert_eq!(node.transport, "xhttp");
         assert_eq!(
             node.params.get("host").map(String::as_str),

--- a/crates/core-grpc/Cargo.toml
+++ b/crates/core-grpc/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "core-grpc"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+bytes = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+hyper = { version = "1", features = ["client", "http2", "server"] }
+hyper-util = { workspace = true, features = ["tokio"] }
+prost = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+tonic = { workspace = true }
+tower = { workspace = true, features = ["util"] }
+tracing = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/crates/core-grpc/src/client.rs
+++ b/crates/core-grpc/src/client.rs
@@ -1,0 +1,489 @@
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use http::{
+    Request, Response, Uri,
+    header::{HeaderValue, USER_AGENT},
+    uri::PathAndQuery,
+};
+use hyper::{
+    body::Incoming,
+    client::conn::http2::{self, SendRequest},
+};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::oneshot;
+use tonic::{Request as GrpcRequest, body::Body, client::Grpc, codec::ProstCodec};
+use tower::Service;
+
+use crate::{
+    DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_QUEUE_CAPACITY, MAX_MESSAGE_SIZE_LIMIT, MAX_QUEUE_CAPACITY,
+    MIN_MESSAGE_SIZE,
+    path::grpc_method_paths,
+    stream::{GrpcTunnelStream, InboundMessages, hunk_outbound, multi_hunk_outbound},
+};
+
+#[derive(Debug, Clone)]
+pub struct GrpcClientConfig {
+    /// HTTP/2 `:authority`, already resolved using Xray's authority/SNI/host
+    /// precedence.
+    pub authority: String,
+    pub service_name: String,
+    pub multi_mode: bool,
+    /// Exact User-Agent value. `None` omits the header entirely.
+    pub user_agent: Option<String>,
+    pub idle_timeout: Duration,
+    pub health_check_timeout: Duration,
+    pub permit_without_stream: bool,
+    pub initial_window_size: Option<u32>,
+    pub max_message_size: usize,
+    pub queue_capacity: usize,
+}
+
+impl Default for GrpcClientConfig {
+    fn default() -> Self {
+        Self {
+            authority: String::new(),
+            service_name: String::new(),
+            multi_mode: false,
+            user_agent: None,
+            idle_timeout: Duration::ZERO,
+            health_check_timeout: Duration::ZERO,
+            permit_without_stream: false,
+            initial_window_size: None,
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            queue_capacity: DEFAULT_QUEUE_CAPACITY,
+        }
+    }
+}
+
+impl GrpcClientConfig {
+    pub fn validate(&self) -> io::Result<()> {
+        if self.authority.is_empty() {
+            return Err(invalid_input("gRPC authority is empty"));
+        }
+        let uri = self.origin()?;
+        if uri.authority().is_none() {
+            return Err(invalid_input("gRPC authority is not a valid URI authority"));
+        }
+        let paths = grpc_method_paths(&self.service_name);
+        let method_path = if self.multi_mode {
+            paths.tun_multi_path()
+        } else {
+            paths.tun_path()
+        };
+        parse_path(&method_path)?;
+        for (name, value) in [
+            ("idle_timeout", self.idle_timeout),
+            ("health_check_timeout", self.health_check_timeout),
+        ] {
+            if value.subsec_nanos() != 0 {
+                return Err(invalid_input(format!(
+                    "gRPC {name} must be an integral number of seconds"
+                )));
+            }
+            if value.as_secs() > i32::MAX as u64 {
+                return Err(invalid_input(format!(
+                    "gRPC {name} exceeds Xray's int32 seconds range"
+                )));
+            }
+        }
+        if self
+            .initial_window_size
+            .is_some_and(|value| value > i32::MAX as u32)
+        {
+            return Err(invalid_input(
+                "gRPC initial_window_size exceeds HTTP/2/Xray's int32 range",
+            ));
+        }
+        if !(MIN_MESSAGE_SIZE..=MAX_MESSAGE_SIZE_LIMIT).contains(&self.max_message_size) {
+            return Err(invalid_input(format!(
+                "gRPC max_message_size must be in {MIN_MESSAGE_SIZE}..={MAX_MESSAGE_SIZE_LIMIT}"
+            )));
+        }
+        if self.queue_capacity == 0 || self.queue_capacity > MAX_QUEUE_CAPACITY {
+            return Err(invalid_input(format!(
+                "gRPC queue_capacity must be in 1..={MAX_QUEUE_CAPACITY}"
+            )));
+        }
+        if self.health_check_timeout.is_zero() && !self.idle_timeout.is_zero() {
+            // grpc-go uses its own default timeout when Time is configured but
+            // Timeout is zero. Hyper's default is 20 seconds; leave it unset.
+        }
+        if let Some(user_agent) = self.user_agent.as_ref() {
+            HeaderValue::from_str(user_agent)
+                .map_err(|error| invalid_input(format!("invalid gRPC user-agent: {error}")))?;
+        }
+        Ok(())
+    }
+
+    fn origin(&self) -> io::Result<Uri> {
+        format!("http://{}", self.authority)
+            .parse()
+            .map_err(|error| invalid_input(format!("invalid gRPC authority: {error}")))
+    }
+}
+
+#[derive(Clone)]
+struct ExactHeaderService {
+    sender: SendRequest<Body>,
+    user_agent: Option<HeaderValue>,
+}
+
+impl Service<Request<Body>> for ExactHeaderService {
+    type Response = Response<Incoming>;
+    type Error = hyper::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Response<Incoming>, hyper::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.sender.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<Body>) -> Self::Future {
+        match self.user_agent.as_ref() {
+            Some(user_agent) => {
+                request.headers_mut().insert(USER_AGENT, user_agent.clone());
+            }
+            None => {
+                request.headers_mut().remove(USER_AGENT);
+            }
+        }
+        Box::pin(self.sender.send_request(request))
+    }
+}
+
+/// A reusable tonic gRPC connection over a caller-provided carrier.
+#[derive(Clone)]
+pub struct GrpcClientConnection {
+    sender: SendRequest<Body>,
+    config: GrpcClientConfig,
+    origin: Uri,
+    user_agent: Option<HeaderValue>,
+}
+
+impl std::fmt::Debug for GrpcClientConnection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GrpcClientConnection")
+            .field("authority", &self.config.authority)
+            .field("service_name", &self.config.service_name)
+            .field("multi_mode", &self.config.multi_mode)
+            .field("user_agent", &self.config.user_agent)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GrpcClientConnection {
+    pub async fn handshake<S>(io: S, config: GrpcClientConfig) -> io::Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        config.validate()?;
+        let origin = config.origin()?;
+        let user_agent = config
+            .user_agent
+            .as_ref()
+            .map(|value| HeaderValue::from_str(value))
+            .transpose()
+            .map_err(|error| invalid_input(format!("invalid gRPC user-agent: {error}")))?;
+
+        let mut builder = http2::Builder::new(TokioExecutor::new());
+        builder.timer(TokioTimer::new());
+        if let Some(window) = config.initial_window_size {
+            builder.initial_stream_window_size(window);
+        }
+        if !config.idle_timeout.is_zero() {
+            builder.keep_alive_interval(config.idle_timeout);
+        }
+        if !config.health_check_timeout.is_zero() {
+            builder.keep_alive_timeout(config.health_check_timeout);
+        }
+        builder.keep_alive_while_idle(config.permit_without_stream);
+
+        let (sender, connection) = builder
+            .handshake(TokioIo::new(io))
+            .await
+            .map_err(|error| io::Error::other(format!("gRPC HTTP/2 handshake: {error}")))?;
+        tokio::spawn(async move {
+            if let Err(error) = connection.await {
+                tracing::debug!(%error, "gRPC HTTP/2 client connection ended");
+            }
+        });
+
+        Ok(Self {
+            sender,
+            config,
+            origin,
+            user_agent,
+        })
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.sender.is_closed()
+    }
+
+    pub async fn open_tunnel(&self) -> io::Result<GrpcTunnelStream> {
+        if self.is_closed() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "gRPC HTTP/2 connection is closed",
+            ));
+        }
+        if self.config.multi_mode {
+            self.open_multi_tunnel().await
+        } else {
+            self.open_hunk_tunnel().await
+        }
+    }
+
+    async fn open_hunk_tunnel(&self) -> io::Result<GrpcTunnelStream> {
+        let (outbound, request_stream) = hunk_outbound(self.config.queue_capacity);
+        let path = grpc_method_paths(&self.config.service_name).tun_path();
+        let mut client = self.dispatcher();
+        let path = parse_path(&path)?;
+        client
+            .ready()
+            .await
+            .map_err(|error| io::Error::other(format!("gRPC service readiness: {error}")))?;
+        let (response_tx, response_rx) = oneshot::channel();
+        let response_task = tokio::spawn(async move {
+            let response = client
+                .streaming(
+                    GrpcRequest::new(request_stream),
+                    path,
+                    ProstCodec::default(),
+                )
+                .await
+                .map(tonic::Response::into_inner)
+                .map_err(status_to_io);
+            let _ = response_tx.send(response);
+        });
+        Ok(GrpcTunnelStream::new(
+            InboundMessages::HunkPending(response_rx),
+            outbound,
+            self.config.max_message_size,
+        )
+        .with_response_task(response_task.abort_handle()))
+    }
+
+    async fn open_multi_tunnel(&self) -> io::Result<GrpcTunnelStream> {
+        let (outbound, request_stream) = multi_hunk_outbound(self.config.queue_capacity);
+        let path = grpc_method_paths(&self.config.service_name).tun_multi_path();
+        let mut client = self.dispatcher();
+        let path = parse_path(&path)?;
+        client
+            .ready()
+            .await
+            .map_err(|error| io::Error::other(format!("gRPC service readiness: {error}")))?;
+        let (response_tx, response_rx) = oneshot::channel();
+        let response_task = tokio::spawn(async move {
+            let response = client
+                .streaming(
+                    GrpcRequest::new(request_stream),
+                    path,
+                    ProstCodec::default(),
+                )
+                .await
+                .map(tonic::Response::into_inner)
+                .map_err(status_to_io);
+            let _ = response_tx.send(response);
+        });
+        Ok(GrpcTunnelStream::new(
+            InboundMessages::MultiPending(response_rx),
+            outbound,
+            self.config.max_message_size,
+        )
+        .with_response_task(response_task.abort_handle()))
+    }
+
+    fn dispatcher(&self) -> Grpc<ExactHeaderService> {
+        let service = ExactHeaderService {
+            sender: self.sender.clone(),
+            user_agent: self.user_agent.clone(),
+        };
+        Grpc::with_origin(service, self.origin.clone())
+            .max_encoding_message_size(self.config.max_message_size)
+            .max_decoding_message_size(self.config.max_message_size)
+    }
+}
+
+fn parse_path(path: &str) -> io::Result<PathAndQuery> {
+    path.parse()
+        .map_err(|error| invalid_input(format!("invalid gRPC method path `{path}`: {error}")))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn status_to_io(status: tonic::Status) -> io::Error {
+    let kind = match status.code() {
+        tonic::Code::Cancelled => io::ErrorKind::ConnectionAborted,
+        tonic::Code::DeadlineExceeded => io::ErrorKind::TimedOut,
+        tonic::Code::InvalidArgument | tonic::Code::FailedPrecondition => {
+            io::ErrorKind::InvalidData
+        }
+        tonic::Code::PermissionDenied | tonic::Code::Unauthenticated => {
+            io::ErrorKind::PermissionDenied
+        }
+        tonic::Code::ResourceExhausted => io::ErrorKind::OutOfMemory,
+        tonic::Code::Unimplemented => io::ErrorKind::Unsupported,
+        tonic::Code::Unavailable => io::ErrorKind::ConnectionRefused,
+        _ => io::ErrorKind::Other,
+    };
+    io::Error::new(kind, format!("gRPC tunnel setup: {status}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{convert::Infallible, future::Future, pin::Pin};
+
+    use futures::Stream;
+    use hyper::{server::conn::http2 as server_http2, service::service_fn};
+    use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tonic::{
+        Request as GrpcRequest, Response as GrpcResponse, Status, Streaming,
+        codec::ProstCodec,
+        server::{Grpc, StreamingService},
+    };
+
+    use super::*;
+    use crate::proto::Hunk;
+
+    #[derive(Clone)]
+    struct DelayedHeadersRpc;
+
+    impl StreamingService<Hunk> for DelayedHeadersRpc {
+        type Response = Hunk;
+        type ResponseStream = Pin<Box<dyn Stream<Item = Result<Hunk, Status>> + Send + 'static>>;
+        type Future = Pin<
+            Box<dyn Future<Output = Result<GrpcResponse<Self::ResponseStream>, Status>> + Send>,
+        >;
+
+        fn call(&mut self, request: GrpcRequest<Streaming<Hunk>>) -> Self::Future {
+            Box::pin(async move {
+                let mut request = request.into_inner();
+                let first = request
+                    .message()
+                    .await?
+                    .ok_or_else(|| Status::invalid_argument("request body ended"))?;
+                let response: Self::ResponseStream = Box::pin(tokio_stream::iter([Ok(first)]));
+                Ok(GrpcResponse::new(response))
+            })
+        }
+    }
+
+    #[test]
+    fn validation_rejects_header_injection_and_empty_limits() {
+        let invalid_header = GrpcClientConfig {
+            authority: "example.com".into(),
+            user_agent: Some("ok\r\nx: injected".into()),
+            ..Default::default()
+        };
+        assert!(invalid_header.validate().is_err());
+
+        let invalid_limit = GrpcClientConfig {
+            authority: "example.com".into(),
+            max_message_size: 0,
+            ..Default::default()
+        };
+        assert!(invalid_limit.validate().is_err());
+
+        for invalid in [
+            GrpcClientConfig {
+                authority: "example.com".into(),
+                idle_timeout: Duration::from_millis(500),
+                ..Default::default()
+            },
+            GrpcClientConfig {
+                authority: "example.com".into(),
+                health_check_timeout: Duration::from_secs(i32::MAX as u64 + 1),
+                ..Default::default()
+            },
+            GrpcClientConfig {
+                authority: "example.com".into(),
+                initial_window_size: Some(i32::MAX as u32 + 1),
+                ..Default::default()
+            },
+            GrpcClientConfig {
+                authority: "example.com".into(),
+                max_message_size: MAX_MESSAGE_SIZE_LIMIT + 1,
+                ..Default::default()
+            },
+            GrpcClientConfig {
+                authority: "example.com".into(),
+                queue_capacity: MAX_QUEUE_CAPACITY + 1,
+                ..Default::default()
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+        }
+    }
+
+    #[test]
+    fn authority_accepts_domain_ipv4_and_bracketed_ipv6() {
+        for authority in [
+            "example.com",
+            "example.com:443",
+            "192.0.2.1",
+            "[2001:db8::1]:443",
+        ] {
+            GrpcClientConfig {
+                authority: authority.into(),
+                ..Default::default()
+            }
+            .validate()
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn open_returns_before_response_headers_to_avoid_xray_bidi_deadlock() {
+        let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+        let server = tokio::spawn(async move {
+            let service = service_fn(|request| async move {
+                let response = Grpc::new(ProstCodec::<Hunk, Hunk>::default())
+                    .streaming(DelayedHeadersRpc, request)
+                    .await;
+                Ok::<_, Infallible>(response)
+            });
+            let mut builder = server_http2::Builder::new(TokioExecutor::new());
+            builder.timer(TokioTimer::new());
+            builder
+                .serve_connection(TokioIo::new(server_io), service)
+                .await
+                .unwrap();
+        });
+
+        let client = GrpcClientConnection::handshake(
+            client_io,
+            GrpcClientConfig {
+                authority: "delayed.example".into(),
+                service_name: "delayed".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let mut tunnel = tokio::time::timeout(Duration::from_millis(250), client.open_tunnel())
+            .await
+            .expect("open_tunnel waited for response headers")
+            .unwrap();
+        tunnel.write_all(b"unlocks-response").await.unwrap();
+        tunnel.flush().await.unwrap();
+        let mut echoed = vec![0; b"unlocks-response".len()];
+        tunnel.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(echoed, b"unlocks-response");
+        tunnel.shutdown().await.unwrap();
+        drop(tunnel);
+        drop(client);
+        server.await.unwrap();
+    }
+}

--- a/crates/core-grpc/src/lib.rs
+++ b/crates/core-grpc/src/lib.rs
@@ -1,0 +1,36 @@
+//! Xray gRPC (`gun`) transport implemented with tonic/prost.
+//!
+//! The crate intentionally owns only the transport framing.  Callers provide
+//! an already connected byte stream, so TLS, REALITY, finalmask and socket
+//! policy remain composable outside the gRPC implementation.
+
+#![forbid(unsafe_code)]
+
+mod path;
+mod proto;
+mod stream;
+
+pub mod client;
+pub mod server;
+
+pub use path::{GrpcMethodPaths, grpc_method_paths};
+pub use stream::{GrpcTunnelStream, TunnelMode};
+
+/// Xray-core compatibility baseline used by the wire oracle tests.
+pub const XRAY_GRPC_BASELINE: &str = "6e3322d219140a025285ded1114fe17a5edb74d8";
+
+/// gRPC implementations commonly default to a four MiB message limit.
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
+/// Smallest limit that can encode a non-empty protobuf `bytes` field:
+/// one tag byte, one length byte and one payload byte.
+pub const MIN_MESSAGE_SIZE: usize = 3;
+
+/// Maximum number of protobuf messages queued in either direction.
+pub const DEFAULT_QUEUE_CAPACITY: usize = 8;
+
+/// Defensive ceiling for a caller-configured decoded protobuf message.
+pub const MAX_MESSAGE_SIZE_LIMIT: usize = 64 * 1024 * 1024;
+
+/// Defensive ceiling for each bounded tunnel channel.
+pub const MAX_QUEUE_CAPACITY: usize = 1024;

--- a/crates/core-grpc/src/path.rs
+++ b/crates/core-grpc/src/path.rs
@@ -1,0 +1,110 @@
+/// Resolved Xray gRPC service and method paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrpcMethodPaths {
+    pub service: String,
+    pub tun: String,
+    pub tun_multi: String,
+}
+
+impl GrpcMethodPaths {
+    pub fn tun_path(&self) -> String {
+        format!("/{}/{}", self.service, self.tun)
+    }
+
+    pub fn tun_multi_path(&self) -> String {
+        format!("/{}/{}", self.service, self.tun_multi)
+    }
+}
+
+/// Reproduce Xray's `getServiceName`, `getTunStreamName` and
+/// `getTunMultiStreamName` behavior, including the custom `/service/method`
+/// and `/service/tun|tun-multi` spellings.
+pub fn grpc_method_paths(raw: &str) -> GrpcMethodPaths {
+    if !raw.starts_with('/') {
+        return GrpcMethodPaths {
+            service: go_path_escape(raw),
+            tun: "Tun".into(),
+            tun_multi: "TunMulti".into(),
+        };
+    }
+
+    let raw_last_slash = raw.rfind('/').unwrap_or(0);
+    let service_last_slash = raw_last_slash.max(1);
+    let service = raw[1..service_last_slash]
+        .split('/')
+        .map(go_path_escape)
+        .collect::<Vec<_>>()
+        .join("/");
+    let ending = &raw[raw_last_slash + 1..];
+    let mut methods = ending.split('|');
+    let tun = go_path_escape(methods.next().unwrap_or_default());
+    let tun_multi = methods
+        .next()
+        .map(go_path_escape)
+        .unwrap_or_else(|| tun.clone());
+
+    GrpcMethodPaths {
+        service,
+        tun,
+        tun_multi,
+    }
+}
+
+/// Equivalent to Go `net/url.PathEscape` in `encodePathSegment` mode.
+fn go_path_escape(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        let allowed = byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'-' | b'_' | b'.' | b'~' | b'$' | b'&' | b'+' | b':' | b'=' | b'@'
+            );
+        if allowed {
+            encoded.push(char::from(byte));
+        } else {
+            const HEX: &[u8; 16] = b"0123456789ABCDEF";
+            encoded.push('%');
+            encoded.push(char::from(HEX[(byte >> 4) as usize]));
+            encoded.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn old_style_uses_default_methods() {
+        assert_eq!(
+            grpc_method_paths("Gun Service/一"),
+            GrpcMethodPaths {
+                service: "Gun%20Service%2F%E4%B8%80".into(),
+                tun: "Tun".into(),
+                tun_multi: "TunMulti".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn custom_path_matches_xray_server_and_client_forms() {
+        let server = grpc_method_paths("/alpha/beta/Tun X|Multi X");
+        assert_eq!(server.service, "alpha/beta");
+        assert_eq!(server.tun, "Tun%20X");
+        assert_eq!(server.tun_multi, "Multi%20X");
+        assert_eq!(server.tun_path(), "/alpha/beta/Tun%20X");
+        assert_eq!(server.tun_multi_path(), "/alpha/beta/Multi%20X");
+
+        let client = grpc_method_paths("/alpha/beta/OnlyMulti");
+        assert_eq!(client.tun, "OnlyMulti");
+        assert_eq!(client.tun_multi, "OnlyMulti");
+    }
+
+    #[test]
+    fn root_custom_path_follows_xray_empty_service_rule() {
+        let paths = grpc_method_paths("/Tun");
+        assert_eq!(paths.service, "");
+        assert_eq!(paths.tun_path(), "//Tun");
+    }
+}

--- a/crates/core-grpc/src/proto.rs
+++ b/crates/core-grpc/src/proto.rs
@@ -1,0 +1,39 @@
+use prost::Message;
+
+/// Exact protobuf shape of Xray's `encoding.Hunk`.
+#[derive(Clone, PartialEq, Message)]
+pub(crate) struct Hunk {
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: Vec<u8>,
+}
+
+/// Exact protobuf shape of Xray's `encoding.MultiHunk`.
+#[derive(Clone, PartialEq, Message)]
+pub(crate) struct MultiHunk {
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub data: Vec<Vec<u8>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hunk_matches_pinned_xray_protobuf_wire() {
+        let message = Hunk {
+            data: vec![0, 1, 127, 128],
+        };
+        assert_eq!(message.encode_to_vec(), [0x0a, 0x04, 0, 1, 127, 128]);
+    }
+
+    #[test]
+    fn multi_hunk_repeats_field_one_without_packing() {
+        let message = MultiHunk {
+            data: vec![b"ab".to_vec(), Vec::new(), b"c".to_vec()],
+        };
+        assert_eq!(
+            message.encode_to_vec(),
+            [0x0a, 0x02, b'a', b'b', 0x0a, 0x00, 0x0a, 0x01, b'c']
+        );
+    }
+}

--- a/crates/core-grpc/src/server.rs
+++ b/crates/core-grpc/src/server.rs
@@ -1,0 +1,659 @@
+use std::{
+    convert::Infallible,
+    future::Future,
+    io,
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
+
+use futures::{Stream, StreamExt, future::BoxFuture};
+use http::{
+    HeaderMap, Request, Response, StatusCode,
+    header::{CONTENT_TYPE, HOST, HeaderName, HeaderValue, USER_AGENT},
+};
+use hyper::{body::Incoming, server::conn::http2, service::service_fn};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::TcpListener,
+    sync::Semaphore,
+    task::JoinSet,
+};
+use tokio_util::sync::CancellationToken;
+use tonic::{
+    Request as GrpcRequest, Response as GrpcResponse, Status, Streaming,
+    body::Body,
+    codec::ProstCodec,
+    server::{Grpc, StreamingService},
+};
+
+use crate::{
+    DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_QUEUE_CAPACITY, MAX_MESSAGE_SIZE_LIMIT, MAX_QUEUE_CAPACITY,
+    MIN_MESSAGE_SIZE,
+    path::grpc_method_paths,
+    proto::{Hunk, MultiHunk},
+    stream::{GrpcTunnelStream, InboundMessages, hunk_outbound, multi_hunk_outbound},
+};
+
+// grpc-go substitutes this value when KeepaliveParams is enabled with Time=0.
+// Xray enables KeepaliveParams when either timeout field is non-zero, so a
+// health-check-only configuration must still emit a ping every two hours.
+const GRPC_GO_DEFAULT_SERVER_KEEPALIVE_TIME: Duration = Duration::from_secs(2 * 60 * 60);
+
+#[derive(Debug, Clone)]
+pub struct GrpcServerConfig {
+    pub service_name: String,
+    pub idle_timeout: Duration,
+    pub health_check_timeout: Duration,
+    pub initial_window_size: Option<u32>,
+    pub max_concurrent_streams: u32,
+    pub max_header_list_size: u32,
+    pub max_message_size: usize,
+    pub queue_capacity: usize,
+    /// Local defensive bound for [`serve_tcp_listener`].
+    pub max_connections: usize,
+    /// Xray semantics: each entry is a trusted marker header name.  The
+    /// presence of any marker permits the first X-Forwarded-For address.
+    pub trusted_x_forwarded_for: Vec<String>,
+}
+
+impl Default for GrpcServerConfig {
+    fn default() -> Self {
+        Self {
+            service_name: String::new(),
+            idle_timeout: Duration::ZERO,
+            health_check_timeout: Duration::ZERO,
+            initial_window_size: None,
+            max_concurrent_streams: 1024,
+            max_header_list_size: 64 * 1024,
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            max_connections: 4096,
+            trusted_x_forwarded_for: Vec::new(),
+        }
+    }
+}
+
+impl GrpcServerConfig {
+    pub fn validate(&self) -> io::Result<()> {
+        let paths = grpc_method_paths(&self.service_name);
+        for path in [paths.tun_path(), paths.tun_multi_path()] {
+            path.parse::<http::uri::PathAndQuery>().map_err(|error| {
+                invalid_input(format!("invalid gRPC method path `{path}`: {error}"))
+            })?;
+        }
+        for (name, value) in [
+            ("idle_timeout", self.idle_timeout),
+            ("health_check_timeout", self.health_check_timeout),
+        ] {
+            if value.subsec_nanos() != 0 {
+                return Err(invalid_input(format!(
+                    "gRPC {name} must be an integral number of seconds"
+                )));
+            }
+            if value.as_secs() > i32::MAX as u64 {
+                return Err(invalid_input(format!(
+                    "gRPC {name} exceeds Xray's int32 seconds range"
+                )));
+            }
+        }
+        if self
+            .initial_window_size
+            .is_some_and(|value| value > i32::MAX as u32)
+        {
+            return Err(invalid_input(
+                "gRPC initial_window_size exceeds HTTP/2/Xray's int32 range",
+            ));
+        }
+        if self.max_concurrent_streams == 0 {
+            return Err(invalid_input(
+                "gRPC max_concurrent_streams must be non-zero",
+            ));
+        }
+        if self.max_header_list_size == 0 {
+            return Err(invalid_input("gRPC max_header_list_size must be non-zero"));
+        }
+        if !(MIN_MESSAGE_SIZE..=MAX_MESSAGE_SIZE_LIMIT).contains(&self.max_message_size) {
+            return Err(invalid_input(format!(
+                "gRPC max_message_size must be in {MIN_MESSAGE_SIZE}..={MAX_MESSAGE_SIZE_LIMIT}"
+            )));
+        }
+        if self.queue_capacity == 0 || self.queue_capacity > MAX_QUEUE_CAPACITY {
+            return Err(invalid_input(format!(
+                "gRPC queue_capacity must be in 1..={MAX_QUEUE_CAPACITY}"
+            )));
+        }
+        if self.max_connections == 0 || self.max_connections > 65_535 {
+            return Err(invalid_input("gRPC max_connections must be in 1..=65535"));
+        }
+        for marker in &self.trusted_x_forwarded_for {
+            HeaderName::from_bytes(marker.as_bytes()).map_err(|error| {
+                invalid_input(format!(
+                    "invalid trustedXForwardedFor marker `{marker}`: {error}"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Serve a cleartext HTTP/2 gRPC listener with bounded connection tasks.
+///
+/// TLS, REALITY, finalmask and PROXY protocol callers should accept and wrap
+/// their carrier themselves, then call [`serve_connection`].
+pub async fn serve_tcp_listener(
+    listener: TcpListener,
+    config: GrpcServerConfig,
+    handler: TunnelHandler,
+    cancellation: CancellationToken,
+) -> io::Result<()> {
+    config.validate()?;
+    let permits = Arc::new(Semaphore::new(config.max_connections));
+    let mut connections = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => break,
+            completed = connections.join_next(), if !connections.is_empty() => {
+                match completed {
+                    Some(Ok(Err(error))) => {
+                        tracing::debug!(%error, "gRPC connection ended with an error");
+                    }
+                    Some(Err(error)) => {
+                        tracing::debug!(%error, "gRPC connection task failed");
+                    }
+                    _ => {}
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, peer_addr) = accepted?;
+                stream.set_nodelay(true)?;
+                let Ok(permit) = permits.clone().try_acquire_owned() else {
+                    tracing::warn!(
+                        %peer_addr,
+                        limit = config.max_connections,
+                        "gRPC connection limit reached"
+                    );
+                    drop(stream);
+                    continue;
+                };
+                let connection_config = config.clone();
+                let connection_handler = handler.clone();
+                connections.spawn(async move {
+                    let _permit = permit;
+                    serve_connection(
+                        stream,
+                        peer_addr,
+                        connection_config,
+                        connection_handler,
+                    )
+                    .await
+                });
+            }
+        }
+    }
+
+    connections.abort_all();
+    while connections.join_next().await.is_some() {}
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct GrpcRequestContext {
+    pub peer_addr: SocketAddr,
+    pub remote_addr: SocketAddr,
+    pub method_path: String,
+    pub authority: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+pub type TunnelHandler = Arc<
+    dyn Fn(GrpcTunnelStream, GrpcRequestContext) -> BoxFuture<'static, io::Result<()>>
+        + Send
+        + Sync,
+>;
+
+/// Serve one already-accepted carrier as an HTTP/2 gRPC connection.
+pub async fn serve_connection<S>(
+    io: S,
+    peer_addr: SocketAddr,
+    config: GrpcServerConfig,
+    handler: TunnelHandler,
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    config.validate()?;
+    let paths = grpc_method_paths(&config.service_name);
+    let tun_path = paths.tun_path();
+    let tun_multi_path = paths.tun_multi_path();
+    let config = Arc::new(config);
+    let service_config = config.clone();
+
+    let service = service_fn(move |request: Request<Incoming>| {
+        let handler = handler.clone();
+        let config = service_config.clone();
+        let tun_path = tun_path.clone();
+        let tun_multi_path = tun_multi_path.clone();
+        async move {
+            let path = request.uri().path().to_string();
+            let response = if path == tun_path {
+                let context = request_context(&request, peer_addr, &config.trusted_x_forwarded_for);
+                let service = HunkRpc {
+                    handler,
+                    context,
+                    max_message_size: config.max_message_size,
+                    queue_capacity: config.queue_capacity,
+                };
+                Grpc::new(ProstCodec::<Hunk, Hunk>::default())
+                    .max_decoding_message_size(config.max_message_size)
+                    .max_encoding_message_size(config.max_message_size)
+                    .streaming(service, request)
+                    .await
+            } else if path == tun_multi_path {
+                let context = request_context(&request, peer_addr, &config.trusted_x_forwarded_for);
+                let service = MultiHunkRpc {
+                    handler,
+                    context,
+                    max_message_size: config.max_message_size,
+                    queue_capacity: config.queue_capacity,
+                };
+                Grpc::new(ProstCodec::<MultiHunk, MultiHunk>::default())
+                    .max_decoding_message_size(config.max_message_size)
+                    .max_encoding_message_size(config.max_message_size)
+                    .streaming(service, request)
+                    .await
+            } else {
+                unimplemented_response()
+            };
+            Ok::<_, Infallible>(response)
+        }
+    });
+
+    let mut server = http2::Builder::new(TokioExecutor::new());
+    server.timer(TokioTimer::new());
+    if let Some(window) = config.initial_window_size {
+        server.initial_stream_window_size(window);
+    }
+    if !config.idle_timeout.is_zero() || !config.health_check_timeout.is_zero() {
+        server.keep_alive_interval(if config.idle_timeout.is_zero() {
+            GRPC_GO_DEFAULT_SERVER_KEEPALIVE_TIME
+        } else {
+            config.idle_timeout
+        });
+    }
+    if !config.health_check_timeout.is_zero() {
+        server.keep_alive_timeout(config.health_check_timeout);
+    }
+    server.max_concurrent_streams(config.max_concurrent_streams);
+    server.max_header_list_size(config.max_header_list_size);
+    server
+        .serve_connection(TokioIo::new(io), service)
+        .await
+        .map_err(|error| io::Error::other(format!("gRPC HTTP/2 server connection: {error}")))
+}
+
+#[derive(Clone)]
+struct HunkRpc {
+    handler: TunnelHandler,
+    context: GrpcRequestContext,
+    max_message_size: usize,
+    queue_capacity: usize,
+}
+
+impl StreamingService<Hunk> for HunkRpc {
+    type Response = Hunk;
+    type ResponseStream = Pin<Box<dyn Stream<Item = Result<Hunk, Status>> + Send + 'static>>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<GrpcResponse<Self::ResponseStream>, Status>> + Send>>;
+
+    fn call(&mut self, request: GrpcRequest<Streaming<Hunk>>) -> Self::Future {
+        let handler = self.handler.clone();
+        let context = self.context.clone();
+        let max_message_size = self.max_message_size;
+        let queue_capacity = self.queue_capacity;
+        Box::pin(async move {
+            let (outbound, response_stream) = hunk_outbound(queue_capacity);
+            let stream = GrpcTunnelStream::new(
+                InboundMessages::Hunk(request.into_inner()),
+                outbound,
+                max_message_size,
+            );
+            spawn_handler(handler, stream, context);
+            let response: Self::ResponseStream = response_stream.map(Ok).boxed();
+            Ok(GrpcResponse::new(response))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct MultiHunkRpc {
+    handler: TunnelHandler,
+    context: GrpcRequestContext,
+    max_message_size: usize,
+    queue_capacity: usize,
+}
+
+impl StreamingService<MultiHunk> for MultiHunkRpc {
+    type Response = MultiHunk;
+    type ResponseStream = Pin<Box<dyn Stream<Item = Result<MultiHunk, Status>> + Send + 'static>>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<GrpcResponse<Self::ResponseStream>, Status>> + Send>>;
+
+    fn call(&mut self, request: GrpcRequest<Streaming<MultiHunk>>) -> Self::Future {
+        let handler = self.handler.clone();
+        let context = self.context.clone();
+        let max_message_size = self.max_message_size;
+        let queue_capacity = self.queue_capacity;
+        Box::pin(async move {
+            let (outbound, response_stream) = multi_hunk_outbound(queue_capacity);
+            let stream = GrpcTunnelStream::new(
+                InboundMessages::Multi(request.into_inner()),
+                outbound,
+                max_message_size,
+            );
+            spawn_handler(handler, stream, context);
+            let response: Self::ResponseStream = response_stream.map(Ok).boxed();
+            Ok(GrpcResponse::new(response))
+        })
+    }
+}
+
+fn spawn_handler(handler: TunnelHandler, stream: GrpcTunnelStream, context: GrpcRequestContext) {
+    tokio::spawn(async move {
+        if let Err(error) = handler(stream, context).await {
+            tracing::debug!(%error, "gRPC tunnel handler ended with an error");
+        }
+    });
+}
+
+fn request_context(
+    request: &Request<Incoming>,
+    peer_addr: SocketAddr,
+    trusted_markers: &[String],
+) -> GrpcRequestContext {
+    let remote_addr = trusted_forwarded_address(request.headers(), peer_addr, trusted_markers)
+        .unwrap_or(peer_addr);
+    GrpcRequestContext {
+        peer_addr,
+        remote_addr,
+        method_path: request.uri().path().to_string(),
+        authority: request
+            .uri()
+            .authority()
+            .map(|authority| authority.as_str().to_owned())
+            .or_else(|| {
+                request
+                    .headers()
+                    .get(HOST)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_owned)
+            }),
+        user_agent: request
+            .headers()
+            .get(USER_AGENT)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned),
+    }
+}
+
+fn trusted_forwarded_address(
+    headers: &HeaderMap,
+    peer_addr: SocketAddr,
+    trusted_markers: &[String],
+) -> Option<SocketAddr> {
+    let forwarded = headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())?;
+    let trusted = trusted_markers.iter().any(|marker| {
+        HeaderName::from_bytes(marker.as_bytes())
+            .ok()
+            .is_some_and(|name| headers.contains_key(name))
+    });
+    if !trusted {
+        if trusted_markers.is_empty() {
+            tracing::warn!(
+                %peer_addr,
+                "ignored X-Forwarded-For because trustedXForwardedFor is empty"
+            );
+        } else {
+            tracing::warn!(
+                %peer_addr,
+                "ignored potentially forged X-Forwarded-For"
+            );
+        }
+        return None;
+    }
+    // Xray takes the substring before the first comma verbatim. In
+    // particular, surrounding whitespace is not silently normalized.
+    let first = forwarded.split(',').next()?.parse::<IpAddr>().ok()?;
+    Some(SocketAddr::new(first, 0))
+}
+
+fn unimplemented_response() -> Response<Body> {
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::OK;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/grpc"));
+    response
+        .headers_mut()
+        .insert("grpc-status", HeaderValue::from_static("12"));
+    response.headers_mut().insert(
+        "grpc-message",
+        HeaderValue::from_static("unimplemented%20gRPC%20method"),
+    );
+    response
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::client::{GrpcClientConfig, GrpcClientConnection};
+
+    fn echo_handler(contexts: Arc<Mutex<Vec<GrpcRequestContext>>>) -> TunnelHandler {
+        Arc::new(move |mut stream, context| {
+            let contexts = contexts.clone();
+            Box::pin(async move {
+                contexts.lock().unwrap().push(context);
+                let mut buffer = [0u8; 4096];
+                loop {
+                    let read = stream.read(&mut buffer).await?;
+                    if read == 0 {
+                        stream.shutdown().await?;
+                        return Ok(());
+                    }
+                    stream.write_all(&buffer[..read]).await?;
+                    stream.flush().await?;
+                }
+            })
+        })
+    }
+
+    async fn round_trip(multi_mode: bool) {
+        let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+        let peer: SocketAddr = "192.0.2.10:12345".parse().unwrap();
+        let contexts = Arc::new(Mutex::new(Vec::new()));
+        let server_config = GrpcServerConfig {
+            service_name: "/test/service/TunX|TunMultiX".into(),
+            idle_timeout: Duration::from_secs(30),
+            health_check_timeout: Duration::from_secs(5),
+            max_message_size: 257,
+            trusted_x_forwarded_for: vec!["x-trusted-cdn".into()],
+            ..Default::default()
+        };
+        let server = tokio::spawn(serve_connection(
+            server_io,
+            peer,
+            server_config,
+            echo_handler(contexts.clone()),
+        ));
+        let client = GrpcClientConnection::handshake(
+            client_io,
+            GrpcClientConfig {
+                authority: "grpc.example".into(),
+                service_name: if multi_mode {
+                    "/test/service/TunMultiX".into()
+                } else {
+                    "/test/service/TunX".into()
+                },
+                multi_mode,
+                user_agent: Some("exact-agent/1".into()),
+                idle_timeout: Duration::from_secs(30),
+                health_check_timeout: Duration::from_secs(5),
+                permit_without_stream: true,
+                max_message_size: 257,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let mut tunnel = client.open_tunnel().await.unwrap();
+        let payload = vec![0x5a; 128 * 1024 + 17];
+        tunnel.write_all(&payload).await.unwrap();
+        tunnel.flush().await.unwrap();
+        let mut echoed = vec![0; payload.len()];
+        tunnel.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(echoed, payload);
+        tunnel.shutdown().await.unwrap();
+        drop(tunnel);
+        drop(client);
+        server.await.unwrap().unwrap();
+
+        let contexts = contexts.lock().unwrap();
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(contexts[0].peer_addr, peer);
+        assert_eq!(contexts[0].remote_addr, peer);
+        assert_eq!(contexts[0].authority.as_deref(), Some("grpc.example"));
+        assert_eq!(contexts[0].user_agent.as_deref(), Some("exact-agent/1"));
+        assert_eq!(
+            contexts[0].method_path,
+            if multi_mode {
+                "/test/service/TunMultiX"
+            } else {
+                "/test/service/TunX"
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn tonic_tun_round_trip() {
+        round_trip(false).await;
+    }
+
+    #[tokio::test]
+    async fn tonic_tun_multi_round_trip() {
+        round_trip(true).await;
+    }
+
+    #[test]
+    fn server_validation_rejects_unrepresentable_xray_values() {
+        for invalid in [
+            GrpcServerConfig {
+                idle_timeout: Duration::from_millis(500),
+                ..Default::default()
+            },
+            GrpcServerConfig {
+                health_check_timeout: Duration::from_secs(i32::MAX as u64 + 1),
+                ..Default::default()
+            },
+            GrpcServerConfig {
+                max_connections: 0,
+                ..Default::default()
+            },
+            GrpcServerConfig {
+                queue_capacity: MAX_QUEUE_CAPACITY + 1,
+                ..Default::default()
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+        }
+    }
+
+    #[test]
+    fn trusted_x_forwarded_for_matches_xray_marker_semantics() {
+        let peer = "127.0.0.1:12345".parse().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("192.0.2.7, 198.51.100.9"),
+        );
+
+        assert_eq!(
+            trusted_forwarded_address(&headers, peer, &["x-forwarded-for".to_owned()]),
+            Some("192.0.2.7:0".parse().unwrap())
+        );
+        assert_eq!(
+            trusted_forwarded_address(&headers, peer, &["x-trusted-cdn".to_owned()]),
+            None
+        );
+
+        headers.insert("x-trusted-cdn", HeaderValue::from_static("1"));
+        assert_eq!(
+            trusted_forwarded_address(&headers, peer, &["X-Trusted-CDN".to_owned()]),
+            Some("192.0.2.7:0".parse().unwrap())
+        );
+
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static(" 192.0.2.7,198.51.100.9"),
+        );
+        assert_eq!(
+            trusted_forwarded_address(&headers, peer, &["x-trusted-cdn".to_owned()]),
+            None,
+            "Xray does not trim the first forwarded address"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_tcp_listener_stops_and_aborts_open_connections() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let contexts = Arc::new(Mutex::new(Vec::new()));
+        let cancellation = CancellationToken::new();
+        let server = tokio::spawn(serve_tcp_listener(
+            listener,
+            GrpcServerConfig {
+                service_name: "listener-test".into(),
+                max_connections: 1,
+                ..Default::default()
+            },
+            echo_handler(contexts),
+            cancellation.clone(),
+        ));
+        let carrier = tokio::net::TcpStream::connect(address).await.unwrap();
+        let client = GrpcClientConnection::handshake(
+            carrier,
+            GrpcClientConfig {
+                authority: "listener.test".into(),
+                service_name: "listener-test".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let mut tunnel = client.open_tunnel().await.unwrap();
+        tunnel.write_all(b"alive").await.unwrap();
+        tunnel.flush().await.unwrap();
+        let mut echoed = [0_u8; 5];
+        tunnel.read_exact(&mut echoed).await.unwrap();
+        assert_eq!(&echoed, b"alive");
+
+        cancellation.cancel();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("gRPC listener did not stop")
+            .unwrap()
+            .unwrap();
+    }
+}

--- a/crates/core-grpc/src/stream.rs
+++ b/crates/core-grpc/src/stream.rs
@@ -1,0 +1,639 @@
+use std::{
+    collections::VecDeque,
+    future::Future,
+    io,
+    io::IoSlice,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::{mpsc, oneshot, watch},
+    task::AbortHandle,
+};
+use tokio_stream::wrappers::{ReceiverStream, WatchStream};
+use tokio_util::sync::PollSender;
+use tonic::Streaming;
+
+use crate::MIN_MESSAGE_SIZE;
+use crate::proto::{Hunk, MultiHunk};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunnelMode {
+    Tun,
+    TunMulti,
+}
+
+#[derive(Debug)]
+struct Queued<M> {
+    sequence: u64,
+    message: M,
+}
+
+/// A request/response stream that acknowledges a message after tonic has
+/// consumed it from the protobuf source stream.  This gives AsyncWrite::flush
+/// a meaningful userspace boundary instead of returning while the item is
+/// still waiting in an mpsc queue.
+pub(crate) struct AcknowledgedStream<M> {
+    inner: ReceiverStream<Queued<M>>,
+    acknowledgements: watch::Sender<u64>,
+    pending_acknowledgement: Option<u64>,
+}
+
+impl<M> Stream for AcknowledgedStream<M> {
+    type Item = M;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<M>> {
+        if let Some(sequence) = self.pending_acknowledgement.take() {
+            self.acknowledgements.send_replace(sequence);
+        }
+        match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(Some(queued)) => {
+                self.pending_acknowledgement = Some(queued.sequence);
+                Poll::Ready(Some(queued.message))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<M> Drop for AcknowledgedStream<M> {
+    fn drop(&mut self) {
+        if let Some(sequence) = self.pending_acknowledgement.take() {
+            self.acknowledgements.send_replace(sequence);
+        }
+    }
+}
+
+pub(crate) struct MessageSender<M> {
+    sender: PollSender<Queued<M>>,
+    acknowledgements: WatchStream<u64>,
+    next_sequence: u64,
+    last_sequence: u64,
+    acknowledged_sequence: u64,
+    closed: bool,
+}
+
+impl<M: Send> MessageSender<M> {
+    fn pair(capacity: usize) -> (Self, AcknowledgedStream<M>) {
+        let (sender, receiver) = mpsc::channel(capacity.max(1));
+        let (acknowledgements, acknowledgement_rx) = watch::channel(0);
+        (
+            Self {
+                sender: PollSender::new(sender),
+                acknowledgements: WatchStream::new(acknowledgement_rx),
+                next_sequence: 1,
+                last_sequence: 0,
+                acknowledged_sequence: 0,
+                closed: false,
+            },
+            AcknowledgedStream {
+                inner: ReceiverStream::new(receiver),
+                acknowledgements,
+                pending_acknowledgement: None,
+            },
+        )
+    }
+
+    fn poll_reserve(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.closed {
+            return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()));
+        }
+        self.sender
+            .poll_reserve(cx)
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))
+    }
+
+    fn send_reserved(&mut self, message: M) -> io::Result<()> {
+        let sequence = self.next_sequence;
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("gRPC hunk sequence exhausted"))?;
+        self.sender
+            .send_item(Queued { sequence, message })
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?;
+        self.last_sequence = sequence;
+        Ok(())
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while self.acknowledged_sequence < self.last_sequence {
+            match self.acknowledgements.poll_next_unpin(cx) {
+                Poll::Ready(Some(sequence)) => self.acknowledged_sequence = sequence,
+                Poll::Ready(None) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "gRPC protobuf body closed before queued data was consumed",
+                    )));
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn close(&mut self) {
+        if !self.closed {
+            self.closed = true;
+            self.sender.close();
+        }
+    }
+}
+
+pub(crate) enum OutboundMessages {
+    Hunk(MessageSender<Hunk>),
+    Multi(MessageSender<MultiHunk>),
+}
+
+pub(crate) enum InboundMessages {
+    Hunk(Streaming<Hunk>),
+    Multi(Streaming<MultiHunk>),
+    HunkPending(oneshot::Receiver<io::Result<Streaming<Hunk>>>),
+    MultiPending(oneshot::Receiver<io::Result<Streaming<MultiHunk>>>),
+}
+
+pub(crate) fn hunk_outbound(capacity: usize) -> (OutboundMessages, AcknowledgedStream<Hunk>) {
+    let (sender, stream) = MessageSender::pair(capacity);
+    (OutboundMessages::Hunk(sender), stream)
+}
+
+pub(crate) fn multi_hunk_outbound(
+    capacity: usize,
+) -> (OutboundMessages, AcknowledgedStream<MultiHunk>) {
+    let (sender, stream) = MessageSender::pair(capacity);
+    (OutboundMessages::Multi(sender), stream)
+}
+
+/// Async byte-stream view of Xray's Hunk/TunMulti protobuf streams.
+pub struct GrpcTunnelStream {
+    inbound: InboundMessages,
+    outbound: OutboundMessages,
+    read_queue: VecDeque<Bytes>,
+    current_read: Bytes,
+    max_message_size: usize,
+    read_eof: bool,
+    write_shutdown: bool,
+    response_task: Option<AbortHandle>,
+}
+
+impl std::fmt::Debug for GrpcTunnelStream {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GrpcTunnelStream")
+            .field("mode", &self.mode())
+            .field("queued_reads", &self.read_queue.len())
+            .field("current_read", &self.current_read.len())
+            .field("max_message_size", &self.max_message_size)
+            .field("read_eof", &self.read_eof)
+            .field("write_shutdown", &self.write_shutdown)
+            .field("has_response_task", &self.response_task.is_some())
+            .finish()
+    }
+}
+
+impl GrpcTunnelStream {
+    pub(crate) fn new(
+        inbound: InboundMessages,
+        outbound: OutboundMessages,
+        max_message_size: usize,
+    ) -> Self {
+        Self {
+            inbound,
+            outbound,
+            read_queue: VecDeque::new(),
+            current_read: Bytes::new(),
+            max_message_size: max_message_size.max(MIN_MESSAGE_SIZE),
+            read_eof: false,
+            write_shutdown: false,
+            response_task: None,
+        }
+    }
+
+    pub(crate) fn with_response_task(mut self, task: AbortHandle) -> Self {
+        self.response_task = Some(task);
+        self
+    }
+
+    pub fn mode(&self) -> TunnelMode {
+        match self.inbound {
+            InboundMessages::Hunk(_) | InboundMessages::HunkPending(_) => TunnelMode::Tun,
+            InboundMessages::Multi(_) | InboundMessages::MultiPending(_) => TunnelMode::TunMulti,
+        }
+    }
+
+    fn validate_inbound(&self, data: Vec<u8>) -> io::Result<Option<Bytes>> {
+        if bytes_field_encoded_len(data.len()) > self.max_message_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "gRPC encoded hunk exceeds configured limit: {} > {}",
+                    bytes_field_encoded_len(data.len()),
+                    self.max_message_size
+                ),
+            ));
+        }
+        Ok((!data.is_empty()).then(|| Bytes::from(data)))
+    }
+
+    fn poll_next_payload(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Option<Bytes>>> {
+        loop {
+            if let Some(data) = self.read_queue.pop_front() {
+                return Poll::Ready(Ok(Some(data)));
+            }
+            if self.read_eof {
+                return Poll::Ready(Ok(None));
+            }
+            match &mut self.inbound {
+                InboundMessages::Hunk(stream) => match Pin::new(stream).poll_next(cx) {
+                    Poll::Ready(Some(Ok(hunk))) => {
+                        if let Some(data) = self.validate_inbound(hunk.data)? {
+                            return Poll::Ready(Ok(Some(data)));
+                        }
+                    }
+                    Poll::Ready(Some(Err(status))) => {
+                        return Poll::Ready(Err(status_to_io(status)));
+                    }
+                    Poll::Ready(None) => self.read_eof = true,
+                    Poll::Pending => return Poll::Pending,
+                },
+                InboundMessages::Multi(stream) => match Pin::new(stream).poll_next(cx) {
+                    Poll::Ready(Some(Ok(hunks))) => {
+                        for hunk in hunks.data {
+                            if let Some(data) = self.validate_inbound(hunk)? {
+                                self.read_queue.push_back(data);
+                            }
+                        }
+                    }
+                    Poll::Ready(Some(Err(status))) => {
+                        return Poll::Ready(Err(status_to_io(status)));
+                    }
+                    Poll::Ready(None) => self.read_eof = true,
+                    Poll::Pending => return Poll::Pending,
+                },
+                InboundMessages::HunkPending(response) => match Pin::new(response).poll(cx) {
+                    Poll::Ready(Ok(Ok(stream))) => {
+                        self.response_task = None;
+                        self.inbound = InboundMessages::Hunk(stream);
+                    }
+                    Poll::Ready(Ok(Err(error))) => {
+                        self.response_task = None;
+                        return Poll::Ready(Err(error));
+                    }
+                    Poll::Ready(Err(_)) => {
+                        self.response_task = None;
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::ConnectionAborted,
+                            "gRPC response task ended before response headers",
+                        )));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                InboundMessages::MultiPending(response) => match Pin::new(response).poll(cx) {
+                    Poll::Ready(Ok(Ok(stream))) => {
+                        self.response_task = None;
+                        self.inbound = InboundMessages::Multi(stream);
+                    }
+                    Poll::Ready(Ok(Err(error))) => {
+                        self.response_task = None;
+                        return Poll::Ready(Err(error));
+                    }
+                    Poll::Ready(Err(_)) => {
+                        self.response_task = None;
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::ConnectionAborted,
+                            "gRPC response task ended before response headers",
+                        )));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+            }
+        }
+    }
+
+    fn poll_outbound_reserve(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.outbound {
+            OutboundMessages::Hunk(sender) => sender.poll_reserve(cx),
+            OutboundMessages::Multi(sender) => sender.poll_reserve(cx),
+        }
+    }
+
+    fn send_reserved(&mut self, chunks: Vec<Vec<u8>>) -> io::Result<()> {
+        match &mut self.outbound {
+            OutboundMessages::Hunk(sender) => {
+                let total = chunks.iter().map(Vec::len).sum();
+                let mut data = Vec::with_capacity(total);
+                for chunk in chunks {
+                    data.extend_from_slice(&chunk);
+                }
+                sender.send_reserved(Hunk { data })
+            }
+            OutboundMessages::Multi(sender) => sender.send_reserved(MultiHunk { data: chunks }),
+        }
+    }
+
+    fn poll_outbound_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.outbound {
+            OutboundMessages::Hunk(sender) => sender.poll_flush(cx),
+            OutboundMessages::Multi(sender) => sender.poll_flush(cx),
+        }
+    }
+
+    fn close_outbound(&mut self) {
+        match &mut self.outbound {
+            OutboundMessages::Hunk(sender) => sender.close(),
+            OutboundMessages::Multi(sender) => sender.close(),
+        }
+    }
+}
+
+impl AsyncRead for GrpcTunnelStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        loop {
+            if !self.current_read.is_empty() {
+                let count = output.remaining().min(self.current_read.len());
+                output.put_slice(&self.current_read.split_to(count));
+                return Poll::Ready(Ok(()));
+            }
+            match self.poll_next_payload(cx) {
+                Poll::Ready(Ok(Some(data))) => self.current_read = data,
+                Poll::Ready(Ok(None)) => return Poll::Ready(Ok(())),
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl AsyncWrite for GrpcTunnelStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if input.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        if self.write_shutdown {
+            return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()));
+        }
+        match self.poll_outbound_reserve(cx) {
+            Poll::Ready(Ok(())) => {
+                let count = input
+                    .len()
+                    .min(max_bytes_field_payload(self.max_message_size));
+                self.send_reserved(vec![input[..count].to_vec()])?;
+                Poll::Ready(Ok(count))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        inputs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        if self.write_shutdown {
+            return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()));
+        }
+        let total_available = inputs.iter().map(|input| input.len()).sum::<usize>();
+        if total_available == 0 {
+            return Poll::Ready(Ok(0));
+        }
+        match self.poll_outbound_reserve(cx) {
+            Poll::Ready(Ok(())) => {
+                let (chunks, written) = if matches!(&self.outbound, OutboundMessages::Multi(_)) {
+                    bounded_multi_chunks(inputs, self.max_message_size)
+                } else {
+                    let mut remaining = max_bytes_field_payload(self.max_message_size);
+                    let mut chunks = Vec::new();
+                    let mut written = 0;
+                    for input in inputs {
+                        if remaining == 0 {
+                            break;
+                        }
+                        let count = remaining.min(input.len());
+                        if count != 0 {
+                            chunks.push(input[..count].to_vec());
+                            written += count;
+                            remaining -= count;
+                        }
+                    }
+                    (chunks, written)
+                };
+                self.send_reserved(chunks)?;
+                Poll::Ready(Ok(written))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_outbound_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if !self.write_shutdown {
+            self.write_shutdown = true;
+            self.close_outbound();
+        }
+        self.poll_outbound_flush(cx)
+    }
+}
+
+impl Drop for GrpcTunnelStream {
+    fn drop(&mut self) {
+        self.close_outbound();
+        if let Some(task) = self.response_task.take() {
+            task.abort();
+        }
+    }
+}
+
+fn protobuf_varint_len(mut value: usize) -> usize {
+    let mut bytes = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        bytes += 1;
+    }
+    bytes
+}
+
+fn bytes_field_encoded_len(payload_len: usize) -> usize {
+    if payload_len == 0 {
+        0
+    } else {
+        1 + protobuf_varint_len(payload_len) + payload_len
+    }
+}
+
+fn max_bytes_field_payload(encoded_limit: usize) -> usize {
+    let mut lower = 0;
+    let mut upper = encoded_limit;
+    while lower < upper {
+        let middle = lower + (upper - lower).div_ceil(2);
+        if bytes_field_encoded_len(middle) <= encoded_limit {
+            lower = middle;
+        } else {
+            upper = middle - 1;
+        }
+    }
+    lower
+}
+
+fn bounded_multi_chunks(inputs: &[IoSlice<'_>], encoded_limit: usize) -> (Vec<Vec<u8>>, usize) {
+    let mut encoded = 0;
+    let mut chunks = Vec::new();
+    let mut written = 0;
+    for input in inputs {
+        if input.is_empty() {
+            continue;
+        }
+        let remaining = encoded_limit.saturating_sub(encoded);
+        let count = input.len().min(max_bytes_field_payload(remaining));
+        if count == 0 {
+            break;
+        }
+        chunks.push(input[..count].to_vec());
+        written += count;
+        encoded += bytes_field_encoded_len(count);
+        if count < input.len() {
+            break;
+        }
+    }
+    (chunks, written)
+}
+
+fn status_to_io(status: tonic::Status) -> io::Error {
+    let kind = match status.code() {
+        tonic::Code::Cancelled => io::ErrorKind::ConnectionAborted,
+        tonic::Code::DeadlineExceeded => io::ErrorKind::TimedOut,
+        tonic::Code::InvalidArgument | tonic::Code::FailedPrecondition => {
+            io::ErrorKind::InvalidData
+        }
+        tonic::Code::NotFound => io::ErrorKind::NotFound,
+        tonic::Code::AlreadyExists => io::ErrorKind::AlreadyExists,
+        tonic::Code::PermissionDenied | tonic::Code::Unauthenticated => {
+            io::ErrorKind::PermissionDenied
+        }
+        tonic::Code::ResourceExhausted => io::ErrorKind::OutOfMemory,
+        tonic::Code::Unimplemented => io::ErrorKind::Unsupported,
+        tonic::Code::Unavailable => io::ErrorKind::ConnectionRefused,
+        _ => io::ErrorKind::Other,
+    };
+    io::Error::new(kind, format!("gRPC stream: {status}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::poll;
+    use prost::Message;
+
+    #[tokio::test]
+    async fn flush_waits_until_tonic_side_consumes_message() {
+        let (mut sender, mut stream) = MessageSender::<Hunk>::pair(1);
+        futures::future::poll_fn(|cx| sender.poll_reserve(cx))
+            .await
+            .unwrap();
+        sender
+            .send_reserved(Hunk {
+                data: b"payload".to_vec(),
+            })
+            .unwrap();
+
+        let mut flush = std::pin::pin!(futures::future::poll_fn(|cx| sender.poll_flush(cx)));
+        assert!(poll!(&mut flush).is_pending());
+        assert_eq!(stream.next().await.unwrap().data, b"payload");
+        // Ack is emitted on the next body poll, mirroring hyper asking whether
+        // more request data is available.
+        assert!(poll!(stream.next()).is_pending());
+        flush.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn closing_body_acknowledges_last_consumed_message() {
+        let (mut sender, mut stream) = MessageSender::<Hunk>::pair(1);
+        futures::future::poll_fn(|cx| sender.poll_reserve(cx))
+            .await
+            .unwrap();
+        sender
+            .send_reserved(Hunk {
+                data: b"last".to_vec(),
+            })
+            .unwrap();
+        assert_eq!(stream.next().await.unwrap().data, b"last");
+        drop(stream);
+        futures::future::poll_fn(|cx| sender.poll_flush(cx))
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn write_bound_accounts_for_protobuf_overhead_exactly() {
+        for limit in MIN_MESSAGE_SIZE..=65_536 {
+            let payload = max_bytes_field_payload(limit);
+            assert!(payload > 0);
+            assert!(bytes_field_encoded_len(payload) <= limit);
+            assert!(bytes_field_encoded_len(payload + 1) > limit);
+            assert!(
+                Hunk {
+                    data: vec![0; payload]
+                }
+                .encoded_len()
+                    <= limit
+            );
+        }
+    }
+
+    #[test]
+    fn tun_multi_vectored_write_never_exceeds_encoded_limit() {
+        let a = vec![1_u8; 127];
+        let b = vec![2_u8; 16_384];
+        let c = vec![3_u8; 17];
+        let inputs = [IoSlice::new(&a), IoSlice::new(&b), IoSlice::new(&c)];
+
+        for limit in [3, 127, 128, 255, 16_384, 65_535] {
+            let (chunks, written) = bounded_multi_chunks(&inputs, limit);
+            assert!(written > 0);
+            assert_eq!(chunks.iter().map(Vec::len).sum::<usize>(), written);
+            assert!(MultiHunk { data: chunks }.encoded_len() <= limit);
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_unopened_tunnel_aborts_pending_response_task() {
+        let (_response_tx, response_rx) = oneshot::channel();
+        let (outbound, _request_stream) = hunk_outbound(1);
+        let task = tokio::spawn(std::future::pending::<()>());
+        let abort = task.abort_handle();
+        let tunnel = GrpcTunnelStream::new(
+            InboundMessages::HunkPending(response_rx),
+            outbound,
+            crate::DEFAULT_MAX_MESSAGE_SIZE,
+        )
+        .with_response_task(abort.clone());
+        drop(tunnel);
+        tokio::task::yield_now().await;
+        assert!(abort.is_finished());
+        let _ = task.await;
+    }
+}

--- a/crates/core-inbound/Cargo.toml
+++ b/crates/core-inbound/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 core-config   = { workspace = true }
+core-grpc     = { workspace = true }
 core-route    = { workspace = true }
 core-resolver = { workspace = true }
 core-outbound = { workspace = true }

--- a/crates/core-inbound/src/grpc.rs
+++ b/crates/core-inbound/src/grpc.rs
@@ -1,0 +1,452 @@
+//! Xray gRPC (`gun`) inbound backed by the reusable VLESS server.
+//!
+//! This module owns listener/runtime composition. Wire framing remains in
+//! `core-grpc`, so TLS, REALITY, finalmask and other authenticated carriers can
+//! call the same `serve_connection` API without duplicating protobuf logic.
+
+use std::{fmt, io, net::SocketAddr, sync::Arc};
+
+use core_config::model::{GrpcListen as GrpcListenConfig, GrpcListenSecurity};
+use core_grpc::{
+    DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_QUEUE_CAPACITY,
+    server::{GrpcServerConfig, TunnelHandler, serve_connection},
+};
+use core_runtime::Runtime;
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Semaphore,
+    task::JoinSet,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    XrayServerTlsAcceptor,
+    reality::RealityListener,
+    vless::{VlessConnectionContext, VlessInboundConfig, serve_vless_stream},
+};
+
+#[derive(Clone)]
+enum GrpcCarrierSecurity {
+    Cleartext,
+    Tls(Arc<XrayServerTlsAcceptor>),
+    Reality(RealityListener),
+}
+
+impl fmt::Debug for GrpcCarrierSecurity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Cleartext => "none",
+            Self::Tls(_) => "tls",
+            Self::Reality(_) => "reality",
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcListener {
+    listen: SocketAddr,
+    server: GrpcServerConfig,
+    vless: Arc<VlessInboundConfig>,
+    carrier: GrpcCarrierSecurity,
+}
+
+impl fmt::Debug for GrpcListener {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GrpcListener")
+            .field("listen", &self.listen)
+            .field("server", &self.server)
+            .field("vless", &self.vless)
+            .field("carrier", &self.carrier)
+            .finish()
+    }
+}
+
+impl GrpcListener {
+    pub fn from_config(config: &GrpcListenConfig) -> io::Result<Self> {
+        if !config.protocol.eq_ignore_ascii_case("vless") {
+            return Err(invalid_input(format!(
+                "unsupported gRPC inner protocol `{}`",
+                config.protocol
+            )));
+        }
+        let host = config.host.trim().trim_matches(['[', ']']);
+        let ip = host
+            .parse()
+            .map_err(|error| invalid_input(format!("invalid gRPC listen host: {error}")))?;
+        let listen = SocketAddr::new(ip, config.port);
+        if listen.port() == 0 {
+            return Err(invalid_input("gRPC listen port must be non-zero"));
+        }
+
+        let settings = &config.grpc_settings;
+        // Xray only consumes `permit_without_stream` in the gRPC dialer
+        // (`dial.go`). Its server (`hub.go`) does not apply that client-side
+        // keepalive permission, so retaining the parsed value without mapping
+        // it into the inbound HTTP/2 builder is intentional compatibility.
+        let server = GrpcServerConfig {
+            service_name: settings.service_name.clone().unwrap_or_default(),
+            idle_timeout: settings
+                .idle_timeout
+                .as_ref()
+                .map(|value| value.duration())
+                .unwrap_or_default(),
+            health_check_timeout: settings
+                .health_check_timeout
+                .as_ref()
+                .map(|value| value.duration())
+                .unwrap_or_default(),
+            initial_window_size: settings.initial_window_size,
+            max_concurrent_streams: config.max_concurrent_streams,
+            max_header_list_size: config.max_header_list_size,
+            max_message_size: settings
+                .max_message_size
+                .unwrap_or(DEFAULT_MAX_MESSAGE_SIZE),
+            queue_capacity: settings.queue_capacity.unwrap_or(DEFAULT_QUEUE_CAPACITY),
+            max_connections: config.max_connections,
+            trusted_x_forwarded_for: config.trusted_x_forwarded_for.clone(),
+        };
+        server.validate()?;
+        let vless = Arc::new(VlessInboundConfig::from_uuid_strings(
+            &config.users,
+            config.handshake_timeout,
+            config.max_mux_sessions,
+        )?);
+        let carrier = match config.security {
+            GrpcListenSecurity::None => {
+                if config.tls_settings.is_some()
+                    || config.reality_settings.is_some()
+                    || config.require_client_certificate
+                {
+                    return Err(invalid_input(
+                        "gRPC security=none cannot include TLS, REALITY or client-certificate settings",
+                    ));
+                }
+                GrpcCarrierSecurity::Cleartext
+            }
+            GrpcListenSecurity::Tls => {
+                if config.reality_settings.is_some() {
+                    return Err(invalid_input(
+                        "gRPC security=tls cannot include realitySettings",
+                    ));
+                }
+                let mut settings = config
+                    .tls_settings
+                    .clone()
+                    .ok_or_else(|| invalid_input("gRPC security=tls requires tlsSettings"))?;
+                require_h2_alpn(&mut settings)?;
+                let acceptor = XrayServerTlsAcceptor::from_xray_settings(
+                    settings,
+                    config.require_client_certificate,
+                )?;
+                GrpcCarrierSecurity::Tls(Arc::new(acceptor))
+            }
+            GrpcListenSecurity::Reality => {
+                if config.tls_settings.is_some() || config.require_client_certificate {
+                    return Err(invalid_input(
+                        "gRPC security=reality cannot include TLS or client-certificate settings",
+                    ));
+                }
+                let mut settings =
+                    config.reality_settings.as_deref().cloned().ok_or_else(|| {
+                        invalid_input("gRPC security=reality requires realitySettings")
+                    })?;
+                settings.host = config.host.clone();
+                settings.port = config.port;
+                settings.protocol = "vless".into();
+                settings.users = config.users.clone();
+                GrpcCarrierSecurity::Reality(RealityListener::from_config(&settings)?)
+            }
+        };
+        Ok(Self {
+            listen,
+            server,
+            vless,
+            carrier,
+        })
+    }
+
+    pub fn listen_addr(&self) -> SocketAddr {
+        self.listen
+    }
+
+    pub fn server_config(&self) -> &GrpcServerConfig {
+        &self.server
+    }
+}
+
+/// Run an h2c, TLS/ECH or REALITY gRPC listener until its task is cancelled.
+pub async fn run_grpc(listener: GrpcListener, runtime: Arc<Runtime>) -> io::Result<()> {
+    let cancellation = CancellationToken::new();
+    let _cancel_on_drop = cancellation.clone().drop_guard();
+    run_grpc_with_cancellation(listener, runtime, cancellation).await
+}
+
+/// Run a gRPC listener with explicit cancellation, used by the application and
+/// deterministic end-to-end tests.
+pub async fn run_grpc_with_cancellation(
+    listener: GrpcListener,
+    runtime: Arc<Runtime>,
+    cancellation: CancellationToken,
+) -> io::Result<()> {
+    let socket = TcpListener::bind(listener.listen).await?;
+    let local = socket.local_addr()?;
+    info!(
+        addr = %local,
+        service = %listener.server.service_name,
+        security = ?listener.carrier,
+        "gRPC inbound listening"
+    );
+
+    let runtime_for_handler = runtime.clone();
+    let vless = listener.vless.clone();
+    let handler_cancellation = cancellation.clone();
+    let handler: TunnelHandler = Arc::new(move |stream, context| {
+        let runtime = runtime_for_handler.clone();
+        let vless = vless.clone();
+        let cancellation = handler_cancellation.clone();
+        Box::pin(async move {
+            serve_vless_stream(
+                stream,
+                VlessConnectionContext {
+                    source: context.remote_addr,
+                    local,
+                },
+                vless,
+                runtime,
+                cancellation,
+            )
+            .await
+        })
+    });
+
+    let permits = Arc::new(Semaphore::new(listener.server.max_connections));
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => break,
+            completed = connections.join_next(), if !connections.is_empty() => {
+                match completed {
+                    Some(Ok(Err(error))) => {
+                        debug!(%error, "gRPC connection ended with an error");
+                    }
+                    Some(Err(error)) => {
+                        debug!(%error, "gRPC connection task failed");
+                    }
+                    _ => {}
+                }
+            }
+            accepted = socket.accept() => {
+                let (stream, peer_addr) = accepted?;
+                if let Err(error) = stream.set_nodelay(true) {
+                    debug!(%peer_addr, %error, "cannot configure accepted gRPC socket");
+                    continue;
+                }
+                let Ok(permit) = permits.clone().try_acquire_owned() else {
+                    warn!(
+                        %peer_addr,
+                        limit = listener.server.max_connections,
+                        "gRPC connection limit reached"
+                    );
+                    drop(stream);
+                    continue;
+                };
+                let connection_config = listener.server.clone();
+                let connection_handler = handler.clone();
+                let carrier = listener.carrier.clone();
+                let cancellation = cancellation.clone();
+                let handshake_timeout = listener.vless.handshake_timeout();
+                let connection_local = stream.local_addr().unwrap_or(local);
+                connections.spawn(async move {
+                    let _permit = permit;
+                    serve_accepted_carrier(
+                        carrier,
+                        stream,
+                        peer_addr,
+                        connection_local,
+                        connection_config,
+                        connection_handler,
+                        handshake_timeout,
+                        cancellation,
+                    )
+                    .await
+                });
+            }
+        }
+    }
+
+    connections.abort_all();
+    while connections.join_next().await.is_some() {}
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_accepted_carrier(
+    carrier: GrpcCarrierSecurity,
+    stream: TcpStream,
+    peer_addr: SocketAddr,
+    local_addr: SocketAddr,
+    config: GrpcServerConfig,
+    handler: TunnelHandler,
+    handshake_timeout: std::time::Duration,
+    cancellation: CancellationToken,
+) -> io::Result<()> {
+    match carrier {
+        GrpcCarrierSecurity::Cleartext => {
+            serve_connection(stream, peer_addr, config, handler).await
+        }
+        GrpcCarrierSecurity::Tls(acceptor) => {
+            let stream = tokio::time::timeout(handshake_timeout, acceptor.accept(stream))
+                .await
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::TimedOut, "gRPC TLS handshake timeout")
+                })??;
+            serve_connection(stream, peer_addr, config, handler).await
+        }
+        GrpcCarrierSecurity::Reality(listener) => {
+            let stream = tokio::time::timeout(
+                handshake_timeout,
+                listener.accept_carrier(stream, peer_addr, local_addr, cancellation),
+            )
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "gRPC REALITY handshake timeout"))?
+            .map_err(|error| io::Error::other(format!("gRPC REALITY carrier: {error:#}")))?;
+            serve_connection(stream, peer_addr, config, handler).await
+        }
+    }
+}
+
+fn require_h2_alpn(settings: &mut core_config::model::XhttpDownloadTlsSettings) -> io::Result<()> {
+    if settings.alpn.is_none() {
+        settings.alpn = Some(vec!["h2".into()]);
+    } else if !settings
+        .alpn
+        .as_ref()
+        .is_some_and(|alpn| alpn.iter().any(|value| value == "h2"))
+    {
+        return Err(invalid_input(
+            "gRPC TLS alpn must contain h2; HTTP/1.1 fallback is not permitted",
+        ));
+    }
+    Ok(())
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_config::model::{
+        CompatDuration, GrpcListenSecurity, GrpcTransportSettings, XhttpDownloadTlsCertificate,
+        XhttpDownloadTlsSettings, XhttpTlsCertificateUsage,
+    };
+    use std::time::Duration;
+
+    fn valid_config() -> GrpcListenConfig {
+        GrpcListenConfig {
+            host: "127.0.0.1".into(),
+            port: 443,
+            protocol: "vless".into(),
+            users: vec!["4f164e20-31aa-4e72-a9b1-a3c0871d2e8d".into()],
+            grpc_settings: GrpcTransportSettings {
+                service_name: Some("escaped/服务".into()),
+                idle_timeout: Some(CompatDuration::Seconds(30)),
+                health_check_timeout: Some(CompatDuration::Human(Duration::from_secs(5))),
+                permit_without_stream: Some(true),
+                initial_window_size: Some(65_535),
+                max_message_size: Some(32 * 1024),
+                queue_capacity: Some(4),
+                ..GrpcTransportSettings::default()
+            },
+            security: GrpcListenSecurity::None,
+            tls_settings: None,
+            require_client_certificate: false,
+            reality_settings: None,
+            handshake_timeout: Duration::from_secs(10),
+            max_mux_sessions: 64,
+            max_connections: 128,
+            max_concurrent_streams: 32,
+            max_header_list_size: 16 * 1024,
+            trusted_x_forwarded_for: vec!["x-wuther-trusted".into()],
+        }
+    }
+
+    #[test]
+    fn maps_every_server_setting() {
+        let listener = GrpcListener::from_config(&valid_config()).unwrap();
+        let server = listener.server_config();
+        assert_eq!(server.service_name, "escaped/服务");
+        assert_eq!(server.idle_timeout, Duration::from_secs(30));
+        assert_eq!(server.health_check_timeout, Duration::from_secs(5));
+        assert_eq!(server.initial_window_size, Some(65_535));
+        assert_eq!(server.max_message_size, 32 * 1024);
+        assert_eq!(server.queue_capacity, 4);
+        assert_eq!(server.max_connections, 128);
+        assert_eq!(server.max_concurrent_streams, 32);
+        assert_eq!(server.max_header_list_size, 16 * 1024);
+        assert_eq!(
+            server.trusted_x_forwarded_for,
+            ["x-wuther-trusted".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_inner_protocol_and_bad_uuid() {
+        let mut config = valid_config();
+        config.protocol = "trojan".into();
+        assert!(GrpcListener::from_config(&config).is_err());
+        config.protocol = "vless".into();
+        config.users = vec!["not-a-uuid".into()];
+        assert!(GrpcListener::from_config(&config).is_err());
+    }
+
+    #[test]
+    fn tls_uses_the_shared_acceptor_and_requires_h2() {
+        let rcgen::CertifiedKey { cert, key_pair } =
+            rcgen::generate_simple_self_signed(vec!["grpc.example".into()]).unwrap();
+        let certificate = XhttpDownloadTlsCertificate {
+            certificate: Some(cert.pem().lines().map(str::to_owned).collect()),
+            key: Some(
+                key_pair
+                    .serialize_pem()
+                    .lines()
+                    .map(str::to_owned)
+                    .collect(),
+            ),
+            usage: Some(XhttpTlsCertificateUsage::Encipherment),
+            ..XhttpDownloadTlsCertificate::default()
+        };
+
+        let mut config = valid_config();
+        config.security = GrpcListenSecurity::Tls;
+        config.tls_settings = Some(XhttpDownloadTlsSettings {
+            certificates: vec![certificate.clone()],
+            ..XhttpDownloadTlsSettings::default()
+        });
+        assert!(GrpcListener::from_config(&config).is_ok());
+
+        config.tls_settings = Some(XhttpDownloadTlsSettings {
+            certificates: vec![certificate],
+            alpn: Some(vec!["http/1.1".into()]),
+            ..XhttpDownloadTlsSettings::default()
+        });
+        assert!(GrpcListener::from_config(&config).is_err());
+    }
+
+    #[test]
+    fn security_settings_never_silently_downgrade() {
+        let mut config = valid_config();
+        config.tls_settings = Some(XhttpDownloadTlsSettings::default());
+        assert!(GrpcListener::from_config(&config).is_err());
+
+        config.security = GrpcListenSecurity::Tls;
+        config.tls_settings = None;
+        assert!(GrpcListener::from_config(&config).is_err());
+
+        config.security = GrpcListenSecurity::Reality;
+        assert!(GrpcListener::from_config(&config).is_err());
+    }
+}

--- a/crates/core-inbound/src/lib.rs
+++ b/crates/core-inbound/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod grpc;
 pub mod listener;
 pub mod mixed;
 pub mod privilege;
@@ -17,6 +18,7 @@ mod xhttp_cors;
 pub mod xhttp_listener;
 mod xhttp_tls;
 
+pub use grpc::{GrpcListener, run_grpc, run_grpc_with_cancellation};
 pub use listener::{bind_with_fallback, select_bind_addr};
 pub use mixed::{MixedListener, run_mixed};
 pub use privilege::{

--- a/crates/core-inbound/src/reality.rs
+++ b/crates/core-inbound/src/reality.rs
@@ -10,8 +10,9 @@ use std::time::Duration;
 use base64::Engine as _;
 use core_config::model::RealityListen as RealityListenConfig;
 use core_reality::{
-    ClientHelloLimits, FallbackLimit, ProxyProtocolVersion, RealityServer, RealityServerConfig,
-    RealityServerError, RealityServerLimits, decode_private_key, decode_short_id,
+    AcceptedRealityStream, ClientHelloLimits, FallbackLimit, ProxyProtocolVersion, RealityServer,
+    RealityServerConfig, RealityServerError, RealityServerLimits, decode_private_key,
+    decode_short_id,
 };
 use core_runtime::Runtime;
 use tokio::net::{TcpListener, TcpStream};
@@ -174,6 +175,52 @@ impl RealityListener {
     pub fn listen_addr(&self) -> SocketAddr {
         self.listen
     }
+
+    /// Authenticate one already-accepted TCP stream and return the reusable
+    /// REALITY carrier. Higher transports such as gRPC and XHTTP consume this
+    /// API before running their own framing.
+    pub async fn accept_carrier(
+        &self,
+        stream: TcpStream,
+        peer: SocketAddr,
+        local: SocketAddr,
+        cancellation: CancellationToken,
+    ) -> anyhow::Result<AcceptedRealityStream> {
+        let accepted = match &self.target {
+            CamouflageTarget::Tcp(address) => {
+                let target = tokio::time::timeout(
+                    self.server.config().limits.target_handshake_timeout,
+                    TcpStream::connect(address),
+                )
+                .await
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::TimedOut, "camouflage target timeout")
+                })??;
+                self.server
+                    .accept_with_target(stream, target, peer, local, cancellation)
+                    .await?
+            }
+            #[cfg(unix)]
+            CamouflageTarget::Unix(path) => {
+                let target = tokio::time::timeout(
+                    self.server.config().limits.target_handshake_timeout,
+                    tokio::net::UnixStream::connect(path),
+                )
+                .await
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::TimedOut, "camouflage target timeout")
+                })??;
+                self.server
+                    .accept_with_target(stream, target, peer, local, cancellation)
+                    .await?
+            }
+        };
+        Ok(accepted)
+    }
+
+    pub fn vless_config(&self) -> Arc<VlessInboundConfig> {
+        self.vless.clone()
+    }
 }
 
 fn target_address(target: &CamouflageTarget) -> &str {
@@ -236,33 +283,9 @@ async fn authenticate_and_serve(
     cancellation: CancellationToken,
 ) -> anyhow::Result<()> {
     let inner_cancellation = cancellation.clone();
-    let accepted = match &listener.target {
-        CamouflageTarget::Tcp(address) => {
-            let target = tokio::time::timeout(
-                listener.server.config().limits.target_handshake_timeout,
-                TcpStream::connect(address),
-            )
-            .await
-            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "camouflage target timeout"))??;
-            listener
-                .server
-                .accept_with_target(stream, target, peer, local, cancellation)
-                .await?
-        }
-        #[cfg(unix)]
-        CamouflageTarget::Unix(path) => {
-            let target = tokio::time::timeout(
-                listener.server.config().limits.target_handshake_timeout,
-                tokio::net::UnixStream::connect(path),
-            )
-            .await
-            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "camouflage target timeout"))??;
-            listener
-                .server
-                .accept_with_target(stream, target, peer, local, cancellation)
-                .await?
-        }
-    };
+    let accepted = listener
+        .accept_carrier(stream, peer, local, cancellation)
+        .await?;
     serve_vless_stream(
         accepted,
         VlessConnectionContext {

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -17,6 +17,7 @@ core-reality = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 core-young   = { workspace = true, features = ["firefox-stack"] }
+core-grpc   = { workspace = true }
 tokio       = { workspace = true }
 async-trait = { workspace = true }
 bytes       = { workspace = true }

--- a/crates/core-outbound/src/proto/trojan.rs
+++ b/crates/core-outbound/src/proto/trojan.rs
@@ -23,7 +23,8 @@ use crate::{
     adapter::{BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, UdpSocketLike},
     proto::addr::encode_socks_addr,
     transport::{
-        TlsOptions, Transport, XhttpOptions, tls::TlsTransport, xhttp_transport::XhttpTransport,
+        GrpcOptions, GrpcTransport, TlsOptions, Transport, XhttpOptions, tcp::TcpTransport,
+        tls::TlsTransport, xhttp_transport::XhttpTransport,
     },
 };
 
@@ -37,11 +38,14 @@ pub struct TrojanOutbound {
     pub host: String,
     pub port: u16,
     pub password: String,
+    pub tls: bool,
     pub sni: Option<String>,
     pub insecure: bool,
     pub alpn: Vec<String>,
+    pub tls_options: Option<TlsOptions>,
     pub udp: bool,
     pub xhttp: Option<XhttpOptions>,
+    pub grpc: Option<GrpcOptions>,
 }
 
 impl TrojanOutbound {
@@ -56,17 +60,20 @@ impl TrojanOutbound {
             host: host.into(),
             port,
             password: password.into(),
+            tls: true,
             sni: None,
             insecure: false,
             alpn: vec![],
+            tls_options: None,
             udp: true,
             xhttp: None,
+            grpc: None,
         }
     }
 
-    async fn connect_tls(&self) -> std::io::Result<BoxedStream> {
-        let tls = TlsTransport::new(TlsOptions {
-            enabled: true,
+    async fn connect_transport(&self) -> std::io::Result<BoxedStream> {
+        let tls = self.tls_options.clone().unwrap_or_else(|| TlsOptions {
+            enabled: self.tls,
             sni: self.sni.clone(),
             insecure: self.insecure,
             alpn: self.alpn.clone(),
@@ -77,7 +84,15 @@ impl TrojanOutbound {
             xray_settings: None,
             resolved_ech_config_list: None,
         });
-        tls.connect(&self.host, self.port).await
+        if let Some(grpc) = self.grpc.as_ref() {
+            GrpcTransport::new(grpc.clone(), tls)
+                .connect(&self.host, self.port)
+                .await
+        } else if self.tls {
+            TlsTransport::new(tls).connect(&self.host, self.port).await
+        } else {
+            TcpTransport::default().connect(&self.host, self.port).await
+        }
     }
 
     async fn dial_transport(&self) -> std::io::Result<BoxedStream> {
@@ -86,7 +101,7 @@ impl TrojanOutbound {
                 .connect(&self.host, self.port)
                 .await
         } else {
-            self.connect_tls().await
+            self.connect_transport().await
         }
     }
 

--- a/crates/core-outbound/src/proto/vless.rs
+++ b/crates/core-outbound/src/proto/vless.rs
@@ -21,11 +21,20 @@
 
 use async_trait::async_trait;
 use bytes::BufMut;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::{
+    io::{AsyncReadExt, ReadHalf, WriteHalf},
+    sync::Mutex as AsyncMutex,
+};
 use uuid::Uuid;
 
 use crate::{
-    adapter::{BoxedStream, Capabilities, DialContext, OutboundAdapter},
+    adapter::{BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, UdpSocketLike},
     transport::{
         GrpcOptions, H2Options, HttpOptions, RealityOptions, RealityTransport, TlsOptions,
         Transport, WsOptions, XhttpOptions, grpc_transport::GrpcTransport,
@@ -73,6 +82,8 @@ pub struct VlessOutbound {
     pub sni: Option<String>,
     pub insecure: bool,
     pub alpn: Vec<String>,
+    /// 完整 TLS/ECH 客户端配置；由注册层一次性严格编译。
+    pub tls_options: Option<TlsOptions>,
     pub reality: Option<RealityOptions>,
     pub network: VlessNetwork,
     pub ws: Option<WsOptions>,
@@ -80,6 +91,147 @@ pub struct VlessOutbound {
     pub h2: Option<H2Options>,
     pub grpc: Option<GrpcOptions>,
     pub xhttp: Option<XhttpOptions>,
+}
+
+/// A VLESS stream whose response header is consumed on the first application
+/// read instead of while dialing.
+///
+/// Xray writes the response header from its downlink copy task. Waiting for
+/// that header in [`OutboundAdapter::dial_tcp`] deadlocks protocols whose
+/// upstream does not produce data until the client sends its first request.
+/// Writes must therefore remain usable immediately after the request header
+/// has been sent.
+struct VlessResponseStream {
+    inner: BoxedStream,
+    state: VlessResponseState,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum VlessResponseState {
+    Version,
+    AddonsLength,
+    Addons(usize),
+    Ready,
+    Failed,
+}
+
+impl VlessResponseStream {
+    fn new(inner: BoxedStream) -> Self {
+        Self {
+            inner,
+            state: VlessResponseState::Version,
+        }
+    }
+
+    fn poll_control_byte(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<u8>> {
+        let mut byte = [0_u8; 1];
+        let mut read_buf = ReadBuf::new(&mut byte);
+        match self.inner.as_mut().poll_read(cx, &mut read_buf) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Ready(Ok(())) if read_buf.filled().is_empty() => {
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "truncated VLESS response header",
+                )))
+            }
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(byte[0])),
+        }
+    }
+
+    fn fail(&mut self, error: io::Error) -> Poll<io::Result<()>> {
+        self.state = VlessResponseState::Failed;
+        Poll::Ready(Err(error))
+    }
+}
+
+impl AsyncRead for VlessResponseStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let this = self.get_mut();
+        loop {
+            match this.state {
+                VlessResponseState::Version => match this.poll_control_byte(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Err(error)) => return this.fail(error),
+                    Poll::Ready(Ok(0)) => this.state = VlessResponseState::AddonsLength,
+                    Poll::Ready(Ok(version)) => {
+                        return this.fail(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "unexpected VLESS response version: expected 0, received {version}"
+                            ),
+                        ));
+                    }
+                },
+                VlessResponseState::AddonsLength => match this.poll_control_byte(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Err(error)) => return this.fail(error),
+                    Poll::Ready(Ok(0)) => this.state = VlessResponseState::Ready,
+                    Poll::Ready(Ok(length)) => {
+                        this.state = VlessResponseState::Addons(usize::from(length));
+                    }
+                },
+                VlessResponseState::Addons(remaining) => {
+                    let mut discard = [0_u8; u8::MAX as usize];
+                    let take = remaining.min(discard.len());
+                    let mut read_buf = ReadBuf::new(&mut discard[..take]);
+                    match this.inner.as_mut().poll_read(cx, &mut read_buf) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(error)) => return this.fail(error),
+                        Poll::Ready(Ok(())) if read_buf.filled().is_empty() => {
+                            return this.fail(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "truncated VLESS response addons",
+                            ));
+                        }
+                        Poll::Ready(Ok(())) => {
+                            let remaining = remaining - read_buf.filled().len();
+                            this.state = if remaining == 0 {
+                                VlessResponseState::Ready
+                            } else {
+                                VlessResponseState::Addons(remaining)
+                            };
+                        }
+                    }
+                }
+                VlessResponseState::Ready => {
+                    return this.inner.as_mut().poll_read(cx, buf);
+                }
+                VlessResponseState::Failed => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::ConnectionAborted,
+                        "VLESS response header validation previously failed",
+                    )));
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for VlessResponseStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.get_mut().inner.as_mut().poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_shutdown(cx)
+    }
 }
 
 impl VlessOutbound {
@@ -94,7 +246,7 @@ impl VlessOutbound {
     }
 
     fn tls_opts(&self) -> TlsOptions {
-        TlsOptions {
+        self.tls_options.clone().unwrap_or_else(|| TlsOptions {
             enabled: self.tls,
             sni: self.sni.clone(),
             insecure: self.insecure,
@@ -105,7 +257,7 @@ impl VlessOutbound {
             verify_peer_cert_by_name: Vec::new(),
             xray_settings: None,
             resolved_ech_config_list: None,
-        }
+        })
     }
 
     /// 按 network 类型派发到对应 transport
@@ -166,16 +318,23 @@ impl VlessOutbound {
                     .await
             }
             VlessNetwork::Grpc => {
-                if self.reality.is_some() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Unsupported,
-                        "VLESS REALITY over gRPC requires a carrier-aware gRPC transport and is not enabled",
-                    ));
-                }
                 let opts = self.grpc.clone().unwrap_or_default();
-                GrpcTransport::new(opts, self.tls_opts())
-                    .connect(&self.host, self.port)
-                    .await
+                if let Some(reality) = &self.reality {
+                    let authority_tls = TlsOptions {
+                        sni: Some(reality.config.server_name.clone()),
+                        alpn: vec!["h2".into()],
+                        ..Default::default()
+                    };
+                    let grpc = GrpcTransport::new(opts, authority_tls);
+                    let carrier = RealityTransport::new(reality.clone())?
+                        .connect(&self.host, self.port)
+                        .await?;
+                    grpc.connect_over(carrier, &self.host, self.port).await
+                } else {
+                    GrpcTransport::new(opts, self.tls_opts())
+                        .connect(&self.host, self.port)
+                        .await
+                }
             }
             VlessNetwork::Xhttp => {
                 if self.reality.is_some() {
@@ -191,6 +350,22 @@ impl VlessOutbound {
             }
         }
     }
+
+    async fn write_request_header(
+        &self,
+        stream: &mut BoxedStream,
+        command: u8,
+        ctx: &DialContext,
+    ) -> io::Result<()> {
+        let mut buffer = Vec::with_capacity(64);
+        buffer.put_u8(0x00);
+        buffer.extend_from_slice(self.uuid.as_bytes());
+        buffer.put_u8(0x00);
+        buffer.put_u8(command);
+        buffer.put_u16(ctx.port);
+        encode_vless_address(&mut buffer, &ctx.host)?;
+        stream.write_all(&buffer).await
+    }
 }
 
 #[async_trait]
@@ -204,7 +379,7 @@ impl OutboundAdapter for VlessOutbound {
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             tcp: true,
-            udp: false,
+            udp: true,
             ipv6: true,
             multiplex: false,
         }
@@ -212,40 +387,105 @@ impl OutboundAdapter for VlessOutbound {
 
     async fn dial_tcp(&self, ctx: DialContext) -> std::io::Result<BoxedStream> {
         let mut stream = self.dial_transport().await?;
-        let mut buf = Vec::with_capacity(64);
-        buf.put_u8(0x00); // version
-        buf.extend_from_slice(self.uuid.as_bytes());
-        buf.put_u8(0x00); // addons length = 0
-        buf.put_u8(0x01); // CONNECT (TCP)
-        buf.put_u16(ctx.port);
-        // ATYP + ADDR：1=IPv4 2=Domain 3=IPv6
-        if let Ok(ip) = ctx.host.parse::<std::net::Ipv4Addr>() {
-            buf.put_u8(0x01);
-            buf.extend_from_slice(&ip.octets());
-        } else if let Ok(ip) = ctx.host.parse::<std::net::Ipv6Addr>() {
-            buf.put_u8(0x03);
-            buf.extend_from_slice(&ip.octets());
-        } else {
-            buf.put_u8(0x02);
-            buf.put_u8(ctx.host.len().min(255) as u8);
-            buf.extend_from_slice(ctx.host.as_bytes());
-        }
-        stream.write_all(&buf).await?;
+        self.write_request_header(&mut stream, 0x01, &ctx).await?;
+        Ok(Box::pin(VlessResponseStream::new(stream)))
+    }
 
-        // 读取 server 响应：Version(1) + AddonsLen(1) + Addons
-        let mut resp_head = [0u8; 2];
-        stream.read_exact(&mut resp_head).await?;
-        if resp_head[1] > 0 {
-            let mut addons = vec![0u8; resp_head[1] as usize];
-            stream.read_exact(&mut addons).await?;
+    async fn dial_udp(&self, ctx: DialContext) -> io::Result<BoxedUdp> {
+        let mut stream = self.dial_transport().await?;
+        self.write_request_header(&mut stream, 0x02, &ctx).await?;
+        let (read, write) = tokio::io::split(VlessResponseStream::new(stream));
+        Ok(Box::new(VlessUdp {
+            target: ctx.host,
+            port: ctx.port,
+            read: AsyncMutex::new(read),
+            write: AsyncMutex::new(write),
+        }))
+    }
+}
+
+fn encode_vless_address(buffer: &mut Vec<u8>, host: &str) -> io::Result<()> {
+    if let Ok(ip) = host.parse::<std::net::Ipv4Addr>() {
+        buffer.put_u8(0x01);
+        buffer.extend_from_slice(&ip.octets());
+    } else if let Ok(ip) = host.parse::<std::net::Ipv6Addr>() {
+        buffer.put_u8(0x03);
+        buffer.extend_from_slice(&ip.octets());
+    } else {
+        if host.is_empty() || host.len() > usize::from(u8::MAX) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "VLESS destination domain must contain 1..=255 bytes",
+            ));
         }
-        Ok(stream)
+        buffer.put_u8(0x02);
+        buffer.put_u8(host.len() as u8);
+        buffer.extend_from_slice(host.as_bytes());
+    }
+    Ok(())
+}
+
+struct VlessUdp {
+    target: String,
+    port: u16,
+    read: AsyncMutex<ReadHalf<VlessResponseStream>>,
+    write: AsyncMutex<WriteHalf<VlessResponseStream>>,
+}
+
+#[async_trait]
+impl UdpSocketLike for VlessUdp {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        if port != self.port || !same_udp_target(target, &self.target) {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "VLESS UDP command is bound to {}:{}, cannot send to {target}:{port}",
+                    self.target, self.port
+                ),
+            ));
+        }
+        let length = u16::try_from(payload.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "VLESS UDP datagram exceeds 65535 bytes",
+            )
+        })?;
+        let mut write = self.write.lock().await;
+        write.write_all(&length.to_be_bytes()).await?;
+        write.write_all(payload).await?;
+        write.flush().await?;
+        Ok(payload.len())
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        let mut read = self.read.lock().await;
+        let length = read.read_u16().await? as usize;
+        let mut payload = vec![0_u8; length];
+        read.read_exact(&mut payload).await?;
+        let copied = output.len().min(length);
+        output[..copied].copy_from_slice(&payload[..copied]);
+        Ok(copied)
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        self.write.lock().await.shutdown().await
+    }
+}
+
+fn same_udp_target(left: &str, right: &str) -> bool {
+    match (
+        left.parse::<std::net::IpAddr>(),
+        right.parse::<std::net::IpAddr>(),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left.eq_ignore_ascii_case(right),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn network_parse() {
@@ -267,5 +507,102 @@ mod tests {
         let ob = VlessOutbound::new("v", "1.2.3.4", 443, u);
         assert_eq!(ob.network, VlessNetwork::Tcp);
         assert_eq!(ob.protocol(), "vless");
+    }
+
+    #[tokio::test]
+    async fn response_header_is_consumed_lazily_without_blocking_writes() {
+        let (client, mut server) = tokio::io::duplex(64);
+        let mut stream = VlessResponseStream::new(Box::pin(client));
+
+        stream.write_all(b"request").await.unwrap();
+        let mut request = [0_u8; 7];
+        server.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"request");
+
+        server
+            .write_all(&[0, 2, 0xaa, 0xbb, b'o', b'k'])
+            .await
+            .unwrap();
+        let mut response = [0_u8; 2];
+        stream.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"ok");
+    }
+
+    #[tokio::test]
+    async fn response_header_rejects_unexpected_version() {
+        let (client, mut server) = tokio::io::duplex(8);
+        let mut stream = VlessResponseStream::new(Box::pin(client));
+        server.write_all(&[1, 0]).await.unwrap();
+
+        let error = stream.read_u8().await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("received 1"));
+    }
+
+    #[tokio::test]
+    async fn response_header_rejects_truncated_addons() {
+        let (client, mut server) = tokio::io::duplex(8);
+        let mut stream = VlessResponseStream::new(Box::pin(client));
+        server.write_all(&[0, 2, 0xaa]).await.unwrap();
+        server.shutdown().await.unwrap();
+
+        let error = stream.read_u8().await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn udp_datagrams_are_length_framed_and_response_header_is_lazy() {
+        let (client, mut server) = tokio::io::duplex(256);
+        let (read, write) =
+            tokio::io::split(VlessResponseStream::new(Box::pin(client) as BoxedStream));
+        let udp = VlessUdp {
+            target: "127.0.0.1".into(),
+            port: 53,
+            read: AsyncMutex::new(read),
+            write: AsyncMutex::new(write),
+        };
+
+        let server_task = tokio::spawn(async move {
+            server.write_all(&[0, 0]).await.unwrap();
+            let length = server.read_u16().await.unwrap() as usize;
+            let mut payload = vec![0; length];
+            server.read_exact(&mut payload).await.unwrap();
+            assert_eq!(&payload, b"dns-query");
+            server.write_u16(payload.len() as u16).await.unwrap();
+            server.write_all(&payload).await.unwrap();
+        });
+
+        assert_eq!(udp.send_to(b"dns-query", "127.0.0.1", 53).await.unwrap(), 9);
+        let mut response = [0_u8; 32];
+        let received = udp.recv_from(&mut response).await.unwrap();
+        assert_eq!(&response[..received], b"dns-query");
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn udp_fixed_destination_rejects_cross_target_and_oversize_datagram() {
+        let (client, _server) = tokio::io::duplex(32);
+        let (read, write) =
+            tokio::io::split(VlessResponseStream::new(Box::pin(client) as BoxedStream));
+        let udp = VlessUdp {
+            target: "dns.example".into(),
+            port: 53,
+            read: AsyncMutex::new(read),
+            write: AsyncMutex::new(write),
+        };
+        assert_eq!(
+            udp.send_to(b"x", "other.example", 53)
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            udp.send_to(&vec![0; usize::from(u16::MAX) + 1], "DNS.EXAMPLE", 53)
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
     }
 }

--- a/crates/core-outbound/src/proto/vmess.rs
+++ b/crates/core-outbound/src/proto/vmess.rs
@@ -60,6 +60,7 @@
 //! ```
 
 use std::{
+    io,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -71,7 +72,7 @@ use aes::{
 };
 use aes_gcm::{
     Aes128Gcm, Nonce,
-    aead::{Aead, KeyInit},
+    aead::{Aead, Payload},
 };
 use async_trait::async_trait;
 use bytes::{Buf, BufMut, BytesMut};
@@ -83,7 +84,7 @@ use sha3::{
     Shake128,
     digest::{ExtendableOutput, XofReader},
 };
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use uuid::Uuid;
 
 use crate::{
@@ -167,6 +168,8 @@ pub struct VmessOutbound {
     pub sni: Option<String>,
     pub insecure: bool,
     pub alpn: Vec<String>,
+    /// 完整 TLS/ECH 客户端配置；由注册层一次性严格编译。
+    pub tls_options: Option<TlsOptions>,
     pub network: VmessNetwork,
     pub ws: Option<WsOptions>,
     pub http: Option<HttpOptions>,
@@ -218,6 +221,7 @@ impl VmessOutbound {
             sni: None,
             insecure: false,
             alpn: vec![],
+            tls_options: None,
             network: VmessNetwork::Tcp,
             ws: None,
             http: None,
@@ -228,7 +232,7 @@ impl VmessOutbound {
     }
 
     fn tls_opts(&self) -> TlsOptions {
-        TlsOptions {
+        self.tls_options.clone().unwrap_or_else(|| TlsOptions {
             enabled: self.tls,
             sni: self.sni.clone(),
             insecure: self.insecure,
@@ -239,7 +243,7 @@ impl VmessOutbound {
             verify_peer_cert_by_name: Vec::new(),
             xray_settings: None,
             resolved_ech_config_list: None,
-        }
+        })
     }
 
     async fn dial_transport(&self) -> std::io::Result<BoxedStream> {
@@ -361,10 +365,17 @@ impl OutboundAdapter for VmessOutbound {
         let mut stream = stream;
         stream.write_all(&wire).await?;
 
-        // 5) 读取响应头部 + 校验 ResponseAuth
+        // 5) The VMess response header is produced by the downlink task.
+        // Consuming it here would deadlock request/response protocols whose
+        // origin does not speak until the caller writes its first payload.
         let resp_key_seed = sha256_first_16(&req_key);
         let resp_iv_seed = sha256_first_16(&iv);
-        verify_response_header(&mut stream, &resp_key_seed, &resp_iv_seed, resp_auth[0]).await?;
+        let stream: BoxedStream = Box::pin(VmessResponseStream::new(
+            stream,
+            &resp_key_seed,
+            &resp_iv_seed,
+            resp_auth[0],
+        ));
 
         // 6) 包装 chunk stream
         wrap_chunk_stream(stream, security, &req_key, &iv, self.options)
@@ -402,13 +413,29 @@ pub fn wrap_chunk_stream(
     req_iv: &[u8; 16],
     options: u8,
 ) -> std::io::Result<BoxedStream> {
-    let send_iv = sha256_first_16(req_iv);
+    if options & VMESS_OPTION_GLOBAL_PADDING != 0 && options & VMESS_OPTION_CHUNK_MASKING == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "VMess GLOBAL_PADDING requires CHUNK_MASKING",
+        ));
+    }
+    if options & VMESS_OPTION_AUTH_LEN != 0 && security == VmessSecurity::None {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "VMess AUTH_LEN requires an AEAD body security",
+        ));
+    }
+
+    let send_iv = *req_iv;
     let send_key = *req_key;
     let recv_iv = sha256_first_16(req_iv);
     let recv_key = sha256_first_16(req_key);
 
-    let send = ChunkCryptor::new(security, &send_key, &send_iv, options);
-    let recv = ChunkCryptor::new(security, &recv_key, &recv_iv, options);
+    let send = ChunkCryptor::new(security, &send_key, &send_iv, options, req_key, req_iv);
+    // Xray intentionally derives response authenticated-length framing from
+    // the request key/IV, while response payload encryption and masking use
+    // SHA-256(request key/IV).
+    let recv = ChunkCryptor::new(security, &recv_key, &recv_iv, options, req_key, req_iv);
 
     Ok(Box::pin(VmessStream {
         inner: stream,
@@ -419,6 +446,7 @@ pub fn wrap_chunk_stream(
         recv_state: RecvState::Length,
         recv_pending_size: 0,
         recv_pending_padding: 0,
+        pending_write: None,
     }))
 }
 
@@ -509,7 +537,13 @@ fn aead_seal_header_length(
     let nonce = Nonce::from_slice(&nonce_full);
     let payload = length.to_be_bytes();
     cipher
-        .encrypt(nonce, payload.as_ref())
+        .encrypt(
+            nonce,
+            Payload {
+                msg: payload.as_ref(),
+                aad: auth_id,
+            },
+        )
         .map_err(|_| io_err("aead seal length"))
 }
 
@@ -524,7 +558,13 @@ fn aead_seal_header_payload(
     let cipher = Aes128Gcm::new_from_slice(&key).map_err(|_| io_err("aead key payload"))?;
     let nonce = Nonce::from_slice(&nonce_full);
     cipher
-        .encrypt(nonce, payload)
+        .encrypt(
+            nonce,
+            Payload {
+                msg: payload,
+                aad: auth_id,
+            },
+        )
         .map_err(|_| io_err("aead seal payload"))
 }
 
@@ -538,45 +578,209 @@ fn sha256_first_16(data: &[u8]) -> [u8; 16] {
     out
 }
 
-async fn verify_response_header(
-    stream: &mut BoxedStream,
-    resp_key_seed: &[u8; 16],
-    resp_iv_seed: &[u8; 16],
-    expect_resp_auth: u8,
-) -> std::io::Result<()> {
-    let mut len_buf = [0u8; 18];
-    stream.read_exact(&mut len_buf).await?;
-    let len_key = kdf_n(resp_key_seed, &[KDF_AEAD_RESP_HEADER_LEN_KEY], 16);
-    let len_nonce = kdf_n(resp_iv_seed, &[KDF_AEAD_RESP_HEADER_LEN_IV], 12);
-    let len_cipher = Aes128Gcm::new_from_slice(&len_key).map_err(|_| io_err("resp len key"))?;
-    let dec_len = len_cipher
-        .decrypt(Nonce::from_slice(&len_nonce), len_buf.as_ref())
-        .map_err(|_| io_err("resp len decrypt"))?;
-    if dec_len.len() != 2 {
-        return Err(io_err("resp len size"));
-    }
-    let header_len = u16::from_be_bytes([dec_len[0], dec_len[1]]) as usize;
+enum VmessResponseHeaderState {
+    Length { buffer: [u8; 18], filled: usize },
+    Payload { buffer: Vec<u8>, filled: usize },
+    Ready,
+    Failed,
+}
 
-    let mut hdr_buf = vec![0u8; header_len + 16];
-    stream.read_exact(&mut hdr_buf).await?;
-    let p_key = kdf_n(resp_key_seed, &[KDF_AEAD_RESP_HEADER_PAYLOAD_KEY], 16);
-    let p_nonce = kdf_n(resp_iv_seed, &[KDF_AEAD_RESP_HEADER_PAYLOAD_IV], 12);
-    let p_cipher = Aes128Gcm::new_from_slice(&p_key).map_err(|_| io_err("resp payload key"))?;
-    let dec = p_cipher
-        .decrypt(Nonce::from_slice(&p_nonce), hdr_buf.as_ref())
-        .map_err(|_| io_err("resp payload decrypt"))?;
-    // 完整解析: ResponseAuth(1) || Options(1) || CmdRespSize(1) || Cmd(1) || CmdResp(M)
-    if dec.is_empty() || dec[0] != expect_resp_auth {
-        return Err(io_err("resp auth mismatch"));
-    }
-    if dec.len() >= 4 {
-        // 跳过 cmd_resp（含 dynamic port 等扩展），mihomo 默认不主动处理
-        let cmd_resp_size = dec[2] as usize;
-        if dec.len() < 4 + cmd_resp_size {
-            return Err(io_err("resp cmd size truncated"));
+/// Strips and authenticates VMess's encrypted response header on the first
+/// application read. Writes always pass through immediately.
+struct VmessResponseStream {
+    inner: BoxedStream,
+    state: VmessResponseHeaderState,
+    length_key: [u8; 16],
+    length_nonce: [u8; 12],
+    payload_key: [u8; 16],
+    payload_nonce: [u8; 12],
+    expected_response_auth: u8,
+}
+
+impl VmessResponseStream {
+    fn new(
+        inner: BoxedStream,
+        response_key: &[u8; 16],
+        response_iv: &[u8; 16],
+        expected_response_auth: u8,
+    ) -> Self {
+        Self {
+            inner,
+            state: VmessResponseHeaderState::Length {
+                buffer: [0; 18],
+                filled: 0,
+            },
+            length_key: kdf_n(response_key, &[KDF_AEAD_RESP_HEADER_LEN_KEY], 16)
+                .try_into()
+                .expect("fixed VMess response length key"),
+            length_nonce: kdf_n(response_iv, &[KDF_AEAD_RESP_HEADER_LEN_IV], 12)
+                .try_into()
+                .expect("fixed VMess response length nonce"),
+            payload_key: kdf_n(response_key, &[KDF_AEAD_RESP_HEADER_PAYLOAD_KEY], 16)
+                .try_into()
+                .expect("fixed VMess response payload key"),
+            payload_nonce: kdf_n(response_iv, &[KDF_AEAD_RESP_HEADER_PAYLOAD_IV], 12)
+                .try_into()
+                .expect("fixed VMess response payload nonce"),
+            expected_response_auth,
         }
     }
-    Ok(())
+
+    fn fail(&mut self, error: io::Error) -> Poll<io::Result<()>> {
+        self.state = VmessResponseHeaderState::Failed;
+        Poll::Ready(Err(error))
+    }
+
+    fn decrypt_length(&self, encrypted: &[u8; 18]) -> io::Result<usize> {
+        let cipher = Aes128Gcm::new_from_slice(&self.length_key)
+            .map_err(|_| invalid_data("invalid VMess response length key"))?;
+        let plaintext = cipher
+            .decrypt(Nonce::from_slice(&self.length_nonce), encrypted.as_ref())
+            .map_err(|_| invalid_data("VMess response length authentication failed"))?;
+        let bytes: [u8; 2] = plaintext
+            .try_into()
+            .map_err(|_| invalid_data("invalid VMess response length plaintext"))?;
+        Ok(usize::from(u16::from_be_bytes(bytes)))
+    }
+
+    fn validate_payload(&self, encrypted: &[u8]) -> io::Result<()> {
+        let cipher = Aes128Gcm::new_from_slice(&self.payload_key)
+            .map_err(|_| invalid_data("invalid VMess response payload key"))?;
+        let plaintext = cipher
+            .decrypt(Nonce::from_slice(&self.payload_nonce), encrypted)
+            .map_err(|_| invalid_data("VMess response payload authentication failed"))?;
+        if plaintext.len() < 4 {
+            return Err(invalid_data("truncated VMess response header"));
+        }
+        if plaintext[0] != self.expected_response_auth {
+            return Err(invalid_data(format!(
+                "unexpected VMess response authentication byte: expected {}, received {}",
+                self.expected_response_auth, plaintext[0]
+            )));
+        }
+        // Xray layout: response-auth, options, command-id, command-length,
+        // command payload. The command itself is advisory (for example the
+        // legacy dynamic-port command), but its declared framing is strict.
+        let command_length = usize::from(plaintext[3]);
+        if plaintext.len() != 4 + command_length {
+            return Err(invalid_data("invalid VMess response command length"));
+        }
+        Ok(())
+    }
+}
+
+fn poll_fill_exact(
+    inner: &mut BoxedStream,
+    cx: &mut Context<'_>,
+    buffer: &mut [u8],
+    filled: &mut usize,
+    label: &'static str,
+) -> Poll<io::Result<()>> {
+    while *filled < buffer.len() {
+        let mut read_buf = ReadBuf::new(&mut buffer[*filled..]);
+        match inner.as_mut().poll_read(cx, &mut read_buf) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+            Poll::Ready(Ok(())) if read_buf.filled().is_empty() => {
+                return Poll::Ready(Err(io::Error::new(io::ErrorKind::UnexpectedEof, label)));
+            }
+            Poll::Ready(Ok(())) => *filled += read_buf.filled().len(),
+        }
+    }
+    Poll::Ready(Ok(()))
+}
+
+impl AsyncRead for VmessResponseStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let this = self.get_mut();
+        loop {
+            let state = std::mem::replace(&mut this.state, VmessResponseHeaderState::Failed);
+            match state {
+                VmessResponseHeaderState::Length {
+                    mut buffer,
+                    mut filled,
+                } => match poll_fill_exact(
+                    &mut this.inner,
+                    cx,
+                    &mut buffer,
+                    &mut filled,
+                    "truncated VMess encrypted response length",
+                ) {
+                    Poll::Pending => {
+                        this.state = VmessResponseHeaderState::Length { buffer, filled };
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(error)) => return this.fail(error),
+                    Poll::Ready(Ok(())) => match this.decrypt_length(&buffer) {
+                        Ok(length) => {
+                            this.state = VmessResponseHeaderState::Payload {
+                                buffer: vec![0; length + 16],
+                                filled: 0,
+                            };
+                        }
+                        Err(error) => return this.fail(error),
+                    },
+                },
+                VmessResponseHeaderState::Payload {
+                    mut buffer,
+                    mut filled,
+                } => match poll_fill_exact(
+                    &mut this.inner,
+                    cx,
+                    &mut buffer,
+                    &mut filled,
+                    "truncated VMess encrypted response payload",
+                ) {
+                    Poll::Pending => {
+                        this.state = VmessResponseHeaderState::Payload { buffer, filled };
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Err(error)) => return this.fail(error),
+                    Poll::Ready(Ok(())) => match this.validate_payload(&buffer) {
+                        Ok(()) => this.state = VmessResponseHeaderState::Ready,
+                        Err(error) => return this.fail(error),
+                    },
+                },
+                VmessResponseHeaderState::Ready => {
+                    this.state = VmessResponseHeaderState::Ready;
+                    return this.inner.as_mut().poll_read(cx, output);
+                }
+                VmessResponseHeaderState::Failed => {
+                    this.state = VmessResponseHeaderState::Failed;
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::ConnectionAborted,
+                        "VMess response header validation previously failed",
+                    )));
+                }
+            }
+        }
+    }
+}
+
+impl AsyncWrite for VmessResponseStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.get_mut().inner.as_mut().poll_write(cx, input)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_shutdown(cx)
+    }
 }
 
 /* ---------------- Shaker (SHAKE128 派生器) ---------------- */
@@ -610,67 +814,103 @@ enum ChunkAead {
     None,
 }
 
+enum LengthAead {
+    Aes128(Aes128Gcm),
+    Chacha(ChaCha20Poly1305),
+}
+
+fn chacha_key_from_16(key: &[u8; 16]) -> [u8; 32] {
+    let first = {
+        let mut hash = Md5::new();
+        Digest::update(&mut hash, key);
+        hash.finalize()
+    };
+    let second = {
+        let mut hash = Md5::new();
+        Digest::update(&mut hash, &first);
+        hash.finalize()
+    };
+    let mut output = [0_u8; 32];
+    output[..16].copy_from_slice(&first);
+    output[16..].copy_from_slice(&second);
+    output
+}
+
 struct ChunkCryptor {
     aead: ChunkAead,
     iv_base: [u8; 16],
+    auth_len_iv_base: [u8; 16],
     counter: u16,
     sec: VmessSecurity,
-    options: u8,
     chunk_masker: Option<Shaker>,
     padding_gen: Option<Shaker>,
-    auth_len_aead: Option<Aes128Gcm>,
+    shared_masker_and_padding: bool,
+    auth_len_aead: Option<LengthAead>,
     auth_len_counter: u16,
 }
 
 impl ChunkCryptor {
-    fn new(sec: VmessSecurity, key: &[u8; 16], iv: &[u8; 16], options: u8) -> Self {
+    fn new(
+        sec: VmessSecurity,
+        key: &[u8; 16],
+        iv: &[u8; 16],
+        options: u8,
+        auth_len_key_seed: &[u8; 16],
+        auth_len_iv: &[u8; 16],
+    ) -> Self {
         let aead = match sec {
             VmessSecurity::Aes128Gcm => {
                 ChunkAead::Aes128(Aes128Gcm::new_from_slice(key).expect("aes128 key"))
             }
             VmessSecurity::Chacha20Poly1305 => {
-                let k1 = {
-                    let mut h = Md5::new();
-                    Digest::update(&mut h, key);
-                    h.finalize()
-                };
-                let k2 = {
-                    let mut h = Md5::new();
-                    Digest::update(&mut h, &k1);
-                    h.finalize()
-                };
-                let mut full = [0u8; 32];
-                full[..16].copy_from_slice(&k1);
-                full[16..].copy_from_slice(&k2);
+                let full = chacha_key_from_16(key);
                 ChunkAead::Chacha(ChaCha20Poly1305::new_from_slice(&full).expect("chacha key"))
             }
             VmessSecurity::None | VmessSecurity::Auto => ChunkAead::None,
         };
-        let chunk_masker = if options & VMESS_OPTION_CHUNK_MASKING != 0 {
+        let uses_authenticated_length = options & VMESS_OPTION_AUTH_LEN != 0;
+        let uses_masking = options & VMESS_OPTION_CHUNK_MASKING != 0;
+        let uses_padding = options & VMESS_OPTION_GLOBAL_PADDING != 0;
+        let shared_masker_and_padding = uses_padding && uses_masking && !uses_authenticated_length;
+        let chunk_masker = if uses_masking && !uses_authenticated_length {
             Some(Shaker::from_seed(iv))
         } else {
             None
         };
-        let padding_gen = if options & VMESS_OPTION_GLOBAL_PADDING != 0 {
+        let padding_gen = if uses_padding && !shared_masker_and_padding {
             Some(Shaker::from_seed(iv))
         } else {
             None
         };
-        let auth_len_aead = if options & VMESS_OPTION_AUTH_LEN != 0 {
-            // KDF 的 key 输入是主 req_key，路径 "auth_len"
-            let auth_key = kdf_n(key, &[KDF_AUTH_LEN], 16);
-            Some(Aes128Gcm::new_from_slice(&auth_key).expect("auth_len key"))
+        let auth_len_aead = if uses_authenticated_length {
+            let auth_key = kdf_n(auth_len_key_seed, &[KDF_AUTH_LEN], 16);
+            match sec {
+                VmessSecurity::Aes128Gcm | VmessSecurity::Auto => Some(LengthAead::Aes128(
+                    Aes128Gcm::new_from_slice(&auth_key).expect("VMess auth-length AES key"),
+                )),
+                VmessSecurity::Chacha20Poly1305 => {
+                    let auth_key: [u8; 16] =
+                        auth_key.try_into().expect("fixed VMess auth-length key");
+                    let full_key = chacha_key_from_16(&auth_key);
+                    Some(LengthAead::Chacha(
+                        ChaCha20Poly1305::new_from_slice(&full_key)
+                            .expect("VMess auth-length ChaCha key"),
+                    ))
+                }
+                VmessSecurity::None => None,
+            }
         } else {
             None
         };
         Self {
             aead,
             iv_base: *iv,
+            auth_len_iv_base: *auth_len_iv,
             counter: 0,
             sec,
-            options,
             chunk_masker,
             padding_gen,
+            shared_masker_and_padding,
             auth_len_aead,
             auth_len_counter: 0,
         }
@@ -687,16 +927,21 @@ impl ChunkCryptor {
     fn next_auth_len_nonce(&mut self) -> [u8; 12] {
         let mut nonce = [0u8; 12];
         nonce[..2].copy_from_slice(&self.auth_len_counter.to_be_bytes());
-        nonce[2..12].copy_from_slice(&self.iv_base[2..12]);
+        nonce[2..12].copy_from_slice(&self.auth_len_iv_base[2..12]);
         self.auth_len_counter = self.auth_len_counter.wrapping_add(1);
         nonce
     }
 
     fn next_padding_len(&mut self) -> usize {
-        match &mut self.padding_gen {
-            Some(g) => (g.next_u16() % 64) as usize,
-            None => 0,
+        if self.shared_masker_and_padding {
+            return self
+                .chunk_masker
+                .as_mut()
+                .map_or(0, |generator| usize::from(generator.next_u16() % 64));
         }
+        self.padding_gen
+            .as_mut()
+            .map_or(0, |generator| usize::from(generator.next_u16() % 64))
     }
 
     fn mask_size_encode(&mut self, size: u16) -> u16 {
@@ -742,11 +987,25 @@ impl ChunkCryptor {
     fn encode_length_field(&mut self, ct_len: u16) -> std::io::Result<Vec<u8>> {
         if self.auth_len_aead.is_some() {
             let nonce = self.next_auth_len_nonce();
-            let pt = ct_len.to_be_bytes();
+            // Xray's AEADChunkSizeParser authenticates
+            // `wire_chunk_size - length_aead_overhead` and adds the overhead
+            // back after opening.
+            let authenticated = ct_len
+                .checked_sub(16)
+                .ok_or_else(|| invalid_data("VMess chunk is smaller than AEAD overhead"))?;
+            let plaintext = authenticated.to_be_bytes();
             let aead = self.auth_len_aead.as_ref().expect("checked");
-            let sealed = aead
-                .encrypt(Nonce::from_slice(&nonce), pt.as_ref())
-                .map_err(|_| io_err("auth_len encrypt"))?;
+            let sealed = match aead {
+                LengthAead::Aes128(cipher) => cipher
+                    .encrypt(Nonce::from_slice(&nonce), plaintext.as_ref())
+                    .map_err(|_| io_err("auth_len AES encrypt"))?,
+                LengthAead::Chacha(cipher) => cipher
+                    .encrypt(
+                        chacha20poly1305::Nonce::from_slice(&nonce),
+                        plaintext.as_ref(),
+                    )
+                    .map_err(|_| io_err("auth_len ChaCha encrypt"))?,
+            };
             return Ok(sealed);
         }
         let masked = self.mask_size_encode(ct_len);
@@ -760,13 +1019,20 @@ impl ChunkCryptor {
             }
             let nonce = self.next_auth_len_nonce();
             let aead = self.auth_len_aead.as_ref().expect("checked");
-            let pt = aead
-                .decrypt(Nonce::from_slice(&nonce), buf)
-                .map_err(|_| io_err("auth_len decrypt"))?;
-            if pt.len() != 2 {
+            let plaintext = match aead {
+                LengthAead::Aes128(cipher) => cipher
+                    .decrypt(Nonce::from_slice(&nonce), buf)
+                    .map_err(|_| io_err("auth_len AES decrypt"))?,
+                LengthAead::Chacha(cipher) => cipher
+                    .decrypt(chacha20poly1305::Nonce::from_slice(&nonce), buf)
+                    .map_err(|_| io_err("auth_len ChaCha decrypt"))?,
+            };
+            if plaintext.len() != 2 {
                 return Err(io_err("auth_len plain size"));
             }
-            return Ok(u16::from_be_bytes([pt[0], pt[1]]));
+            return u16::from_be_bytes([plaintext[0], plaintext[1]])
+                .checked_add(16)
+                .ok_or_else(|| invalid_data("VMess authenticated chunk length overflow"));
         }
         if buf.len() != 2 {
             return Err(io_err("plain length buf size"));
@@ -791,6 +1057,12 @@ enum RecvState {
     Body,
 }
 
+struct PendingWrite {
+    packet: Vec<u8>,
+    offset: usize,
+    plaintext_len: usize,
+}
+
 pin_project! {
     struct VmessStream {
         #[pin]
@@ -802,6 +1074,7 @@ pin_project! {
         recv_state: RecvState,
         recv_pending_size: usize,    // 解密后的密文长度（含 tag）
         recv_pending_padding: usize, // 该 chunk 末尾的 padding
+        pending_write: Option<PendingWrite>,
     }
 }
 
@@ -828,9 +1101,11 @@ impl AsyncRead for VmessStream {
                             return Ok(false);
                         }
                         let buf = this.cipher_buf.split_to(need).to_vec();
+                        // Xray advances the shared SHAKE padding generator
+                        // before decoding the masked length field.
+                        let padding = this.recv.next_padding_len();
                         let total = this.recv.decode_length_field(&buf)? as usize;
                         // total = ct_len + padding_len（GLOBAL_PADDING 启用时）
-                        let padding = this.recv.next_padding_len();
                         if total < padding {
                             return Err(io_err("chunk total smaller than padding"));
                         }
@@ -889,37 +1164,61 @@ impl AsyncWrite for VmessStream {
         data: &[u8],
     ) -> Poll<std::io::Result<usize>> {
         let mut this = self.project();
-        let max = PAYLOAD_MAX - this.send.tag_len();
-        let chunk = &data[..data.len().min(max)];
-        let sealed = match this.send.seal_payload(chunk) {
-            Ok(v) => v,
-            Err(e) => return Poll::Ready(Err(e)),
-        };
-        // padding
-        let padding_len = this.send.next_padding_len();
-        let mut padding = vec![0u8; padding_len];
-        rand::rngs::OsRng.fill_bytes(&mut padding);
-        let total_size = (sealed.len() + padding_len) as u16;
-        let length_field = match this.send.encode_length_field(total_size) {
-            Ok(v) => v,
-            Err(e) => return Poll::Ready(Err(e)),
-        };
-        let mut packet = Vec::with_capacity(length_field.len() + sealed.len() + padding_len);
-        packet.extend_from_slice(&length_field);
-        packet.extend_from_slice(&sealed);
-        packet.extend_from_slice(&padding);
-        let mut written = 0;
-        while written < packet.len() {
-            match this.inner.as_mut().poll_write(cx, &packet[written..]) {
+        if this.pending_write.is_none() {
+            if data.is_empty() {
+                return Poll::Ready(Ok(0));
+            }
+            let max = PAYLOAD_MAX - this.send.tag_len();
+            let chunk = &data[..data.len().min(max)];
+            let sealed = match this.send.seal_payload(chunk) {
+                Ok(value) => value,
+                Err(error) => return Poll::Ready(Err(error)),
+            };
+            // Xray asks the padding generator before encoding the size.
+            let padding_len = this.send.next_padding_len();
+            let mut padding = vec![0_u8; padding_len];
+            rand::rngs::OsRng.fill_bytes(&mut padding);
+            let total_size = (sealed.len() + padding_len) as u16;
+            let length_field = match this.send.encode_length_field(total_size) {
+                Ok(value) => value,
+                Err(error) => return Poll::Ready(Err(error)),
+            };
+            let mut packet = Vec::with_capacity(length_field.len() + sealed.len() + padding_len);
+            packet.extend_from_slice(&length_field);
+            packet.extend_from_slice(&sealed);
+            packet.extend_from_slice(&padding);
+            *this.pending_write = Some(PendingWrite {
+                packet,
+                offset: 0,
+                plaintext_len: chunk.len(),
+            });
+        }
+
+        loop {
+            let pending = this
+                .pending_write
+                .as_mut()
+                .expect("VMess pending write initialized");
+            match this
+                .inner
+                .as_mut()
+                .poll_write(cx, &pending.packet[pending.offset..])
+            {
                 Poll::Ready(Ok(0)) => {
                     return Poll::Ready(Err(std::io::ErrorKind::WriteZero.into()));
                 }
-                Poll::Ready(Ok(n)) => written += n,
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Ready(Ok(written)) => {
+                    pending.offset += written;
+                    if pending.offset == pending.packet.len() {
+                        let plaintext_len = pending.plaintext_len;
+                        *this.pending_write = None;
+                        return Poll::Ready(Ok(plaintext_len));
+                    }
+                }
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
                 Poll::Pending => return Poll::Pending,
             }
         }
-        Poll::Ready(Ok(chunk.len()))
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
@@ -933,6 +1232,10 @@ impl AsyncWrite for VmessStream {
 
 fn io_err(s: &'static str) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, s)
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
 }
 
 #[allow(dead_code)]
@@ -1021,16 +1324,16 @@ mod tests {
         let key = [0xaau8; 16];
         let iv = [0xbbu8; 16];
         let opts = VMESS_DEFAULT_OPTIONS;
-        let mut send = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts);
-        let mut recv = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts);
+        let mut send = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts, &key, &iv);
+        let mut recv = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts, &key, &iv);
         let pt = b"hello vmess full feature";
         let sealed = send.seal_payload(pt).unwrap();
         let padding_len_send = send.next_padding_len();
         let total_size = (sealed.len() + padding_len_send) as u16;
         let length_field = send.encode_length_field(total_size).unwrap();
         // 接收
-        let total_dec = recv.decode_length_field(&length_field).unwrap() as usize;
         let padding_len_recv = recv.next_padding_len();
+        let total_dec = recv.decode_length_field(&length_field).unwrap() as usize;
         assert_eq!(padding_len_send, padding_len_recv);
         let ct_len = total_dec - padding_len_recv;
         assert_eq!(ct_len, sealed.len());
@@ -1043,8 +1346,10 @@ mod tests {
         let key = [0x11u8; 16];
         let iv = [0x22u8; 16];
         let opts = VMESS_OPTION_CHUNK_STREAM;
-        let mut send = ChunkCryptor::new(VmessSecurity::Chacha20Poly1305, &key, &iv, opts);
-        let mut recv = ChunkCryptor::new(VmessSecurity::Chacha20Poly1305, &key, &iv, opts);
+        let mut send =
+            ChunkCryptor::new(VmessSecurity::Chacha20Poly1305, &key, &iv, opts, &key, &iv);
+        let mut recv =
+            ChunkCryptor::new(VmessSecurity::Chacha20Poly1305, &key, &iv, opts, &key, &iv);
         let ct = send.seal_payload(b"payload").unwrap();
         let lf = send.encode_length_field(ct.len() as u16).unwrap();
         assert_eq!(lf.len(), 2);
@@ -1058,8 +1363,8 @@ mod tests {
         let key = [0x33u8; 16];
         let iv = [0x44u8; 16];
         let opts = VMESS_OPTION_CHUNK_STREAM | VMESS_OPTION_AUTH_LEN;
-        let mut send = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts);
-        let mut recv = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts);
+        let mut send = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts, &key, &iv);
+        let mut recv = ChunkCryptor::new(VmessSecurity::Aes128Gcm, &key, &iv, opts, &key, &iv);
         let ct = send.seal_payload(b"auth_len test").unwrap();
         let lf = send.encode_length_field(ct.len() as u16).unwrap();
         assert_eq!(lf.len(), 18);

--- a/crates/core-outbound/src/proto/vmess_legacy.rs
+++ b/crates/core-outbound/src/proto/vmess_legacy.rs
@@ -33,7 +33,8 @@ use crate::{
     adapter::{BoxedStream, Capabilities, DialContext, OutboundAdapter},
     proto::vmess::{VMESS_OPTION_CHUNK_STREAM, VmessSecurity, build_legacy_header_payload},
     transport::{
-        TlsOptions, Transport, WsOptions, tcp::TcpTransport, tls::TlsTransport, ws::WsTransport,
+        GrpcOptions, TlsOptions, Transport, WsOptions, grpc_transport::GrpcTransport,
+        tcp::TcpTransport, tls::TlsTransport, ws::WsTransport,
     },
 };
 
@@ -51,7 +52,9 @@ pub struct VmessLegacyOutbound {
     pub sni: Option<String>,
     pub insecure: bool,
     pub alpn: Vec<String>,
+    pub tls_options: Option<TlsOptions>,
     pub ws: Option<WsOptions>,
+    pub grpc: Option<GrpcOptions>,
 }
 
 impl VmessLegacyOutbound {
@@ -73,7 +76,9 @@ impl VmessLegacyOutbound {
             sni: None,
             insecure: false,
             alpn: vec![],
+            tls_options: None,
             ws: None,
+            grpc: None,
         }
     }
 }
@@ -96,30 +101,36 @@ impl OutboundAdapter for VmessLegacyOutbound {
     }
 
     async fn dial_tcp(&self, ctx: DialContext) -> std::io::Result<BoxedStream> {
-        let mut stream: BoxedStream = if let Some(ws) = self.ws.as_ref().filter(|w| w.enabled) {
-            WsTransport::new(ws.clone(), self.tls)
-                .connect(&self.host, self.port)
-                .await?
-        } else if self.tls {
-            TlsTransport::new(TlsOptions {
-                enabled: true,
-                sni: self.sni.clone(),
-                insecure: self.insecure,
-                alpn: self.alpn.clone(),
-                fingerprint: String::new(),
-                enable_session_resumption: false,
-                pinned_peer_cert_sha256: Vec::new(),
-                verify_peer_cert_by_name: Vec::new(),
-                xray_settings: None,
-                resolved_ech_config_list: None,
-            })
-            .connect(&self.host, self.port)
-            .await?
-        } else {
-            TcpTransport::default()
-                .connect(&self.host, self.port)
-                .await?
-        };
+        let tls_options = self.tls_options.clone().unwrap_or_else(|| TlsOptions {
+            enabled: self.tls,
+            sni: self.sni.clone(),
+            insecure: self.insecure,
+            alpn: self.alpn.clone(),
+            fingerprint: String::new(),
+            enable_session_resumption: false,
+            pinned_peer_cert_sha256: Vec::new(),
+            verify_peer_cert_by_name: Vec::new(),
+            xray_settings: None,
+            resolved_ech_config_list: None,
+        });
+        let mut stream: BoxedStream =
+            if let Some(grpc) = self.grpc.as_ref().filter(|grpc| grpc.enabled) {
+                GrpcTransport::new(grpc.clone(), tls_options.clone())
+                    .connect(&self.host, self.port)
+                    .await?
+            } else if let Some(ws) = self.ws.as_ref().filter(|w| w.enabled) {
+                WsTransport::new(ws.clone(), self.tls)
+                    .connect(&self.host, self.port)
+                    .await?
+            } else if self.tls {
+                TlsTransport::new(tls_options)
+                    .connect(&self.host, self.port)
+                    .await?
+            } else {
+                TcpTransport::default()
+                    .connect(&self.host, self.port)
+                    .await?
+            };
 
         // 1) Compute AuthInfo + cmd_key + header_iv
         let now = chrono::Utc::now().timestamp() as u64;

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -51,7 +51,9 @@ use crate::{
     },
     socks5::Socks5Outbound,
     stub::StubOutbound,
-    transport::{GrpcOptions, H2Options, HttpOptions, RealityOptions, WsOptions, XhttpOptions},
+    transport::{
+        GrpcOptions, H2Options, HttpOptions, RealityOptions, TlsOptions, WsOptions, XhttpOptions,
+    },
 };
 
 pub type ResolveFn = Arc<dyn Fn(&str) -> Option<SharedOutbound> + Send + Sync>;
@@ -426,10 +428,17 @@ fn build_vmess(node: &ParsedNode) -> Result<SharedOutbound, String> {
         if let Some(alpn) = node.params.get("alpn") {
             ob.alpn = alpn.split(',').map(|s| s.trim().to_string()).collect();
         }
-        // VMess Legacy 也支持 ws transport
+        let tls_options =
+            build_node_tls_options(node, ob.tls, ob.sni.clone(), ob.insecure, ob.alpn.clone())?;
+        if ob.tls {
+            ob.tls_options = Some(tls_options);
+        }
+        // VMess Legacy uses the same outer transport stack as AEAD VMess.
         let net = resolve_network_string(node);
-        if VmessNetwork::parse(&net) == VmessNetwork::Ws {
-            ob.ws = Some(build_ws_options(node));
+        match VmessNetwork::parse(&net) {
+            VmessNetwork::Ws => ob.ws = Some(build_ws_options(node)),
+            VmessNetwork::Grpc => ob.grpc = Some(build_grpc_options(node)?),
+            _ => {}
         }
         return Ok(Arc::new(ob));
     }
@@ -463,6 +472,11 @@ fn build_vmess(node: &ParsedNode) -> Result<SharedOutbound, String> {
         .unwrap_or(false);
     if let Some(alpn) = node.params.get("alpn") {
         ob.alpn = alpn.split(',').map(|s| s.trim().to_string()).collect();
+    }
+    let tls_options =
+        build_node_tls_options(node, ob.tls, ob.sni.clone(), ob.insecure, ob.alpn.clone())?;
+    if ob.tls {
+        ob.tls_options = Some(tls_options);
     }
     // VMess network 分发：tcp / ws / http / h2 / grpc / xhttp
     let network_str = resolve_network_string(node);
@@ -499,7 +513,7 @@ fn apply_vmess_network_options(node: &ParsedNode, ob: &mut VmessOutbound) -> Res
             ob.h2 = Some(build_h2_options(node));
         }
         VmessNetwork::Grpc => {
-            ob.grpc = Some(build_grpc_options(node));
+            ob.grpc = Some(build_grpc_options(node)?);
         }
         VmessNetwork::Xhttp => {
             ob.xhttp = Some(build_xhttp_options(
@@ -566,6 +580,15 @@ fn build_vless(node: &ParsedNode) -> Result<SharedOutbound, String> {
             },
         });
     }
+    if ob.reality.is_some() {
+        reject_ordinary_tls_with_reality(node)?;
+    } else {
+        let tls_options =
+            build_node_tls_options(node, ob.tls, ob.sni.clone(), ob.insecure, ob.alpn.clone())?;
+        if ob.tls {
+            ob.tls_options = Some(tls_options);
+        }
+    }
     let network_str = resolve_network_string(node);
     ob.network = VlessNetwork::parse(&network_str);
     apply_vless_network_options(node, &mut ob)?;
@@ -585,7 +608,7 @@ fn apply_vless_network_options(node: &ParsedNode, ob: &mut VlessOutbound) -> Res
             ob.h2 = Some(build_h2_options(node));
         }
         VlessNetwork::Grpc => {
-            ob.grpc = Some(build_grpc_options(node));
+            ob.grpc = Some(build_grpc_options(node)?);
         }
         VlessNetwork::Xhttp => {
             ob.xhttp = Some(build_xhttp_options(
@@ -651,22 +674,487 @@ fn build_h2_options(node: &ParsedNode) -> H2Options {
     }
 }
 
-fn build_grpc_options(node: &ParsedNode) -> GrpcOptions {
-    GrpcOptions {
+fn build_grpc_options(node: &ParsedNode) -> Result<GrpcOptions, &'static str> {
+    let authority = grpc_param(node, &["authority", "grpc-authority", "grpc_authority"])?
+        .unwrap_or_default()
+        .to_owned();
+    let service_name = grpc_param(
+        node,
+        &[
+            "serviceName",
+            "service_name",
+            "service-name",
+            "grpc-service-name",
+            "grpc_service_name",
+        ],
+    )?
+    .unwrap_or_default()
+    .to_owned();
+    let multi_mode = parse_grpc_bool(grpc_param(
+        node,
+        &["multiMode", "multi_mode", "multi-mode", "grpc-multi-mode"],
+    )?)?
+    .unwrap_or(false);
+    let idle_timeout = parse_grpc_duration(grpc_param(
+        node,
+        &[
+            "idle_timeout",
+            "idleTimeout",
+            "idle-timeout",
+            "grpc-idle-timeout",
+        ],
+    )?)?;
+    let health_check_timeout = parse_grpc_duration(grpc_param(
+        node,
+        &[
+            "health_check_timeout",
+            "healthCheckTimeout",
+            "health-check-timeout",
+            "grpc-health-check-timeout",
+        ],
+    )?)?;
+    let permit_without_stream = parse_grpc_bool(grpc_param(
+        node,
+        &[
+            "permit_without_stream",
+            "permitWithoutStream",
+            "permit-without-stream",
+            "grpc-permit-without-stream",
+        ],
+    )?)?
+    .unwrap_or(false);
+    let initial_window_size = parse_grpc_window(grpc_param(
+        node,
+        &[
+            "initial_windows_size",
+            "initial_window_size",
+            "initialWindowSize",
+            "initial-window-size",
+            "initial-windows-size",
+            "grpc-initial-window-size",
+        ],
+    )?)?;
+    let user_agent = grpc_param(
+        node,
+        &[
+            "user_agent",
+            "userAgent",
+            "user-agent",
+            "grpc-user-agent",
+            "grpc_user_agent",
+        ],
+    )?
+    .unwrap_or_default()
+    .to_owned();
+    let max_message_size = parse_grpc_positive_usize(
+        grpc_param(
+            node,
+            &[
+                "max_message_size",
+                "maxMessageSize",
+                "max-message-size",
+                "grpc-max-message-size",
+            ],
+        )?,
+        core_grpc::DEFAULT_MAX_MESSAGE_SIZE,
+        core_grpc::MIN_MESSAGE_SIZE,
+        core_grpc::MAX_MESSAGE_SIZE_LIMIT,
+    )?;
+    let queue_capacity = parse_grpc_positive_usize(
+        grpc_param(
+            node,
+            &[
+                "queue_capacity",
+                "queueCapacity",
+                "queue-capacity",
+                "grpc-queue-capacity",
+            ],
+        )?,
+        core_grpc::DEFAULT_QUEUE_CAPACITY,
+        1,
+        core_grpc::MAX_QUEUE_CAPACITY,
+    )?;
+
+    Ok(GrpcOptions {
         enabled: true,
-        service_name: node
-            .params
-            .get("serviceName")
-            .or_else(|| node.params.get("grpc-service-name"))
-            .cloned()
-            .unwrap_or_default(),
-        user_agent: node
-            .params
-            .get("grpc-user-agent")
-            .cloned()
-            .unwrap_or_default(),
+        authority,
+        service_name,
+        multi_mode,
+        idle_timeout,
+        health_check_timeout,
+        permit_without_stream,
+        initial_window_size,
+        user_agent,
+        max_message_size,
+        queue_capacity,
         host: node.params.get("host").cloned().unwrap_or_default(),
+    })
+}
+
+fn build_node_tls_options(
+    node: &ParsedNode,
+    enabled: bool,
+    fallback_sni: Option<String>,
+    fallback_insecure: bool,
+    fallback_alpn: Vec<String>,
+) -> Result<TlsOptions, String> {
+    const ADVANCED_KEYS: &[&str] = &[
+        "serverName",
+        "server-name",
+        "server_name",
+        "sni",
+        "alpn",
+        "allowInsecure",
+        "allow-insecure",
+        "allow_insecure",
+        "fingerprint",
+        "fp",
+        "utls",
+        "enableSessionResumption",
+        "enable-session-resumption",
+        "enable_session_resumption",
+        "disableSystemRoot",
+        "disable-system-root",
+        "disable_system_root",
+        "minVersion",
+        "min-version",
+        "min_version",
+        "maxVersion",
+        "max-version",
+        "max_version",
+        "cipherSuites",
+        "cipher-suites",
+        "cipher_suites",
+        "curvePreferences",
+        "curve-preferences",
+        "curve_preferences",
+        "masterKeyLog",
+        "master-key-log",
+        "master_key_log",
+        "pinnedPeerCertSha256",
+        "pinned-peer-cert-sha256",
+        "pinned_peer_cert_sha256",
+        "verifyPeerCertByName",
+        "verify-peer-cert-by-name",
+        "verify_peer_cert_by_name",
+        "echConfigList",
+        "ech-config-list",
+        "ech_config_list",
+    ];
+    let ech_toggle = first_param(node, &["ech"])
+        .map(|value| parse_bool_param("ech", value))
+        .transpose()?;
+    let has_complete_settings = node.tls_settings.is_some()
+        || ech_toggle == Some(true)
+        || ADVANCED_KEYS
+            .iter()
+            .any(|key| node.params.contains_key(*key));
+    if has_complete_settings && !enabled {
+        return Err("TLS/ECH settings are present while TLS is disabled".into());
     }
+    if !has_complete_settings {
+        return Ok(TlsOptions {
+            enabled,
+            sni: fallback_sni,
+            insecure: fallback_insecure,
+            alpn: fallback_alpn,
+            ..TlsOptions::default()
+        });
+    }
+
+    let mut settings = node.tls_settings.clone().unwrap_or_default();
+    let fingerprint = first_param(node, &["fingerprint", "fp"]);
+    let utls = first_param(node, &["utls"]);
+    if fingerprint
+        .zip(utls)
+        .is_some_and(|(fingerprint, utls)| !fingerprint.eq_ignore_ascii_case(utls))
+    {
+        return Err("TLS fingerprint conflicts with utls".into());
+    }
+    if let Some(value) = fingerprint.or(utls) {
+        if settings
+            .fingerprint
+            .as_deref()
+            .is_some_and(|typed| !typed.eq_ignore_ascii_case(value))
+        {
+            return Err("typed TLS fingerprint conflicts with URI fingerprint".into());
+        }
+        settings.fingerprint = Some(value.to_owned());
+    }
+
+    let explicit_server_name = node
+        .sni
+        .as_deref()
+        .or_else(|| first_param(node, &["serverName", "server-name", "server_name", "sni"]));
+    if let Some(explicit) = explicit_server_name {
+        if settings
+            .server_name
+            .as_ref()
+            .is_some_and(|typed| typed != explicit)
+        {
+            return Err("typed TLS serverName conflicts with protocol SNI".into());
+        }
+        settings.server_name = Some(explicit.to_owned());
+    } else if settings.server_name.is_none() {
+        settings.server_name = fallback_sni;
+    }
+    settings.server_name = merge_optional_string_param(
+        node,
+        &["serverName", "server-name", "server_name", "sni"],
+        "serverName",
+        settings.server_name,
+        true,
+    )?;
+    settings.allow_insecure = merge_optional_bool_param(
+        node,
+        &["allowInsecure", "allow-insecure", "allow_insecure"],
+        "allowInsecure",
+        settings.allow_insecure,
+    )?;
+    if fallback_insecure {
+        if settings.allow_insecure == Some(false) {
+            return Err("typed TLS allowInsecure conflicts with protocol setting".into());
+        }
+        settings.allow_insecure = Some(true);
+    }
+    settings.enable_session_resumption = merge_optional_bool_param(
+        node,
+        &[
+            "enableSessionResumption",
+            "enable-session-resumption",
+            "enable_session_resumption",
+        ],
+        "enableSessionResumption",
+        settings.enable_session_resumption,
+    )?;
+    settings.disable_system_root = merge_optional_bool_param(
+        node,
+        &[
+            "disableSystemRoot",
+            "disable-system-root",
+            "disable_system_root",
+        ],
+        "disableSystemRoot",
+        settings.disable_system_root,
+    )?;
+    settings.min_version = merge_optional_string_param(
+        node,
+        &["minVersion", "min-version", "min_version"],
+        "minVersion",
+        settings.min_version,
+        true,
+    )?;
+    settings.max_version = merge_optional_string_param(
+        node,
+        &["maxVersion", "max-version", "max_version"],
+        "maxVersion",
+        settings.max_version,
+        true,
+    )?;
+    settings.cipher_suites = merge_optional_string_param(
+        node,
+        &["cipherSuites", "cipher-suites", "cipher_suites"],
+        "cipherSuites",
+        settings.cipher_suites,
+        false,
+    )?;
+    settings.curve_preferences = merge_optional_string_list_param(
+        node,
+        &["curvePreferences", "curve-preferences", "curve_preferences"],
+        "curvePreferences",
+        settings.curve_preferences,
+    )?;
+    settings.master_key_log = merge_optional_string_param(
+        node,
+        &["masterKeyLog", "master-key-log", "master_key_log"],
+        "masterKeyLog",
+        settings.master_key_log,
+        false,
+    )?;
+    settings.pinned_peer_cert_sha256 = merge_optional_string_param(
+        node,
+        &[
+            "pinnedPeerCertSha256",
+            "pinned-peer-cert-sha256",
+            "pinned_peer_cert_sha256",
+        ],
+        "pinnedPeerCertSha256",
+        settings.pinned_peer_cert_sha256,
+        true,
+    )?;
+    settings.verify_peer_cert_by_name = merge_optional_string_param(
+        node,
+        &[
+            "verifyPeerCertByName",
+            "verify-peer-cert-by-name",
+            "verify_peer_cert_by_name",
+        ],
+        "verifyPeerCertByName",
+        settings.verify_peer_cert_by_name,
+        true,
+    )?;
+    settings.ech_config_list = merge_optional_string_param(
+        node,
+        &["echConfigList", "ech-config-list", "ech_config_list"],
+        "echConfigList",
+        settings.ech_config_list,
+        false,
+    )?;
+    if let Some(enabled) = ech_toggle {
+        if enabled != settings.ech_config_list.is_some() {
+            return Err(if enabled {
+                "ech=true requires a non-empty echConfigList".into()
+            } else {
+                "ech=false conflicts with echConfigList".into()
+            });
+        }
+    }
+    if !fallback_alpn.is_empty() {
+        if settings
+            .alpn
+            .as_ref()
+            .is_some_and(|typed| typed != &fallback_alpn)
+        {
+            return Err("typed TLS alpn conflicts with protocol ALPN".into());
+        }
+        settings.alpn = Some(fallback_alpn);
+    }
+
+    settings
+        .validate()
+        .map_err(|error| format!("TLS settings: {error}"))?;
+    TlsOptions::from_xray_settings(settings).map_err(|error| error.to_string())
+}
+
+fn reject_ordinary_tls_with_reality(node: &ParsedNode) -> Result<(), String> {
+    const TLS_ONLY_KEYS: &[&str] = &[
+        "enableSessionResumption",
+        "enable-session-resumption",
+        "enable_session_resumption",
+        "disableSystemRoot",
+        "disable-system-root",
+        "disable_system_root",
+        "minVersion",
+        "min-version",
+        "min_version",
+        "maxVersion",
+        "max-version",
+        "max_version",
+        "cipherSuites",
+        "cipher-suites",
+        "cipher_suites",
+        "curvePreferences",
+        "curve-preferences",
+        "curve_preferences",
+        "pinnedPeerCertSha256",
+        "pinned-peer-cert-sha256",
+        "pinned_peer_cert_sha256",
+        "verifyPeerCertByName",
+        "verify-peer-cert-by-name",
+        "verify_peer_cert_by_name",
+        "echConfigList",
+        "ech-config-list",
+        "ech_config_list",
+        "alpn",
+        "allowInsecure",
+        "allow-insecure",
+        "allow_insecure",
+        "utls",
+    ];
+    let ech_enabled = first_param(node, &["ech"])
+        .map(|value| parse_bool_param("ech", value))
+        .transpose()?
+        .unwrap_or(false);
+    if node.tls_settings.is_some()
+        || ech_enabled
+        || TLS_ONLY_KEYS
+            .iter()
+            .any(|key| node.params.contains_key(*key))
+    {
+        return Err("ordinary TLS/ECH settings cannot be combined with REALITY".into());
+    }
+    Ok(())
+}
+
+fn grpc_param<'a>(node: &'a ParsedNode, keys: &[&str]) -> Result<Option<&'a str>, &'static str> {
+    let mut value = None;
+    for key in keys {
+        let Some(candidate) = node.params.get(*key).map(String::as_str) else {
+            continue;
+        };
+        if let Some(existing) = value
+            && existing != candidate
+        {
+            return Err("grpc(conflicting-options)");
+        }
+        value = Some(candidate);
+    }
+    Ok(value)
+}
+
+fn parse_grpc_bool(value: Option<&str>) -> Result<Option<bool>, &'static str> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(Some(true)),
+        "false" | "0" | "no" | "off" => Ok(Some(false)),
+        _ => Err("grpc(invalid-boolean-option)"),
+    }
+}
+
+fn parse_grpc_duration(value: Option<&str>) -> Result<std::time::Duration, &'static str> {
+    let Some(value) = value else {
+        return Ok(std::time::Duration::ZERO);
+    };
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<i64>() {
+        if seconds > i64::from(i32::MAX) {
+            return Err("grpc(invalid-duration)");
+        }
+        return Ok(std::time::Duration::from_secs(seconds.max(0) as u64));
+    }
+    let duration = parse_tuic_duration(value).ok_or("grpc(invalid-duration)")?;
+    if duration.subsec_nanos() != 0 || duration.as_secs() > i32::MAX as u64 {
+        return Err("grpc(invalid-duration)");
+    }
+    Ok(duration)
+}
+
+fn parse_grpc_window(value: Option<&str>) -> Result<Option<u32>, &'static str> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value
+        .trim()
+        .parse::<i64>()
+        .map_err(|_| "grpc(invalid-initial-window-size)")?;
+    if value <= 0 {
+        return Ok(None);
+    }
+    if value > i64::from(i32::MAX) {
+        return Err("grpc(invalid-initial-window-size)");
+    }
+    Ok(Some(value as u32))
+}
+
+fn parse_grpc_positive_usize(
+    value: Option<&str>,
+    default: usize,
+    minimum: usize,
+    maximum: usize,
+) -> Result<usize, &'static str> {
+    let Some(value) = value else {
+        return Ok(default);
+    };
+    let parsed = value
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| "grpc(invalid-resource-limit)")?;
+    if !(minimum..=maximum).contains(&parsed) {
+        return Err("grpc(invalid-resource-limit)");
+    }
+    Ok(parsed)
 }
 
 fn build_xhttp_options(
@@ -1509,6 +1997,17 @@ fn overlay_range(target: &mut String, value: Option<TypedRange>) {
 fn build_trojan(node: &ParsedNode) -> Result<TrojanOutbound, String> {
     let pwd = node.password.clone().unwrap_or_default();
     let mut ob = TrojanOutbound::new(&node.name, &node.host, node.port, pwd);
+    if node
+        .params
+        .get("security")
+        .is_some_and(|value| value.eq_ignore_ascii_case("none"))
+        || node
+            .params
+            .get("tls")
+            .is_some_and(|value| value.eq_ignore_ascii_case("false") || value == "0")
+    {
+        ob.tls = false;
+    }
     ob.udp = node.udp;
     ob.sni = node
         .sni
@@ -1523,17 +2022,25 @@ fn build_trojan(node: &ParsedNode) -> Result<TrojanOutbound, String> {
     if let Some(alpn) = node.params.get("alpn") {
         ob.alpn = alpn.split(',').map(|s| s.trim().to_string()).collect();
     }
-    if matches!(
-        node.transport.to_ascii_lowercase().as_str(),
-        "xhttp" | "splithttp"
-    ) {
-        ob.xhttp = Some(build_xhttp_options_with_tls_requirement(
-            node,
-            ob.sni.clone(),
-            ob.insecure,
-            ob.alpn.clone(),
-            true,
-        )?);
+    let tls_options =
+        build_node_tls_options(node, ob.tls, ob.sni.clone(), ob.insecure, ob.alpn.clone())?;
+    if ob.tls {
+        ob.tls_options = Some(tls_options);
+    }
+    match resolve_network_string(node).to_ascii_lowercase().as_str() {
+        "xhttp" | "splithttp" => {
+            ob.xhttp = Some(build_xhttp_options_with_tls_requirement(
+                node,
+                ob.sni.clone(),
+                ob.insecure,
+                ob.alpn.clone(),
+                true,
+            )?);
+        }
+        "grpc" | "gun" => {
+            ob.grpc = Some(build_grpc_options(node)?);
+        }
+        _ => {}
     }
     Ok(ob)
 }
@@ -2647,7 +3154,7 @@ fn proto_static_name(p: &NodeProtocol) -> &'static str {
 mod tests {
     use base64::Engine;
     use core_config::{
-        model::XhttpConfig as TypedXhttpConfig,
+        model::{XhttpConfig as TypedXhttpConfig, XhttpDownloadTlsSettings},
         node_uri::{NodeProtocol, ParsedNode},
     };
     use uuid::Uuid;
@@ -2710,6 +3217,176 @@ mod tests {
         node.udp = true;
         let outbound = build_outbound(&node).unwrap();
         assert!(outbound.capabilities().udp);
+    }
+
+    #[test]
+    fn grpc_registry_maps_every_xray_field_and_alias() {
+        let mut node = ParsedNode::new("grpc", NodeProtocol::Vless, "grpc.example", 443);
+        node.transport = "grpc".into();
+        node.params
+            .insert("grpc-authority".into(), "authority.example".into());
+        node.params
+            .insert("grpc-service-name".into(), "/pkg.Service/TunX".into());
+        node.params.insert("multiMode".into(), "true".into());
+        node.params.insert("idleTimeout".into(), "30".into());
+        node.params
+            .insert("health_check_timeout".into(), "5s".into());
+        node.params
+            .insert("permit-without-stream".into(), "1".into());
+        node.params
+            .insert("initialWindowSize".into(), "1048576".into());
+        node.params.insert("user_agent".into(), "golang".into());
+        node.params
+            .insert("max-message-size".into(), "8388608".into());
+        node.params.insert("queueCapacity".into(), "32".into());
+
+        let options = super::build_grpc_options(&node).unwrap();
+        assert_eq!(options.authority, "authority.example");
+        assert_eq!(options.service_name, "/pkg.Service/TunX");
+        assert!(options.multi_mode);
+        assert_eq!(options.idle_timeout, std::time::Duration::from_secs(30));
+        assert_eq!(
+            options.health_check_timeout,
+            std::time::Duration::from_secs(5)
+        );
+        assert!(options.permit_without_stream);
+        assert_eq!(options.initial_window_size, Some(1_048_576));
+        assert_eq!(options.user_agent, "golang");
+        assert_eq!(options.max_message_size, 8_388_608);
+        assert_eq!(options.queue_capacity, 32);
+    }
+
+    #[test]
+    fn grpc_registry_fails_closed_on_conflicts_and_invalid_limits() {
+        let mut node = ParsedNode::new("grpc", NodeProtocol::Vless, "grpc.example", 443);
+        node.transport = "grpc".into();
+        node.params.insert("serviceName".into(), "one".into());
+        node.params.insert("grpc-service-name".into(), "two".into());
+        assert_eq!(
+            super::build_grpc_options(&node).unwrap_err(),
+            "grpc(conflicting-options)"
+        );
+
+        node.params.remove("grpc-service-name");
+        node.params.insert("max-message-size".into(), "0".into());
+        assert_eq!(
+            super::build_grpc_options(&node).unwrap_err(),
+            "grpc(invalid-resource-limit)"
+        );
+
+        node.params.remove("max-message-size");
+        node.params.insert("multiMode".into(), "maybe".into());
+        let error = match super::build_outbound(&node) {
+            Ok(_) => panic!("invalid gRPC boolean must fail closed"),
+            Err(error) => error,
+        };
+        assert_eq!(error, "grpc(invalid-boolean-option)");
+
+        node.params.remove("multiMode");
+        node.params.insert("idleTimeout".into(), "500ms".into());
+        assert_eq!(
+            super::build_grpc_options(&node).unwrap_err(),
+            "grpc(invalid-duration)"
+        );
+
+        node.params
+            .insert("idleTimeout".into(), (i32::MAX as u64 + 1).to_string());
+        assert_eq!(
+            super::build_grpc_options(&node).unwrap_err(),
+            "grpc(invalid-duration)"
+        );
+
+        node.params.remove("idleTimeout");
+        node.params.insert(
+            "initialWindowSize".into(),
+            (i32::MAX as u64 + 1).to_string(),
+        );
+        assert_eq!(
+            super::build_grpc_options(&node).unwrap_err(),
+            "grpc(invalid-initial-window-size)"
+        );
+    }
+
+    #[test]
+    fn grpc_registry_preserves_complete_tls_settings_and_rejects_disabled_tls() {
+        let mut node = ParsedNode::new("grpc-tls", NodeProtocol::Vless, "grpc.example", 443);
+        node.uuid = Some("2dd61d93-75d8-4da4-ac0e-6aece7eac365".into());
+        node.transport = "grpc".into();
+        node.params.insert("serviceName".into(), "full-tls".into());
+        node.tls_settings = Some(XhttpDownloadTlsSettings {
+            server_name: Some("certificate.example".into()),
+            alpn: Some(vec!["h2".into()]),
+            enable_session_resumption: Some(true),
+            fingerprint: Some("chrome".into()),
+            min_version: Some("1.2".into()),
+            max_version: Some("1.3".into()),
+            cipher_suites: Some("TLS_AES_128_GCM_SHA256".into()),
+            curve_preferences: Some(vec!["X25519".into()]),
+            pinned_peer_cert_sha256: Some("11".repeat(32)),
+            verify_peer_cert_by_name: Some("certificate.example".into()),
+            ..Default::default()
+        });
+
+        let error = match build_outbound(&node) {
+            Ok(_) => panic!("advanced TLS fields must not be ignored while TLS is disabled"),
+            Err(error) => error,
+        };
+        assert_eq!(error, "TLS/ECH settings are present while TLS is disabled");
+
+        let mut disabled = ParsedNode::new(
+            "grpc-disabled-tls",
+            NodeProtocol::Vless,
+            "grpc.example",
+            443,
+        );
+        disabled.uuid = node.uuid.clone();
+        disabled.transport = "grpc".into();
+        disabled
+            .params
+            .insert("sni".into(), "ignored.example".into());
+        assert!(build_outbound(&disabled).is_err());
+
+        node.tls = true;
+        node.sni = Some("certificate.example".into());
+        let options =
+            super::build_node_tls_options(&node, true, node.sni.clone(), false, vec!["h2".into()])
+                .unwrap();
+        assert_eq!(options.sni.as_deref(), Some("certificate.example"));
+        assert_eq!(options.alpn, ["h2"]);
+        assert_eq!(options.fingerprint, "chrome");
+        assert!(options.enable_session_resumption);
+        assert_eq!(options.pinned_peer_cert_sha256, [[0x11; 32]]);
+        assert_eq!(options.verify_peer_cert_by_name, ["certificate.example"]);
+        let settings = options.xray_settings.unwrap();
+        assert_eq!(settings.min_version.as_deref(), Some("1.2"));
+        assert_eq!(settings.max_version.as_deref(), Some("1.3"));
+        assert_eq!(
+            settings.cipher_suites.as_deref(),
+            Some("TLS_AES_128_GCM_SHA256")
+        );
+        assert_eq!(settings.curve_preferences.unwrap(), ["X25519"]);
+
+        node.tls_settings = None;
+        node.params.insert("ech".into(), "true".into());
+        assert_eq!(
+            super::build_node_tls_options(&node, true, node.sni.clone(), false, vec!["h2".into()])
+                .unwrap_err(),
+            "ech=true requires a non-empty echConfigList"
+        );
+    }
+
+    #[test]
+    fn trojan_uses_registered_grpc_carrier_without_forcing_direct_tls() {
+        let mut node = ParsedNode::new("trojan-grpc", NodeProtocol::Trojan, "grpc.example", 443);
+        node.password = Some("secret".into());
+        node.transport = "grpc".into();
+        node.params.insert("security".into(), "none".into());
+        node.params.insert("serviceName".into(), "trojan".into());
+        node.params.insert("multiMode".into(), "true".into());
+
+        let concrete = super::build_trojan(&node).unwrap();
+        assert!(!concrete.tls);
+        assert!(concrete.grpc.as_ref().is_some_and(|grpc| grpc.multi_mode));
     }
 
     #[test]

--- a/crates/core-outbound/src/transport/browser_identity.rs
+++ b/crates/core-outbound/src/transport/browser_identity.rs
@@ -1,0 +1,408 @@
+//! Xray-compatible process-anchored browser identity generation.
+//!
+//! Xray anchors these values once per process. Its pseudo-random stream is
+//! seeded with FNV-1 over selected CPU topology values and uses Go's legacy
+//! `math/rand` source. Only the first four values are consumed (curl, Firefox,
+//! Safari, then Chromium), so this module derives exactly that prefix instead
+//! of carrying the full 607-word generator state.
+//!
+//! The small legacy RNG compatibility routine and cooked constants are
+//! derived from Go's BSD-3-Clause `src/math/rand/rng.go`.
+
+use std::sync::OnceLock;
+
+use chrono::{TimeZone, Utc};
+
+const GO_RNG_LEN: i32 = 607;
+const GO_INT32_MAX: i64 = (1_i64 << 31) - 1;
+const GO_RNG_MASK: u64 = (1_u64 << 63) - 1;
+const GO_FLOAT_DENOMINATOR: f64 = (1_u64 << 63) as f64;
+const PREFIX_WORDS: usize = 20;
+
+// rngCooked[314..=333].
+const FEED_COOKED: [i64; PREFIX_WORDS] = [
+    -3825019837890901156,
+    4602025990114250980,
+    1044646352569048800,
+    9106614159853161675,
+    -8394115921626182539,
+    -4304087667751778808,
+    2681532557646850893,
+    3681559472488511871,
+    -3915372517896561773,
+    -2889241648411946534,
+    -6564663803938238204,
+    -8060058171802589521,
+    581945337509520675,
+    3648778920718647903,
+    -4799698790548231394,
+    -7602572252857820065,
+    220828013409515943,
+    -1072987336855386047,
+    4287360518296753003,
+    -4633371852008891965,
+];
+
+// rngCooked[587..=606].
+const TAP_COOKED: [i64; PREFIX_WORDS] = [
+    -245039190118465649,
+    -6320577374581628592,
+    7208698530190629697,
+    7276901792339343736,
+    -7490986807540332668,
+    4133292154170828382,
+    2918308698224194548,
+    -7703910638917631350,
+    -3929437324238184044,
+    -4300543082831323144,
+    -6344160503358350167,
+    5896236396443472108,
+    -758328221503023383,
+    -1894351639983151068,
+    -307900319840287220,
+    -6278469401177312761,
+    -2171292963361310674,
+    8382142935188824023,
+    9103922860780351547,
+    4152330101494654406,
+];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct BrowserIdentity {
+    pub(super) firefox_ua: String,
+    pub(super) chrome_ua: String,
+    pub(super) edge_ua: String,
+}
+
+pub(super) fn browser_identity() -> &'static BrowserIdentity {
+    static IDENTITY: OnceLock<BrowserIdentity> = OnceLock::new();
+    IDENTITY.get_or_init(|| browser_identity_for(cpu_seed(), Utc::now().timestamp()))
+}
+
+fn browser_identity_for(seed: i64, now_unix: i64) -> BrowserIdentity {
+    let random = go_float64_prefix(seed);
+    let current_day = now_unix / 86_400;
+
+    // Package-level initialization order in Xray's common/utils/browser.go is
+    // curl, Firefox, Safari, then Chromium. `random` is that exact four-value
+    // prefix even though gRPC only exposes the Firefox/Chromium identities.
+    let firefox_time_diff =
+        current_day - utc_day(2024, 7, 29) - 25 - (random[1].powi(2) * 50.0).floor() as i64;
+    let firefox_version = firefox_time_diff / 30 + 128;
+
+    let chrome_time_diff =
+        current_day - utc_day(2026, 1, 13) - 35 - (random[3].powi(2) * 105.0).floor() as i64;
+    let chrome_version = 144 + chrome_time_diff / 35;
+
+    let chrome_ua = format!(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) \
+         Chrome/{chrome_version}.0.0.0 Safari/537.36"
+    );
+    BrowserIdentity {
+        firefox_ua: format!(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:{firefox_version}.0) \
+             Gecko/20100101 Firefox/{firefox_version}.0"
+        ),
+        edge_ua: format!("{chrome_ua}Edg/{chrome_version}.0.0.0"),
+        chrome_ua,
+    }
+}
+
+fn utc_day(year: i32, month: u32, day: u32) -> i64 {
+    utc_timestamp(year, month, day) / 86_400
+}
+
+fn utc_timestamp(year: i32, month: u32, day: u32) -> i64 {
+    Utc.with_ymd_and_hms(year, month, day, 0, 0, 0)
+        .single()
+        .expect("valid Xray browser release date")
+        .timestamp()
+}
+
+fn go_seedrand(x: i32) -> i32 {
+    const A: i64 = 48_271;
+    const Q: i64 = 44_488;
+    const R: i64 = 3_399;
+    let x = i64::from(x);
+    let hi = x / Q;
+    let lo = x % Q;
+    let mut next = A * lo - R * hi;
+    if next < 0 {
+        next += GO_INT32_MAX;
+    }
+    next as i32
+}
+
+/// Return enough of Go's `Rand.Float64` prefix for Xray's four package-level
+/// browser version initializers. Extra words preserve Go's retry-on-1.0 rule.
+fn go_float64_prefix(seed: i64) -> [f64; 4] {
+    let mut seed = seed % GO_INT32_MAX;
+    if seed < 0 {
+        seed += GO_INT32_MAX;
+    }
+    if seed == 0 {
+        seed = 89_482_311;
+    }
+
+    let mut x = seed as i32;
+    let mut feed = [0_i64; PREFIX_WORDS];
+    let mut tap = [0_i64; PREFIX_WORDS];
+    for index in -20..GO_RNG_LEN {
+        x = go_seedrand(x);
+        if index < 0 {
+            continue;
+        }
+        let mut value = i64::from(x).wrapping_shl(40);
+        x = go_seedrand(x);
+        value ^= i64::from(x).wrapping_shl(20);
+        x = go_seedrand(x);
+        value ^= i64::from(x);
+
+        if (314..=333).contains(&index) {
+            let slot = (index - 314) as usize;
+            feed[slot] = value ^ FEED_COOKED[slot];
+        } else if (587..=606).contains(&index) {
+            let slot = (index - 587) as usize;
+            tap[slot] = value ^ TAP_COOKED[slot];
+        }
+    }
+
+    let mut result = [0.0; 4];
+    let mut produced = 0;
+    for slot in (0..PREFIX_WORDS).rev() {
+        let integer = (feed[slot].wrapping_add(tap[slot]) as u64 & GO_RNG_MASK) as f64;
+        let value = integer / GO_FLOAT_DENOMINATOR;
+        if value == 1.0 {
+            continue;
+        }
+        result[produced] = value;
+        produced += 1;
+        if produced == result.len() {
+            return result;
+        }
+    }
+    unreachable!("twenty Go RNG words all rounded to 1.0")
+}
+
+fn cpu_seed() -> i64 {
+    cpu_seed_from_parts(cpu_seed_parts())
+}
+
+fn cpu_seed_from_parts(parts: CpuSeedParts) -> i64 {
+    let text = format!(
+        "{}{}{}{}{}{}",
+        parts.family,
+        parts.model,
+        parts.physical_cores,
+        parts.logical_cores,
+        parts.cache_line,
+        parts.threads_per_core
+    );
+    // hash/fnv.New64 is FNV-1 (multiply, then XOR), not FNV-1a.
+    let mut hash = 14_695_981_039_346_656_037_u64;
+    for byte in text.bytes() {
+        hash = hash.wrapping_mul(1_099_511_628_211);
+        hash ^= u64::from(byte);
+    }
+    hash as i64
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CpuSeedParts {
+    family: i32,
+    model: i32,
+    physical_cores: i32,
+    logical_cores: i32,
+    cache_line: i32,
+    threads_per_core: i32,
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn cpu_seed_parts() -> CpuSeedParts {
+    #[cfg(target_arch = "x86")]
+    use std::arch::x86::{__cpuid, __cpuid_count};
+    #[cfg(target_arch = "x86_64")]
+    use std::arch::x86_64::{__cpuid, __cpuid_count};
+
+    let leaf0 = __cpuid(0);
+    let max_basic = leaf0.eax;
+    let mut vendor_bytes = Vec::with_capacity(12);
+    vendor_bytes.extend_from_slice(&leaf0.ebx.to_le_bytes());
+    vendor_bytes.extend_from_slice(&leaf0.edx.to_le_bytes());
+    vendor_bytes.extend_from_slice(&leaf0.ecx.to_le_bytes());
+    let vendor = match vendor_bytes.as_slice() {
+        b"GenuineIntel" => CpuVendor::Intel,
+        b"AuthenticAMD" | b"AMDisbetter!" => CpuVendor::Amd,
+        b"HygonGenuine" => CpuVendor::Hygon,
+        _ => CpuVendor::Other,
+    };
+    let leaf1 = (max_basic >= 1).then(|| __cpuid(1));
+    let (family, model) = leaf1.map_or((0, 0), |leaf| {
+        let base_family = ((leaf.eax >> 8) & 0xf) as i32;
+        let mut family = base_family;
+        let mut extended_model = base_family == 0x6;
+        if base_family == 0xf {
+            family += ((leaf.eax >> 20) & 0xff) as i32;
+            extended_model = true;
+        }
+        let mut model = ((leaf.eax >> 4) & 0xf) as i32;
+        if extended_model {
+            model += ((leaf.eax >> 12) & 0xf0) as i32;
+        }
+        (family, model)
+    });
+    let max_extended = __cpuid(0x8000_0000).eax;
+    let cache_line = leaf1.map_or(0, |leaf| {
+        let primary = ((leaf.ebx & 0xff00) >> 5) as i32;
+        if primary == 0 && max_extended >= 0x8000_0006 {
+            (__cpuid(0x8000_0006).ecx & 0xff) as i32
+        } else {
+            primary
+        }
+    });
+
+    let threads_per_core = match vendor {
+        CpuVendor::Intel | CpuVendor::Amd if max_basic >= 4 => {
+            if max_basic < 0xb {
+                if vendor != CpuVendor::Intel {
+                    1
+                } else if leaf1.is_some_and(|leaf| leaf.edx & (1 << 28) != 0) {
+                    let logical = leaf1.map_or(0, |leaf| ((leaf.ebx >> 16) & 0xff) as i32);
+                    let physical = ((__cpuid(4).eax >> 26) + 1) as i32;
+                    if logical > 1 && physical > 0 {
+                        logical / physical
+                    } else {
+                        1
+                    }
+                } else {
+                    1
+                }
+            } else {
+                let topology = __cpuid_count(0xb, 0).ebx & 0xffff;
+                if topology != 0 {
+                    topology as i32
+                } else if vendor == CpuVendor::Amd
+                    && family >= 23
+                    && leaf1.is_some_and(|leaf| leaf.edx & (1 << 28) != 0)
+                {
+                    if max_extended >= 0x8000_001e {
+                        (((__cpuid(0x8000_001e).ebx >> 8) & 0xff) + 1) as i32
+                    } else {
+                        2
+                    }
+                } else {
+                    1
+                }
+            }
+        }
+        _ => 1,
+    };
+
+    let logical_cores = match vendor {
+        CpuVendor::Intel if max_basic >= 0xb => (__cpuid_count(0xb, 1).ebx & 0xffff) as i32,
+        CpuVendor::Intel | CpuVendor::Amd | CpuVendor::Hygon => {
+            leaf1.map_or(0, |leaf| ((leaf.ebx >> 16) & 0xff) as i32)
+        }
+        CpuVendor::Other => 0,
+    };
+    let physical_cores = if logical_cores > 0 && threads_per_core > 0 {
+        logical_cores / threads_per_core
+    } else if vendor == CpuVendor::Amd && max_extended >= 0x8000_0008 {
+        let count = __cpuid(0x8000_0008).ecx & 0xff;
+        (count + 1) as i32
+    } else {
+        0
+    };
+
+    CpuSeedParts {
+        family,
+        model,
+        physical_cores,
+        logical_cores,
+        cache_line,
+        threads_per_core,
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CpuVendor {
+    Intel,
+    Amd,
+    Hygon,
+    Other,
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn cpu_seed_parts() -> CpuSeedParts {
+    let logical = std::thread::available_parallelism()
+        .map(|value| value.get() as i32)
+        .unwrap_or(1);
+    CpuSeedParts {
+        family: 0,
+        model: 0,
+        physical_cores: logical,
+        logical_cores: logical,
+        cache_line: 64,
+        threads_per_core: 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn go_rng_prefix_matches_go_math_rand_golden_values() {
+        assert_eq!(
+            go_float64_prefix(1).map(f64::to_bits),
+            [
+                0x3fe359608841ff3f,
+                0x3fee18a683d7cfc6,
+                0x3fe5441371d9a55d,
+                0x3fdc03825dbda6be,
+            ]
+        );
+        assert_eq!(
+            go_float64_prefix(-7_477_466_199_320_545_235).map(f64::to_bits),
+            [
+                0x3fecc7fb013f8c45,
+                0x3fd9702f87520799,
+                0x3fe434d699616be1,
+                0x3fe722352a05b031,
+            ]
+        );
+    }
+
+    #[test]
+    fn browser_versions_match_xray_go_oracle() {
+        let identity = browser_identity_for(1, 1_774_051_200);
+        assert!(identity.firefox_ua.contains("Firefox/145.0"));
+        assert!(identity.chrome_ua.contains("Chrome/144.0.0.0"));
+        assert!(identity.edge_ua.ends_with("Edg/144.0.0.0"));
+    }
+
+    #[test]
+    fn cpu_topology_fnv_seed_matches_xray_go_oracle() {
+        assert_eq!(
+            cpu_seed_from_parts(CpuSeedParts {
+                family: 6,
+                model: 183,
+                physical_cores: 12,
+                logical_cores: 24,
+                cache_line: 64,
+                threads_per_core: 2,
+            }),
+            -4_444_068_514_562_985_806
+        );
+        assert_eq!(
+            go_float64_prefix(-4_444_068_514_562_985_806).map(f64::to_bits),
+            [
+                0x3fd487b50e0f21bd,
+                0x3fdc03f01b8eaa49,
+                0x3fdcbe0e75b97523,
+                0x3fe0ac5408168242,
+            ]
+        );
+    }
+}

--- a/crates/core-outbound/src/transport/grpc_transport.rs
+++ b/crates/core-outbound/src/transport/grpc_transport.rs
@@ -1,46 +1,80 @@
-//! gRPC (gun) 传输层 —— 与 mihomo `transport/gun/gun.go` 等价。
+//! Xray gRPC (`gun`) outbound transport.
 //!
-//! 把 VLESS/VMess/Trojan 的字节流封装在 gRPC 双向流中：
-//! 1. TLS+ALPN h2
-//! 2. POST `/<service-name>/Tun` （或自定义）
-//! 3. Content-Type: application/grpc
-//! 4. body 是一系列 gRPC frame：`flag(1) || length(4 BE) || data`
-//!    - flag=0：普通帧
-//! 5. 双向都按这个 frame 格式 read/write
+//! Protobuf and gRPC semantics are delegated to `core-grpc` (tonic/prost);
+//! this module only supplies WutherCore's TCP/TLS carrier and connection pool.
 
-use std::{
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use bytes::{Buf, Bytes, BytesMut};
-use http::{HeaderName, HeaderValue, Request as HttpRequest};
-use hyper::body::{Body as HyperBody, Frame, Incoming};
-use parking_lot::Mutex as PlMutex;
-use tokio::{
-    io::{AsyncRead, AsyncWrite, ReadBuf},
-    sync::{Mutex as AsyncMutex, mpsc},
-};
+use core_grpc::client::{GrpcClientConfig, GrpcClientConnection};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::Mutex;
 
 use crate::{
     adapter::BoxedStream,
-    transport::{TlsOptions, Transport, tls::TlsTransport},
+    transport::{TlsOptions, Transport, tcp::TcpTransport, tls::TlsTransport},
 };
 
-#[derive(Debug, Clone, Default)]
+use super::browser_identity::browser_identity;
+
+#[derive(Debug, Clone)]
 pub struct GrpcOptions {
     pub enabled: bool,
+    /// Xray `authority`. Takes precedence over the compatibility `host`.
+    pub authority: String,
+    /// Legacy WutherCore spelling retained for existing profiles.
+    pub host: String,
     pub service_name: String,
+    pub multi_mode: bool,
+    pub idle_timeout: Duration,
+    pub health_check_timeout: Duration,
+    pub permit_without_stream: bool,
+    pub initial_window_size: Option<u32>,
     pub user_agent: String,
-    pub host: String, // ":authority"
+    pub max_message_size: usize,
+    pub queue_capacity: usize,
+}
+
+impl Default for GrpcOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            authority: String::new(),
+            host: String::new(),
+            service_name: String::new(),
+            multi_mode: false,
+            idle_timeout: Duration::ZERO,
+            health_check_timeout: Duration::ZERO,
+            permit_without_stream: false,
+            initial_window_size: None,
+            user_agent: String::new(),
+            max_message_size: core_grpc::DEFAULT_MAX_MESSAGE_SIZE,
+            queue_capacity: core_grpc::DEFAULT_QUEUE_CAPACITY,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedConnection {
+    host: String,
+    port: u16,
+    client: GrpcClientConnection,
 }
 
 pub struct GrpcTransport {
     opts: GrpcOptions,
     tls: TlsOptions,
-    sender: AsyncMutex<Option<hyper::client::conn::http2::SendRequest<GrpcBody>>>,
+    connection: Arc<Mutex<Option<CachedConnection>>>,
+}
+
+impl std::fmt::Debug for GrpcTransport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GrpcTransport")
+            .field("opts", &self.opts)
+            .field("tls", &self.tls)
+            .finish_non_exhaustive()
+    }
 }
 
 impl GrpcTransport {
@@ -48,7 +82,94 @@ impl GrpcTransport {
         Self {
             opts,
             tls,
-            sender: AsyncMutex::new(None),
+            connection: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Open one gRPC tunnel over an already authenticated carrier.
+    ///
+    /// REALITY, finalmask and other outer transports use this entry point so
+    /// the gRPC protobuf/HTTP2 stack is shared instead of reimplemented.
+    pub async fn connect_over<S>(
+        &self,
+        carrier: S,
+        host: &str,
+        port: u16,
+    ) -> std::io::Result<BoxedStream>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let config = self.client_config(host, port);
+        config.validate()?;
+        let connection = GrpcClientConnection::handshake(carrier, config).await?;
+        Ok(Box::pin(connection.open_tunnel().await?))
+    }
+
+    async fn get_or_connect(&self, host: &str, port: u16) -> std::io::Result<GrpcClientConnection> {
+        let client_config = self.client_config(host, port);
+        client_config.validate()?;
+        let mut cached = self.connection.lock().await;
+        if let Some(connection) = cached.as_ref()
+            && connection.host == host
+            && connection.port == port
+            && !connection.client.is_closed()
+        {
+            return Ok(connection.client.clone());
+        }
+
+        let carrier = if self.tls.enabled {
+            let mut tls = self.tls.clone();
+            tls.enabled = true;
+            if tls.alpn.is_empty() {
+                tls.alpn.push("h2".into());
+            } else if !tls.alpn.iter().any(|protocol| protocol == "h2") {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "gRPC over TLS requires `h2` in ALPN",
+                ));
+            }
+            TlsTransport::new(tls).connect(host, port).await?
+        } else {
+            TcpTransport::default().connect(host, port).await?
+        };
+        let client = GrpcClientConnection::handshake(carrier, client_config).await?;
+        *cached = Some(CachedConnection {
+            host: host.to_owned(),
+            port,
+            client: client.clone(),
+        });
+        Ok(client)
+    }
+
+    fn authority(&self, host: &str, port: u16) -> String {
+        if !self.opts.authority.is_empty() {
+            return self.opts.authority.clone();
+        }
+        if !self.opts.host.is_empty() {
+            return self.opts.host.clone();
+        }
+        if let Some(server_name) = self.tls.sni.as_ref().filter(|value| !value.is_empty()) {
+            return server_name.clone();
+        }
+        if host.contains(':') && !host.starts_with('[') {
+            format!("[{host}]:{port}")
+        } else {
+            host.to_owned()
+        }
+    }
+
+    fn client_config(&self, host: &str, port: u16) -> GrpcClientConfig {
+        GrpcClientConfig {
+            authority: self.authority(host, port),
+            service_name: self.opts.service_name.clone(),
+            multi_mode: self.opts.multi_mode,
+            user_agent: resolved_user_agent(&self.opts.user_agent),
+            idle_timeout: self.opts.idle_timeout,
+            health_check_timeout: self.opts.health_check_timeout,
+            permit_without_stream: self.opts.permit_without_stream,
+            initial_window_size: self.opts.initial_window_size,
+            max_message_size: self.opts.max_message_size,
+            queue_capacity: self.opts.queue_capacity,
         }
     }
 }
@@ -56,354 +177,137 @@ impl GrpcTransport {
 #[async_trait]
 impl Transport for GrpcTransport {
     async fn connect(&self, host: &str, port: u16) -> std::io::Result<BoxedStream> {
-        // 复用 / 建立 h2 连接
-        let mut sender = {
-            let mut guard = self.sender.lock().await;
-            if let Some(s) = guard.as_ref() {
-                if !s.is_closed() {
-                    s.clone()
-                } else {
-                    let s = init_h2(host, port, &self.tls).await?;
-                    *guard = Some(s.clone());
-                    s
-                }
-            } else {
-                let s = init_h2(host, port, &self.tls).await?;
-                *guard = Some(s.clone());
-                s
-            }
-        };
-
-        let service = if self.opts.service_name.is_empty() {
-            "GunService"
-        } else {
-            &self.opts.service_name
-        };
-        let path = format!("/{service}/Tun");
-        let authority = if self.opts.host.is_empty() {
-            host.to_string()
-        } else {
-            self.opts.host.clone()
-        };
-        let user_agent = if self.opts.user_agent.is_empty() {
-            format!("grpc-go/{}", env!("CARGO_PKG_VERSION"))
-        } else {
-            self.opts.user_agent.clone()
-        };
-
-        let (tx, rx) = mpsc::channel::<Vec<u8>>(8);
-        let body = GrpcBody::Stream(rx);
-        let uri = format!("https://{authority}{path}");
-        let mut req = HttpRequest::builder()
-            .method("POST")
-            .uri(uri.as_str())
-            .body(body)
-            .map_err(|e| io_err(format!("grpc request: {e}")))?;
-        req.headers_mut().insert(
-            HeaderName::from_static("content-type"),
-            HeaderValue::from_static("application/grpc"),
-        );
-        req.headers_mut().insert(
-            HeaderName::from_static("user-agent"),
-            HeaderValue::from_str(&user_agent).map_err(|e| io_err(format!("ua: {e}")))?,
-        );
-        req.headers_mut().insert(
-            HeaderName::from_static("te"),
-            HeaderValue::from_static("trailers"),
-        );
-
-        let resp = sender
-            .send_request(req)
-            .await
-            .map_err(|e| io_err(format!("grpc send_request: {e}")))?;
-        if !resp.status().is_success() {
-            return Err(io_err(format!("grpc server status {}", resp.status())));
-        }
-        Ok(Box::pin(GrpcStream {
-            tx,
-            rx_body: resp.into_body(),
-            recv_buf: BytesMut::new(),
-            plain_buf: BytesMut::new(),
-        }))
-    }
-}
-
-async fn init_h2(
-    host: &str,
-    port: u16,
-    tls_opts: &TlsOptions,
-) -> std::io::Result<hyper::client::conn::http2::SendRequest<GrpcBody>> {
-    let mut tls = tls_opts.clone();
-    tls.enabled = true;
-    if !tls.alpn.iter().any(|a| a == "h2") {
-        tls.alpn.push("h2".into());
-    }
-    let stream = TlsTransport::new(tls).connect(host, port).await?;
-    let io = HyperTokioIo::new(stream);
-    let (sender, conn) = hyper::client::conn::http2::handshake::<_, _, GrpcBody>(TokioExecutor, io)
-        .await
-        .map_err(|e| io_err(format!("grpc h2 handshake: {e}")))?;
-    tokio::spawn(async move {
-        let _ = conn.await;
-    });
-    Ok(sender)
-}
-
-pub enum GrpcBody {
-    Stream(mpsc::Receiver<Vec<u8>>),
-}
-
-impl HyperBody for GrpcBody {
-    type Data = Bytes;
-    type Error = std::io::Error;
-    fn poll_frame(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame<Bytes>, std::io::Error>>> {
-        match self.get_mut() {
-            GrpcBody::Stream(rx) => match rx.poll_recv(cx) {
-                Poll::Ready(Some(d)) => Poll::Ready(Some(Ok(Frame::data(Bytes::from(d))))),
-                Poll::Ready(None) => Poll::Ready(None),
-                Poll::Pending => Poll::Pending,
-            },
-        }
-    }
-}
-
-struct GrpcStream {
-    tx: mpsc::Sender<Vec<u8>>,
-    rx_body: Incoming,
-    recv_buf: BytesMut,  // 来自网络的原始 gRPC frame 字节
-    plain_buf: BytesMut, // 已解析的明文 payload
-}
-
-impl GrpcStream {
-    /// 尝试从 recv_buf 解一个 gRPC frame
-    /// frame: flag(1) || length(4 BE) || data(length)
-    fn try_decode_one(&mut self) -> bool {
-        if self.recv_buf.len() < 5 {
-            return false;
-        }
-        let length = u32::from_be_bytes([
-            self.recv_buf[1],
-            self.recv_buf[2],
-            self.recv_buf[3],
-            self.recv_buf[4],
-        ]) as usize;
-        if self.recv_buf.len() < 5 + length {
-            return false;
-        }
-        let _flag = self.recv_buf[0];
-        self.recv_buf.advance(5);
-        let data = self.recv_buf.split_to(length);
-        // gun 协议在 data 前还有一个 protobuf field marker 0x0a + varint len
-        // mihomo 实现里 read 时跳过这两个字节（具体 0x0a + 1 byte len，因 payload < 128）
-        let payload = if data.len() >= 2 && data[0] == 0x0a {
-            // 解析 varint len（最多 5 字节）
-            let mut idx = 1usize;
-            let mut len_val: usize = 0;
-            let mut shift = 0;
-            while idx < data.len() {
-                let b = data[idx];
-                len_val |= ((b & 0x7f) as usize) << shift;
-                idx += 1;
-                if (b & 0x80) == 0 {
-                    break;
-                }
-                shift += 7;
-                if shift > 28 {
-                    return false; // 过长 varint
-                }
-            }
-            if data.len() < idx + len_val {
-                return false;
-            }
-            &data[idx..idx + len_val]
-        } else {
-            &data[..]
-        };
-        self.plain_buf.extend_from_slice(payload);
-        true
-    }
-}
-
-impl AsyncRead for GrpcStream {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
+        let mut reconnect = false;
         loop {
-            if !self.plain_buf.is_empty() {
-                let n = std::cmp::min(buf.remaining(), self.plain_buf.len());
-                buf.put_slice(&self.plain_buf[..n]);
-                self.plain_buf.advance(n);
-                return Poll::Ready(Ok(()));
-            }
-            if self.try_decode_one() {
-                continue;
-            }
-            // 读更多
-            match Pin::new(&mut self.rx_body).poll_frame(cx) {
-                Poll::Ready(Some(Ok(frame))) => match frame.into_data() {
-                    Ok(data) => {
-                        if data.is_empty() {
-                            return Poll::Ready(Ok(()));
-                        }
-                        self.recv_buf.extend_from_slice(&data);
-                        continue;
-                    }
-                    Err(_) => return Poll::Ready(Ok(())),
-                },
-                Poll::Ready(Some(Err(e))) => {
-                    return Poll::Ready(Err(io_err(format!("grpc body: {e}"))));
+            let client = self.get_or_connect(host, port).await?;
+            match client.open_tunnel().await {
+                Ok(stream) => return Ok(Box::pin(stream)),
+                Err(error) if !reconnect && client.is_closed() => {
+                    reconnect = true;
+                    *self.connection.lock().await = None;
+                    tracing::debug!(%error, "retrying gRPC tunnel on a fresh HTTP/2 connection");
                 }
-                Poll::Ready(None) => return Poll::Ready(Ok(())),
-                Poll::Pending => return Poll::Pending,
+                Err(error) => return Err(error),
             }
         }
     }
 }
 
-impl AsyncWrite for GrpcStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        data: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        // 编码为 gRPC frame: flag(0) || length(4 BE) || (0x0a varint(len) data)
-        let mut payload = Vec::with_capacity(data.len() + 5);
-        payload.push(0x0a);
-        write_varint(&mut payload, data.len() as u64);
-        payload.extend_from_slice(data);
-        let mut frame = Vec::with_capacity(5 + payload.len());
-        frame.push(0u8); // flag
-        frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-        frame.extend_from_slice(&payload);
-
-        let n = data.len();
-        let tx = self.tx.clone();
-        let mut fut = Box::pin(async move { tx.send(frame).await });
-        match std::future::Future::poll(fut.as_mut(), cx) {
-            Poll::Ready(Ok(())) => Poll::Ready(Ok(n)),
-            Poll::Ready(Err(_)) => Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into())),
-            Poll::Pending => Poll::Pending,
-        }
+fn resolved_user_agent(configured: &str) -> Option<String> {
+    let identity = browser_identity();
+    match configured {
+        "" | "chrome" => Some(identity.chrome_ua.clone()),
+        "firefox" => Some(identity.firefox_ua.clone()),
+        "edge" => Some(identity.edge_ua.clone()),
+        "golang" => None,
+        _ => Some(configured.to_owned()),
     }
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-}
-
-fn write_varint(out: &mut Vec<u8>, mut v: u64) {
-    while v >= 0x80 {
-        out.push(((v & 0x7f) as u8) | 0x80);
-        v >>= 7;
-    }
-    out.push(v as u8);
-}
-
-/* ---------------- Hyper IO 适配（与 h2_transport 等价） ---------------- */
-
-struct HyperTokioIo<S> {
-    inner: S,
-}
-impl<S> HyperTokioIo<S> {
-    fn new(inner: S) -> Self {
-        Self { inner }
-    }
-}
-impl<S: AsyncRead + Unpin> hyper::rt::Read for HyperTokioIo<S> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        mut buf: hyper::rt::ReadBufCursor<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let want = buf.remaining();
-        let mut tmp = vec![0u8; want.min(16 * 1024)];
-        let mut rb = ReadBuf::new(&mut tmp);
-        match Pin::new(&mut self.inner).poll_read(cx, &mut rb) {
-            Poll::Ready(Ok(())) => {
-                let filled = rb.filled().len();
-                if filled > 0 {
-                    buf.put_slice(&tmp[..filled]);
-                }
-                Poll::Ready(Ok(()))
-            }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-impl<S: AsyncWrite + Unpin> hyper::rt::Write for HyperTokioIo<S> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
-    }
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
-    }
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
-}
-#[derive(Clone)]
-struct TokioExecutor;
-impl<F> hyper::rt::Executor<F> for TokioExecutor
-where
-    F: std::future::Future + Send + 'static,
-    F::Output: Send + 'static,
-{
-    fn execute(&self, fut: F) {
-        tokio::spawn(fut);
-    }
-}
-
-fn io_err<S: Into<String>>(s: S) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::Other, s.into())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core_grpc::server::{GrpcServerConfig, TunnelHandler, serve_connection};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
-    fn varint_round_trip() {
-        for v in [0u64, 1, 127, 128, 16383, 16384, 1 << 30] {
-            let mut buf = Vec::new();
-            write_varint(&mut buf, v);
-            let mut idx = 0;
-            let mut decoded: u64 = 0;
-            let mut shift = 0;
-            loop {
-                let b = buf[idx];
-                idx += 1;
-                decoded |= ((b & 0x7f) as u64) << shift;
-                if (b & 0x80) == 0 {
-                    break;
-                }
-                shift += 7;
-            }
-            assert_eq!(decoded, v);
-        }
+    fn options_default_is_bounded_and_xray_compatible() {
+        let options = GrpcOptions::default();
+        assert!(!options.enabled);
+        assert!(!options.multi_mode);
+        assert_eq!(options.max_message_size, 4 * 1024 * 1024);
+        assert_eq!(options.queue_capacity, 8);
     }
 
     #[test]
-    fn options_default() {
-        let o = GrpcOptions::default();
-        assert!(!o.enabled);
-        assert_eq!(o.service_name, "");
+    fn authority_precedence_matches_xray() {
+        let mut options = GrpcOptions {
+            authority: "explicit.example".into(),
+            host: "legacy.example".into(),
+            ..Default::default()
+        };
+        let mut tls = TlsOptions {
+            sni: Some("sni.example".into()),
+            ..Default::default()
+        };
+        let transport = GrpcTransport::new(options.clone(), tls.clone());
+        assert_eq!(
+            transport.authority("origin.example", 443),
+            "explicit.example"
+        );
+
+        options.authority.clear();
+        let transport = GrpcTransport::new(options.clone(), tls.clone());
+        assert_eq!(transport.authority("origin.example", 443), "legacy.example");
+
+        options.host.clear();
+        let transport = GrpcTransport::new(options, tls.clone());
+        assert_eq!(transport.authority("origin.example", 443), "sni.example");
+
+        tls.sni = None;
+        let transport = GrpcTransport::new(GrpcOptions::default(), tls);
+        assert_eq!(transport.authority("2001:db8::1", 443), "[2001:db8::1]:443");
+    }
+
+    #[test]
+    fn user_agent_aliases_do_not_append_library_suffixes() {
+        assert!(resolved_user_agent("chrome").unwrap().contains("Chrome/"));
+        assert!(resolved_user_agent("firefox").unwrap().contains("Firefox/"));
+        assert!(resolved_user_agent("edge").unwrap().contains("Edg/"));
+        assert_eq!(resolved_user_agent("golang"), None);
+        assert_eq!(resolved_user_agent("custom/1").as_deref(), Some("custom/1"));
+        assert_eq!(
+            resolved_user_agent("Chrome").as_deref(),
+            Some("Chrome"),
+            "Xray special user-agent aliases are case-sensitive"
+        );
+    }
+
+    #[tokio::test]
+    async fn tls_requires_h2_alpn_before_opening_a_socket() {
+        let transport = GrpcTransport::new(
+            GrpcOptions::default(),
+            TlsOptions {
+                enabled: true,
+                alpn: vec!["http/1.1".into()],
+                ..Default::default()
+            },
+        );
+        let error = match transport.connect("127.0.0.1", 9).await {
+            Ok(_) => panic!("non-h2 ALPN must fail before dialing"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("requires `h2`"));
+    }
+
+    #[tokio::test]
+    async fn caller_supplied_carrier_uses_the_real_grpc_stack() {
+        let (client, server) = tokio::io::duplex(64 * 1024);
+        let handler: TunnelHandler = Arc::new(|mut stream, _context| {
+            Box::pin(async move {
+                let (mut read, mut write) = tokio::io::split(&mut stream);
+                tokio::io::copy(&mut read, &mut write).await?;
+                Ok(())
+            })
+        });
+        let server_task = tokio::spawn(serve_connection(
+            server,
+            "127.0.0.1:12345".parse().unwrap(),
+            GrpcServerConfig::default(),
+            handler,
+        ));
+        let transport = GrpcTransport::new(GrpcOptions::default(), TlsOptions::default());
+        let mut stream = transport
+            .connect_over(client, "carrier.example", 443)
+            .await
+            .unwrap();
+        stream.write_all(b"carrier-round-trip").await.unwrap();
+        stream.flush().await.unwrap();
+        let mut response = [0_u8; 18];
+        stream.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"carrier-round-trip");
+        stream.shutdown().await.unwrap();
+        server_task.abort();
     }
 }

--- a/crates/core-outbound/src/transport/mod.rs
+++ b/crates/core-outbound/src/transport/mod.rs
@@ -9,7 +9,7 @@
 //! * [`tls::TlsTransport`]      —— TLS over TCP（rustls + ring + webpki-roots）
 //! * [`ws::WsTransport`]        —— WebSocket，可选叠加 TLS（即 wss）
 
-use std::io;
+use std::{fmt, io};
 
 use async_trait::async_trait;
 use core_config::model::XhttpDownloadTlsSettings;
@@ -17,6 +17,7 @@ use core_config::model::XhttpDownloadTlsSettings;
 use crate::adapter::BoxedStream;
 
 pub(crate) mod boring_tls;
+mod browser_identity;
 pub(crate) mod ech;
 pub mod grpc_transport;
 pub mod h2_transport;
@@ -42,7 +43,7 @@ pub trait Transport: Send + Sync {
 }
 
 /// 公共 TLS 选项。
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct TlsOptions {
     pub enabled: bool,
     pub sni: Option<String>,
@@ -61,18 +62,39 @@ pub struct TlsOptions {
     /// Xray `verifyPeerCertByName`：非空时不使用拨号 SNI 做名称验证，而是
     /// 依次尝试这里的 DNS/IP 名称。
     pub verify_peer_cert_by_name: Vec<String>,
-    /// 完整 Xray TLS 配置。仅 XHTTP 使用此对象；保留完整值可保证 TCP 与
-    /// QUIC 后端在能力选择时不会丢字段或静默忽略高级配置。
+    /// 完整 Xray TLS 配置。XHTTP、gRPC 及其他叠加在 TLS 上的载体共用此
+    /// 对象；保留完整值可保证 TCP 与 QUIC 后端不会丢字段或静默忽略高级配置。
     pub xray_settings: Option<XhttpDownloadTlsSettings>,
     /// `echConfigList` 为 DNS URL 时由异步解析器写入；不参与用户配置序列化。
     pub(crate) resolved_ech_config_list: Option<Vec<u8>>,
+}
+
+impl fmt::Debug for TlsOptions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TlsOptions")
+            .field("enabled", &self.enabled)
+            .field("sni", &self.sni)
+            .field("insecure", &self.insecure)
+            .field("alpn", &self.alpn)
+            .field("enable_session_resumption", &self.enable_session_resumption)
+            .field("fingerprint", &self.fingerprint)
+            .field("pin_count", &self.pinned_peer_cert_sha256.len())
+            .field("verify_peer_cert_by_name", &self.verify_peer_cert_by_name)
+            .field("has_xray_settings", &self.xray_settings.is_some())
+            .field(
+                "has_resolved_ech_config",
+                &self.resolved_ech_config_list.is_some(),
+            )
+            .finish()
+    }
 }
 
 impl TlsOptions {
     /// Compile one complete, strongly typed Xray TLS object into executable
     /// transport options. Callers only pass the source settings; certificates,
     /// pins, name overrides, ALPN, resumption, fingerprint and ECH stay on one
-    /// validation/parsing path shared by XHTTP, Realm and stacked transports.
+    /// validation/parsing path shared by XHTTP, REALITY and stacked transports.
     pub fn from_xray_settings(settings: XhttpDownloadTlsSettings) -> io::Result<Self> {
         settings
             .validate()

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -17,8 +17,8 @@ use core_api::ApiServer;
 use core_config::loader::load_from_path;
 use core_feeds::{FeedDiskCache, FeedManager, FeedSink, FeedUpdate};
 use core_inbound::{
-    MixedListener, XhttpListenerHandle, ensure_best_effort_privilege, run_mixed,
-    start_xhttp_listeners,
+    GrpcListener, MixedListener, XhttpListenerHandle, ensure_best_effort_privilege, run_grpc,
+    run_mixed, start_xhttp_listeners,
 };
 use core_outbound::proto::wireguard::{
     WireGuardServer, WireGuardServerConfig, WireGuardServerPeerConfig,
@@ -1185,6 +1185,22 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         info!(addr = %addr, udp = mixed.udp, "mixed inbound: HTTP+SOCKS5 ready");
     } else {
         info!("listen.local 未配置，跳过 Mixed 入站");
+    }
+
+    // Xray gRPC（gun）入站。core-grpc 负责真实 tonic/prost Tun/TunMulti
+    // framing，core-inbound 负责 VLESS TCP/UDP/mux 与统一路由运行时。
+    for config in &plan.listen.grpc {
+        let listener = GrpcListener::from_config(config)
+            .map_err(|error| anyhow::anyhow!("gRPC listener configuration failed: {error}"))?;
+        let address = listener.listen_addr();
+        let service = listener.server_config().service_name.clone();
+        let rt = runtime.clone();
+        handles.push(tokio::spawn(async move {
+            if let Err(error) = run_grpc(listener, rt).await {
+                warn!(target: "inbound::grpc", %address, %error, "gRPC listener exited");
+            }
+        }));
+        info!(addr = %address, %service, "VLESS-over-gRPC inbound ready");
     }
 
     // 控制面板/API

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -16,6 +16,11 @@ core-outbound = { workspace = true }
 core-smart   = { workspace = true }
 
 [dev-dependencies]
+base64       = { workspace = true }
+core-grpc     = { workspace = true }
+core-outbound = { workspace = true }
+core-reality  = { workspace = true }
+futures       = { workspace = true }
 hex          = { workspace = true }
 quinn        = { workspace = true }
 rcgen        = "0.13"
@@ -25,3 +30,4 @@ sha2         = { workspace = true }
 tokio        = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-util   = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/tests-e2e/tests/e2e_grpc_xray.rs
+++ b/tests-e2e/tests/e2e_grpc_xray.rs
@@ -1,0 +1,1686 @@
+//! Real tonic/prost gRPC transport interoperability against pinned Xray-core.
+//!
+//! Run explicitly with:
+//!
+//! ```text
+//! XRAY_BIN=/path/to/xray cargo test -p tests-e2e --test e2e_grpc_xray -- --ignored
+//! ```
+
+use std::{
+    env, fs, io,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex, Once},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use base64::Engine as _;
+use core_config::{
+    model::{XhttpDownloadTlsCertificate, XhttpDownloadTlsSettings, XhttpTlsCertificateUsage},
+    node_uri::{NodeProtocol, ParsedNode, parse_uri},
+};
+use core_grpc::server::{GrpcRequestContext, GrpcServerConfig, TunnelHandler, serve_connection};
+use core_inbound::{GrpcListener, run_grpc};
+use core_outbound::{
+    adapter::DialContext,
+    registry::build_outbound,
+    transport::{GrpcOptions, GrpcTransport, TlsOptions, Transport},
+};
+use core_runtime::Runtime;
+use rcgen::{CertificateParams, CustomExtension, KeyPair};
+use rustls::{crypto::aws_lc_rs::kx_group::X25519, pki_types::PrivatePkcs8KeyDer};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::{TcpListener, TcpStream, UdpSocket},
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
+use tokio_rustls::TlsAcceptor;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(20);
+const XRAY_UUID: &str = "11111111-1111-1111-1111-111111111111";
+const XRAY_PINNED_VERSION: &str = "26.7.11";
+const XRAY_PINNED_COMMIT: &str = "50231ea";
+const SERVICE_NAME: &str = "wuthercore-grpc-interop";
+const CUSTOM_SERVER_SERVICE: &str = "/wuther/core/Tun X|Tun Multi X";
+const CUSTOM_TUN_SERVICE: &str = "/wuther/core/Tun X";
+const CUSTOM_MULTI_SERVICE: &str = "/wuther/core/Tun Multi X";
+const ESCAPED_LEGACY_SERVICE: &str = "Gun Service/一";
+const REALITY_SERVER_NAME: &str = "grpc-reality.example";
+const REALITY_SHORT_ID: &str = "0123456789abcdef";
+
+fn init_test_tracing() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("core_inbound=debug,core_grpc=debug")
+            .with_test_writer()
+            .try_init();
+    });
+}
+
+#[derive(Clone, Copy)]
+struct InteropCase {
+    label: &'static str,
+    multi_mode: bool,
+    server_service: &'static str,
+    client_service: &'static str,
+}
+
+const INTEROP_CASES: [InteropCase; 8] = [
+    InteropCase {
+        label: "empty-tun",
+        multi_mode: false,
+        server_service: "",
+        client_service: "",
+    },
+    InteropCase {
+        label: "empty-tun-multi",
+        multi_mode: true,
+        server_service: "",
+        client_service: "",
+    },
+    InteropCase {
+        label: "tun",
+        multi_mode: false,
+        server_service: SERVICE_NAME,
+        client_service: SERVICE_NAME,
+    },
+    InteropCase {
+        label: "escaped-legacy-tun",
+        multi_mode: false,
+        server_service: ESCAPED_LEGACY_SERVICE,
+        client_service: ESCAPED_LEGACY_SERVICE,
+    },
+    InteropCase {
+        label: "escaped-legacy-tun-multi",
+        multi_mode: true,
+        server_service: ESCAPED_LEGACY_SERVICE,
+        client_service: ESCAPED_LEGACY_SERVICE,
+    },
+    InteropCase {
+        label: "tun-multi",
+        multi_mode: true,
+        server_service: SERVICE_NAME,
+        client_service: SERVICE_NAME,
+    },
+    InteropCase {
+        label: "custom-tun",
+        multi_mode: false,
+        server_service: CUSTOM_SERVER_SERVICE,
+        client_service: CUSTOM_TUN_SERVICE,
+    },
+    InteropCase {
+        label: "custom-tun-multi",
+        multi_mode: true,
+        server_service: CUSTOM_SERVER_SERVICE,
+        client_service: CUSTOM_MULTI_SERVICE,
+    },
+];
+
+struct XrayProcess {
+    child: Child,
+    config: PathBuf,
+}
+
+impl Drop for XrayProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = fs::remove_file(&self.config);
+    }
+}
+
+struct BackgroundTask(JoinHandle<()>);
+
+impl Drop for BackgroundTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+struct TestCertificate {
+    certificate_path: PathBuf,
+    key_path: PathBuf,
+    certificate_pem: String,
+}
+
+impl TestCertificate {
+    fn generate(name: &str) -> Self {
+        let rcgen::CertifiedKey { cert, key_pair } =
+            rcgen::generate_simple_self_signed(vec![name.to_owned()])
+                .expect("generate gRPC TLS test certificate");
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let prefix = env::temp_dir().join(format!(
+            "wuthercore-grpc-tls-{}-{nonce}",
+            std::process::id()
+        ));
+        let certificate_path = prefix.with_extension("crt.pem");
+        let key_path = prefix.with_extension("key.pem");
+        let certificate_pem = cert.pem();
+        fs::write(&certificate_path, &certificate_pem).expect("write gRPC TLS test certificate");
+        fs::write(&key_path, key_pair.serialize_pem()).expect("write gRPC TLS test key");
+        Self {
+            certificate_path,
+            key_path,
+            certificate_pem,
+        }
+    }
+
+    fn certificate_json(&self) -> String {
+        serde_json::to_string(&self.certificate_path.to_string_lossy())
+            .expect("serialize certificate path")
+    }
+
+    fn key_json(&self) -> String {
+        serde_json::to_string(&self.key_path.to_string_lossy()).expect("serialize key path")
+    }
+
+    fn certificate_yaml(&self) -> String {
+        self.certificate_path.to_string_lossy().replace('\'', "''")
+    }
+
+    fn key_yaml(&self) -> String {
+        self.key_path.to_string_lossy().replace('\'', "''")
+    }
+}
+
+impl Drop for TestCertificate {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.certificate_path);
+        let _ = fs::remove_file(&self.key_path);
+    }
+}
+
+fn xray_binary() -> PathBuf {
+    let binary = env::var_os("XRAY_BIN")
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .expect("set XRAY_BIN to the pinned official Xray executable");
+    assert_pinned_xray(&binary);
+    binary
+}
+
+fn assert_pinned_xray(binary: &Path) {
+    let output = Command::new(binary)
+        .arg("version")
+        .output()
+        .expect("run `xray version` for pin verification");
+    assert!(
+        output.status.success(),
+        "`xray version` failed for {}",
+        binary.display()
+    );
+    let version = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        version.contains(&format!("Xray {XRAY_PINNED_VERSION}"))
+            && version.contains(XRAY_PINNED_COMMIT),
+        "XRAY_BIN must be pinned to Xray {XRAY_PINNED_VERSION} \
+         ({XRAY_PINNED_COMMIT}); got: {version}"
+    );
+}
+
+fn temp_config(name: &str, body: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let path = env::temp_dir().join(format!(
+        "wuthercore-grpc-{name}-{}-{nonce}.json",
+        std::process::id()
+    ));
+    fs::write(&path, body).expect("write Xray gRPC interoperability config");
+    path
+}
+
+fn spawn_xray(binary: &Path, name: &str, config: String) -> XrayProcess {
+    let config = temp_config(name, &config);
+    let child = Command::new(binary)
+        .arg("run")
+        .arg("-c")
+        .arg(&config)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("start official Xray");
+    XrayProcess { child, config }
+}
+
+async fn reserve_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("reserve loopback port");
+    listener.local_addr().expect("reserved address").port()
+}
+
+async fn wait_for_listener(port: u16, process: &mut XrayProcess) {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            if let Some(status) = process.child.try_wait().expect("query Xray status") {
+                panic!("Xray exited before becoming ready: {status}");
+            }
+            if TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+                return;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("Xray listener readiness timeout");
+}
+
+async fn spawn_echo_server() -> (SocketAddr, BackgroundTask) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind echo server");
+    let address = listener.local_addr().expect("echo address");
+    let task = tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let (mut reader, mut writer) = stream.split();
+                let _ = tokio::io::copy(&mut reader, &mut writer).await;
+            });
+        }
+    });
+    (address, BackgroundTask(task))
+}
+
+async fn spawn_reality_camouflage_target() -> (SocketAddr, BackgroundTask) {
+    let mut params = CertificateParams::new(vec![REALITY_SERVER_NAME.into()])
+        .expect("build REALITY camouflage certificate");
+    params
+        .custom_extensions
+        .push(CustomExtension::from_oid_content(
+            &[1, 3, 6, 1, 4, 1, 55555, 3],
+            {
+                let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+                (0..2048)
+                    .map(|_| {
+                        state ^= state << 13;
+                        state ^= state >> 7;
+                        state ^= state << 17;
+                        state as u8
+                    })
+                    .collect()
+            },
+        ));
+    let signing_key = KeyPair::generate().expect("generate camouflage key");
+    let certificate = params
+        .self_signed(&signing_key)
+        .expect("sign camouflage certificate");
+    let mut provider = rustls::crypto::aws_lc_rs::default_provider();
+    provider.kx_groups = vec![X25519];
+    let config = rustls::ServerConfig::builder_with_provider(Arc::new(provider))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .expect("build TLS 1.3 camouflage provider")
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![certificate.der().clone()],
+            PrivatePkcs8KeyDer::from(signing_key.serialize_der()).into(),
+        )
+        .expect("install camouflage certificate");
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind REALITY camouflage target");
+    let address = listener.local_addr().expect("camouflage address");
+    let task = tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                // REALITY consumes only the target's first TLS server flight.
+                let _ = acceptor.accept(stream).await;
+            });
+        }
+    });
+    (address, BackgroundTask(task))
+}
+
+fn grpc_options(case: InteropCase) -> GrpcOptions {
+    GrpcOptions {
+        enabled: true,
+        authority: "authority.grpc.example".into(),
+        service_name: case.client_service.into(),
+        multi_mode: case.multi_mode,
+        idle_timeout: Duration::from_secs(30),
+        health_check_timeout: Duration::from_secs(5),
+        permit_without_stream: true,
+        initial_window_size: Some(1 << 20),
+        user_agent: "wuthercore-grpc-interop/1".into(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn wuthercore_tonic_client_to_official_xray_server_tun_and_tun_multi() {
+    let binary = xray_binary();
+    for case in INTEROP_CASES {
+        let (echo, _echo_task) = spawn_echo_server().await;
+        let xray_port = reserve_port().await;
+        let config = format!(
+            r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {xray_port},
+    "protocol": "dokodemo-door",
+    "settings": {{
+      "address": "127.0.0.1",
+      "port": {},
+      "network": "tcp"
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "none",
+      "grpcSettings": {{
+        "serviceName": "{}",
+        "idle_timeout": 30,
+        "health_check_timeout": 5,
+        "initial_windows_size": 1048576
+      }}
+    }}
+  }}],
+  "outbounds": [{{ "protocol": "freedom" }}]
+}}"#,
+            echo.port(),
+            case.server_service
+        );
+        let mut xray = spawn_xray(&binary, &format!("rust-client-{}", case.label), config);
+        wait_for_listener(xray_port, &mut xray).await;
+
+        let transport = GrpcTransport::new(grpc_options(case), TlsOptions::default());
+        let mut stream = timeout(TEST_TIMEOUT, transport.connect("127.0.0.1", xray_port))
+            .await
+            .expect("Rust gRPC dial timeout")
+            .expect("Rust tonic client dials official Xray");
+        let payload = interop_payload(case.multi_mode);
+        stream
+            .write_all(&payload)
+            .await
+            .expect("write gRPC payload");
+        stream.flush().await.expect("flush gRPC payload");
+        let mut echoed = vec![0; payload.len()];
+        timeout(TEST_TIMEOUT, stream.read_exact(&mut echoed))
+            .await
+            .expect("gRPC echo timeout")
+            .expect("read gRPC echo");
+        assert_eq!(echoed, payload, "case={}", case.label);
+        stream.shutdown().await.expect("shutdown gRPC tunnel");
+    }
+}
+
+fn interop_payload(multi_mode: bool) -> Vec<u8> {
+    let marker = if multi_mode {
+        b"official-grpc-tun-multi|" as &[u8]
+    } else {
+        b"official-grpc-tun|"
+    };
+    let mut payload = Vec::with_capacity(256 * 1024 + 17);
+    while payload.len() < 256 * 1024 + 17 {
+        payload.extend_from_slice(marker);
+        payload.extend(0_u8..=250);
+    }
+    payload.truncate(256 * 1024 + 17);
+    payload
+}
+
+async fn spawn_grpc_vless_server(
+    service_name: &str,
+) -> (
+    SocketAddr,
+    BackgroundTask,
+    Arc<Mutex<Vec<GrpcRequestContext>>>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind Rust gRPC server");
+    let address = listener.local_addr().expect("Rust gRPC server address");
+    let config = GrpcServerConfig {
+        service_name: service_name.into(),
+        idle_timeout: Duration::from_secs(30),
+        health_check_timeout: Duration::from_secs(5),
+        initial_window_size: Some(1 << 20),
+        ..Default::default()
+    };
+    let contexts = Arc::new(Mutex::new(Vec::new()));
+    let handler_contexts = contexts.clone();
+    let handler: TunnelHandler = Arc::new(move |mut stream, context| {
+        let contexts = handler_contexts.clone();
+        Box::pin(async move {
+            contexts.lock().unwrap().push(context);
+            read_vless_request(&mut stream).await?;
+            stream.write_all(&[0, 0]).await?;
+            stream.flush().await?;
+            echo_until_eof(&mut stream).await
+        })
+    });
+    let task = tokio::spawn(async move {
+        while let Ok((stream, peer)) = listener.accept().await {
+            let config = config.clone();
+            let handler = handler.clone();
+            tokio::spawn(async move {
+                let _ = serve_connection(stream, peer, config, handler).await;
+            });
+        }
+    });
+    (address, BackgroundTask(task), contexts)
+}
+
+async fn read_vless_request<S>(stream: &mut S) -> io::Result<()>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut fixed = [0_u8; 18];
+    stream.read_exact(&mut fixed).await?;
+    if fixed[0] != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "official Xray sent a non-VLESS-v0 request",
+        ));
+    }
+    let addon_len = fixed[17] as usize;
+    let mut addon = vec![0; addon_len];
+    stream.read_exact(&mut addon).await?;
+
+    let mut command_and_port = [0_u8; 3];
+    stream.read_exact(&mut command_and_port).await?;
+    if command_and_port[0] != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "official Xray VLESS request is not TCP",
+        ));
+    }
+    let mut address_type = [0_u8; 1];
+    stream.read_exact(&mut address_type).await?;
+    match address_type[0] {
+        1 => {
+            let mut address = [0_u8; 4];
+            stream.read_exact(&mut address).await?;
+        }
+        2 => {
+            let mut length = [0_u8; 1];
+            stream.read_exact(&mut length).await?;
+            let mut address = vec![0; usize::from(length[0])];
+            stream.read_exact(&mut address).await?;
+        }
+        3 => {
+            let mut address = [0_u8; 16];
+            stream.read_exact(&mut address).await?;
+        }
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported VLESS address type: {other}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn echo_until_eof<S>(stream: &mut S) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let count = stream.read(&mut buffer).await?;
+        if count == 0 {
+            stream.shutdown().await?;
+            return Ok(());
+        }
+        stream.write_all(&buffer[..count]).await?;
+        stream.flush().await?;
+    }
+}
+
+async fn socks5_connect(port: u16) -> io::Result<TcpStream> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).await?;
+    stream.write_all(&[5, 1, 0]).await?;
+    let mut method = [0_u8; 2];
+    stream.read_exact(&mut method).await?;
+    if method != [5, 0] {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("unexpected SOCKS5 auth reply: {method:?}"),
+        ));
+    }
+    let target = b"example.com";
+    let mut request = vec![5, 1, 0, 3, target.len() as u8];
+    request.extend_from_slice(target);
+    request.extend_from_slice(&443_u16.to_be_bytes());
+    stream.write_all(&request).await?;
+
+    let mut response = [0_u8; 4];
+    stream.read_exact(&mut response).await?;
+    if response[0] != 5 || response[1] != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("SOCKS5 CONNECT failed: {response:?}"),
+        ));
+    }
+    match response[3] {
+        1 => {
+            let mut rest = [0_u8; 6];
+            stream.read_exact(&mut rest).await?;
+        }
+        3 => {
+            let mut length = [0_u8; 1];
+            stream.read_exact(&mut length).await?;
+            let mut rest = vec![0; usize::from(length[0]) + 2];
+            stream.read_exact(&mut rest).await?;
+        }
+        4 => {
+            let mut rest = [0_u8; 18];
+            stream.read_exact(&mut rest).await?;
+        }
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported SOCKS5 reply address type: {other}"),
+            ));
+        }
+    }
+    Ok(stream)
+}
+
+async fn spawn_udp_echo_server() -> (SocketAddr, BackgroundTask) {
+    let socket = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("bind UDP echo server");
+    let address = socket.local_addr().expect("UDP echo address");
+    let task = tokio::spawn(async move {
+        let mut buffer = vec![0_u8; 65_535];
+        while let Ok((length, peer)) = socket.recv_from(&mut buffer).await {
+            if socket.send_to(&buffer[..length], peer).await.is_err() {
+                break;
+            }
+        }
+    });
+    (address, BackgroundTask(task))
+}
+
+async fn socks5_connect_target(port: u16, target: SocketAddr) -> io::Result<TcpStream> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).await?;
+    stream.write_all(&[5, 1, 0]).await?;
+    let mut method = [0_u8; 2];
+    stream.read_exact(&mut method).await?;
+    if method != [5, 0] {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("unexpected SOCKS5 auth reply: {method:?}"),
+        ));
+    }
+    let mut request = vec![5, 1, 0];
+    match target.ip() {
+        std::net::IpAddr::V4(address) => {
+            request.push(1);
+            request.extend_from_slice(&address.octets());
+        }
+        std::net::IpAddr::V6(address) => {
+            request.push(4);
+            request.extend_from_slice(&address.octets());
+        }
+    }
+    request.extend_from_slice(&target.port().to_be_bytes());
+    stream.write_all(&request).await?;
+
+    let mut response = [0_u8; 4];
+    stream.read_exact(&mut response).await?;
+    if response[0] != 5 || response[1] != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("SOCKS5 CONNECT failed: {response:?}"),
+        ));
+    }
+    match response[3] {
+        1 => {
+            let mut rest = [0_u8; 6];
+            stream.read_exact(&mut rest).await?;
+        }
+        3 => {
+            let mut length = [0_u8; 1];
+            stream.read_exact(&mut length).await?;
+            let mut rest = vec![0; usize::from(length[0]) + 2];
+            stream.read_exact(&mut rest).await?;
+        }
+        4 => {
+            let mut rest = [0_u8; 18];
+            stream.read_exact(&mut rest).await?;
+        }
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported SOCKS5 reply address type: {other}"),
+            ));
+        }
+    }
+    Ok(stream)
+}
+
+async fn socks5_udp_associate(port: u16) -> io::Result<(TcpStream, UdpSocket, SocketAddr)> {
+    let mut control = TcpStream::connect(("127.0.0.1", port)).await?;
+    control.write_all(&[5, 1, 0]).await?;
+    let mut method = [0_u8; 2];
+    control.read_exact(&mut method).await?;
+    if method != [5, 0] {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("unexpected SOCKS5 auth reply: {method:?}"),
+        ));
+    }
+    control.write_all(&[5, 3, 0, 1, 0, 0, 0, 0, 0, 0]).await?;
+    let mut response = [0_u8; 4];
+    control.read_exact(&mut response).await?;
+    if response[0] != 5 || response[1] != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("SOCKS5 UDP ASSOCIATE failed: {response:?}"),
+        ));
+    }
+    let relay_ip = match response[3] {
+        1 => {
+            let mut address = [0_u8; 4];
+            control.read_exact(&mut address).await?;
+            let address = std::net::Ipv4Addr::from(address);
+            std::net::IpAddr::V4(if address.is_unspecified() {
+                std::net::Ipv4Addr::LOCALHOST
+            } else {
+                address
+            })
+        }
+        4 => {
+            let mut address = [0_u8; 16];
+            control.read_exact(&mut address).await?;
+            let address = std::net::Ipv6Addr::from(address);
+            std::net::IpAddr::V6(if address.is_unspecified() {
+                std::net::Ipv6Addr::LOCALHOST
+            } else {
+                address
+            })
+        }
+        3 => {
+            let mut length = [0_u8; 1];
+            control.read_exact(&mut length).await?;
+            let mut domain = vec![0_u8; usize::from(length[0])];
+            control.read_exact(&mut domain).await?;
+            let domain = std::str::from_utf8(&domain)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid relay domain"))?;
+            tokio::net::lookup_host((domain, 0))
+                .await?
+                .next()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "relay domain unresolved"))?
+                .ip()
+        }
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported SOCKS5 relay address type: {other}"),
+            ));
+        }
+    };
+    let mut port_bytes = [0_u8; 2];
+    control.read_exact(&mut port_bytes).await?;
+    let relay = SocketAddr::new(relay_ip, u16::from_be_bytes(port_bytes));
+    let bind = if relay.is_ipv4() {
+        "127.0.0.1:0"
+    } else {
+        "[::1]:0"
+    };
+    let socket = UdpSocket::bind(bind).await?;
+    Ok((control, socket, relay))
+}
+
+fn socks5_udp_packet(target: SocketAddr, payload: &[u8]) -> Vec<u8> {
+    let mut packet = vec![0, 0, 0];
+    match target.ip() {
+        std::net::IpAddr::V4(address) => {
+            packet.push(1);
+            packet.extend_from_slice(&address.octets());
+        }
+        std::net::IpAddr::V6(address) => {
+            packet.push(4);
+            packet.extend_from_slice(&address.octets());
+        }
+    }
+    packet.extend_from_slice(&target.port().to_be_bytes());
+    packet.extend_from_slice(payload);
+    packet
+}
+
+fn socks5_udp_payload(packet: &[u8]) -> io::Result<&[u8]> {
+    if packet.len() < 4 || packet[..3] != [0, 0, 0] {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid SOCKS5 UDP header",
+        ));
+    }
+    let address_length = match packet[3] {
+        1 => 4,
+        4 => 16,
+        3 => {
+            let length = *packet.get(4).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::UnexpectedEof, "truncated SOCKS5 domain")
+            })?;
+            1 + usize::from(length)
+        }
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported SOCKS5 UDP address type: {other}"),
+            ));
+        }
+    };
+    let payload_offset = 4 + address_length + 2;
+    packet
+        .get(payload_offset..)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "truncated SOCKS5 UDP packet"))
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn official_xray_client_to_wuthercore_tonic_server_tun_and_tun_multi() {
+    let binary = xray_binary();
+    for case in INTEROP_CASES {
+        let (server, _server_task, contexts) = spawn_grpc_vless_server(case.server_service).await;
+        let socks_port = reserve_port().await;
+        let config = format!(
+            r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {socks_port},
+    "protocol": "socks",
+    "settings": {{ "auth": "noauth", "udp": false }}
+  }}],
+  "outbounds": [{{
+    "protocol": "vless",
+    "settings": {{
+      "vnext": [{{
+        "address": "127.0.0.1",
+        "port": {},
+        "users": [{{ "id": "{XRAY_UUID}", "encryption": "none" }}]
+      }}]
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "none",
+      "grpcSettings": {{
+        "authority": "authority.grpc.example",
+        "serviceName": "{}",
+        "multiMode": {},
+        "idle_timeout": 30,
+        "health_check_timeout": 5,
+        "permit_without_stream": true,
+        "initial_windows_size": 1048576,
+        "user_agent": "wuthercore-xray-interop/1"
+      }}
+    }}
+  }}]
+}}"#,
+            server.port(),
+            case.client_service,
+            case.multi_mode
+        );
+        let mut xray = spawn_xray(&binary, &format!("xray-client-{}", case.label), config);
+        wait_for_listener(socks_port, &mut xray).await;
+
+        let mut socks = timeout(TEST_TIMEOUT, socks5_connect(socks_port))
+            .await
+            .expect("SOCKS5 handshake timeout")
+            .expect("SOCKS5 CONNECT through official Xray");
+        let payload = interop_payload(case.multi_mode);
+        socks
+            .write_all(&payload)
+            .await
+            .expect("write SOCKS payload");
+        socks.flush().await.expect("flush SOCKS payload");
+        let mut echoed = vec![0; payload.len()];
+        timeout(TEST_TIMEOUT, socks.read_exact(&mut echoed))
+            .await
+            .expect("official Xray client echo timeout")
+            .expect("read official Xray client echo");
+        assert_eq!(echoed, payload, "case={}", case.label);
+        let contexts = contexts.lock().unwrap();
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(
+            contexts[0].authority.as_deref(),
+            Some("authority.grpc.example")
+        );
+        assert_eq!(
+            contexts[0].user_agent.as_deref(),
+            Some("wuthercore-xray-interop/1")
+        );
+        let paths = core_grpc::grpc_method_paths(case.client_service);
+        assert_eq!(
+            contexts[0].method_path,
+            if case.multi_mode {
+                paths.tun_multi_path()
+            } else {
+                paths.tun_path()
+            }
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn official_xray_client_to_registered_wuthercore_grpc_vless_inbound() {
+    let binary = xray_binary();
+    for multi_mode in [false, true] {
+        let (echo, _echo_task) = spawn_echo_server().await;
+        let (udp_echo, _udp_echo_task) = spawn_udp_echo_server().await;
+        let grpc_port = reserve_port().await;
+        let service = if multi_mode {
+            "registered-inbound-multi"
+        } else {
+            "registered-inbound-tun"
+        };
+        let yaml = format!(
+            r#"
+version: 1
+profile: server
+name: grpc-inbound-interop
+listen:
+  panel: false
+  grpc:
+    - host: 127.0.0.1
+      port: {grpc_port}
+      protocol: vless
+      users: [{XRAY_UUID}]
+      grpcSettings:
+        serviceName: {service}
+        multiMode: {multi_mode}
+        idle_timeout: 30
+        health_check_timeout: 5
+        permit_without_stream: true
+        initial_windows_size: 1048576
+        max_message_size: 8388608
+        queue_capacity: 16
+      handshakeTimeout: 10s
+      maxMuxSessions: 128
+      maxConnections: 256
+      maxConcurrentStreams: 128
+      maxHeaderListSize: 65536
+route:
+  preset: direct
+"#
+        );
+        let plan =
+            core_config::loader::load_from_str(&yaml).expect("compile registered gRPC inbound");
+        let listener =
+            GrpcListener::from_config(&plan.listen.grpc[0]).expect("build gRPC listener");
+        let runtime = Arc::new(Runtime::build(plan).expect("build registered gRPC runtime"));
+        let server_task = BackgroundTask(tokio::spawn(async move {
+            run_grpc(listener, runtime)
+                .await
+                .expect("registered gRPC listener");
+        }));
+        sleep(Duration::from_millis(100)).await;
+
+        let socks_port = reserve_port().await;
+        let xray_config = format!(
+            r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {socks_port},
+    "protocol": "socks",
+    "settings": {{ "auth": "noauth", "udp": true }}
+  }}],
+  "outbounds": [{{
+    "protocol": "vless",
+    "settings": {{
+      "vnext": [{{
+        "address": "127.0.0.1",
+        "port": {grpc_port},
+        "users": [{{ "id": "{XRAY_UUID}", "encryption": "none" }}]
+      }}]
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "none",
+      "grpcSettings": {{
+        "authority": "registered.grpc.example",
+        "serviceName": "{service}",
+        "multiMode": {multi_mode},
+        "idle_timeout": 30,
+        "health_check_timeout": 5,
+        "permit_without_stream": true,
+        "initial_windows_size": 1048576,
+        "user_agent": "wuthercore-registered-inbound/1"
+      }}
+    }}
+  }}]
+}}"#
+        );
+        let mut xray = spawn_xray(
+            &binary,
+            if multi_mode {
+                "registered-inbound-multi"
+            } else {
+                "registered-inbound-tun"
+            },
+            xray_config,
+        );
+        wait_for_listener(socks_port, &mut xray).await;
+
+        let mut socks = timeout(TEST_TIMEOUT, socks5_connect_target(socks_port, echo))
+            .await
+            .expect("SOCKS5 target handshake timeout")
+            .expect("official Xray connects to registered WutherCore gRPC inbound");
+        let payload = interop_payload(multi_mode);
+        socks.write_all(&payload).await.unwrap();
+        socks.flush().await.unwrap();
+        let mut echoed = vec![0; payload.len()];
+        timeout(TEST_TIMEOUT, socks.read_exact(&mut echoed))
+            .await
+            .expect("registered gRPC inbound echo timeout")
+            .expect("read registered gRPC inbound echo");
+        assert_eq!(echoed, payload);
+        socks.shutdown().await.unwrap();
+
+        let (_udp_control, udp_socket, relay) =
+            timeout(TEST_TIMEOUT, socks5_udp_associate(socks_port))
+                .await
+                .expect("SOCKS5 UDP ASSOCIATE timeout")
+                .expect("official Xray opens UDP association");
+        let udp_payload = if multi_mode {
+            b"registered-inbound-udp-multi".as_slice()
+        } else {
+            b"registered-inbound-udp-tun".as_slice()
+        };
+        let packet = socks5_udp_packet(udp_echo, udp_payload);
+        udp_socket.send_to(&packet, relay).await.unwrap();
+        let mut response = [0_u8; 512];
+        let (length, source) = timeout(TEST_TIMEOUT, udp_socket.recv_from(&mut response))
+            .await
+            .expect("registered gRPC inbound UDP echo timeout")
+            .expect("receive SOCKS5 UDP response");
+        assert_eq!(source, relay);
+        assert_eq!(
+            socks5_udp_payload(&response[..length]).unwrap(),
+            udp_payload
+        );
+        drop(server_task);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn official_xray_and_wuthercore_interoperate_over_registered_grpc_tls() {
+    init_test_tracing();
+    let binary = xray_binary();
+    let certificate = TestCertificate::generate("grpc.example");
+
+    for multi_mode in [false, true] {
+        let mode = if multi_mode { "multi" } else { "tun" };
+
+        // Official Xray client -> registered WutherCore TLS gRPC server.
+        {
+            let (echo, _echo_task) = spawn_echo_server().await;
+            let grpc_port = reserve_port().await;
+            let service = format!("registered-tls-inbound-{mode}");
+            let yaml = format!(
+                r#"
+version: 1
+profile: server
+name: grpc-tls-inbound-interop
+listen:
+  panel: false
+  grpc:
+    - host: 127.0.0.1
+      port: {grpc_port}
+      protocol: vless
+      users: [{XRAY_UUID}]
+      security: tls
+      tlsSettings:
+        serverName: grpc.example
+        alpn: [h2]
+        certificates:
+          - certificateFile: '{}'
+            keyFile: '{}'
+            usage: encipherment
+      grpcSettings:
+        serviceName: {service}
+        multiMode: {multi_mode}
+      handshakeTimeout: 10s
+      maxMuxSessions: 128
+      maxConnections: 256
+      maxConcurrentStreams: 128
+      maxHeaderListSize: 65536
+route:
+  preset: direct
+"#,
+                certificate.certificate_yaml(),
+                certificate.key_yaml(),
+            );
+            let plan = core_config::loader::load_from_str(&yaml)
+                .expect("compile registered TLS gRPC inbound");
+            let listener =
+                GrpcListener::from_config(&plan.listen.grpc[0]).expect("build TLS gRPC listener");
+            let runtime =
+                Arc::new(Runtime::build(plan).expect("build registered TLS gRPC runtime"));
+            let server_task = BackgroundTask(tokio::spawn(async move {
+                run_grpc(listener, runtime)
+                    .await
+                    .expect("registered TLS gRPC listener");
+            }));
+            sleep(Duration::from_millis(100)).await;
+
+            let socks_port = reserve_port().await;
+            let certificate_path = certificate.certificate_json();
+            let xray_config = format!(
+                r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {socks_port},
+    "protocol": "socks",
+    "settings": {{ "auth": "noauth", "udp": false }}
+  }}],
+  "outbounds": [{{
+    "protocol": "vless",
+    "settings": {{
+      "vnext": [{{
+        "address": "127.0.0.1",
+        "port": {grpc_port},
+        "users": [{{ "id": "{XRAY_UUID}", "encryption": "none" }}]
+      }}]
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "tls",
+      "tlsSettings": {{
+        "serverName": "grpc.example",
+        "alpn": ["h2"],
+        "disableSystemRoot": true,
+        "certificates": [{{
+          "certificateFile": {certificate_path},
+          "usage": "verify"
+        }}]
+      }},
+      "grpcSettings": {{
+        "serviceName": "{service}",
+        "multiMode": {multi_mode}
+      }}
+    }}
+  }}]
+}}"#
+            );
+            let mut xray = spawn_xray(
+                &binary,
+                &format!("registered-tls-inbound-{mode}"),
+                xray_config,
+            );
+            wait_for_listener(socks_port, &mut xray).await;
+            let mut socks = timeout(TEST_TIMEOUT, socks5_connect_target(socks_port, echo))
+                .await
+                .expect("TLS gRPC SOCKS handshake timeout")
+                .expect("official Xray reaches WutherCore TLS gRPC inbound");
+            let payload = format!("official-xray-to-wuther-grpc-tls-{mode}").into_bytes();
+            socks.write_all(&payload).await.unwrap();
+            socks.flush().await.unwrap();
+            let mut echoed = vec![0; payload.len()];
+            timeout(TEST_TIMEOUT, socks.read_exact(&mut echoed))
+                .await
+                .expect("TLS gRPC inbound echo timeout")
+                .expect("read TLS gRPC inbound echo");
+            assert_eq!(echoed, payload);
+            drop(xray);
+            drop(server_task);
+        }
+
+        // Registered WutherCore client -> official Xray TLS gRPC server.
+        {
+            let (echo, _echo_task) = spawn_echo_server().await;
+            let xray_port = reserve_port().await;
+            let service = format!("registered-tls-outbound-{mode}");
+            let certificate_path = certificate.certificate_json();
+            let key_path = certificate.key_json();
+            let config = format!(
+                r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {xray_port},
+    "protocol": "vless",
+    "settings": {{
+      "clients": [{{ "id": "{XRAY_UUID}" }}],
+      "decryption": "none"
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "tls",
+      "tlsSettings": {{
+        "serverName": "grpc.example",
+        "alpn": ["h2"],
+        "certificates": [{{
+          "certificateFile": {certificate_path},
+          "keyFile": {key_path},
+          "usage": "encipherment"
+        }}]
+      }},
+      "grpcSettings": {{
+        "serviceName": "{service}",
+        "multiMode": {multi_mode}
+      }}
+    }}
+  }}],
+  "outbounds": [{{
+    "protocol": "freedom",
+    "settings": {{
+      "finalRules": [
+        {{
+          "action": "allow",
+          "network": "tcp",
+          "port": {},
+          "ip": ["127.0.0.1/32"]
+        }},
+        {{ "action": "block" }}
+      ]
+    }}
+  }}]
+}}"#,
+                echo.port()
+            );
+            let mut xray = spawn_xray(&binary, &format!("registered-tls-outbound-{mode}"), config);
+            wait_for_listener(xray_port, &mut xray).await;
+
+            let mut node = ParsedNode::new(
+                format!("registered-tls-outbound-{mode}"),
+                NodeProtocol::Vless,
+                "127.0.0.1",
+                xray_port,
+            );
+            node.uuid = Some(XRAY_UUID.into());
+            node.transport = "grpc".into();
+            node.tls = true;
+            node.sni = Some("grpc.example".into());
+            node.params.insert("serviceName".into(), service);
+            node.params
+                .insert("multiMode".into(), multi_mode.to_string());
+            node.tls_settings = Some(XhttpDownloadTlsSettings {
+                certificates: vec![XhttpDownloadTlsCertificate {
+                    certificate: Some(
+                        certificate
+                            .certificate_pem
+                            .lines()
+                            .map(str::to_owned)
+                            .collect(),
+                    ),
+                    usage: Some(XhttpTlsCertificateUsage::Verify),
+                    ..XhttpDownloadTlsCertificate::default()
+                }],
+                server_name: Some("grpc.example".into()),
+                alpn: Some(vec!["h2".into()]),
+                ..XhttpDownloadTlsSettings::default()
+            });
+            let outbound = build_outbound(&node).expect("compile registered TLS gRPC outbound");
+            let mut stream = timeout(
+                TEST_TIMEOUT,
+                outbound.dial_tcp(DialContext::tcp(echo.ip().to_string(), echo.port())),
+            )
+            .await
+            .expect("registered TLS gRPC outbound dial timeout")
+            .expect("WutherCore reaches official Xray TLS gRPC server");
+            let payload = format!("wuther-to-official-xray-grpc-tls-{mode}").into_bytes();
+            stream.write_all(&payload).await.unwrap();
+            stream.flush().await.unwrap();
+            let mut echoed = vec![0; payload.len()];
+            timeout(TEST_TIMEOUT, stream.read_exact(&mut echoed))
+                .await
+                .expect("TLS gRPC outbound echo timeout")
+                .expect("read TLS gRPC outbound echo");
+            assert_eq!(echoed, payload);
+            stream.shutdown().await.unwrap();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn official_xray_and_wuthercore_interoperate_over_grpc_reality() {
+    init_test_tracing();
+    let binary = xray_binary();
+    let private_key = [0x42_u8; 32];
+    let encoded_private = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(private_key);
+    let public_key =
+        core_reality::x25519_public_key(&private_key).expect("derive REALITY public key");
+    let encoded_public = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(public_key);
+
+    for multi_mode in [false, true] {
+        let mode = if multi_mode { "multi" } else { "tun" };
+
+        // Official Xray client -> registered WutherCore REALITY gRPC server.
+        {
+            let (camouflage, _camouflage_task) = spawn_reality_camouflage_target().await;
+            let (echo, _echo_task) = spawn_echo_server().await;
+            let grpc_port = reserve_port().await;
+            let service = format!("registered-reality-inbound-{mode}");
+            let yaml = format!(
+                r#"
+version: 1
+profile: server
+name: grpc-reality-inbound-interop
+listen:
+  panel: false
+  grpc:
+    - host: 127.0.0.1
+      port: {grpc_port}
+      protocol: vless
+      users: [{XRAY_UUID}]
+      security: reality
+      realitySettings:
+        target: {camouflage}
+        serverNames: [{REALITY_SERVER_NAME}]
+        privateKey: {encoded_private}
+        shortIds: [{REALITY_SHORT_ID}]
+      grpcSettings:
+        serviceName: {service}
+        multiMode: {multi_mode}
+      handshakeTimeout: 10s
+      maxMuxSessions: 128
+      maxConnections: 256
+      maxConcurrentStreams: 128
+      maxHeaderListSize: 65536
+route:
+  preset: direct
+"#
+            );
+            let plan = core_config::loader::load_from_str(&yaml)
+                .expect("compile registered REALITY gRPC inbound");
+            let listener = GrpcListener::from_config(&plan.listen.grpc[0])
+                .expect("build REALITY gRPC listener");
+            let runtime =
+                Arc::new(Runtime::build(plan).expect("build registered REALITY gRPC runtime"));
+            let server_task = BackgroundTask(tokio::spawn(async move {
+                run_grpc(listener, runtime)
+                    .await
+                    .expect("registered REALITY gRPC listener");
+            }));
+            sleep(Duration::from_millis(100)).await;
+
+            let socks_port = reserve_port().await;
+            let xray_config = format!(
+                r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {socks_port},
+    "protocol": "socks",
+    "settings": {{ "auth": "noauth", "udp": false }}
+  }}],
+  "outbounds": [{{
+    "protocol": "vless",
+    "settings": {{
+      "vnext": [{{
+        "address": "127.0.0.1",
+        "port": {grpc_port},
+        "users": [{{ "id": "{XRAY_UUID}", "encryption": "none" }}]
+      }}]
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "reality",
+      "realitySettings": {{
+        "serverName": "{REALITY_SERVER_NAME}",
+        "fingerprint": "chrome",
+        "password": "{encoded_public}",
+        "shortId": "{REALITY_SHORT_ID}",
+        "spiderX": "/"
+      }},
+      "grpcSettings": {{
+        "serviceName": "{service}",
+        "multiMode": {multi_mode}
+      }}
+    }}
+  }}]
+}}"#
+            );
+            let mut xray = spawn_xray(
+                &binary,
+                &format!("registered-reality-inbound-{mode}"),
+                xray_config,
+            );
+            wait_for_listener(socks_port, &mut xray).await;
+            let mut socks = timeout(TEST_TIMEOUT, socks5_connect_target(socks_port, echo))
+                .await
+                .expect("REALITY gRPC SOCKS handshake timeout")
+                .expect("official Xray reaches WutherCore REALITY gRPC inbound");
+            let payload = format!("official-xray-to-wuther-grpc-reality-{mode}").into_bytes();
+            socks.write_all(&payload).await.unwrap();
+            socks.flush().await.unwrap();
+            let mut echoed = vec![0; payload.len()];
+            timeout(TEST_TIMEOUT, socks.read_exact(&mut echoed))
+                .await
+                .expect("REALITY gRPC inbound echo timeout")
+                .expect("read REALITY gRPC inbound echo");
+            assert_eq!(echoed, payload);
+            drop(xray);
+            drop(server_task);
+        }
+
+        // Registered WutherCore client -> official Xray REALITY gRPC server.
+        {
+            let (camouflage, _camouflage_task) = spawn_reality_camouflage_target().await;
+            let (echo, _echo_task) = spawn_echo_server().await;
+            let xray_port = reserve_port().await;
+            let service = format!("registered-reality-outbound-{mode}");
+            let config = format!(
+                r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {xray_port},
+    "protocol": "vless",
+    "settings": {{
+      "clients": [{{ "id": "{XRAY_UUID}" }}],
+      "decryption": "none"
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "reality",
+      "realitySettings": {{
+        "target": "{camouflage}",
+        "serverNames": ["{REALITY_SERVER_NAME}"],
+        "privateKey": "{encoded_private}",
+        "shortIds": ["{REALITY_SHORT_ID}"]
+      }},
+      "grpcSettings": {{
+        "serviceName": "{service}",
+        "multiMode": {multi_mode}
+      }}
+    }}
+  }}],
+  "outbounds": [{{
+    "protocol": "freedom",
+    "settings": {{
+      "finalRules": [
+        {{
+          "action": "allow",
+          "network": "tcp",
+          "port": {},
+          "ip": ["127.0.0.1/32"]
+        }},
+        {{ "action": "block" }}
+      ]
+    }}
+  }}]
+}}"#,
+                echo.port()
+            );
+            let mut xray = spawn_xray(
+                &binary,
+                &format!("registered-reality-outbound-{mode}"),
+                config,
+            );
+            wait_for_listener(xray_port, &mut xray).await;
+
+            let uri = format!(
+                "vless://{XRAY_UUID}@127.0.0.1:{xray_port}?security=reality&sni={REALITY_SERVER_NAME}&fp=chrome&pbk={encoded_public}&sid={REALITY_SHORT_ID}&spx=%2F&type=grpc"
+            );
+            let mut node = parse_uri(&uri).expect("parse REALITY gRPC VLESS URI");
+            node.name = format!("registered-reality-outbound-{mode}");
+            node.params.insert("serviceName".into(), service);
+            node.params
+                .insert("multiMode".into(), multi_mode.to_string());
+            let outbound = build_outbound(&node).expect("compile registered REALITY gRPC outbound");
+            let mut stream = timeout(
+                TEST_TIMEOUT,
+                outbound.dial_tcp(DialContext::tcp(echo.ip().to_string(), echo.port())),
+            )
+            .await
+            .expect("registered REALITY gRPC outbound dial timeout")
+            .expect("WutherCore reaches official Xray REALITY gRPC server");
+            let payload = format!("wuther-to-official-xray-grpc-reality-{mode}").into_bytes();
+            stream.write_all(&payload).await.unwrap();
+            stream.flush().await.unwrap();
+            let mut echoed = vec![0; payload.len()];
+            timeout(TEST_TIMEOUT, stream.read_exact(&mut echoed))
+                .await
+                .expect("REALITY gRPC outbound echo timeout")
+                .expect("read REALITY gRPC outbound echo");
+            assert_eq!(echoed, payload);
+            stream.shutdown().await.unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn registered_vless_vmess_and_trojan_clients_use_real_grpc_carrier() {
+    let binary = xray_binary();
+    for (protocol, settings, variant, vmess_security) in [
+        (
+            NodeProtocol::Vless,
+            format!(r#"{{"clients":[{{"id":"{XRAY_UUID}"}}],"decryption":"none"}}"#),
+            "default",
+            None,
+        ),
+        (
+            NodeProtocol::Vmess,
+            format!(r#"{{"clients":[{{"id":"{XRAY_UUID}","alterId":0}}]}}"#),
+            "aes",
+            Some("aes-128-gcm"),
+        ),
+        (
+            NodeProtocol::Vmess,
+            format!(r#"{{"clients":[{{"id":"{XRAY_UUID}","alterId":0}}]}}"#),
+            "chacha",
+            Some("chacha20-poly1305"),
+        ),
+        (
+            NodeProtocol::Trojan,
+            r#"{"clients":[{"password":"grpc-secret"}]}"#.to_owned(),
+            "default",
+            None,
+        ),
+    ] {
+        for multi_mode in [false, true] {
+            let (echo, _echo_task) = spawn_echo_server().await;
+            let echo_port = echo.port();
+            let xray_port = reserve_port().await;
+            let service = format!(
+                "registered-{}-{variant}-{}",
+                protocol.as_str(),
+                if multi_mode { "multi" } else { "tun" }
+            );
+            let config = format!(
+                r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {xray_port},
+    "protocol": "{}",
+    "settings": {settings},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "none",
+      "grpcSettings": {{
+        "serviceName": "{service}",
+        "multiMode": {multi_mode}
+      }}
+    }}
+  }}],
+  "outbounds": [{{
+    "protocol": "freedom",
+    "settings": {{
+      "finalRules": [
+        {{
+          "action": "allow",
+          "network": "tcp",
+          "port": {echo_port},
+          "ip": ["127.0.0.1/32"]
+        }},
+        {{ "action": "block" }}
+      ]
+    }}
+  }}]
+}}"#,
+                protocol.as_str()
+            );
+            let label = format!(
+                "registered-{}-{variant}-{}",
+                protocol.as_str(),
+                if multi_mode { "multi" } else { "tun" }
+            );
+            let mut xray = spawn_xray(&binary, &label, config);
+            wait_for_listener(xray_port, &mut xray).await;
+
+            let mut node = ParsedNode::new(&label, protocol.clone(), "127.0.0.1", xray_port);
+            node.transport = "grpc".into();
+            node.tls = false;
+            node.params.insert("serviceName".into(), service);
+            node.params
+                .insert("multiMode".into(), multi_mode.to_string());
+            match protocol {
+                NodeProtocol::Vless | NodeProtocol::Vmess => {
+                    node.uuid = Some(XRAY_UUID.into());
+                    if let Some(security) = vmess_security {
+                        node.params.insert("security".into(), security.into());
+                    }
+                }
+                NodeProtocol::Trojan => {
+                    node.password = Some("grpc-secret".into());
+                    node.params.insert("security".into(), "none".into());
+                }
+                _ => unreachable!(),
+            }
+            let outbound = build_outbound(&node).expect("compile registered gRPC outbound");
+            assert_eq!(
+                outbound.protocol(),
+                protocol.as_str(),
+                "registered gRPC node became a stub"
+            );
+            let mut stream = timeout(
+                TEST_TIMEOUT,
+                outbound.dial_tcp(DialContext::tcp(echo.ip().to_string(), echo.port())),
+            )
+            .await
+            .expect("registered gRPC outbound dial timeout")
+            .expect("registered protocol dials through gRPC");
+            let payload = interop_payload(multi_mode);
+            stream.write_all(&payload).await.unwrap();
+            stream.flush().await.unwrap();
+            let mut echoed = vec![0; payload.len()];
+            timeout(TEST_TIMEOUT, stream.read_exact(&mut echoed))
+                .await
+                .expect("registered gRPC outbound echo timeout")
+                .expect("registered gRPC outbound read");
+            assert_eq!(echoed, payload, "protocol={}", protocol.as_str());
+            stream.shutdown().await.unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires XRAY_BIN pointing to the pinned official Xray binary"]
+async fn registered_vless_client_sends_udp_datagrams_over_real_grpc_carrier() {
+    let binary = xray_binary();
+    for multi_mode in [false, true] {
+        let (echo, _echo_task) = spawn_udp_echo_server().await;
+        let xray_port = reserve_port().await;
+        let service = if multi_mode {
+            "registered-vless-udp-multi"
+        } else {
+            "registered-vless-udp-tun"
+        };
+        let config = format!(
+            r#"{{
+  "log": {{ "loglevel": "warning" }},
+  "inbounds": [{{
+    "listen": "127.0.0.1",
+    "port": {xray_port},
+    "protocol": "vless",
+    "settings": {{
+      "clients": [{{ "id": "{XRAY_UUID}" }}],
+      "decryption": "none"
+    }},
+    "streamSettings": {{
+      "network": "grpc",
+      "security": "none",
+      "grpcSettings": {{
+        "serviceName": "{service}",
+        "multiMode": {multi_mode}
+      }}
+    }}
+  }}],
+  "outbounds": [{{
+    "protocol": "freedom",
+    "settings": {{
+      "finalRules": [
+        {{
+          "action": "allow",
+          "network": "udp",
+          "port": {},
+          "ip": ["127.0.0.1/32"]
+        }},
+        {{ "action": "block" }}
+      ]
+    }}
+  }}]
+}}"#,
+            echo.port()
+        );
+        let mut xray = spawn_xray(
+            &binary,
+            if multi_mode {
+                "registered-vless-udp-multi"
+            } else {
+                "registered-vless-udp-tun"
+            },
+            config,
+        );
+        wait_for_listener(xray_port, &mut xray).await;
+
+        let mut node = ParsedNode::new(
+            if multi_mode {
+                "registered-vless-udp-multi"
+            } else {
+                "registered-vless-udp-tun"
+            },
+            NodeProtocol::Vless,
+            "127.0.0.1",
+            xray_port,
+        );
+        node.uuid = Some(XRAY_UUID.into());
+        node.transport = "grpc".into();
+        node.tls = false;
+        node.params.insert("serviceName".into(), service.into());
+        node.params
+            .insert("multiMode".into(), multi_mode.to_string());
+        let outbound = build_outbound(&node).expect("compile registered gRPC UDP outbound");
+        assert!(outbound.capabilities().udp);
+        let udp = timeout(
+            TEST_TIMEOUT,
+            outbound.dial_udp(DialContext::udp(echo.ip().to_string(), echo.port())),
+        )
+        .await
+        .expect("registered VLESS UDP dial timeout")
+        .expect("registered VLESS opens UDP over gRPC");
+        let payload = if multi_mode {
+            b"vless-udp-over-grpc-tun-multi".as_slice()
+        } else {
+            b"vless-udp-over-grpc-tun".as_slice()
+        };
+        assert_eq!(
+            udp.send_to(payload, &echo.ip().to_string(), echo.port())
+                .await
+                .unwrap(),
+            payload.len()
+        );
+        let mut response = [0_u8; 128];
+        let received = timeout(TEST_TIMEOUT, udp.recv_from(&mut response))
+            .await
+            .expect("registered VLESS UDP echo timeout")
+            .expect("receive VLESS UDP response");
+        assert_eq!(&response[..received], payload);
+        udp.close().await.unwrap();
+    }
+}


### PR DESCRIPTION
## 背景与目标

本变更为 WutherCore 增加完整的 Xray gRPC（gun）传输支持，覆盖真实客户端、真实服务端、`Tun`/`TunMulti` 流式 RPC、TLS/REALITY、安全校验、配置注册和现有代理协议承载。实现使用 tonic 与 prost，不以自定义占位帧、普通 HTTP/2 请求或仅配置映射代替 gRPC 协议。

Xray 26.7.11 已提示 gRPC 传输属于兼容性功能并建议新部署迁移到 XHTTP，但现有节点、订阅和服务端仍需要完整互操作，因此本实现保留严格、可测试、失败关闭的全功能支持。

## 分支与提交关系

- 开发分支：`codex/transport-grpc-full`
- 基线分支：`codex/protocol-xhttp-full`
- 相对基线提交数：1
- 提交：`bfb441f1a3f5b5996f336184edcc9bdb8de5ec95`
- 使用独立 worktree 开发，没有修改主工作区。

本 PR 以 XHTTP 分支为基线，是因为 gRPC 复用该分支提供的统一 TLS/ECH/REALITY 传输抽象。这样可以避免在 gRPC 提交中重复复制基础设施，并确保 PR 差异严格只有一个 gRPC 实现提交。XHTTP 合并后，本分支可直接改基到 `main`。

## 核心协议实现

- 新增独立 `core-grpc` crate，使用 `tonic`、`prost`、`hyper`、`tower` 和 Tokio 实现实际 gRPC 数据面。
- 按 Xray protobuf wire format 实现 `Hunk` 与 `MultiHunk`，并用固定金丝雀测试验证字段编号和重复字段编码。
- 支持标准路径 `/{service}/Tun`、`/{service}/TunMulti`，兼容空服务名、旧式默认方法和 Xray 自定义路径规则。
- 客户端执行真实 tonic HTTP/2 握手与双向流式 RPC，不会把 gRPC 退化为普通 HTTP/2 隧道。
- 服务端以真实 tonic service 接收 `Tun` 与 `TunMulti`，支持单连接服务、关闭通知和活动连接回收。

## 流、背压与关闭语义

- 将 tonic 流式消息转换为实现 `AsyncRead`/`AsyncWrite` 的双向字节流，供现有代理协议直接承载。
- `flush` 会等待消息被 tonic 发送侧实际消费，避免只写入本地队列就提前返回。
- 对单消息大小、编码后 protobuf 大小、队列深度、连接数、并发流和空闲时间设置显式上限。
- `TunMulti` 的聚合与向量写入不会超过编码后限制。
- 正常 EOF、远端取消、请求体错误、未打开隧道、服务关闭和连接中止均有确定的资源回收路径。
- 客户端允许在响应头返回前取得可写流，避免与 Xray 双向流的惰性响应语义形成死锁。

## 客户端与现有协议承载

- VLESS、VMess、VMess Legacy 和 Trojan 均通过统一注册表使用真实 gRPC carrier。
- 支持 VLESS TCP、UDP 数据报和 mux 请求。
- VMess 覆盖 AES-GCM 与 ChaCha20-Poly1305 安全模式。
- 支持 `multiMode`、`serviceName`、`authority`、`userAgent`、自定义请求头、空闲超时、健康检查超时和初始窗口等 Xray 字段。
- authority、Host、SNI 与目标地址具有明确优先级；冲突或头部注入会在建连前失败。

## 服务端与入站支持

- 新增结构化 `listen.grpc` 入站配置，可启动 VLESS-over-gRPC 服务端。
- 支持 `Tun` 与 `TunMulti`、TCP、UDP、VLESS mux、用户 UUID 校验和统一路由运行时。
- gRPC 入站已接入主程序启动流程，不只是库级接口。
- 支持明文 h2c、TLS 和 REALITY；TLS 强制协商 `h2`，不允许安全配置静默降级。
- 监听器会校验地址、服务名、UUID、转发头、消息限制、并发限制、超时和安全字段。

## 配置字段与兼容性

- 客户端和服务端字段均注册为强类型模型，覆盖 Xray 常用驼峰字段及项目兼容别名。
- 注册 `serviceName`、`multiMode`、`authority`、`userAgent`、`idleTimeout`、`healthCheckTimeout`、`permitWithoutStream`、初始连接/流窗口、请求头以及资源限制。
- TLS/REALITY 配置沿用统一的完整安全模型，包括 SNI、ALPN、证书固定、名称验证、客户端证书和 REALITY 密钥字段。
- 未知字段、别名冲突、无界资源、非法 UUID、错误路径、非法头部和无法执行的安全组合均在配置阶段拒绝。
- `Cargo.lock` 已包含 tonic、prost 及其传递依赖的固定版本，构建不依赖 CI 临时解析。

## 安全与资源治理

- 客户端和服务端均设置有界消息大小和队列容量。
- 入站连接数、每连接并发流、活动逻辑流和请求生命周期均受限。
- 仅在显式信任时读取转发来源地址，并按 Xray 标记语义解析。
- TLS 必须协商 HTTP/2 ALPN；REALITY 使用真实握手实现，不回退到普通 TLS。
- 用户提供的 authority、User-Agent 和额外请求头经过严格语法与注入检查。

## 验证结果

- `cargo test -p core-grpc`：18 项通过。
- `cargo test -p core-config grpc`：7 项通过。
- `cargo test -p core-inbound grpc --lib`：4 项通过。
- `cargo test -p core-outbound grpc --lib`：11 项通过。
- `cargo test -p wuther-core`：16 项通过。
- `cargo check --workspace --all-targets`：通过。
- `cargo fmt --all -- --check`：通过。
- `git diff --check codex/protocol-xhttp-full...HEAD`：通过。
- 官方 Xray 26.7.11（提交 `50231ea`）互操作：7 项全部通过。

官方互操作覆盖：

- WutherCore tonic 客户端到官方 Xray 服务端的 `Tun` 与 `TunMulti`。
- 官方 Xray 客户端到 WutherCore tonic 服务端的 `Tun` 与 `TunMulti`。
- 官方 Xray 客户端到注册式 WutherCore VLESS/gRPC 入站。
- WutherCore 与官方 Xray 之间的 TLS/gRPC 双向互操作。
- WutherCore 与官方 Xray 之间的 REALITY/gRPC 双向互操作。
- VLESS、VMess AES-GCM、VMess ChaCha20-Poly1305、Trojan 通过真实 gRPC carrier。
- VLESS UDP 数据报通过真实 gRPC carrier。
- 默认、空服务名、自定义服务名、转义旧式服务名以及单流/多流模式。

## 审阅说明

本 PR 保持草稿状态。建议先审阅 `core-grpc` 的 wire format、流背压与关闭语义，再审阅配置映射、协议注册和入站启动接线。
