### PR TITLE
修复 TUIC 非法必填配置未在注册阶段拒绝

### DIFF
--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -135,7 +135,7 @@ pub fn build_outbound(node: &ParsedNode) -> Result<SharedOutbound, String> {
         NodeProtocol::Ssh => build_ssh(node),
         NodeProtocol::Hysteria => build_hysteria_v1(node),
         NodeProtocol::Hysteria2 => build_hysteria2(node),
-        NodeProtocol::Tuic => build_tuic(node),
+        NodeProtocol::Tuic => build_tuic(node)?,
         NodeProtocol::Wireguard => build_wireguard(node),
         NodeProtocol::Mieru => build_mieru(node),
         NodeProtocol::Sudoku => build_sudoku(node),
@@ -2178,11 +2178,10 @@ fn build_hysteria2(node: &ParsedNode) -> SharedOutbound {
     Arc::new(ob)
 }
 
-fn build_tuic(node: &ParsedNode) -> SharedOutbound {
-    match tuic_from_node(node) {
-        Ok(outbound) => Arc::new(outbound),
-        Err(protocol) => StubOutbound::new(node.name.clone(), protocol),
-    }
+fn build_tuic(node: &ParsedNode) -> Result<SharedOutbound, String> {
+    tuic_from_node(node)
+        .map(|outbound| Arc::new(outbound) as SharedOutbound)
+        .map_err(str::to_owned)
 }
 
 fn tuic_from_node(node: &ParsedNode) -> Result<TuicOutbound, &'static str> {


### PR DESCRIPTION
## 背景

在对完整协议与传输层实现执行全量回归时，现有 TUIC 注册测试暴露出一个确定问题：当 UUID、密码或 UDP 中继模式等必填配置非法时，`tuic_from_node` 返回的错误会被 `build_tuic` 转换成一个占位出站对象。这样 `build_outbound` 仍返回成功，配置错误不会在注册阶段被拒绝，既与现有测试契约不符，也可能让错误延迟到实际连接阶段。

## 修改内容

- 将 `build_tuic` 的返回类型改为 `Result<SharedOutbound, String>`。
- 保留 `tuic_from_node` 产生的精确错误标签，并转换为注册层使用的字符串错误。
- 在统一出站构建分派处使用 `?` 传播 TUIC 配置错误。
- 不改变合法 TUIC 节点的构建、TCP/UDP 数据面、认证与 QUIC 行为。

## 行为变化

以下非法配置现在会在出站注册阶段立即失败，而不会生成占位对象：

- 缺失或格式非法的 UUID；
- 缺失密码；
- 不支持的 `udp-relay-mode`。

错误标签继续保持现有契约，例如 `tuic(invalid-uuid)`、`tuic(missing-password)` 与 `tuic(invalid-udp-relay-mode)`。

## 验证

- `cargo test -p core-outbound registry::tests::tuic_registry_rejects_invalid_required_options --lib`
- `cargo test -p core-outbound --lib`
- 结果：TUIC 定向测试通过；`core-outbound` 全量 354 个测试全部通过。
- `cargo fmt --all -- --check`
- `git diff --check`

## 分支关系

本 PR 基于 `codex/protocol-xhttp-full`，相对该基线仅包含 1 个 TUIC 校验修复提交。FinalMask 完整实现将作为后续独立分支叠加，避免把两个协议实现混在同一个提交中。
