### PR TITLE
完整实现 FinalMask 客户端、服务端与全量配置

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "base64 0.22.1",
  "core-young",
  "hex",
+ "http 1.4.2",
  "humantime-serde",
  "ipnet",
  "once_cell",
@@ -1150,8 +1151,8 @@ dependencies = [
  "core-smart",
  "futures",
  "h2 0.4.15",
- "h3",
- "h3-quinn",
+ "h3 0.0.8",
+ "h3-quinn 0.0.10 (git+https://github.com/hyperium/h3?rev=c38a1af632afbbbc8f6716c196ad67f40bc122e3)",
  "hex",
  "http 1.4.2",
  "http-body-util",
@@ -1253,14 +1254,17 @@ dependencies = [
  "cronet",
  "ctr",
  "curve25519-dalek",
+ "data-encoding",
  "flate2",
  "fnv",
  "futures",
+ "ggstd",
  "h2 0.4.15",
- "h3",
- "h3-quinn",
+ "h3 0.0.8",
+ "h3-quinn 0.0.10 (git+https://github.com/hyperium/h3?rev=c38a1af632afbbbc8f6716c196ad67f40bc122e3)",
  "hex",
  "hickory-proto 0.26.1",
+ "hickory-resolver",
  "hkdf",
  "hmac",
  "http 1.4.2",
@@ -1271,8 +1275,10 @@ dependencies = [
  "ipnet",
  "libc",
  "md-5",
+ "num-bigint-dig",
  "parking_lot",
  "pbkdf2",
+ "percent-encoding",
  "pin-project-lite",
  "quinn",
  "quinn-proto",
@@ -1280,6 +1286,9 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rc4",
  "rcgen 0.14.8",
+ "regex",
+ "rsa",
+ "rsteria2",
  "russh",
  "russh-keys",
  "rustls 0.23.40",
@@ -2362,6 +2371,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ggstd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e924479d38dab35ad7dae658abe8429467c5ca109a72e50ce61e8e616fd6487"
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,13 +2473,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "h3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "futures-util",
+ "http 1.4.2",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "h3-quinn"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2e732c8d91a74731663ac8479ab505042fbf547b9a207213ab7fbcbfc4f8b4"
+dependencies = [
+ "bytes",
+ "futures",
+ "h3 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quinn",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "h3-quinn"
 version = "0.0.10"
 source = "git+https://github.com/hyperium/h3?rev=c38a1af632afbbbc8f6716c196ad67f40bc122e3#c38a1af632afbbbc8f6716c196ad67f40bc122e3"
 dependencies = [
  "bytes",
  "futures-util",
- "h3",
+ "h3 0.0.8",
  "quinn",
  "tokio-util",
 ]
@@ -3601,6 +3644,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.7",
+ "serde",
  "smallvec",
  "zeroize",
 ]
@@ -4523,6 +4567,30 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsteria2"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abe0be87d7e1a8450a64dba96a009906f5b8a5a5cbe87f6770d3d34d71da9bf"
+dependencies = [
+ "blake2",
+ "bytes",
+ "h3 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h3-quinn 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 1.4.2",
+ "quinn",
+ "quinn-proto",
+ "rand 0.9.5",
+ "rustls 0.23.40",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "sha2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/crates/core-config/Cargo.toml
+++ b/crates/core-config/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }
 core-young = { workspace = true }
+http = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/core-config/src/lib.rs
+++ b/crates/core-config/src/lib.rs
@@ -18,8 +18,10 @@ pub mod node_uri;
 pub mod profile;
 mod ruleset_compat;
 pub mod runtime_plan;
+pub mod stream_settings;
 
 pub use error::{ConfigError, ConfigErrorKind, ConfigResult};
 pub use loader::{load_from_path, load_from_str};
 pub use model::*;
 pub use runtime_plan::RuntimePlan;
+pub use stream_settings::*;

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -642,6 +642,9 @@ pub struct RealityListen {
     pub limit_fallback_download: RealityFallbackLimit,
     #[serde(default)]
     pub limits: RealityResourceLimits,
+    /// Socket policy and TCP FinalMask applied before the REALITY ClientHello.
+    #[serde(default, rename = "streamSettings", alias = "stream_settings")]
+    pub stream_settings: Option<crate::NodeStreamSettings>,
 }
 
 impl std::fmt::Debug for RealityListen {
@@ -671,6 +674,7 @@ impl std::fmt::Debug for RealityListen {
             .field("limit_fallback_upload", &self.limit_fallback_upload)
             .field("limit_fallback_download", &self.limit_fallback_download)
             .field("limits", &self.limits)
+            .field("has_stream_settings", &self.stream_settings.is_some())
             .finish()
     }
 }
@@ -827,10 +831,15 @@ pub struct ListenLocalDetail {
     pub auth: Vec<String>,
     #[serde(default = "default_true")]
     pub udp: bool,
+    /// Xray-compatible listener socket policy and server-side final masks.
+    /// Both spellings are accepted so native YAML and imported Xray objects
+    /// share one typed configuration path.
+    #[serde(default, rename = "streamSettings", alias = "stream_settings")]
+    pub stream_settings: Option<crate::NodeStreamSettings>,
 }
 
 /// `listen.xhttp` 的单项/数组兼容表示。
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum XhttpListenSet {
     One(XhttpListener),
@@ -864,7 +873,7 @@ pub const XHTTP_MAX_ACTIVE_HTTP_STREAMS: usize = 1_000_000;
 /// `settings` 直接复用出站使用的完整 [`XhttpConfig`]，不会把字段降级为
 /// `serde_json::Value` 或字符串 map。TLS 的 `cert` / `key` 都是文件路径；
 /// 文件读取留给运行时，配置编译阶段负责要求路径非空且成对出现。
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct XhttpListener {
     #[serde(default = "default_true")]
@@ -954,6 +963,10 @@ pub struct XhttpListener {
         skip_serializing_if = "Option::is_none"
     )]
     pub cors_origins: Option<Vec<String>>,
+    /// Xray-compatible listener socket policy and final masks.  TCP masks are
+    /// applied before TLS; UDP masks and QUIC parameters are applied below H3.
+    #[serde(default, rename = "streamSettings", alias = "stream_settings")]
+    pub stream_settings: Option<crate::NodeStreamSettings>,
     #[serde(
         default,
         rename = "settings",
@@ -1130,6 +1143,8 @@ pub struct NodeDetail {
     /// 对应协议注册器做严格校验；用于 WireGuard peers/allowed-ips 等结构。
     #[serde(default, alias = "protocol-options", alias = "protocol_options")]
     pub params: BTreeMap<String, serde_json::Value>,
+    #[serde(default, rename = "streamSettings", alias = "stream_settings")]
+    pub stream_settings: Option<crate::stream_settings::NodeStreamSettings>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/crates/core-config/src/node_uri.rs
+++ b/crates/core-config/src/node_uri.rs
@@ -140,6 +140,10 @@ pub struct ParsedNode {
     pub raw: String,
     /// 协议自定义参数（query / json 字段）。
     pub params: std::collections::BTreeMap<String, String>,
+    /// Typed Xray-compatible transport policy. URI nodes leave this empty;
+    /// structured nodes populate it from `streamSettings`.
+    #[serde(default)]
+    pub stream_settings: Option<crate::stream_settings::NodeStreamSettings>,
 }
 
 impl ParsedNode {
@@ -171,6 +175,7 @@ impl ParsedNode {
             udp: true,
             raw: String::new(),
             params: Default::default(),
+            stream_settings: None,
         }
     }
 }

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -19,6 +19,7 @@ use crate::{
     error::{ConfigError, ConfigResult},
     model::*,
     node_uri::{NodeProtocol, ParsedNode, parse_uri, validate_reality_client_settings},
+    stream_settings::NodeStreamSettings,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -123,6 +124,7 @@ pub struct MixedListen {
     pub host: String,
     pub port: u16,
     pub udp: bool,
+    pub stream_settings: Option<NodeStreamSettings>,
 }
 
 impl MixedListen {
@@ -169,6 +171,9 @@ pub struct XhttpListenPlan {
     /// `None` 使用 XrayCompatible；`Some([])` 禁用 CORS；非空值为 allowlist。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cors_origins: Option<Vec<String>>,
+    /// Listener-side socket policy plus the FinalMask layer below HTTP/TLS.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_settings: Option<NodeStreamSettings>,
     /// 与客户端/出站共享同一个完整强类型 XHTTP 配置。
     pub settings: XhttpConfig,
 }
@@ -360,6 +365,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
             host: host_for(share).into(),
             port: p,
             udp: true,
+            stream_settings: None,
         },
         ListenLocal::Detail(d) => MixedListen {
             host: if d.host.is_empty() {
@@ -369,6 +375,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
             },
             port: d.port,
             udp: d.udp,
+            stream_settings: d.stream_settings,
         },
     });
     if mixed.as_ref().is_some_and(|listener| listener.port == 0) {
@@ -1070,6 +1077,7 @@ fn compile_reality_listeners(listeners: &[RealityListen]) -> ConfigResult<Vec<Re
             &format!("{location}.limitFallbackDownload"),
         )?;
         validate_reality_resource_limits(source.limits, &format!("{location}.limits"))?;
+        validate_reality_listener_stream_settings(source.stream_settings.as_ref(), &location)?;
 
         let mut normalized = source.clone();
         normalized.target = Some(RealityTarget::Address(target));
@@ -1428,6 +1436,8 @@ fn compile_xhttp_listeners(
             )));
         }
 
+        validate_xhttp_listener_stream_settings(listener.stream_settings.as_ref(), has_h3, &path)?;
+
         listener
             .settings
             .validate()
@@ -1499,6 +1509,7 @@ fn compile_xhttp_listeners(
             max_active_http_streams: listener.max_active_http_streams,
             http_idle_timeout: listener.http_idle_timeout,
             cors_origins,
+            stream_settings: listener.stream_settings,
             settings: listener.settings,
         });
     }
@@ -1548,7 +1559,69 @@ fn compile_nodes(specs: &[NodeSpec]) -> ConfigResult<Vec<ParsedNode>> {
         }
         out.push(node);
     }
+    validate_dialer_proxy_graph(&out)?;
     Ok(out)
+}
+
+fn validate_dialer_proxy_graph(nodes: &[ParsedNode]) -> ConfigResult<()> {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let by_name = nodes
+        .iter()
+        .map(|node| (node.name.as_str(), node))
+        .collect::<BTreeMap<_, _>>();
+    for node in nodes {
+        let Some(proxy) = node
+            .stream_settings
+            .as_ref()
+            .and_then(|stream| stream.sockopt.as_ref())
+            .map(|sockopt| sockopt.dialer_proxy.trim())
+            .filter(|proxy| !proxy.is_empty())
+        else {
+            continue;
+        };
+        if !by_name.contains_key(proxy)
+            && !matches!(proxy.to_ascii_uppercase().as_str(), "DIRECT" | "BLOCK")
+        {
+            return Err(ConfigError::bad_node(format!(
+                "node {} 的 streamSettings.sockopt.dialerProxy 引用了不存在的 outbound `{proxy}`",
+                node.name
+            )));
+        }
+    }
+
+    fn visit<'a>(
+        name: &'a str,
+        by_name: &BTreeMap<&'a str, &'a ParsedNode>,
+        visiting: &mut BTreeSet<&'a str>,
+        visited: &mut BTreeSet<&'a str>,
+    ) -> Result<(), String> {
+        if visited.contains(name) {
+            return Ok(());
+        }
+        if !visiting.insert(name) {
+            return Err(format!("dialerProxy 检测到循环链：{name}"));
+        }
+        if let Some(next) = by_name
+            .get(name)
+            .and_then(|node| node.stream_settings.as_ref())
+            .and_then(|stream| stream.sockopt.as_ref())
+            .map(|sockopt| sockopt.dialer_proxy.trim())
+            .filter(|next| by_name.contains_key(next))
+        {
+            visit(next, by_name, visiting, visited)?;
+        }
+        visiting.remove(name);
+        visited.insert(name);
+        Ok(())
+    }
+
+    let mut visiting = BTreeSet::new();
+    let mut visited = BTreeSet::new();
+    for name in by_name.keys().copied() {
+        visit(name, &by_name, &mut visiting, &mut visited).map_err(ConfigError::bad_node)?;
+    }
+    Ok(())
 }
 
 fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
@@ -1961,6 +2034,7 @@ fn detail_to_parsed(d: &NodeDetail) -> ConfigResult<ParsedNode> {
             node.params.insert("ip-family".into(), ip_family.clone());
         }
     }
+    apply_stream_settings(&mut node, &d.name, d.stream_settings.as_ref())?;
     Ok(node)
 }
 
@@ -2011,6 +2085,50 @@ fn insert_optional_param(
     Ok(())
 }
 
+fn validate_reality_listener_stream_settings(
+    settings: Option<&NodeStreamSettings>,
+    path: &str,
+) -> ConfigResult<()> {
+    use crate::stream_settings::{AddressPortStrategy, DomainStrategy};
+
+    let Some(settings) = settings else {
+        return Ok(());
+    };
+    if let Some(network) = settings.network.as_deref()
+        && !network.is_empty()
+        && !network.eq_ignore_ascii_case("tcp")
+        && !network.eq_ignore_ascii_case("raw")
+    {
+        return Err(ConfigError::invalid(format!(
+            "{path}.streamSettings.network 必须是 tcp/raw，实际为 `{network}`"
+        )));
+    }
+    validate_stream_settings(path, settings).map_err(|error| {
+        ConfigError::invalid(format!("{path}.streamSettings 配置无效: {error}"))
+    })?;
+
+    if let Some(finalmask) = settings.finalmask.as_ref()
+        && (!finalmask.udp.is_empty() || finalmask.quic_params.is_some())
+    {
+        return Err(ConfigError::invalid(format!(
+            "{path}.streamSettings 的 UDP finalmask/quicParams 不能用于 TCP REALITY 监听"
+        )));
+    }
+    if let Some(sockopt) = settings.sockopt.as_ref()
+        && (!matches!(sockopt.domain_strategy, DomainStrategy::AsIs)
+            || !sockopt.dialer_proxy.trim().is_empty()
+            || sockopt.penetrate
+            || !matches!(sockopt.address_port_strategy, AddressPortStrategy::None)
+            || sockopt.happy_eyeballs != Default::default()
+            || !sockopt.trusted_x_forwarded_for.is_empty())
+    {
+        return Err(ConfigError::invalid(format!(
+            "{path}.streamSettings.sockopt 包含 REALITY 入站无法执行的出站拨号/HTTP 字段"
+        )));
+    }
+    Ok(())
+}
+
 fn insert_grpc_duration_param(
     node: &mut ParsedNode,
     key: &str,
@@ -2027,6 +2145,321 @@ fn insert_grpc_duration_param(
         )));
     }
     insert_optional_param(node, key, Some(&duration.as_secs().to_string()))
+}
+
+fn validate_xhttp_listener_stream_settings(
+    settings: Option<&NodeStreamSettings>,
+    uses_http3: bool,
+    path: &str,
+) -> ConfigResult<()> {
+    use crate::stream_settings::{AddressPortStrategy, DomainStrategy};
+
+    let Some(settings) = settings else {
+        return Ok(());
+    };
+    if let Some(network) = settings.network.as_deref()
+        && !network.is_empty()
+        && !network.eq_ignore_ascii_case("xhttp")
+        && !network.eq_ignore_ascii_case("splithttp")
+    {
+        return Err(ConfigError::invalid(format!(
+            "{path}.streamSettings.network 必须是 xhttp/splithttp，实际为 `{network}`"
+        )));
+    }
+    // Reuse the canonical mask and platform validation so listener and node
+    // configurations cannot drift on fragment ranges, XMC credentials, XDNS,
+    // QUIC limits or platform-specific socket options.
+    validate_stream_settings(path, settings).map_err(|error| {
+        ConfigError::invalid(format!("{path}.streamSettings 配置无效: {error}"))
+    })?;
+
+    if let Some(sockopt) = settings.sockopt.as_ref() {
+        let outbound_only = !matches!(sockopt.domain_strategy, DomainStrategy::AsIs)
+            || !sockopt.dialer_proxy.trim().is_empty()
+            || sockopt.penetrate
+            || !matches!(sockopt.address_port_strategy, AddressPortStrategy::None)
+            || sockopt.happy_eyeballs != Default::default();
+        if outbound_only {
+            return Err(ConfigError::invalid(format!(
+                "{path}.streamSettings.sockopt 包含仅出站拨号可执行的 domainStrategy/dialerProxy/penetrate/addressPortStrategy/happyEyeballs"
+            )));
+        }
+        if uses_http3
+            && (sockopt.tcp_fast_open.is_some()
+                || sockopt.tcp_keep_alive_interval != 0
+                || sockopt.tcp_keep_alive_idle != 0
+                || !sockopt.tcp_congestion.is_empty()
+                || sockopt.tcp_window_clamp != 0
+                || sockopt.tcp_user_timeout != 0
+                || sockopt.tcp_max_seg != 0
+                || sockopt.tcp_mptcp
+                || sockopt.accept_proxy_protocol)
+        {
+            return Err(ConfigError::invalid(format!(
+                "{path}.streamSettings.sockopt 的 TCP/PROXY 字段不能用于 H3 UDP 监听"
+            )));
+        }
+    }
+
+    if let Some(finalmask) = settings.finalmask.as_ref() {
+        if uses_http3 {
+            if !finalmask.tcp.is_empty() {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.streamSettings.finalmask.tcp 不能用于 H3 UDP 监听"
+                )));
+            }
+            if finalmask
+                .quic_params
+                .as_ref()
+                .is_some_and(|params| match &params.udp_hop.ports {
+                    crate::stream_settings::PortListValue::Empty => false,
+                    crate::stream_settings::PortListValue::Text(value) => !value.trim().is_empty(),
+                    crate::stream_settings::PortListValue::Number(_) => true,
+                })
+            {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.streamSettings.finalmask.quicParams.udpHop 只改变客户端目标端口，不能在服务端监听中执行"
+                )));
+            }
+        } else if !finalmask.udp.is_empty() || finalmask.quic_params.is_some() {
+            return Err(ConfigError::invalid(format!(
+                "{path}.streamSettings 的 UDP finalmask/quicParams 不能用于 TCP XHTTP 监听"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn apply_stream_settings(
+    node: &mut ParsedNode,
+    node_name: &str,
+    stream: Option<&crate::stream_settings::NodeStreamSettings>,
+) -> ConfigResult<()> {
+    if let Some(stream) = stream {
+        if let Some(network) = stream.network.as_deref() {
+            node.transport = match network.to_ascii_lowercase().as_str() {
+                "raw" | "tcp" => "tcp".to_string(),
+                other => other.to_string(),
+            };
+        }
+        validate_stream_settings(node_name, stream)?;
+        node.stream_settings = Some(stream.clone());
+    }
+    Ok(())
+}
+
+fn validate_stream_settings(
+    node_name: &str,
+    stream: &crate::stream_settings::NodeStreamSettings,
+) -> ConfigResult<()> {
+    use crate::stream_settings::{TcpMaskConfig, UdpMaskConfig};
+
+    if let Some(sockopt) = &stream.sockopt {
+        for (index, name) in sockopt.trusted_x_forwarded_for.iter().enumerate() {
+            http::HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+                ConfigError::bad_node(format!(
+                    "node {node_name} trustedXForwardedFor[{index}] 不是合法 HTTP 请求头名称：{error}"
+                ))
+            })?;
+        }
+        if sockopt
+            .tcp_keep_alive_idle
+            .saturating_mul(sockopt.tcp_keep_alive_interval)
+            < 0
+        {
+            return Err(ConfigError::bad_node(format!(
+                "node {node_name} tcpKeepAliveIdle 与 tcpKeepAliveInterval 必须同时启用或同时禁用"
+            )));
+        }
+        for custom in &sockopt.custom_sockopt {
+            if custom.opt.is_empty() {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} customSockopt.opt 不能为空"
+                )));
+            }
+            if !matches!(custom.value_type.as_str(), "int" | "str") {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} customSockopt.type 仅支持 int 或 str"
+                )));
+            }
+            #[cfg(target_os = "windows")]
+            if custom.value_type == "str"
+                && (custom.system.is_empty() || custom.system.eq_ignore_ascii_case("windows"))
+            {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} 在 Windows 上不支持字符串 customSockopt；配置不会被静默忽略"
+                )));
+            }
+        }
+
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "windows",
+            target_os = "macos",
+            target_os = "ios"
+        )))]
+        if !sockopt.interface.is_empty() {
+            return Err(ConfigError::bad_node(format!(
+                "node {node_name} 在当前平台不支持 sockopt.interface；配置不会被静默忽略"
+            )));
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
+        if sockopt.mark != 0 {
+            return Err(ConfigError::bad_node(format!(
+                "node {node_name} 在当前平台不支持 sockopt.mark；配置不会被静默忽略"
+            )));
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        if sockopt.tcp_mptcp {
+            return Err(ConfigError::bad_node(format!(
+                "node {node_name} 在当前平台不支持 tcpMptcp；配置不会被静默忽略"
+            )));
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        if sockopt.tcp_window_clamp > 0
+            || sockopt.tcp_user_timeout > 0
+            || sockopt.tcp_max_seg > 0
+            || !sockopt.tcp_congestion.is_empty()
+        {
+            return Err(ConfigError::bad_node(format!(
+                "node {node_name} 配置了当前平台不支持的 Linux TCP 选项（congestion/window/user-timeout/MSS）"
+            )));
+        }
+    }
+
+    if let Some(finalmask) = &stream.finalmask {
+        for mask in &finalmask.tcp {
+            match mask {
+                TcpMaskConfig::Fragment(cfg) => {
+                    let packets = cfg.packets.trim();
+                    if !packets.is_empty() && !packets.eq_ignore_ascii_case("tlshello") {
+                        let valid = packets
+                            .parse::<i64>()
+                            .ok()
+                            .map(|value| value != 0)
+                            .unwrap_or_else(|| {
+                                packets
+                                    .split_once('-')
+                                    .and_then(|(from, to)| {
+                                        Some((
+                                            from.trim().parse::<i64>().ok()?,
+                                            to.trim().parse::<i64>().ok()?,
+                                        ))
+                                    })
+                                    .is_some_and(|(from, _)| from != 0)
+                            });
+                        if !valid {
+                            return Err(ConfigError::bad_node(format!(
+                                "node {node_name} fragment.packets 必须是 tlshello、非零整数或整数范围"
+                            )));
+                        }
+                    }
+                    let lengths = if cfg.lengths.is_empty() {
+                        std::slice::from_ref(&cfg.length)
+                    } else {
+                        cfg.lengths.as_slice()
+                    };
+                    if lengths.last().is_none_or(|range| range.from == 0) {
+                        return Err(ConfigError::bad_node(format!(
+                            "node {node_name} fragment 最后一个 lengths 项的最小值不能为 0"
+                        )));
+                    }
+                }
+                TcpMaskConfig::Xmc(cfg) if cfg.password.is_empty() => {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {node_name} xmc.password 不能为空"
+                    )));
+                }
+                _ => {}
+            }
+        }
+        for mask in &finalmask.udp {
+            if let UdpMaskConfig::Xdns(cfg) = mask {
+                if cfg.domain.is_some() {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {node_name} finalmask.xdns.domain 已被 Xray 26.7.11 移除；请分别使用 domains（服务端）和 resolvers（客户端）"
+                    )));
+                }
+                if cfg.domains.is_empty() && cfg.resolvers.is_empty() {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {node_name} xdns.domains 与 resolvers 不能同时为空"
+                    )));
+                }
+                if let Some(resolver) = cfg
+                    .resolvers
+                    .iter()
+                    .find(|resolver| !resolver.contains("+udp://"))
+                {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {node_name} xdns resolver `{resolver}` 缺少 +udp://"
+                    )));
+                }
+            }
+        }
+        if let Some(quic) = &finalmask.quic_params {
+            let profile = quic.bbr_profile.to_ascii_lowercase();
+            if !matches!(
+                profile.as_str(),
+                "" | "conservative" | "standard" | "aggressive"
+            ) {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} quicParams.bbrProfile 非法"
+                )));
+            }
+            let congestion = quic.congestion.to_ascii_lowercase();
+            if !matches!(
+                congestion.as_str(),
+                "" | "brutal" | "force-brutal" | "reno" | "bbr"
+            ) {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} quicParams.congestion 非法"
+                )));
+            }
+            for (field, value) in [
+                ("initStreamReceiveWindow", quic.init_stream_receive_window),
+                ("maxStreamReceiveWindow", quic.max_stream_receive_window),
+                (
+                    "initConnectionReceiveWindow",
+                    quic.init_connection_receive_window,
+                ),
+                (
+                    "maxConnectionReceiveWindow",
+                    quic.max_connection_receive_window,
+                ),
+            ] {
+                if value > 0 && value < 16_384 {
+                    return Err(ConfigError::bad_node(format!(
+                        "node {node_name} quicParams.{field} 至少为 16384"
+                    )));
+                }
+            }
+            if quic.max_idle_timeout != 0 && !(4..=120).contains(&quic.max_idle_timeout) {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} quicParams.maxIdleTimeout 必须在 4..=120"
+                )));
+            }
+            if quic.keep_alive_period != 0 && !(2..=60).contains(&quic.keep_alive_period) {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} quicParams.keepAlivePeriod 必须在 2..=60"
+                )));
+            }
+            if quic.max_incoming_streams != 0 && quic.max_incoming_streams < 8 {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} quicParams.maxIncomingStreams 至少为 8"
+                )));
+            }
+            if (quic.udp_hop.interval.from != 0 && quic.udp_hop.interval.from < 5)
+                || (quic.udp_hop.interval.to != 0 && quic.udp_hop.interval.to < 5)
+            {
+                return Err(ConfigError::bad_node(format!(
+                    "node {node_name} quicParams.udpHop.interval 的非零值至少为 5"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn compile_groups(
@@ -3265,6 +3698,39 @@ limits:
     }
 
     #[test]
+    fn reality_listener_stream_settings_are_preserved_and_fail_closed() {
+        let mut source = valid_reality_listener();
+        source.stream_settings = Some(
+            serde_json::from_value(serde_json::json!({
+                "network": "raw",
+                "sockopt": {"acceptProxyProtocol": true},
+                "finalmask": {
+                    "tcp": [{"type": "sudoku", "settings": {"password": "secret"}}]
+                }
+            }))
+            .unwrap(),
+        );
+        let normalized = compile_reality_listeners(&[source.clone()])
+            .unwrap()
+            .remove(0);
+        let settings = normalized.stream_settings.expect("REALITY streamSettings");
+        assert!(settings.sockopt.unwrap().accept_proxy_protocol);
+        assert!(matches!(
+            &settings.finalmask.unwrap().tcp[..],
+            [crate::stream_settings::TcpMaskConfig::Sudoku(_)]
+        ));
+
+        source.stream_settings = Some(
+            serde_json::from_value(serde_json::json!({
+                "network": "raw",
+                "finalmask": {"udp": [{"type": "noise"}]}
+            }))
+            .unwrap(),
+        );
+        assert!(compile_reality_listeners(&[source]).is_err());
+    }
+
+    #[test]
     fn reality_server_snake_aliases_work_and_unknown_fields_fail() {
         let source: RealityListen = serde_yaml::from_str(&format!(
             r#"
@@ -3711,6 +4177,84 @@ listen:
             Some("certs/server.pem")
         );
         assert_eq!(h3.socket_addr().unwrap(), "[::]:8443".parse().unwrap());
+    }
+
+    #[test]
+    fn xhttp_listener_stream_settings_cover_tcp_h3_and_trusted_xff() {
+        let plan = compile_cfg(
+            r#"
+version: 1
+profile: server
+listen:
+  xhttp:
+    - enabled: false
+      address: 127.0.0.1
+      port: 8080
+      streamSettings:
+        network: xhttp
+        sockopt:
+          acceptProxyProtocol: true
+          trustedXForwardedFor: [X-Trusted-CDN]
+        finalmask:
+          tcp:
+            - type: sudoku
+              settings: {password: tcp-secret}
+    - enabled: false
+      address: "::1"
+      port: 8443
+      tls: {cert: cert.pem, key: key.pem}
+      alpn: [h3]
+      streamSettings:
+        network: splithttp
+        finalmask:
+          udp:
+            - type: salamander
+              settings: {password: udp-secret}
+          quicParams:
+            congestion: reno
+            maxIncomingStreams: 32
+"#,
+        );
+        let tcp = plan.listen.xhttp[0]
+            .stream_settings
+            .as_ref()
+            .expect("TCP listener streamSettings");
+        assert_eq!(
+            tcp.sockopt.as_ref().unwrap().trusted_x_forwarded_for,
+            ["X-Trusted-CDN"]
+        );
+        assert!(matches!(
+            &tcp.finalmask.as_ref().unwrap().tcp[..],
+            [crate::stream_settings::TcpMaskConfig::Sudoku(_)]
+        ));
+
+        let h3 = plan.listen.xhttp[1]
+            .stream_settings
+            .as_ref()
+            .expect("H3 listener streamSettings");
+        assert!(matches!(
+            &h3.finalmask.as_ref().unwrap().udp[..],
+            [crate::stream_settings::UdpMaskConfig::Salamander(_)]
+        ));
+        assert_eq!(
+            h3.finalmask
+                .as_ref()
+                .unwrap()
+                .quic_params
+                .as_ref()
+                .unwrap()
+                .max_incoming_streams,
+            32
+        );
+
+        let mut invalid = plan.listen.xhttp[0].stream_settings.clone().unwrap();
+        invalid.finalmask.as_mut().unwrap().udp =
+            vec![serde_json::from_value(serde_json::json!({"type": "noise"})).unwrap()];
+        assert!(validate_xhttp_listener_stream_settings(Some(&invalid), false, "test").is_err());
+
+        invalid.finalmask.as_mut().unwrap().udp.clear();
+        invalid.sockopt.as_mut().unwrap().trusted_x_forwarded_for = vec!["bad header".into()];
+        assert!(validate_xhttp_listener_stream_settings(Some(&invalid), false, "test").is_err());
     }
 
     #[test]
@@ -4931,5 +5475,47 @@ route: {preset: direct}
         apply_defaults(&mut config);
         let error = compile(config).unwrap_err().to_string();
         assert!(error.contains("不能分配给多个对端"), "error = {error}");
+    }
+
+    #[test]
+    fn link_node_keeps_structured_stream_settings() {
+        let detail: NodeDetail = serde_json::from_str(
+            r#"{
+                "name":"linked",
+                "link":"ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@1.2.3.4:8388#ignored",
+                "streamSettings":{"network":"raw","sockopt":{"domainStrategy":"UseIPv4"}}
+            }"#,
+        )
+        .unwrap();
+        let node = detail_to_parsed(&detail).unwrap();
+        assert_eq!(node.name, "linked");
+        assert_eq!(node.transport, "tcp");
+        assert_eq!(
+            node.stream_settings
+                .unwrap()
+                .sockopt
+                .unwrap()
+                .domain_strategy,
+            crate::stream_settings::DomainStrategy::UseIpv4
+        );
+    }
+
+    #[test]
+    fn dialer_proxy_cycle_is_rejected_before_registry_build() {
+        let make = |name: &str, proxy: &str| {
+            let mut node = ParsedNode::new(name, NodeProtocol::Direct, "127.0.0.1", 1);
+            node.stream_settings = Some(crate::stream_settings::NodeStreamSettings {
+                sockopt: Some(crate::stream_settings::OutboundSocketConfig {
+                    dialer_proxy: proxy.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            node
+        };
+        let error = validate_dialer_proxy_graph(&[make("a", "b"), make("b", "a")])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("循环链"), "error={error}");
     }
 }

--- a/crates/core-config/src/stream_settings.rs
+++ b/crates/core-config/src/stream_settings.rs
@@ -1,0 +1,874 @@
+//! Xray-compatible stream socket policy and final-mask configuration.
+//!
+//! Field names and defaults in this module are pinned to Xray-core 26.7.11
+//! (`6e3322d219140a025285ded1114fe17a5edb74d8`). Keeping the wire-facing
+//! configuration typed here prevents an accepted setting from being silently
+//! discarded by the outbound runtime.
+
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use crate::model::XhttpDownloadTlsSettings;
+
+/// `streamSettings` on an outbound node.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct NodeStreamSettings {
+    /// Xray names raw TCP `tcp`; `raw` is accepted by the higher-level model.
+    pub network: Option<String>,
+    pub sockopt: Option<OutboundSocketConfig>,
+    pub finalmask: Option<FinalMaskConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct OutboundSocketConfig {
+    pub mark: i32,
+    pub tcp_fast_open: Option<BoolOrI32>,
+    /// Inbound-only in Xray. Registered so an imported Xray object is not
+    /// rejected; it is deliberately ignored for outbound sockets.
+    pub tproxy: Option<String>,
+    /// Inbound-only in Xray.
+    pub accept_proxy_protocol: bool,
+    pub domain_strategy: DomainStrategy,
+    pub dialer_proxy: String,
+    pub tcp_keep_alive_interval: i32,
+    pub tcp_keep_alive_idle: i32,
+    pub tcp_congestion: String,
+    pub interface: String,
+    /// Inbound listener-only in Xray.
+    pub v6only: bool,
+    pub tcp_window_clamp: i32,
+    pub tcp_user_timeout: i32,
+    pub tcp_max_seg: i32,
+    /// Freedom/inbound metadata option, not a socket dial option.
+    pub penetrate: bool,
+    pub tcp_mptcp: bool,
+    #[serde(rename = "customSockopt")]
+    pub custom_sockopt: Vec<CustomSockoptConfig>,
+    pub address_port_strategy: AddressPortStrategy,
+    pub happy_eyeballs: HappyEyeballsConfig,
+    /// HTTP/gRPC inbound-only in Xray.
+    pub trusted_x_forwarded_for: Vec<String>,
+}
+
+impl OutboundSocketConfig {
+    /// Xray's protobuf TFO value: omitted/0 means do not call setsockopt,
+    /// `false` means explicitly disable (-1), `true` means queue 256.
+    pub fn tfo_value(&self) -> i32 {
+        match self.tcp_fast_open {
+            None | Some(BoolOrI32::Int(0)) => 0,
+            Some(BoolOrI32::Bool(true)) => 256,
+            Some(BoolOrI32::Bool(false)) => -1,
+            Some(BoolOrI32::Int(v)) => v,
+        }
+    }
+
+    pub fn is_effectively_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum BoolOrI32 {
+    Bool(bool),
+    Int(i32),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct CustomSockoptConfig {
+    /// Xray 26.7.11 accidentally spells this field `Syetem` internally but the
+    /// JSON spelling remains `system`.
+    pub system: String,
+    pub network: String,
+    pub level: String,
+    pub opt: String,
+    pub value: String,
+    #[serde(rename = "type")]
+    pub value_type: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+pub enum DomainStrategy {
+    #[default]
+    #[serde(rename = "AsIs", alias = "asis", alias = "")]
+    AsIs,
+    #[serde(rename = "UseIP", alias = "useip")]
+    UseIp,
+    #[serde(rename = "UseIPv4", alias = "useipv4")]
+    UseIpv4,
+    #[serde(rename = "UseIPv6", alias = "useipv6")]
+    UseIpv6,
+    #[serde(rename = "UseIPv4v6", alias = "useipv4v6")]
+    UseIpv4v6,
+    #[serde(rename = "UseIPv6v4", alias = "useipv6v4")]
+    UseIpv6v4,
+    #[serde(rename = "ForceIP", alias = "forceip")]
+    ForceIp,
+    #[serde(rename = "ForceIPv4", alias = "forceipv4")]
+    ForceIpv4,
+    #[serde(rename = "ForceIPv6", alias = "forceipv6")]
+    ForceIpv6,
+    #[serde(rename = "ForceIPv4v6", alias = "forceipv4v6")]
+    ForceIpv4v6,
+    #[serde(rename = "ForceIPv6v4", alias = "forceipv6v4")]
+    ForceIpv6v4,
+}
+
+impl<'de> Deserialize<'de> for DomainStrategy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.to_ascii_lowercase().as_str() {
+            "" | "asis" => Ok(Self::AsIs),
+            "useip" => Ok(Self::UseIp),
+            "useipv4" => Ok(Self::UseIpv4),
+            "useipv6" => Ok(Self::UseIpv6),
+            "useipv4v6" => Ok(Self::UseIpv4v6),
+            "useipv6v4" => Ok(Self::UseIpv6v4),
+            "forceip" => Ok(Self::ForceIp),
+            "forceipv4" => Ok(Self::ForceIpv4),
+            "forceipv6" => Ok(Self::ForceIpv6),
+            "forceipv4v6" => Ok(Self::ForceIpv4v6),
+            "forceipv6v4" => Ok(Self::ForceIpv6v4),
+            _ => Err(de::Error::custom(format!(
+                "unsupported domain strategy `{value}`"
+            ))),
+        }
+    }
+}
+
+impl DomainStrategy {
+    pub fn force(self) -> bool {
+        matches!(
+            self,
+            Self::ForceIp
+                | Self::ForceIpv4
+                | Self::ForceIpv6
+                | Self::ForceIpv4v6
+                | Self::ForceIpv6v4
+        )
+    }
+
+    pub fn use_ip(self) -> bool {
+        !matches!(self, Self::AsIs)
+    }
+
+    pub fn prefer_ipv6(self) -> bool {
+        matches!(
+            self,
+            Self::UseIpv6 | Self::UseIpv6v4 | Self::ForceIpv6 | Self::ForceIpv6v4
+        )
+    }
+
+    pub fn allow_ipv4(self) -> bool {
+        !matches!(self, Self::UseIpv6 | Self::ForceIpv6)
+    }
+
+    pub fn allow_ipv6(self) -> bool {
+        !matches!(self, Self::UseIpv4 | Self::ForceIpv4)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+pub enum AddressPortStrategy {
+    #[default]
+    #[serde(rename = "none", alias = "None", alias = "")]
+    None,
+    #[serde(rename = "srvPortOnly", alias = "SrvPortOnly", alias = "srvportonly")]
+    SrvPortOnly,
+    #[serde(
+        rename = "srvAddressOnly",
+        alias = "SrvAddressOnly",
+        alias = "srvaddressonly"
+    )]
+    SrvAddressOnly,
+    #[serde(
+        rename = "srvPortAndAddress",
+        alias = "SrvPortAndAddress",
+        alias = "srvportandaddress"
+    )]
+    SrvPortAndAddress,
+    #[serde(rename = "txtPortOnly", alias = "TxtPortOnly", alias = "txtportonly")]
+    TxtPortOnly,
+    #[serde(
+        rename = "txtAddressOnly",
+        alias = "TxtAddressOnly",
+        alias = "txtaddressonly"
+    )]
+    TxtAddressOnly,
+    #[serde(
+        rename = "txtPortAndAddress",
+        alias = "TxtPortAndAddress",
+        alias = "txtportandaddress"
+    )]
+    TxtPortAndAddress,
+}
+
+impl<'de> Deserialize<'de> for AddressPortStrategy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        match value.to_ascii_lowercase().as_str() {
+            "" | "none" => Ok(Self::None),
+            "srvportonly" => Ok(Self::SrvPortOnly),
+            "srvaddressonly" => Ok(Self::SrvAddressOnly),
+            "srvportandaddress" => Ok(Self::SrvPortAndAddress),
+            "txtportonly" => Ok(Self::TxtPortOnly),
+            "txtaddressonly" => Ok(Self::TxtAddressOnly),
+            "txtportandaddress" => Ok(Self::TxtPortAndAddress),
+            _ => Err(de::Error::custom(format!(
+                "unsupported address and port strategy `{value}`"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct HappyEyeballsConfig {
+    #[serde(rename = "prioritizeIPv6")]
+    pub prioritize_ipv6: bool,
+    pub interleave: u32,
+    pub try_delay_ms: u64,
+    pub max_concurrent_try: u32,
+}
+
+impl Default for HappyEyeballsConfig {
+    fn default() -> Self {
+        Self {
+            prioritize_ipv6: false,
+            interleave: 1,
+            try_delay_ms: 0,
+            max_concurrent_try: 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct FinalMaskConfig {
+    pub tcp: Vec<TcpMaskConfig>,
+    pub udp: Vec<UdpMaskConfig>,
+    pub quic_params: Option<QuicParamsConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "type", content = "settings")]
+pub enum TcpMaskConfig {
+    #[serde(rename = "header-custom")]
+    HeaderCustom(HeaderCustomTcpConfig),
+    #[serde(rename = "fragment")]
+    Fragment(FragmentMaskConfig),
+    #[serde(rename = "sudoku")]
+    Sudoku(SudokuMaskConfig),
+    #[serde(rename = "xmc")]
+    Xmc(XmcMaskConfig),
+}
+
+impl<'de> Deserialize<'de> for TcpMaskConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = MaskEnvelope::deserialize(deserializer)?;
+        let settings = raw.settings.unwrap_or_else(empty_settings);
+        match raw.kind.as_str() {
+            "header-custom" => decode_mask(settings).map(Self::HeaderCustom),
+            "fragment" => decode_mask(settings).map(Self::Fragment),
+            "sudoku" => decode_mask(settings).map(Self::Sudoku),
+            "xmc" => decode_mask(settings).map(Self::Xmc),
+            kind => Err(de::Error::custom(format!(
+                "unknown TCP finalmask type `{kind}`"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "type", content = "settings")]
+pub enum UdpMaskConfig {
+    #[serde(rename = "header-custom")]
+    HeaderCustom(HeaderCustomUdpConfig),
+    #[serde(rename = "mkcp-legacy")]
+    MkcpLegacy(MkcpLegacyMaskConfig),
+    #[serde(rename = "noise")]
+    Noise(NoiseMaskConfig),
+    #[serde(rename = "salamander")]
+    Salamander(SalamanderMaskConfig),
+    #[serde(rename = "sudoku")]
+    Sudoku(SudokuMaskConfig),
+    #[serde(rename = "xdns")]
+    Xdns(XdnsMaskConfig),
+    #[serde(rename = "xicmp")]
+    Xicmp(XicmpMaskConfig),
+    #[serde(rename = "realm")]
+    Realm(RealmMaskConfig),
+}
+
+impl<'de> Deserialize<'de> for UdpMaskConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = MaskEnvelope::deserialize(deserializer)?;
+        let settings = raw.settings.unwrap_or_else(empty_settings);
+        match raw.kind.as_str() {
+            "header-custom" => decode_mask(settings).map(Self::HeaderCustom),
+            "mkcp-legacy" => decode_mask(settings).map(Self::MkcpLegacy),
+            "noise" => decode_mask(settings).map(Self::Noise),
+            "salamander" => decode_mask(settings).map(Self::Salamander),
+            "sudoku" => decode_mask(settings).map(Self::Sudoku),
+            "xdns" => decode_mask(settings).map(Self::Xdns),
+            "xicmp" => decode_mask(settings).map(Self::Xicmp),
+            "realm" => decode_mask(settings).map(Self::Realm),
+            kind => Err(de::Error::custom(format!(
+                "unknown UDP finalmask type `{kind}`"
+            ))),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MaskEnvelope {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    settings: Option<serde_json::Value>,
+}
+
+fn empty_settings() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+fn decode_mask<E, T>(settings: serde_json::Value) -> Result<T, E>
+where
+    E: de::Error,
+    T: serde::de::DeserializeOwned,
+{
+    serde_json::from_value(settings).map_err(E::custom)
+}
+
+/// Xray integer range: either `7` or a string such as `"3-9"`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct I32Range {
+    pub left: i32,
+    pub right: i32,
+    pub from: i32,
+    pub to: i32,
+}
+
+impl I32Range {
+    pub const fn fixed(value: i32) -> Self {
+        Self {
+            left: value,
+            right: value,
+            from: value,
+            to: value,
+        }
+    }
+
+    pub fn new(left: i32, right: i32) -> Self {
+        Self {
+            left,
+            right,
+            from: left.min(right),
+            to: left.max(right),
+        }
+    }
+}
+
+impl Serialize for I32Range {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.left == self.right {
+            serializer.serialize_i32(self.left)
+        } else {
+            serializer.serialize_str(&format!("{}-{}", self.left, self.right))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for I32Range {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = I32Range;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("an integer or an integer range like 1-5")
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let value = i32::try_from(value).map_err(E::custom)?;
+                Ok(I32Range::fixed(value))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let value = i32::try_from(value).map_err(E::custom)?;
+                Ok(I32Range::fixed(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                parse_i32_range(value).map_err(E::custom)
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+fn parse_i32_range(value: &str) -> Result<I32Range, String> {
+    let value = value.trim();
+    if let Ok(single) = i32::from_str(value) {
+        return Ok(I32Range::fixed(single));
+    }
+    // A range separator is the first '-' after the optional sign of `left`.
+    let start = usize::from(value.starts_with('-'));
+    let separator = value[start..]
+        .find('-')
+        .map(|offset| start + offset)
+        .ok_or_else(|| format!("invalid integer range `{value}`"))?;
+    let left = value[..separator]
+        .parse::<i32>()
+        .map_err(|_| format!("invalid range start `{value}`"))?;
+    let right = value[separator + 1..]
+        .parse::<i32>()
+        .map_err(|_| format!("invalid range end `{value}`"))?;
+    Ok(I32Range::new(left, right))
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct FragmentMaskConfig {
+    pub packets: String,
+    pub length: I32Range,
+    pub delay: I32Range,
+    pub lengths: Vec<I32Range>,
+    pub delays: Vec<I32Range>,
+    pub max_split: I32Range,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct HeaderCustomTcpConfig {
+    pub clients: Vec<Vec<HeaderCustomTcpItem>>,
+    pub servers: Vec<Vec<HeaderCustomTcpItem>>,
+    pub errors: Vec<Vec<HeaderCustomTcpItem>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct HeaderCustomTcpItem {
+    pub delay: I32Range,
+    pub rand: i32,
+    pub rand_range: Option<I32Range>,
+    pub capture: String,
+    #[serde(rename = "type")]
+    pub packet_type: String,
+    pub reuse: String,
+    pub transform: Option<CustomTransform>,
+    pub packet: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct HeaderCustomUdpConfig {
+    pub mode: String,
+    pub client: Vec<HeaderCustomUdpItem>,
+    pub server: Vec<HeaderCustomUdpItem>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct HeaderCustomUdpItem {
+    pub rand: i32,
+    pub rand_range: Option<I32Range>,
+    pub capture: String,
+    #[serde(rename = "type")]
+    pub packet_type: String,
+    pub reuse: String,
+    pub transform: Option<CustomTransform>,
+    pub packet: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct CustomTransform {
+    pub op: String,
+    pub args: Vec<CustomTransformArg>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct CustomTransformArg {
+    #[serde(rename = "type")]
+    pub bytes_type: String,
+    pub bytes: Option<serde_json::Value>,
+    pub u64: Option<u64>,
+    pub reuse: String,
+    pub metadata: String,
+    pub transform: Option<Box<CustomTransform>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct SudokuMaskConfig {
+    pub password: String,
+    pub ascii: String,
+    pub custom_table: String,
+    #[serde(rename = "custom_table")]
+    pub legacy_custom_table: String,
+    pub custom_tables: Vec<String>,
+    #[serde(rename = "custom_tables")]
+    pub legacy_custom_sets: Vec<String>,
+    pub padding_min: u32,
+    #[serde(rename = "padding_min")]
+    pub legacy_padding_min: u32,
+    pub padding_max: u32,
+    #[serde(rename = "padding_max")]
+    pub legacy_padding_max: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct XmcMaskConfig {
+    pub hostname: String,
+    pub usernames: Vec<String>,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct NoiseMaskConfig {
+    pub reset: I32Range,
+    pub noise: Vec<NoiseItemConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct NoiseItemConfig {
+    pub rand: I32Range,
+    pub rand_range: Option<I32Range>,
+    #[serde(rename = "type")]
+    pub packet_type: String,
+    pub packet: Option<serde_json::Value>,
+    pub delay: I32Range,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct MkcpLegacyMaskConfig {
+    pub header: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct SalamanderMaskConfig {
+    pub password: String,
+    pub packet_size: I32Range,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct XdnsMaskConfig {
+    /// Removed by Xray 26.7.11. Kept only so validation can emit the precise
+    /// migration error instead of treating it as an unknown field.
+    pub domain: Option<serde_json::Value>,
+    pub domains: Vec<String>,
+    pub resolvers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct XicmpMaskConfig {
+    #[serde(rename = "dgram")]
+    pub dgram: bool,
+    pub ips: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct RealmMaskConfig {
+    pub url: String,
+    pub stun_servers: Vec<String>,
+    /// Complete Xray TLS object shared with XHTTP/downloadSettings. Realm uses
+    /// the same validated executor, so advanced fields (certificates, pins,
+    /// versions, curves, uTLS fingerprints and ECH) cannot diverge or be lost.
+    pub tls_config: Option<XhttpDownloadTlsSettings>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct QuicParamsConfig {
+    pub congestion: String,
+    pub debug: bool,
+    pub bbr_profile: String,
+    pub brutal_up: BandwidthValue,
+    pub brutal_down: BandwidthValue,
+    pub udp_hop: UdpHopConfig,
+    pub init_stream_receive_window: u64,
+    pub max_stream_receive_window: u64,
+    pub init_connection_receive_window: u64,
+    pub max_connection_receive_window: u64,
+    pub max_idle_timeout: i64,
+    pub keep_alive_period: i64,
+    #[serde(rename = "disablePathMTUDiscovery")]
+    pub disable_path_mtu_discovery: bool,
+    pub max_incoming_streams: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, deny_unknown_fields, rename_all = "camelCase")]
+pub struct UdpHopConfig {
+    pub ports: PortListValue,
+    pub interval: I32Range,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum PortListValue {
+    #[default]
+    Empty,
+    Number(u32),
+    Text(String),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum BandwidthValue {
+    #[default]
+    Empty,
+    Number(u64),
+    Text(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xray_range_accepts_signed_and_reversed_values() {
+        let a: I32Range = serde_json::from_str("\"-1919--810\"").unwrap();
+        assert_eq!((a.left, a.right, a.from, a.to), (-1919, -810, -1919, -810));
+        let b: I32Range = serde_json::from_str("\"9-3\"").unwrap();
+        assert_eq!((b.left, b.right, b.from, b.to), (9, 3, 3, 9));
+        let c: I32Range = serde_json::from_str("-7").unwrap();
+        assert_eq!(c, I32Range::fixed(-7));
+    }
+
+    #[test]
+    fn sockopt_defaults_match_xray_26_7_11() {
+        let cfg: OutboundSocketConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.domain_strategy, DomainStrategy::AsIs);
+        assert_eq!(cfg.tfo_value(), 0);
+        assert_eq!(cfg.happy_eyeballs.interleave, 1);
+        assert_eq!(cfg.happy_eyeballs.try_delay_ms, 0);
+        assert_eq!(cfg.happy_eyeballs.max_concurrent_try, 4);
+    }
+
+    #[test]
+    fn tfo_bool_and_integer_match_xray_mapping() {
+        let yes: OutboundSocketConfig = serde_json::from_str(r#"{"tcpFastOpen":true}"#).unwrap();
+        let no: OutboundSocketConfig = serde_json::from_str(r#"{"tcpFastOpen":false}"#).unwrap();
+        let zero: OutboundSocketConfig = serde_json::from_str(r#"{"tcpFastOpen":0}"#).unwrap();
+        assert_eq!(yes.tfo_value(), 256);
+        assert_eq!(no.tfo_value(), -1);
+        assert_eq!(zero.tfo_value(), 0);
+    }
+
+    #[test]
+    fn xray_strings_are_case_insensitive() {
+        let cfg: OutboundSocketConfig = serde_json::from_str(
+            r#"{"domainStrategy":"FORCEIPv6V4","addressPortStrategy":"TXTPORTANDADDRESS"}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.domain_strategy, DomainStrategy::ForceIpv6v4);
+        assert_eq!(
+            cfg.address_port_strategy,
+            AddressPortStrategy::TxtPortAndAddress
+        );
+    }
+
+    #[test]
+    fn mask_settings_may_be_omitted_like_xray_loader() {
+        let tcp: TcpMaskConfig = serde_json::from_str(r#"{"type":"fragment"}"#).unwrap();
+        assert!(matches!(tcp, TcpMaskConfig::Fragment(_)));
+        let udp: UdpMaskConfig = serde_json::from_str(r#"{"type":"mkcp-legacy"}"#).unwrap();
+        assert!(matches!(udp, UdpMaskConfig::MkcpLegacy(_)));
+    }
+
+    #[test]
+    fn legacy_sudoku_keys_keep_their_official_json_spelling() {
+        let config: SudokuMaskConfig = serde_json::from_str(
+            r#"{"password":"p","custom_table":"xxppvvvv","custom_tables":["ppxxvvvv"],"padding_min":1,"padding_max":2}"#,
+        )
+        .unwrap();
+        assert_eq!(config.legacy_custom_table, "xxppvvvv");
+        assert_eq!(config.legacy_custom_sets, ["ppxxvvvv"]);
+        assert_eq!(config.legacy_padding_min, 1);
+        let encoded = serde_json::to_value(config).unwrap();
+        assert_eq!(encoded["custom_table"], "xxppvvvv");
+        assert!(encoded.get("legacyCustomTable").is_none());
+    }
+
+    #[test]
+    fn complete_stream_shape_registers_socket_tcp_udp_and_quic_fields() {
+        let stream: NodeStreamSettings = serde_json::from_str(
+            r#"{
+                "network":"raw",
+                "sockopt":{
+                    "mark":7,"tcpFastOpen":128,"domainStrategy":"UseIPv6v4",
+                    "dialerProxy":"DIRECT","tcpKeepAliveInterval":20,
+                    "tcpKeepAliveIdle":30,"tcpCongestion":"bbr",
+                    "interface":"Ethernet","tcpWindowClamp":65535,
+                    "tcpUserTimeout":1200,"tcpMaxSeg":1400,"tcpMptcp":true,
+                    "customSockopt":[{"system":"windows","network":"tcp","level":"6","opt":"1","value":"1","type":"int"}],
+                    "addressPortStrategy":"txtPortAndAddress",
+                    "happyEyeballs":{"prioritizeIPv6":true,"interleave":2,"tryDelayMs":250,"maxConcurrentTry":3}
+                },
+                "finalmask":{
+                    "tcp":[
+                        {"type":"header-custom","settings":{"clients":[],"servers":[],"errors":[]}},
+                        {"type":"fragment","settings":{"packets":"tlshello","length":"2-5","delay":"0-1","maxSplit":3}},
+                        {"type":"sudoku","settings":{"password":"p"}},
+                        {"type":"xmc","settings":{"hostname":"mc.example","usernames":["Dream"],"password":"p"}}
+                    ],
+                    "udp":[
+                        {"type":"header-custom","settings":{"mode":"prefix"}},
+                        {"type":"mkcp-legacy"},{"type":"noise"},
+                        {"type":"salamander","settings":{"password":"p","packetSize":"1200-1400"}},
+                        {"type":"sudoku","settings":{"password":"p"}},
+                        {"type":"xdns","settings":{"resolvers":["8.8.8.8+udp://example.com:53"]}},
+                        {"type":"xicmp","settings":{"dgram":true,"ips":["192.0.2.1"]}},
+                        {"type":"realm","settings":{"url":"realm://token@example.com/id","stunServers":["stun.example:3478"]}}
+                    ],
+                    "quicParams":{"congestion":"bbr","bbrProfile":"standard","brutalUp":"10 mbps","udpHop":{"ports":"2000-3000","interval":"5-10"},"maxIdleTimeout":30,"keepAlivePeriod":10,"disablePathMTUDiscovery":true,"maxIncomingStreams":16}
+                }
+            }"#,
+        )
+        .unwrap();
+        let socket = stream.sockopt.unwrap();
+        assert_eq!(socket.tfo_value(), 128);
+        assert_eq!(socket.happy_eyeballs.max_concurrent_try, 3);
+        let finalmask = stream.finalmask.unwrap();
+        assert_eq!(finalmask.tcp.len(), 4);
+        assert_eq!(finalmask.udp.len(), 8);
+        assert_eq!(
+            finalmask.quic_params.unwrap().udp_hop.ports,
+            PortListValue::Text("2000-3000".into())
+        );
+    }
+
+    #[test]
+    fn listener_stream_settings_are_compiled_into_runtime_plan() {
+        let plan = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: desktop
+name: inbound-finalmask
+listen:
+  local:
+    host: 127.0.0.1
+    port: 7890
+    streamSettings:
+      network: raw
+      sockopt:
+        acceptProxyProtocol: true
+        trustedXForwardedFor: [X-Trusted-CDN]
+      finalmask:
+        tcp:
+          - type: sudoku
+            settings: { password: inbound-secret }
+route:
+  preset: direct
+"#,
+        )
+        .unwrap();
+        let settings = plan
+            .listen
+            .mixed
+            .unwrap()
+            .stream_settings
+            .expect("listener streamSettings");
+        assert!(settings.sockopt.unwrap().accept_proxy_protocol);
+        assert!(matches!(
+            &settings.finalmask.unwrap().tcp[..],
+            [TcpMaskConfig::Sudoku(_)]
+        ));
+    }
+
+    #[test]
+    fn unknown_nested_stream_field_is_rejected() {
+        let error = serde_json::from_str::<NodeStreamSettings>(
+            r#"{"sockopt":{"domainStrategy":"AsIs","silentlyIgnored":true}}"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("silentlyIgnored"));
+    }
+
+    #[test]
+    fn realm_tls_object_is_complete_strongly_typed_and_strict() {
+        let mask: UdpMaskConfig = serde_json::from_str(
+            r#"{
+                "type":"realm",
+                "settings":{
+                    "url":"realm://token@example.com/id",
+                    "stunServers":["stun.example:3478"],
+                    "tlsConfig":{
+                        "serverName":"control.example",
+                        "alpn":"h2,http/1.1",
+                        "enableSessionResumption":true,
+                        "minVersion":"1.2",
+                        "maxVersion":"1.3",
+                        "cipherSuites":"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                        "curvePreferences":["x25519","curveP256"],
+                        "pinnedPeerCertSha256":"00:11",
+                        "verifyPeerCertByName":"control.example",
+                        "echConfigList":"https://ech.example/config",
+                        "echSockopt":{"mark":7},
+                        "certificates":[{"certificate":["pem"],"usage":"verify"}]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let UdpMaskConfig::Realm(realm) = mask else {
+            panic!("realm mask");
+        };
+        let tls = realm.tls_config.unwrap();
+        assert_eq!(tls.alpn.unwrap(), ["h2", "http/1.1"]);
+        assert_eq!(tls.curve_preferences.unwrap(), ["x25519", "curveP256"]);
+        assert_eq!(
+            tls.certificates[0].usage,
+            Some(crate::model::XhttpTlsCertificateUsage::Verify)
+        );
+        assert_eq!(tls.ech_socket_settings.unwrap().mark, Some(7));
+
+        let error = serde_json::from_str::<XhttpDownloadTlsSettings>(r#"{"serverNmae":"typo"}"#)
+            .unwrap_err();
+        assert!(error.to_string().contains("serverNmae"));
+    }
+}

--- a/crates/core-inbound/src/listener.rs
+++ b/crates/core-inbound/src/listener.rs
@@ -5,6 +5,7 @@ use std::{
     ops::RangeInclusive,
 };
 
+use core_config::OutboundSocketConfig;
 use core_config::model::Share;
 use tokio::net::TcpListener;
 use tracing::{info, warn};
@@ -36,8 +37,18 @@ pub async fn bind_with_fallback(
     report: &PrivilegeReport,
     fallback_range: Option<RangeInclusive<u16>>,
 ) -> std::io::Result<TcpListener> {
+    bind_with_fallback_settings(desired, report, fallback_range, None).await
+}
+
+/// `bind_with_fallback` plus the typed Xray-compatible listener socket policy.
+pub async fn bind_with_fallback_settings(
+    desired: SocketAddr,
+    report: &PrivilegeReport,
+    fallback_range: Option<RangeInclusive<u16>>,
+    socket_config: Option<&OutboundSocketConfig>,
+) -> std::io::Result<TcpListener> {
     // 1) 直接尝试期望端口
-    match TcpListener::bind(desired).await {
+    match core_outbound::transport::tcp::bind_inbound_listener(desired, socket_config) {
         Ok(l) => return Ok(l),
         Err(e) => {
             let reason = match e.kind() {
@@ -62,7 +73,7 @@ pub async fn bind_with_fallback(
     let range = fallback_range.unwrap_or(9001..=9099);
     for port in range.clone() {
         let alt = SocketAddr::new(desired.ip(), port);
-        if let Ok(l) = TcpListener::bind(alt).await {
+        if let Ok(l) = core_outbound::transport::tcp::bind_inbound_listener(alt, socket_config) {
             info!(
                 target: "inbound::listener",
                 want = %desired,

--- a/crates/core-inbound/src/mixed.rs
+++ b/crates/core-inbound/src/mixed.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use base64::Engine;
+use core_outbound::BoxedStream;
 use core_runtime::{InboundMetadata, ListenerHandler, Runtime};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf},
@@ -69,19 +70,59 @@ pub struct MixedListener {
     pub auth: Option<Vec<core_config::runtime_plan::UserPass>>,
     /// Whether RFC 1928 UDP ASSOCIATE is accepted on the mixed listener.
     pub udp: bool,
+    /// Listener-side socket policy and TCP final masks.
+    pub stream_settings: Option<core_config::NodeStreamSettings>,
 }
 
-async fn bind_mixed_listener(listen: SocketAddr) -> io::Result<TcpListener> {
-    TcpListener::bind(listen).await
+async fn bind_mixed_listener(
+    listen: SocketAddr,
+    socket_config: Option<&core_config::OutboundSocketConfig>,
+) -> io::Result<TcpListener> {
+    core_outbound::transport::tcp::bind_inbound_listener(listen, socket_config)
 }
 
 pub async fn run_mixed(listener: MixedListener, runtime: Arc<Runtime>) -> io::Result<()> {
+    validate_mixed_stream_settings(listener.stream_settings.as_ref())?;
+    let socket_config = listener
+        .stream_settings
+        .as_ref()
+        .and_then(|settings| settings.sockopt.as_ref());
     // Host-resource arbitration reserves this exact address. Falling back to a
     // different port would make the reservation and the live socket diverge.
-    let l = bind_mixed_listener(listener.listen).await?;
+    let l = bind_mixed_listener(listener.listen, socket_config).await?;
     let bound = l.local_addr()?;
     info!(addr = %bound, "mixed inbound listening");
     serve_mixed(l, listener, runtime).await
+}
+
+fn validate_mixed_stream_settings(
+    settings: Option<&core_config::NodeStreamSettings>,
+) -> io::Result<()> {
+    if let Some(network) = settings.and_then(|settings| settings.network.as_deref())
+        && !network.is_empty()
+        && !network.eq_ignore_ascii_case("tcp")
+        && !network.eq_ignore_ascii_case("raw")
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("mixed inbound only supports streamSettings.network=tcp/raw, got `{network}`"),
+        ));
+    }
+    if let Some(finalmask) = settings.and_then(|settings| settings.finalmask.as_ref()) {
+        if !finalmask.udp.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "mixed inbound cannot attach raw UDP final masks to SOCKS5 UDP ASSOCIATE; a protocol UDP listener must call wrap_udp_server",
+            ));
+        }
+        if finalmask.quic_params.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "mixed inbound network=tcp/raw cannot execute finalmask.quicParams",
+            ));
+        }
+    }
+    Ok(())
 }
 
 async fn serve_mixed(
@@ -90,6 +131,7 @@ async fn serve_mixed(
     runtime: Arc<Runtime>,
 ) -> io::Result<()> {
     let auth = listener.auth.map(Arc::new);
+    let stream_settings = listener.stream_settings.map(Arc::new);
     let connection_permits = Arc::new(Semaphore::new(MIXED_MAX_CONNECTIONS));
     let udp_session_permits = Arc::new(Semaphore::new(MIXED_MAX_UDP_TARGET_SESSIONS));
     // JoinSet aborts every in-flight connection when this listener future is
@@ -111,10 +153,21 @@ async fn serve_mixed(
                 let runtime = runtime.clone();
                 let auth = auth.clone();
                 let udp = listener.udp;
+                let stream_settings = stream_settings.clone();
                 let udp_session_permits = udp_session_permits.clone();
                 connections.spawn(async move {
                     let _permit = permit;
-                    if let Err(e) = handle(sock, peer, runtime, auth, udp, udp_session_permits).await {
+                    if let Err(e) = handle(
+                        sock,
+                        peer,
+                        runtime,
+                        auth,
+                        udp,
+                        udp_session_permits,
+                        stream_settings,
+                    )
+                    .await
+                    {
                         debug!(error = %e, peer = %peer, "mixed handle error");
                     }
                 });
@@ -130,14 +183,47 @@ async fn serve_mixed(
 
 async fn handle(
     sock: TcpStream,
-    peer: SocketAddr,
+    mut peer: SocketAddr,
     runtime: Arc<Runtime>,
     auth: Option<Arc<Vec<core_config::runtime_plan::UserPass>>>,
     udp_enabled: bool,
     udp_session_permits: Arc<Semaphore>,
+    stream_settings: Option<Arc<core_config::NodeStreamSettings>>,
 ) -> io::Result<()> {
-    let mut peek = [0u8; 1];
-    let n = timeout(MIXED_PROTOCOL_DETECT_TIMEOUT, sock.peek(&mut peek))
+    let mut local = sock.local_addr()?;
+    let mut stream: BoxedStream = Box::pin(sock);
+    if stream_settings
+        .as_ref()
+        .and_then(|settings| settings.sockopt.as_ref())
+        .is_some_and(|sockopt| sockopt.accept_proxy_protocol)
+    {
+        let endpoints = timeout(
+            MIXED_PROTOCOL_DETECT_TIMEOUT,
+            read_proxy_protocol(&mut stream, peer, local),
+        )
+        .await
+        .map_err(|_| {
+            io::Error::new(io::ErrorKind::TimedOut, "PROXY protocol header timed out")
+        })??;
+        peer = endpoints.0;
+        local = endpoints.1;
+    }
+    if let Some(masks) = stream_settings
+        .as_ref()
+        .and_then(|settings| settings.finalmask.as_ref())
+        .map(|finalmask| finalmask.tcp.as_slice())
+        .filter(|masks| !masks.is_empty())
+    {
+        stream = core_outbound::transport::finalmask::wrap_tcp_server(
+            stream,
+            masks,
+            Some(local),
+            Some(peer),
+        )
+        .await?;
+    }
+    let mut first = [0u8; 1];
+    timeout(MIXED_PROTOCOL_DETECT_TIMEOUT, stream.read_exact(&mut first))
         .await
         .map_err(|_| {
             io::Error::new(
@@ -145,13 +231,12 @@ async fn handle(
                 "mixed protocol detection timed out",
             )
         })??;
-    if n == 0 {
-        return Ok(());
-    }
-    if peek[0] == 0x05 {
+    let stream: BoxedStream = Box::pin(PrefixedStream::new(stream, first[0]));
+    if first[0] == 0x05 {
         handle_socks5(
-            sock,
+            stream,
             peer,
+            local,
             runtime,
             auth.as_deref().map(|v| v.as_slice()),
             udp_enabled,
@@ -159,15 +244,230 @@ async fn handle(
         )
         .await
     } else {
-        handle_http(sock, peer, runtime, auth.as_deref().map(|v| v.as_slice())).await
+        handle_http(
+            stream,
+            peer,
+            local,
+            runtime,
+            auth.as_deref().map(|v| v.as_slice()),
+            stream_settings
+                .as_ref()
+                .and_then(|settings| settings.sockopt.as_ref())
+                .map(|sockopt| sockopt.trusted_x_forwarded_for.as_slice())
+                .unwrap_or_default(),
+        )
+        .await
+    }
+}
+
+/// Replays the protocol discriminator consumed after FinalMask decoding.
+struct PrefixedStream {
+    inner: BoxedStream,
+    prefix: Option<u8>,
+}
+
+impl PrefixedStream {
+    fn new(inner: BoxedStream, prefix: u8) -> Self {
+        Self {
+            inner,
+            prefix: Some(prefix),
+        }
+    }
+}
+
+impl AsyncRead for PrefixedStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if buf.remaining() > 0
+            && let Some(prefix) = this.prefix.take()
+        {
+            buf.put_slice(&[prefix]);
+            return Poll::Ready(Ok(()));
+        }
+        this.inner.as_mut().poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for PrefixedStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.get_mut().inner.as_mut().poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_shutdown(cx)
+    }
+}
+
+const PROXY_V2_SIGNATURE: &[u8; 12] = b"\r\n\r\n\0\r\nQUIT\n";
+const PROXY_V1_MAX_LINE: usize = 108;
+
+/// Consume a required HAProxy PROXY protocol v1/v2 header and return the
+/// logical source and destination endpoints.  LOCAL/UNKNOWN preserve the
+/// kernel endpoints, while TCP4/TCP6 accept and ignore arbitrary v2 TLVs.
+pub(crate) async fn read_proxy_protocol<R>(
+    stream: &mut R,
+    peer: SocketAddr,
+    local: SocketAddr,
+) -> io::Result<(SocketAddr, SocketAddr)>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
+    let mut prefix = [0u8; 6];
+    stream.read_exact(&mut prefix).await?;
+    if &prefix == b"PROXY " {
+        return read_proxy_v1(stream, peer, local).await;
+    }
+    if prefix == PROXY_V2_SIGNATURE[..6] {
+        let mut signature_tail = [0u8; 6];
+        stream.read_exact(&mut signature_tail).await?;
+        if signature_tail != PROXY_V2_SIGNATURE[6..] {
+            return Err(invalid_data("invalid PROXY protocol v2 signature"));
+        }
+        return read_proxy_v2(stream, peer, local).await;
+    }
+    Err(invalid_data("required PROXY protocol header is missing"))
+}
+
+async fn read_proxy_v1<R>(
+    stream: &mut R,
+    peer: SocketAddr,
+    local: SocketAddr,
+) -> io::Result<(SocketAddr, SocketAddr)>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
+    let mut line = b"PROXY ".to_vec();
+    while line.len() < PROXY_V1_MAX_LINE {
+        let byte = stream.read_u8().await?;
+        line.push(byte);
+        if line.ends_with(b"\r\n") {
+            break;
+        }
+    }
+    if !line.ends_with(b"\r\n") {
+        return Err(invalid_data("PROXY protocol v1 header exceeds 108 bytes"));
+    }
+    let text = std::str::from_utf8(&line[6..line.len() - 2])
+        .map_err(|_| invalid_data("PROXY protocol v1 header is not ASCII"))?;
+    let fields = text.split_ascii_whitespace().collect::<Vec<_>>();
+    if fields.first() == Some(&"UNKNOWN") {
+        return Ok((peer, local));
+    }
+    if fields.len() != 5 || !matches!(fields[0], "TCP4" | "TCP6") {
+        return Err(invalid_data("invalid PROXY protocol v1 address record"));
+    }
+    let source_ip = fields[1]
+        .parse::<IpAddr>()
+        .map_err(|_| invalid_data("invalid PROXY protocol v1 source address"))?;
+    let destination_ip = fields[2]
+        .parse::<IpAddr>()
+        .map_err(|_| invalid_data("invalid PROXY protocol v1 destination address"))?;
+    let source_port = fields[3]
+        .parse::<u16>()
+        .map_err(|_| invalid_data("invalid PROXY protocol v1 source port"))?;
+    let destination_port = fields[4]
+        .parse::<u16>()
+        .map_err(|_| invalid_data("invalid PROXY protocol v1 destination port"))?;
+    let expected_v4 = fields[0] == "TCP4";
+    if source_ip.is_ipv4() != expected_v4 || destination_ip.is_ipv4() != expected_v4 {
+        return Err(invalid_data("PROXY protocol v1 address family mismatch"));
+    }
+    Ok((
+        SocketAddr::new(source_ip, source_port),
+        SocketAddr::new(destination_ip, destination_port),
+    ))
+}
+
+async fn read_proxy_v2<R>(
+    stream: &mut R,
+    peer: SocketAddr,
+    local: SocketAddr,
+) -> io::Result<(SocketAddr, SocketAddr)>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
+    let mut header = [0u8; 4];
+    stream.read_exact(&mut header).await?;
+    if header[0] >> 4 != 0x2 {
+        return Err(invalid_data("invalid PROXY protocol v2 version"));
+    }
+    let command = header[0] & 0x0f;
+    if command > 1 {
+        return Err(invalid_data("unsupported PROXY protocol v2 command"));
+    }
+    let length = u16::from_be_bytes([header[2], header[3]]) as usize;
+    let mut payload = vec![0u8; length];
+    stream.read_exact(&mut payload).await?;
+    if command == 0 {
+        return Ok((peer, local));
+    }
+    let family = header[1] >> 4;
+    let protocol = header[1] & 0x0f;
+    if family == 0 && protocol == 0 {
+        return Ok((peer, local));
+    }
+    if protocol != 1 {
+        return Err(invalid_data(
+            "PROXY protocol v2 record on a TCP listener must use STREAM",
+        ));
+    }
+    match family {
+        1 => {
+            if payload.len() < 12 {
+                return Err(invalid_data("truncated PROXY protocol v2 TCP4 address"));
+            }
+            let source = SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(
+                    payload[0], payload[1], payload[2], payload[3],
+                )),
+                u16::from_be_bytes([payload[8], payload[9]]),
+            );
+            let destination = SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(
+                    payload[4], payload[5], payload[6], payload[7],
+                )),
+                u16::from_be_bytes([payload[10], payload[11]]),
+            );
+            Ok((source, destination))
+        }
+        2 => {
+            if payload.len() < 36 {
+                return Err(invalid_data("truncated PROXY protocol v2 TCP6 address"));
+            }
+            let source_bytes: [u8; 16] = payload[..16].try_into().unwrap();
+            let destination_bytes: [u8; 16] = payload[16..32].try_into().unwrap();
+            let source = SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(source_bytes)),
+                u16::from_be_bytes([payload[32], payload[33]]),
+            );
+            let destination = SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(destination_bytes)),
+                u16::from_be_bytes([payload[34], payload[35]]),
+            );
+            Ok((source, destination))
+        }
+        _ => Err(invalid_data("unsupported PROXY protocol v2 address family")),
     }
 }
 
 /* ---------------- SOCKS5 ---------------- */
 
 async fn handle_socks5(
-    mut sock: TcpStream,
+    mut sock: BoxedStream,
     peer: SocketAddr,
+    inbound_addr: SocketAddr,
     runtime: Arc<Runtime>,
     auth: Option<&[core_config::runtime_plan::UserPass]>,
     udp_enabled: bool,
@@ -190,12 +490,21 @@ async fn handle_socks5(
                     .await?;
                 return Err(invalid_data("SOCKS5 CONNECT target port must not be zero"));
             }
-            handle_socks5_connect(sock, peer, runtime, request.address, request.port).await
+            handle_socks5_connect(
+                sock,
+                peer,
+                inbound_addr,
+                runtime,
+                request.address,
+                request.port,
+            )
+            .await
         }
         SOCKS_CMD_UDP_ASSOCIATE if udp_enabled => {
             handle_socks5_udp_associate(
                 sock,
                 peer,
+                inbound_addr,
                 runtime,
                 request.address,
                 request.port,
@@ -231,10 +540,13 @@ async fn handle_socks5(
     }
 }
 
-async fn negotiate_socks5_auth(
-    sock: &mut TcpStream,
+async fn negotiate_socks5_auth<S>(
+    sock: &mut S,
     auth: Option<&[core_config::runtime_plan::UserPass]>,
-) -> io::Result<()> {
+) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + ?Sized,
+{
     // VER + NMETHODS
     let mut head = [0u8; 2];
     read_control(sock, &mut head).await?;
@@ -308,7 +620,10 @@ async fn negotiate_socks5_auth(
     Ok(())
 }
 
-async fn read_socks5_request(sock: &mut TcpStream) -> Result<SocksRequest, SocksRequestError> {
+async fn read_socks5_request<S>(sock: &mut S) -> Result<SocksRequest, SocksRequestError>
+where
+    S: AsyncRead + AsyncWrite + Unpin + ?Sized,
+{
     let mut h = [0u8; 4];
     read_control(sock, &mut h)
         .await
@@ -372,14 +687,14 @@ async fn read_socks5_request(sock: &mut TcpStream) -> Result<SocksRequest, Socks
 }
 
 async fn handle_socks5_connect(
-    mut sock: TcpStream,
+    mut sock: BoxedStream,
     peer: SocketAddr,
+    inbound_addr: SocketAddr,
     runtime: Arc<Runtime>,
     address: SocksAddress,
     port: u16,
 ) -> io::Result<()> {
     let handler = ListenerHandler::new(runtime);
-    let inbound_addr = sock.local_addr()?;
     let metadata =
         InboundMetadata::tcp("socks5", "Socks5", peer, inbound_addr, address.host(), port);
     match handler.prepare_tcp(metadata).await {
@@ -467,21 +782,30 @@ impl SocksRequestError {
     }
 }
 
-async fn read_control(sock: &mut TcpStream, buf: &mut [u8]) -> io::Result<()> {
+async fn read_control<R>(sock: &mut R, buf: &mut [u8]) -> io::Result<()>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
     timeout(SOCKS_CONTROL_IO_TIMEOUT, sock.read_exact(buf))
         .await
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SOCKS5 control read timed out"))??;
     Ok(())
 }
 
-async fn write_control(sock: &mut TcpStream, buf: &[u8]) -> io::Result<()> {
+async fn write_control<W>(sock: &mut W, buf: &[u8]) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
     timeout(SOCKS_CONTROL_IO_TIMEOUT, sock.write_all(buf))
         .await
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "SOCKS5 control write timed out"))??;
     Ok(())
 }
 
-async fn send_socks5_reply(sock: &mut TcpStream, reply: u8, bound: SocketAddr) -> io::Result<()> {
+async fn send_socks5_reply<W>(sock: &mut W, reply: u8, bound: SocketAddr) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
     let mut frame = Vec::with_capacity(22);
     frame.extend_from_slice(&[SOCKS_VERSION, reply, 0x00]);
     SocksAddress::Ip(bound.ip()).encode(&mut frame)?;
@@ -801,15 +1125,15 @@ fn advertised_udp_addr(
 }
 
 async fn handle_socks5_udp_associate(
-    mut control: TcpStream,
+    mut control: BoxedStream,
     peer: SocketAddr,
+    control_local: SocketAddr,
     runtime: Arc<Runtime>,
     client_address: SocksAddress,
     client_port: u16,
     limits: UdpRelayLimits,
     udp_session_permits: Arc<Semaphore>,
 ) -> io::Result<()> {
-    let control_local = control.local_addr()?;
     let mut client_pin = match client_pin_from_request(&client_address, client_port, peer).await {
         Ok(pin) => pin,
         Err(error) => {
@@ -1199,10 +1523,12 @@ async fn shutdown_udp_sessions(
 /* ---------------- HTTP ---------------- */
 
 async fn handle_http(
-    mut sock: TcpStream,
+    mut sock: BoxedStream,
     peer: SocketAddr,
+    inbound_addr: SocketAddr,
     runtime: Arc<Runtime>,
     auth: Option<&[core_config::runtime_plan::UserPass]>,
+    trusted_x_forwarded_for: &[String],
 ) -> io::Result<()> {
     let (head, prefetched) = match read_http_head(&mut sock, HTTP_HEADER_TIMEOUT).await {
         Ok(value) => value,
@@ -1256,7 +1582,7 @@ async fn handle_http(
     };
 
     let handler = ListenerHandler::new(runtime);
-    let inbound_addr = sock.local_addr()?;
+    let peer = apply_trusted_x_forwarded_for(&request, trusted_x_forwarded_for, peer);
     match route {
         HttpRoute::Connect(authority) => {
             let metadata = InboundMetadata::tcp(
@@ -1697,6 +2023,38 @@ impl HttpRequestHead {
             .map(trim_http_ows)
             .any(|option| option.eq_ignore_ascii_case(name.as_bytes()))
     }
+}
+
+/// Xray interprets `trustedXForwardedFor` as a list of trusted marker header
+/// names (for example `X-Trusted-CDN`), not as a CIDR allowlist.  Only when at
+/// least one marker is present may the first IP in X-Forwarded-For replace the
+/// transport peer; malformed/domain values are ignored.
+fn apply_trusted_x_forwarded_for(
+    request: &HttpRequestHead,
+    trusted_headers: &[String],
+    peer: SocketAddr,
+) -> SocketAddr {
+    let Some(value) = request.header("x-forwarded-for") else {
+        return peer;
+    };
+    if !trusted_headers
+        .iter()
+        .any(|name| request.header(name).is_some())
+    {
+        return peer;
+    }
+    let first = value
+        .split(|byte| *byte == b',')
+        .next()
+        .map(trim_http_ows)
+        .unwrap_or_default();
+    let Ok(first) = std::str::from_utf8(first) else {
+        return peer;
+    };
+    let Ok(ip) = first.parse::<IpAddr>() else {
+        return peer;
+    };
+    SocketAddr::new(ip, 0)
 }
 
 fn parse_absolute_target(target: &str) -> io::Result<ForwardTarget> {
@@ -2360,7 +2718,10 @@ fn validate_http_trailer_name(name: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
-async fn write_http_control(sock: &mut TcpStream, response: &[u8]) -> io::Result<()> {
+async fn write_http_control<W>(sock: &mut W, response: &[u8]) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
     timeout(HTTP_CONTROL_IO_TIMEOUT, sock.write_all(response))
         .await
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "HTTP response write timed out"))?
@@ -2386,11 +2747,119 @@ mod tests {
         let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = occupied.local_addr().unwrap();
 
-        let error = bind_mixed_listener(address)
+        let error = bind_mixed_listener(address, None)
             .await
             .expect_err("must not fall back to an undeclared port");
 
         assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+    }
+
+    #[test]
+    fn mixed_stream_settings_fail_closed_for_unexecutable_udp_and_quic_fields() {
+        let udp = core_config::NodeStreamSettings {
+            network: Some("raw".into()),
+            finalmask: Some(core_config::FinalMaskConfig {
+                udp: vec![core_config::UdpMaskConfig::MkcpLegacy(Default::default())],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let error = validate_mixed_stream_settings(Some(&udp)).unwrap_err();
+        assert!(error.to_string().contains("wrap_udp_server"));
+
+        let quic = core_config::NodeStreamSettings {
+            network: Some("raw".into()),
+            finalmask: Some(core_config::FinalMaskConfig {
+                quic_params: Some(core_config::QuicParamsConfig {
+                    congestion: "bbr".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let error = validate_mixed_stream_settings(Some(&quic)).unwrap_err();
+        assert!(error.to_string().contains("quicParams"));
+
+        let tcp = core_config::NodeStreamSettings {
+            network: Some("raw".into()),
+            finalmask: Some(core_config::FinalMaskConfig {
+                tcp: vec![core_config::TcpMaskConfig::Fragment(Default::default())],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        validate_mixed_stream_settings(Some(&tcp)).unwrap();
+    }
+
+    #[tokio::test]
+    async fn proxy_protocol_v1_preserves_payload_and_overrides_endpoints() {
+        let (mut writer, mut reader) = tokio::io::duplex(256);
+        tokio::spawn(async move {
+            writer
+                .write_all(b"PROXY TCP4 192.0.2.10 198.51.100.20 4567 443\r\nhello")
+                .await
+                .unwrap();
+        });
+        let kernel_peer = "127.0.0.1:1234".parse().unwrap();
+        let kernel_local = "127.0.0.1:7890".parse().unwrap();
+        let (peer, local) = read_proxy_protocol(&mut reader, kernel_peer, kernel_local)
+            .await
+            .unwrap();
+        assert_eq!(peer, "192.0.2.10:4567".parse().unwrap());
+        assert_eq!(local, "198.51.100.20:443".parse().unwrap());
+        let mut payload = [0u8; 5];
+        reader.read_exact(&mut payload).await.unwrap();
+        assert_eq!(&payload, b"hello");
+    }
+
+    #[tokio::test]
+    async fn proxy_protocol_v2_tcp6_consumes_tlvs_without_eating_payload() {
+        let source = "2001:db8::1".parse::<Ipv6Addr>().unwrap();
+        let destination = "2001:db8::2".parse::<Ipv6Addr>().unwrap();
+        let mut record = PROXY_V2_SIGNATURE.to_vec();
+        record.extend_from_slice(&[0x21, 0x21]);
+        let address_and_tlv_length = 36u16 + 5;
+        record.extend_from_slice(&address_and_tlv_length.to_be_bytes());
+        record.extend_from_slice(&source.octets());
+        record.extend_from_slice(&destination.octets());
+        record.extend_from_slice(&12345u16.to_be_bytes());
+        record.extend_from_slice(&8443u16.to_be_bytes());
+        record.extend_from_slice(&[0x01, 0x00, 0x02, b'h', b'2']);
+        record.extend_from_slice(b"next");
+        let (mut writer, mut reader) = tokio::io::duplex(256);
+        tokio::spawn(async move {
+            writer.write_all(&record).await.unwrap();
+        });
+        let (peer, local) = read_proxy_protocol(
+            &mut reader,
+            "127.0.0.1:1".parse().unwrap(),
+            "127.0.0.1:2".parse().unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(peer, "[2001:db8::1]:12345".parse().unwrap());
+        assert_eq!(local, "[2001:db8::2]:8443".parse().unwrap());
+        let mut payload = [0u8; 4];
+        reader.read_exact(&mut payload).await.unwrap();
+        assert_eq!(&payload, b"next");
+    }
+
+    #[test]
+    fn trusted_xff_requires_configured_marker_header() {
+        let request = parse_http_request_head(
+            b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nX-Forwarded-For: 192.0.2.1, 198.51.100.2\r\nX-Trusted-CDN: \r\n\r\n",
+        )
+        .unwrap();
+        let peer = "127.0.0.1:1234".parse().unwrap();
+        assert_eq!(
+            apply_trusted_x_forwarded_for(&request, &["X-Trusted-CDN".into()], peer),
+            "192.0.2.1:0".parse().unwrap()
+        );
+        assert_eq!(
+            apply_trusted_x_forwarded_for(&request, &["X-Other".into()], peer),
+            peer
+        );
     }
 
     fn test_runtime() -> Arc<Runtime> {
@@ -2429,6 +2898,7 @@ route:
             listen: addr,
             auth,
             udp,
+            stream_settings: None,
         };
         let runtime = test_runtime();
         let task = tokio::spawn(async move {

--- a/crates/core-inbound/src/reality.rs
+++ b/crates/core-inbound/src/reality.rs
@@ -9,13 +9,14 @@ use std::time::Duration;
 
 use base64::Engine as _;
 use core_config::model::RealityListen as RealityListenConfig;
+use core_outbound::BoxedStream;
 use core_reality::{
     AcceptedRealityStream, ClientHelloLimits, FallbackLimit, ProxyProtocolVersion, RealityServer,
     RealityServerConfig, RealityServerError, RealityServerLimits, decode_private_key,
     decode_short_id,
 };
 use core_runtime::Runtime;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpStream;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -28,6 +29,7 @@ pub struct RealityListener {
     server: RealityServer,
     target: CamouflageTarget,
     vless: Arc<VlessInboundConfig>,
+    stream_settings: Option<Arc<core_config::NodeStreamSettings>>,
 }
 
 impl fmt::Debug for RealityListener {
@@ -38,6 +40,7 @@ impl fmt::Debug for RealityListener {
             .field("server", &self.server.config())
             .field("target", &self.target)
             .field("vless", &self.vless)
+            .field("has_stream_settings", &self.stream_settings.is_some())
             .finish()
     }
 }
@@ -51,6 +54,7 @@ enum CamouflageTarget {
 
 impl RealityListener {
     pub fn from_config(config: &RealityListenConfig) -> io::Result<Self> {
+        validate_reality_stream_settings(config.stream_settings.as_ref())?;
         let listen = format!("{}:{}", config.host, config.port)
             .parse()
             .map_err(|error| invalid_input(format!("invalid REALITY listen address: {error}")))?;
@@ -169,6 +173,7 @@ impl RealityListener {
             server,
             target,
             vless,
+            stream_settings: config.stream_settings.clone().map(Arc::new),
         })
     }
 
@@ -232,7 +237,13 @@ fn target_address(target: &CamouflageTarget) -> &str {
 }
 
 pub async fn run_reality(listener: RealityListener, runtime: Arc<Runtime>) -> io::Result<()> {
-    let socket = TcpListener::bind(listener.listen).await?;
+    let socket = core_outbound::transport::tcp::bind_inbound_listener(
+        listener.listen,
+        listener
+            .stream_settings
+            .as_deref()
+            .and_then(|settings| settings.sockopt.as_ref()),
+    )?;
     let bound = socket.local_addr()?;
     info!(addr = %bound, "REALITY inbound listening");
     let cancellation = CancellationToken::new();
@@ -241,13 +252,28 @@ pub async fn run_reality(listener: RealityListener, runtime: Arc<Runtime>) -> io
     loop {
         tokio::select! {
             accepted = socket.accept() => {
-                let (stream, peer) = accepted?;
-                let local = stream.local_addr()?;
+                let (stream, kernel_peer) = accepted?;
+                let kernel_local = stream.local_addr()?;
                 let _ = stream.set_nodelay(true);
                 let listener = listener.clone();
                 let runtime = runtime.clone();
                 let cancellation = cancellation.clone();
                 connections.spawn(async move {
+                    let (stream, peer, local) = match prepare_reality_carrier(
+                        stream,
+                        kernel_peer,
+                        kernel_local,
+                        listener.stream_settings.as_deref(),
+                        listener.server.config().limits.handshake_timeout,
+                    )
+                    .await
+                    {
+                        Ok(prepared) => prepared,
+                        Err(error) => {
+                            debug!(%kernel_peer, %error, "REALITY FinalMask/PROXY preparation failed");
+                            return;
+                        }
+                    };
                     if let Err(error) = authenticate_and_serve(
                         listener,
                         stream,
@@ -276,7 +302,7 @@ pub async fn run_reality(listener: RealityListener, runtime: Arc<Runtime>) -> io
 
 async fn authenticate_and_serve(
     listener: RealityListener,
-    stream: TcpStream,
+    stream: BoxedStream,
     peer: SocketAddr,
     local: SocketAddr,
     runtime: Arc<Runtime>,
@@ -298,6 +324,83 @@ async fn authenticate_and_serve(
     )
     .await?;
     Ok(())
+}
+
+fn validate_reality_stream_settings(
+    settings: Option<&core_config::NodeStreamSettings>,
+) -> io::Result<()> {
+    use core_config::{AddressPortStrategy, DomainStrategy};
+
+    let Some(settings) = settings else {
+        return Ok(());
+    };
+    if let Some(network) = settings.network.as_deref()
+        && !network.is_empty()
+        && !network.eq_ignore_ascii_case("tcp")
+        && !network.eq_ignore_ascii_case("raw")
+    {
+        return Err(invalid_input(format!(
+            "REALITY streamSettings.network must be tcp/raw, got `{network}`"
+        )));
+    }
+    if let Some(finalmask) = settings.finalmask.as_ref()
+        && (!finalmask.udp.is_empty() || finalmask.quic_params.is_some())
+    {
+        return Err(invalid_input(
+            "REALITY TCP listener cannot execute UDP finalmask or quicParams",
+        ));
+    }
+    if let Some(sockopt) = settings.sockopt.as_ref() {
+        if !matches!(sockopt.domain_strategy, DomainStrategy::AsIs)
+            || !sockopt.dialer_proxy.trim().is_empty()
+            || sockopt.penetrate
+            || !matches!(sockopt.address_port_strategy, AddressPortStrategy::None)
+            || sockopt.happy_eyeballs != Default::default()
+            || !sockopt.trusted_x_forwarded_for.is_empty()
+        {
+            return Err(invalid_input(
+                "REALITY inbound streamSettings.sockopt contains outbound/HTTP-only fields",
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn prepare_reality_carrier(
+    stream: TcpStream,
+    mut peer: SocketAddr,
+    mut local: SocketAddr,
+    settings: Option<&core_config::NodeStreamSettings>,
+    timeout: Duration,
+) -> io::Result<(BoxedStream, SocketAddr, SocketAddr)> {
+    let mut stream: BoxedStream = Box::pin(stream);
+    if settings
+        .and_then(|settings| settings.sockopt.as_ref())
+        .is_some_and(|sockopt| sockopt.accept_proxy_protocol)
+    {
+        let endpoints = tokio::time::timeout(
+            timeout,
+            crate::mixed::read_proxy_protocol(&mut stream, peer, local),
+        )
+        .await
+        .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "REALITY PROXY header timeout"))??;
+        peer = endpoints.0;
+        local = endpoints.1;
+    }
+    if let Some(masks) = settings
+        .and_then(|settings| settings.finalmask.as_ref())
+        .map(|finalmask| finalmask.tcp.as_slice())
+        .filter(|masks| !masks.is_empty())
+    {
+        stream = core_outbound::transport::finalmask::wrap_tcp_server(
+            stream,
+            masks,
+            Some(local),
+            Some(peer),
+        )
+        .await?;
+    }
+    Ok((stream, peer, local))
 }
 
 fn parse_version(value: &str) -> io::Result<[u8; 3]> {
@@ -360,6 +463,7 @@ mod tests {
             limit_fallback_upload: RealityFallbackLimit::default(),
             limit_fallback_download: RealityFallbackLimit::default(),
             limits: RealityResourceLimits::default(),
+            stream_settings: None,
         }
     }
 

--- a/crates/core-inbound/src/xhttp.rs
+++ b/crates/core-inbound/src/xhttp.rs
@@ -24,7 +24,7 @@ use std::{
 
 use base64::Engine;
 use bytes::{Buf, Bytes};
-use core_config::model::XHTTP_MAX_ACCEPT_QUEUE;
+use core_config::{NodeStreamSettings, model::XHTTP_MAX_ACCEPT_QUEUE};
 use core_outbound::{
     BoxedStream,
     proto::xhttp::{
@@ -324,6 +324,7 @@ struct ServerInner {
     host: String,
     path: String,
     cors_policy: CorsPolicy,
+    trusted_x_forwarded_for: Vec<HeaderName>,
     sessions: Mutex<HashMap<String, Arc<Session>>>,
     sessions_changed: Notify,
     packet_body_budget: PacketBodyBudget,
@@ -701,6 +702,7 @@ impl XhttpServer {
                     host,
                     path,
                     cors_policy,
+                    trusted_x_forwarded_for: Vec::new(),
                     sessions: Mutex::new(HashMap::new()),
                     sessions_changed: Notify::new(),
                     packet_body_budget,
@@ -719,6 +721,31 @@ impl XhttpServer {
 
     pub fn config(&self) -> &Config {
         &self.inner.config
+    }
+
+    pub(crate) fn configure_trusted_x_forwarded_for(
+        &mut self,
+        trusted_headers: &[String],
+    ) -> io::Result<()> {
+        let trusted_headers = trusted_headers
+            .iter()
+            .map(|name| {
+                HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("invalid trustedXForwardedFor header name `{name}`: {error}"),
+                    )
+                })
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+        let inner = Arc::get_mut(&mut self.inner).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "XHTTP trustedXForwardedFor must be configured before the server is shared",
+            )
+        })?;
+        inner.trusted_x_forwarded_for = trusted_headers;
+        Ok(())
     }
 
     pub(crate) fn configure_listener_resources(
@@ -1485,6 +1512,36 @@ mod tests {
         assert!(!host_matches("[::1]:not-a-port", "::1"));
         assert!(!host_matches("example.com:99999", "example.com"));
         assert!(!host_matches("user@example.com", "example.com"));
+    }
+
+    #[test]
+    fn trusted_x_forwarded_for_requires_marker_and_uses_first_ip() {
+        let peer: SocketAddr = "127.0.0.1:44321".parse().unwrap();
+        let marker = HeaderName::from_static("x-trusted-cdn");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static(" 2001:db8::7, 198.51.100.2"),
+        );
+        assert_eq!(
+            apply_trusted_x_forwarded_for(&headers, std::slice::from_ref(&marker), peer),
+            peer
+        );
+
+        headers.insert(marker.clone(), HeaderValue::from_static("present"));
+        assert_eq!(
+            apply_trusted_x_forwarded_for(&headers, &[marker], peer),
+            "[2001:db8::7]:0".parse().unwrap()
+        );
+        headers.insert("x-forwarded-for", HeaderValue::from_static("proxy.example"));
+        assert_eq!(
+            apply_trusted_x_forwarded_for(
+                &headers,
+                &[HeaderName::from_static("x-trusted-cdn")],
+                peer
+            ),
+            peer
+        );
     }
 
     #[test]
@@ -4159,6 +4216,16 @@ impl XhttpServer {
         endpoint: quinn::Endpoint,
         shutdown: CancellationToken,
     ) -> io::Result<()> {
+        self.serve_h3_endpoint_with_quic_params(endpoint, shutdown, None)
+            .await
+    }
+
+    pub(crate) async fn serve_h3_endpoint_with_quic_params(
+        &self,
+        endpoint: quinn::Endpoint,
+        shutdown: CancellationToken,
+        quic_params: Option<core_outbound::transport::finalmask::quic::AppliedQuicParams>,
+    ) -> io::Result<()> {
         let local_addr = endpoint.local_addr()?;
         let mut connections = JoinSet::new();
         loop {
@@ -4187,10 +4254,14 @@ impl XhttpServer {
             };
             let server = self.clone();
             let connection_shutdown = shutdown.child_token();
+            let quic_params = quic_params.clone();
             connections.spawn(async move {
                 let _connection_slot = connection_slot;
                 match incoming.await {
                     Ok(connection) => {
+                        if let Some(quic_params) = quic_params.as_ref() {
+                            quic_params.apply_max_receive_window(&connection);
+                        }
                         let peer_addr = connection.remote_address();
                         if let Err(error) = server
                             .serve_h3_connection_until(
@@ -4359,6 +4430,11 @@ impl XhttpServer {
         peer_addr: SocketAddr,
         local_addr: SocketAddr,
     ) -> io::Result<()> {
+        let peer_addr = apply_trusted_x_forwarded_for(
+            request.headers(),
+            &self.inner.trusted_x_forwarded_for,
+            peer_addr,
+        );
         if let Err(error) = validate_route(&self.inner, &request) {
             return send_h3_request_error(&mut stream, error, HeaderMap::new()).await;
         }
@@ -5249,6 +5325,37 @@ fn validate_head<B>(
     })
 }
 
+/// Xray treats `trustedXForwardedFor` entries as marker header names.  The
+/// first X-Forwarded-For address is trusted only when at least one configured
+/// marker is present; the request source port is deliberately reset to zero.
+fn apply_trusted_x_forwarded_for(
+    headers: &HeaderMap,
+    trusted_headers: &[HeaderName],
+    peer: SocketAddr,
+) -> SocketAddr {
+    let Some(value) = headers.get("x-forwarded-for") else {
+        return peer;
+    };
+    if !trusted_headers
+        .iter()
+        .any(|name| headers.contains_key(name))
+    {
+        return peer;
+    }
+    let first = value
+        .as_bytes()
+        .split(|byte| *byte == b',')
+        .next()
+        .unwrap_or_default();
+    let Ok(first) = std::str::from_utf8(first) else {
+        return peer;
+    };
+    let Ok(ip) = first.trim_matches([' ', '\t']).parse::<std::net::IpAddr>() else {
+        return peer;
+    };
+    SocketAddr::new(ip, 0)
+}
+
 fn validate_route<B>(inner: &ServerInner, request: &Request<B>) -> Result<(), RequestError> {
     if request_header_size(request) > inner.config.normalized_server_max_header_bytes() {
         return Err(RequestError::new(
@@ -5688,14 +5795,58 @@ fn is_clean_h2_streaming_end(error: &(dyn StdError + 'static)) -> bool {
     })
 }
 
-async fn accept_tls_with_timeout(
+async fn accept_tls_with_timeout<S>(
     acceptor: &TlsAcceptor,
-    stream: tokio::net::TcpStream,
+    stream: S,
     timeout: Duration,
-) -> io::Result<tokio_rustls::server::TlsStream<tokio::net::TcpStream>> {
+) -> io::Result<tokio_rustls::server::TlsStream<S>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     tokio::time::timeout(timeout, acceptor.accept(stream))
         .await
         .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "XHTTP TLS handshake timed out"))?
+}
+
+async fn prepare_inbound_tcp_carrier(
+    stream: tokio::net::TcpStream,
+    mut peer_addr: SocketAddr,
+    mut local_addr: SocketAddr,
+    settings: Option<&NodeStreamSettings>,
+) -> io::Result<(BoxedStream, SocketAddr, SocketAddr)> {
+    let mut stream: BoxedStream = Box::pin(stream);
+    if settings
+        .and_then(|settings| settings.sockopt.as_ref())
+        .is_some_and(|sockopt| sockopt.accept_proxy_protocol)
+    {
+        let endpoints = tokio::time::timeout(
+            READ_HEADER_TIMEOUT,
+            crate::mixed::read_proxy_protocol(&mut stream, peer_addr, local_addr),
+        )
+        .await
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::TimedOut,
+                "XHTTP PROXY protocol header timed out",
+            )
+        })??;
+        peer_addr = endpoints.0;
+        local_addr = endpoints.1;
+    }
+    if let Some(masks) = settings
+        .and_then(|settings| settings.finalmask.as_ref())
+        .map(|finalmask| finalmask.tcp.as_slice())
+        .filter(|masks| !masks.is_empty())
+    {
+        stream = core_outbound::transport::finalmask::wrap_tcp_server(
+            stream,
+            masks,
+            Some(local_addr),
+            Some(peer_addr),
+        )
+        .await?;
+    }
+    Ok((stream, peer_addr, local_addr))
 }
 
 impl XhttpServer {
@@ -5845,8 +5996,13 @@ impl XhttpServer {
         listener: TcpListener,
         shutdown: CancellationToken,
     ) -> io::Result<()> {
-        self.serve_listener_with_policy(listener, shutdown, HttpVersionPolicy::HTTP1_AND_HTTP2)
-            .await
+        self.serve_listener_with_policy(
+            listener,
+            shutdown,
+            HttpVersionPolicy::HTTP1_AND_HTTP2,
+            None,
+        )
+        .await
     }
 
     /// Accept and serve plaintext connections under an explicit HTTP version
@@ -5856,6 +6012,7 @@ impl XhttpServer {
         listener: TcpListener,
         shutdown: CancellationToken,
         policy: HttpVersionPolicy,
+        stream_settings: Option<Arc<NodeStreamSettings>>,
     ) -> io::Result<()> {
         let mut connections = JoinSet::new();
         loop {
@@ -5879,12 +6036,27 @@ impl XhttpServer {
                 _ = self.inner.cancelled.cancelled() => break,
                 accepted = listener.accept() => accepted,
             };
-            let (stream, peer_addr) = accepted?;
-            let local_addr = stream.local_addr()?;
+            let (stream, kernel_peer_addr) = accepted?;
+            let kernel_local_addr = stream.local_addr()?;
             let server = self.clone();
             let connection_shutdown = shutdown.child_token();
+            let stream_settings = stream_settings.clone();
             connections.spawn(async move {
                 let _connection_slot = connection_slot;
+                let (stream, peer_addr, local_addr) = match prepare_inbound_tcp_carrier(
+                    stream,
+                    kernel_peer_addr,
+                    kernel_local_addr,
+                    stream_settings.as_deref(),
+                )
+                .await
+                {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        tracing::debug!(%kernel_peer_addr, %error, "XHTTP FinalMask/PROXY preparation ended");
+                        return;
+                    }
+                };
                 if let Err(error) = server
                     .serve_io_until_with_policy(
                         stream,
@@ -5922,6 +6094,7 @@ impl XhttpServer {
             acceptor,
             shutdown,
             HttpVersionPolicy::HTTP1_AND_HTTP2,
+            None,
         )
         .await
     }
@@ -5934,6 +6107,7 @@ impl XhttpServer {
         acceptor: TlsAcceptor,
         shutdown: CancellationToken,
         allowed_policy: HttpVersionPolicy,
+        stream_settings: Option<Arc<NodeStreamSettings>>,
     ) -> io::Result<()> {
         let mut connections = JoinSet::new();
         loop {
@@ -5957,13 +6131,28 @@ impl XhttpServer {
                 _ = self.inner.cancelled.cancelled() => break,
                 accepted = listener.accept() => accepted,
             };
-            let (stream, peer_addr) = accepted?;
-            let local_addr = stream.local_addr()?;
+            let (stream, kernel_peer_addr) = accepted?;
+            let kernel_local_addr = stream.local_addr()?;
             let server = self.clone();
             let acceptor = acceptor.clone();
             let connection_shutdown = shutdown.child_token();
+            let stream_settings = stream_settings.clone();
             connections.spawn(async move {
                 let _connection_slot = connection_slot;
+                let (stream, peer_addr, local_addr) = match prepare_inbound_tcp_carrier(
+                    stream,
+                    kernel_peer_addr,
+                    kernel_local_addr,
+                    stream_settings.as_deref(),
+                )
+                .await
+                {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        tracing::debug!(%kernel_peer_addr, %error, "XHTTP FinalMask/PROXY preparation ended");
+                        return;
+                    }
+                };
                 match accept_tls_with_timeout(&acceptor, stream, READ_HEADER_TIMEOUT).await {
                     Ok(stream) => {
                         let negotiated_policy = match allowed_policy
@@ -6011,6 +6200,7 @@ impl XhttpServer {
         acceptor: boring::ssl::SslAcceptor,
         shutdown: CancellationToken,
         allowed_policy: HttpVersionPolicy,
+        stream_settings: Option<Arc<NodeStreamSettings>>,
     ) -> io::Result<()> {
         let mut connections = JoinSet::new();
         loop {
@@ -6034,13 +6224,28 @@ impl XhttpServer {
                 _ = self.inner.cancelled.cancelled() => break,
                 accepted = listener.accept() => accepted,
             };
-            let (stream, peer_addr) = accepted?;
-            let local_addr = stream.local_addr()?;
+            let (stream, kernel_peer_addr) = accepted?;
+            let kernel_local_addr = stream.local_addr()?;
             let server = self.clone();
             let acceptor = acceptor.clone();
             let connection_shutdown = shutdown.child_token();
+            let stream_settings = stream_settings.clone();
             connections.spawn(async move {
                 let _connection_slot = connection_slot;
+                let (stream, peer_addr, local_addr) = match prepare_inbound_tcp_carrier(
+                    stream,
+                    kernel_peer_addr,
+                    kernel_local_addr,
+                    stream_settings.as_deref(),
+                )
+                .await
+                {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        tracing::debug!(%kernel_peer_addr, %error, "XHTTP FinalMask/PROXY preparation ended");
+                        return;
+                    }
+                };
                 let handshake = tokio::time::timeout(
                     READ_HEADER_TIMEOUT,
                     tokio_boring::accept(&acceptor, stream),
@@ -6090,6 +6295,11 @@ impl XhttpServer {
         peer_addr: SocketAddr,
         local_addr: SocketAddr,
     ) -> Response<XhttpBody> {
+        let peer_addr = apply_trusted_x_forwarded_for(
+            request.headers(),
+            &self.inner.trusted_x_forwarded_for,
+            peer_addr,
+        );
         if let Err(error) = validate_route(&self.inner, &request) {
             return error_response(error, HeaderMap::new());
         }

--- a/crates/core-inbound/src/xhttp_listener.rs
+++ b/crates/core-inbound/src/xhttp_listener.rs
@@ -45,7 +45,10 @@ enum BoundTransport {
         acceptor: boring::ssl::SslAcceptor,
         policy: HttpVersionPolicy,
     },
-    Http3(quinn::Endpoint),
+    Http3 {
+        endpoint: quinn::Endpoint,
+        quic_params: core_outbound::transport::finalmask::quic::AppliedQuicParams,
+    },
 }
 
 /// Running XHTTP listener and all of its logical Raw relays.
@@ -144,6 +147,13 @@ pub async fn start_xhttp_listener(
     };
     let (mut server, receiver) =
         XhttpServer::new_with_cors(config, Some(plan.accept_queue), cors_policy)?;
+    let trusted_x_forwarded_for = plan
+        .stream_settings
+        .as_ref()
+        .and_then(|settings| settings.sockopt.as_ref())
+        .map(|sockopt| sockopt.trusted_x_forwarded_for.as_slice())
+        .unwrap_or_default();
+    server.configure_trusted_x_forwarded_for(trusted_x_forwarded_for)?;
     server.configure_listener_resources(
         plan.max_active_connections,
         plan.max_concurrent_streams,
@@ -156,6 +166,7 @@ pub async fn start_xhttp_listener(
     let transport = prepare_transport(plan, address).await?;
     let local_addr = transport_local_addr(&transport)?;
     let shutdown = CancellationToken::new();
+    let stream_settings = plan.stream_settings.clone().map(Arc::new);
     let task = tokio::spawn(run_listener(
         server.clone(),
         receiver,
@@ -164,6 +175,7 @@ pub async fn start_xhttp_listener(
         plan.tag.clone(),
         target,
         plan.max_active_relays,
+        stream_settings,
         shutdown.clone(),
     ));
     info!(
@@ -281,32 +293,63 @@ async fn prepare_transport(
         let quic_crypto = QuicServerConfig::try_from(tls).map_err(|error| {
             invalid_input(format!("invalid XHTTP h3 TLS configuration: {error}"))
         })?;
-        let max_idle_timeout = plan.http_idle_timeout.try_into().map_err(|_| {
-            invalid_input(format!(
-                "XHTTP h3 http-idle-timeout {:?} exceeds QUIC's supported range",
-                plan.http_idle_timeout
-            ))
-        })?;
-        let mut transport_config = quinn::TransportConfig::default();
-        transport_config
-            .congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
-        transport_config.max_idle_timeout(Some(max_idle_timeout));
-        transport_config
-            .max_concurrent_bidi_streams(quinn::VarInt::from_u32(plan.max_concurrent_streams));
         let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(quic_crypto));
-        server_config.transport_config(Arc::new(transport_config));
-        let endpoint = quinn::Endpoint::server(server_config, address).map_err(|error| {
+        let finalmask = plan
+            .stream_settings
+            .as_ref()
+            .and_then(|settings| settings.finalmask.as_ref());
+        let quic_params = core_outbound::transport::finalmask::quic::apply_xhttp_server_config(
+            &mut server_config,
+            finalmask.and_then(|finalmask| finalmask.quic_params.as_ref()),
+            plan.http_idle_timeout,
+            plan.max_concurrent_streams,
+        )?;
+        let socket = core_outbound::transport::tcp::bind_inbound_udp_socket(
+            address,
+            plan.stream_settings
+                .as_ref()
+                .and_then(|settings| settings.sockopt.as_ref()),
+        )?;
+        let local_addr = socket.local_addr()?;
+        let raw = core_outbound::transport::finalmask::inbound_udp_carrier(socket);
+        let carrier = match finalmask
+            .map(|finalmask| finalmask.udp.as_slice())
+            .filter(|masks| !masks.is_empty())
+        {
+            Some(masks) => {
+                core_outbound::transport::finalmask::wrap_udp_server(
+                    raw,
+                    masks,
+                    Some(local_addr),
+                    None,
+                )
+                .await?
+            }
+            None => raw,
+        };
+        let socket =
+            core_outbound::transport::finalmask::QuinnUdpSocket::new_server(carrier, local_addr);
+        let endpoint = quinn::Endpoint::new_with_abstract_socket(
+            quinn::EndpointConfig::default(),
+            Some(server_config),
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        )
+        .map_err(|error| {
             io::Error::new(
                 error.kind(),
                 format!("bind XHTTP h3 UDP listener {address}: {error}"),
             )
         })?;
-        return Ok(BoundTransport::Http3(endpoint));
+        return Ok(BoundTransport::Http3 {
+            endpoint,
+            quic_params,
+        });
     }
 
     let policy = tcp_http_version_policy(&plan.alpn)?;
     if plan.cleartext {
-        let listener = bind_tcp(address).await?;
+        let listener = bind_tcp(address, plan.stream_settings.as_ref()).await?;
         return Ok(BoundTransport::Cleartext { listener, policy });
     }
 
@@ -317,7 +360,7 @@ async fn prepare_transport(
         &plan.alpn,
         false,
     )?;
-    let listener = bind_tcp(address).await?;
+    let listener = bind_tcp(address, plan.stream_settings.as_ref()).await?;
     Ok(match tls {
         PreparedTlsAcceptor::Rustls(acceptor) => BoundTransport::Tls {
             listener,
@@ -339,8 +382,15 @@ fn tcp_http_version_policy(alpn: &[XhttpListenAlpn]) -> io::Result<HttpVersionPo
         .ok_or_else(|| invalid_input("XHTTP TCP listener ALPN must allow http/1.1 or h2"))
 }
 
-async fn bind_tcp(address: SocketAddr) -> io::Result<TcpListener> {
-    TcpListener::bind(address).await.map_err(|error| {
+async fn bind_tcp(
+    address: SocketAddr,
+    stream_settings: Option<&core_config::NodeStreamSettings>,
+) -> io::Result<TcpListener> {
+    core_outbound::transport::tcp::bind_inbound_listener(
+        address,
+        stream_settings.and_then(|settings| settings.sockopt.as_ref()),
+    )
+    .map_err(|error| {
         io::Error::new(
             error.kind(),
             format!("bind XHTTP TCP listener {address}: {error}"),
@@ -353,7 +403,7 @@ fn transport_local_addr(transport: &BoundTransport) -> io::Result<SocketAddr> {
         BoundTransport::Cleartext { listener, .. } => listener.local_addr(),
         BoundTransport::Tls { listener, .. } => listener.local_addr(),
         BoundTransport::BoringTls { listener, .. } => listener.local_addr(),
-        BoundTransport::Http3(endpoint) => endpoint.local_addr(),
+        BoundTransport::Http3 { endpoint, .. } => endpoint.local_addr(),
     }
 }
 
@@ -365,6 +415,7 @@ async fn run_listener(
     tag: String,
     target: XhttpListenTargetPlan,
     max_active_relays: usize,
+    stream_settings: Option<Arc<core_config::NodeStreamSettings>>,
     shutdown: CancellationToken,
 ) -> io::Result<()> {
     let transport_server = server.clone();
@@ -373,7 +424,12 @@ async fn run_listener(
         match transport {
             BoundTransport::Cleartext { listener, policy } => {
                 transport_server
-                    .serve_listener_with_policy(listener, transport_shutdown, policy)
+                    .serve_listener_with_policy(
+                        listener,
+                        transport_shutdown,
+                        policy,
+                        stream_settings,
+                    )
                     .await
             }
             BoundTransport::Tls {
@@ -382,7 +438,13 @@ async fn run_listener(
                 policy,
             } => {
                 transport_server
-                    .serve_tls_listener_with_policy(listener, acceptor, transport_shutdown, policy)
+                    .serve_tls_listener_with_policy(
+                        listener,
+                        acceptor,
+                        transport_shutdown,
+                        policy,
+                        stream_settings,
+                    )
                     .await
             }
             BoundTransport::BoringTls {
@@ -396,12 +458,20 @@ async fn run_listener(
                         acceptor,
                         transport_shutdown,
                         policy,
+                        stream_settings,
                     )
                     .await
             }
-            BoundTransport::Http3(endpoint) => {
+            BoundTransport::Http3 {
+                endpoint,
+                quic_params,
+            } => {
                 transport_server
-                    .serve_h3_endpoint(endpoint, transport_shutdown)
+                    .serve_h3_endpoint_with_quic_params(
+                        endpoint,
+                        transport_shutdown,
+                        Some(quic_params),
+                    )
                     .await
             }
         }

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -36,6 +36,10 @@ ipnet       = { workspace = true }
 if-addrs    = "0.15"
 cronet      = { workspace = true, optional = true }
 hickory-proto = { workspace = true }
+hickory-resolver = { workspace = true, features = ["system-config"] }
+data-encoding = "2"
+percent-encoding = "2"
+regex       = { workspace = true }
 
 # 协议层依赖
 aes-gcm           = { workspace = true }
@@ -74,6 +78,7 @@ quinn             = { workspace = true }
 quinn-proto       = { workspace = true }
 h3                = { workspace = true }
 h3-quinn          = { workspace = true }
+rsteria2          = "=0.1.1"
 http              = "1"
 blake2            = "0.10"
 # WireGuard NoiseIK、Cookie、重放窗口、密钥轮换均由成熟实现负责；
@@ -86,6 +91,9 @@ hyper-util        = { version = "0.1", features = ["client", "client-legacy", "t
 http-body-util    = "0.1"
 rand_chacha       = "0.3"
 smoltcp           = { version = "0.11", default-features = false, features = ["std", "alloc", "log", "medium-ip", "proto-ipv4", "proto-ipv6", "proto-ipv4-fragmentation", "proto-ipv6-fragmentation", "fragmentation-buffer-size-65536", "reassembly-buffer-size-65536", "reassembly-buffer-count-4", "assembler-max-segment-count-32", "iface-max-addr-count-8", "iface-max-route-count-2", "socket-tcp", "socket-udp", "async"] }
+ggstd             = "0.1"
+rsa               = "0.9"
+num-bigint-dig    = "0.8"
 # socket2：在 Linux/Android 上对 outbound socket 设置 SO_MARK，配合
 # `ip rule fwmark X lookup main` 让代理出站绕开 TUN 自身路由表，
 # 避免"resolve 出 IP 后 connect 又被 TUN 截走"的死循环。

--- a/crates/core-outbound/src/adapter.rs
+++ b/crates/core-outbound/src/adapter.rs
@@ -213,6 +213,7 @@ fn prepare_outbound_udp_socket_with(
     if let Err(e) = bind_result {
         tracing::debug!(target: "dial::udp", error = %e, "outbound interface bind failed (non-fatal)");
     }
+    crate::transport::tcp::apply_current_udp_socket_config(&sock, peer)?;
     let local = socket.local_addr()?;
     Ok(crate::loopback::register_udp(local))
 }
@@ -561,6 +562,20 @@ pub type BoxedStream = Pin<Box<dyn ProxyStream>>;
 pub trait UdpSocketLike: Send + Sync {
     async fn send_to(&self, buf: &[u8], target: &str, port: u16) -> std::io::Result<usize>;
     async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize>;
+    /// Receive a datagram together with its transport source when the carrier
+    /// can expose one. Connected/proxied associations may return `None`; raw
+    /// carriers override this for finalmask stages such as realm, UDP hopping,
+    /// xdns and server-side demultiplexing.
+    async fn recv_from_endpoint(
+        &self,
+        buf: &mut [u8],
+    ) -> std::io::Result<(usize, Option<std::net::SocketAddr>)> {
+        self.recv_from(buf).await.map(|length| (length, None))
+    }
+    /// Local transport endpoint when the carrier exposes it.
+    fn local_addr(&self) -> std::io::Result<Option<std::net::SocketAddr>> {
+        Ok(None)
+    }
     /// 关闭通道；某些协议需要发协议级断开。
     async fn close(&self) -> std::io::Result<()> {
         Ok(())

--- a/crates/core-outbound/src/direct.rs
+++ b/crates/core-outbound/src/direct.rs
@@ -137,6 +137,18 @@ impl UdpSocketLike for DirectUdp {
         let _ = &self.loopback_guard;
         self.sock.recv(buf).await
     }
+
+    async fn recv_from_endpoint(
+        &self,
+        buf: &mut [u8],
+    ) -> std::io::Result<(usize, Option<SocketAddr>)> {
+        let length = self.recv_from(buf).await?;
+        Ok((length, Some(self.peer)))
+    }
+
+    fn local_addr(&self) -> std::io::Result<Option<SocketAddr>> {
+        self.sock.local_addr().map(Some)
+    }
 }
 
 impl DirectUdp {

--- a/crates/core-outbound/src/lib.rs
+++ b/crates/core-outbound/src/lib.rs
@@ -14,6 +14,8 @@
 pub mod adapter;
 pub mod loopback;
 pub mod registry;
+#[allow(unsafe_code)]
+pub mod socket_policy;
 
 pub mod block;
 pub mod direct;

--- a/crates/core-outbound/src/loopback.rs
+++ b/crates/core-outbound/src/loopback.rs
@@ -204,6 +204,10 @@ impl TrackedTcpStream<tokio::net::TcpStream> {
     pub fn local_addr(&self) -> std::io::Result<SocketAddr> {
         self.inner.local_addr()
     }
+
+    pub fn peer_addr(&self) -> std::io::Result<SocketAddr> {
+        self.inner.peer_addr()
+    }
 }
 
 impl<S> AsyncRead for TrackedTcpStream<S>

--- a/crates/core-outbound/src/proto/hysteria2.rs
+++ b/crates/core-outbound/src/proto/hysteria2.rs
@@ -29,16 +29,11 @@ use std::{
 };
 
 use async_trait::async_trait;
-use blake2::digest::{Update, VariableOutput};
-use bytes::Bytes;
 use quinn::{ClientConfig, Endpoint, RecvStream, SendStream, crypto::rustls::QuicClientConfig};
 use rustls::ClientConfig as RustlsConfig;
 use tokio::sync::Mutex as AsyncMutex;
 
-use crate::adapter::{
-    BoxedStream, Capabilities, DialContext, OutboundAdapter, prepare_outbound_udp_socket_for_addr,
-    resolve_host,
-};
+use crate::adapter::{BoxedStream, Capabilities, DialContext, OutboundAdapter, resolve_host};
 
 #[derive(Debug, Clone)]
 pub struct Hysteria2Outbound {
@@ -117,45 +112,99 @@ impl Hysteria2Outbound {
         }
         let quic_client_config: QuicClientConfig = QuicClientConfig::try_from(tls_config)
             .map_err(|e| io_err(format!("hysteria2 quic config: {e}")))?;
-        let client_config = ClientConfig::new(Arc::new(quic_client_config));
+        let mut client_config = ClientConfig::new(Arc::new(quic_client_config));
+        let active_policy = crate::socket_policy::current();
+        let quic_params = active_policy
+            .as_ref()
+            .and_then(|policy| policy.settings.finalmask.as_ref())
+            .and_then(|finalmask| finalmask.quic_params.as_ref());
+        let applied_quic = crate::transport::finalmask::quic::apply_client_config(
+            &mut client_config,
+            quic_params,
+        )?;
 
-        // 3) 绑定本地 UDP socket（IPv4 + IPv6 双栈）
-        let bind_addr: SocketAddr = if target_addr.is_ipv6() {
+        // 3) 在协议之下构造 UDP carrier。finalmask 必须位于 Quinn 之下；
+        // 对 dial_udp 的返回值做 payload 包装会错误地包住 Hysteria relay。
+        let nominal_local: SocketAddr = if target_addr.is_ipv6() {
             "[::]:0".parse().unwrap()
         } else {
             "0.0.0.0:0".parse().unwrap()
         };
-
-        let (endpoint, loopback_guard) = if let Some(obfs_pwd) = &self.obfs_password {
-            // 用 Salamander obfs 包装 UDP socket
-            let std_socket = std::net::UdpSocket::bind(bind_addr)?;
-            let loopback_guard = prepare_outbound_udp_socket_for_addr(&std_socket, target_addr)?;
-            std_socket.set_nonblocking(true)?;
-            let obfs_runtime = quinn::TokioRuntime;
-            let obfs_socket = SalamanderSocket::new(std_socket, obfs_pwd.as_bytes())?;
-            let mut endpoint = Endpoint::new_with_abstract_socket(
-                quinn::EndpointConfig::default(),
-                None,
-                Arc::new(obfs_socket),
-                Arc::new(obfs_runtime),
+        let mut masks = active_policy
+            .as_ref()
+            .and_then(|policy| policy.settings.finalmask.as_ref())
+            .map(|finalmask| finalmask.udp.clone())
+            .unwrap_or_default();
+        if let Some(password) = &self.obfs_password {
+            masks.push(core_config::UdpMaskConfig::Salamander(
+                core_config::SalamanderMaskConfig {
+                    password: password.clone(),
+                    ..Default::default()
+                },
+            ));
+        }
+        if applied_quic.udp_hop.is_some()
+            && masks.iter().any(|mask| {
+                matches!(
+                    mask,
+                    core_config::UdpMaskConfig::Realm(_) | core_config::UdpMaskConfig::Xicmp(_)
+                )
+            })
+        {
+            return Err(io_err(
+                "finalmask realm/xicmp is incompatible with quicParams.udpHop, matching Xray's outermost-carrier rule",
+            ));
+        }
+        let proxy = active_policy.as_ref().and_then(|policy| policy.proxy());
+        let (raw, carrier_local) = if let Some(hop) = applied_quic.udp_hop.clone() {
+            crate::transport::finalmask::UdpHopCarrier::open(
+                hop,
+                proxy,
+                self.host.clone(),
+                target_addr,
             )
-            .map_err(|e| io_err(format!("hysteria2 endpoint with obfs: {e}")))?;
-            endpoint.set_default_client_config(client_config);
-            (endpoint, loopback_guard)
+            .await?
+        } else if let Some(proxy) = proxy {
+            (
+                crate::socket_policy::dial_udp_through_proxy(
+                    proxy,
+                    self.host.clone(),
+                    target_addr.port(),
+                )
+                .await?,
+                nominal_local,
+            )
         } else {
-            let std_socket = std::net::UdpSocket::bind(bind_addr)?;
-            let loopback_guard = prepare_outbound_udp_socket_for_addr(&std_socket, target_addr)?;
-            std_socket.set_nonblocking(true)?;
-            let mut endpoint = Endpoint::new(
-                quinn::EndpointConfig::default(),
-                None,
-                std_socket,
-                Arc::new(quinn::TokioRuntime),
-            )
-            .map_err(|e| io_err(format!("hysteria2 endpoint: {e}")))?;
-            endpoint.set_default_client_config(client_config);
-            (endpoint, loopback_guard)
+            crate::transport::finalmask::open_direct_carrier(self.host.clone(), target_addr)?
         };
+        let carrier = if masks.is_empty() {
+            raw
+        } else {
+            crate::transport::finalmask::wrap_udp_client(
+                raw,
+                &masks,
+                self.host.clone(),
+                target_addr.port(),
+                None,
+                Some(target_addr),
+            )
+            .await?
+        };
+        let abstract_socket = crate::transport::finalmask::QuinnUdpSocket::new(
+            carrier,
+            carrier_local,
+            target_addr,
+            self.host.clone(),
+            target_addr.port(),
+        );
+        let mut endpoint = Endpoint::new_with_abstract_socket(
+            quinn::EndpointConfig::default(),
+            None,
+            abstract_socket,
+            Arc::new(quinn::TokioRuntime),
+        )
+        .map_err(|e| io_err(format!("hysteria2 finalmask endpoint: {e}")))?;
+        endpoint.set_default_client_config(client_config);
 
         // 4) 建立 QUIC 连接
         let server_name = self.sni.clone().unwrap_or_else(|| self.host.clone());
@@ -187,7 +236,7 @@ impl Hysteria2Outbound {
             .method("POST")
             .uri(auth_uri)
             .header("Hysteria-Auth", self.password.as_str())
-            .header("Hysteria-CC-RX", self.down_mbps.to_string())
+            .header("Hysteria-CC-RX", applied_quic.brutal_down.to_string())
             .header("Hysteria-Padding", random_padding())
             .body(())
             .map_err(|e| io_err(format!("h3 build: {e}")))?;
@@ -209,17 +258,20 @@ impl Hysteria2Outbound {
             return Err(io_err(format!("hysteria2 auth status {}", resp.status())));
         }
         // 必要 headers：Hysteria-CC-RX (server 限速), Hysteria-Padding (校验)
-        let _server_cc_rx = resp
+        let server_cc_rx = resp
             .headers()
             .get("hysteria-cc-rx")
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(0);
+        applied_quic.finish_hysteria_negotiation(server_cc_rx);
+        if let Some(window) = applied_quic.max_connection_receive_window {
+            connection.set_receive_window(window);
+        }
 
         Ok(Hysteria2Session {
             connection,
             endpoint,
-            _loopback_guard: loopback_guard,
         })
     }
 }
@@ -287,7 +339,6 @@ struct Hysteria2Session {
     /// endpoint 持有住，否则 socket 关闭
     #[allow(dead_code)]
     endpoint: Endpoint,
-    _loopback_guard: crate::loopback::LoopbackUdpGuard,
 }
 
 impl Hysteria2Session {
@@ -339,179 +390,6 @@ impl tokio::io::AsyncWrite for QuinnBiStream {
     }
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         Pin::new(&mut self.send).poll_shutdown(cx)
-    }
-}
-
-/* ---------------- Salamander obfs UDP socket ---------------- */
-
-#[derive(Debug)]
-struct SalamanderSocket {
-    inner: Arc<tokio::net::UdpSocket>,
-    state: quinn::udp::UdpSocketState,
-    key: Vec<u8>,
-}
-
-impl SalamanderSocket {
-    fn new(socket: std::net::UdpSocket, key: &[u8]) -> std::io::Result<Self> {
-        let state = quinn::udp::UdpSocketState::new((&socket).into())?;
-        let inner = Arc::new(tokio::net::UdpSocket::from_std(socket)?);
-        Ok(Self {
-            inner,
-            state,
-            key: key.to_vec(),
-        })
-    }
-
-    /// 给 buf 应用 Salamander obfs：buf[..8] 是 salt（出站时随机生成；入站时读取）
-    fn apply_obfs_outbound(&self, buf: &mut Vec<u8>) {
-        use rand::RngCore;
-        let mut salt = [0u8; 8];
-        rand::rngs::OsRng.fill_bytes(&mut salt);
-        // keystream = BLAKE2b-256(key || salt)，长度 = buf.len()
-        let mut h = blake2::Blake2bVar::new(32).expect("blake2b 32B");
-        h.update(&self.key);
-        h.update(&salt);
-        let mut ks = [0u8; 32];
-        h.finalize_variable(&mut ks).expect("blake2b finalize");
-        // 扩展 keystream 到 buf 长度（重复 SHAKE 思路：加 counter）
-        let mut full = Vec::with_capacity(buf.len());
-        let mut counter = 0u64;
-        while full.len() < buf.len() {
-            let mut h2 = blake2::Blake2bVar::new(32).expect("blake2b 32B");
-            h2.update(&self.key);
-            h2.update(&salt);
-            h2.update(&counter.to_be_bytes());
-            let mut block = [0u8; 32];
-            h2.finalize_variable(&mut block).expect("blake2b finalize");
-            full.extend_from_slice(&block);
-            counter += 1;
-        }
-        for (i, b) in buf.iter_mut().enumerate() {
-            *b ^= full[i];
-        }
-        // 在 buf 前插入 8 字节 salt
-        let mut new_buf = Vec::with_capacity(buf.len() + 8);
-        new_buf.extend_from_slice(&salt);
-        new_buf.extend_from_slice(buf);
-        *buf = new_buf;
-        let _ = ks;
-    }
-
-    fn apply_obfs_inbound(&self, buf: &mut Vec<u8>) -> bool {
-        if buf.len() < 8 {
-            return false;
-        }
-        let mut salt = [0u8; 8];
-        salt.copy_from_slice(&buf[..8]);
-        let payload_len = buf.len() - 8;
-        let mut full = Vec::with_capacity(payload_len);
-        let mut counter = 0u64;
-        while full.len() < payload_len {
-            let mut h = blake2::Blake2bVar::new(32).expect("blake2b 32B");
-            h.update(&self.key);
-            h.update(&salt);
-            h.update(&counter.to_be_bytes());
-            let mut block = [0u8; 32];
-            h.finalize_variable(&mut block).expect("blake2b finalize");
-            full.extend_from_slice(&block);
-            counter += 1;
-        }
-        let mut new_buf = Vec::with_capacity(payload_len);
-        for i in 0..payload_len {
-            new_buf.push(buf[8 + i] ^ full[i]);
-        }
-        *buf = new_buf;
-        true
-    }
-}
-
-impl quinn::AsyncUdpSocket for SalamanderSocket {
-    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn quinn::UdpPoller>> {
-        let inner = self.inner.clone();
-        Box::pin(SalamanderPoller { inner })
-    }
-
-    fn try_send(&self, transmit: &quinn::udp::Transmit) -> std::io::Result<()> {
-        let mut buf = transmit.contents.to_vec();
-        self.apply_obfs_outbound(&mut buf);
-        let new_transmit = quinn::udp::Transmit {
-            destination: transmit.destination,
-            ecn: transmit.ecn,
-            contents: &buf,
-            segment_size: None, // 改写后不能用 GSO
-            src_ip: transmit.src_ip,
-        };
-        self.state.try_send((&*self.inner).into(), &new_transmit)
-    }
-
-    fn poll_recv(
-        &self,
-        cx: &mut Context,
-        bufs: &mut [std::io::IoSliceMut<'_>],
-        meta: &mut [quinn::udp::RecvMeta],
-    ) -> Poll<std::io::Result<usize>> {
-        loop {
-            ready_or_pending!(self.inner.poll_recv_ready(cx));
-            let res = self.inner.try_io(tokio::io::Interest::READABLE, || {
-                self.state.recv((&*self.inner).into(), bufs, meta)
-            });
-            match res {
-                Ok(n) => {
-                    // 对每条消息做 inbound obfs
-                    for (i, m) in meta.iter_mut().enumerate().take(n) {
-                        let len = m.len;
-                        let buf = &mut bufs[i];
-                        let mut data = buf[..len].to_vec();
-                        if self.apply_obfs_inbound(&mut data) {
-                            buf[..data.len()].copy_from_slice(&data);
-                            m.len = data.len();
-                        }
-                    }
-                    return Poll::Ready(Ok(n));
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-                Err(e) => return Poll::Ready(Err(e)),
-            }
-        }
-    }
-
-    fn local_addr(&self) -> std::io::Result<SocketAddr> {
-        self.inner.local_addr()
-    }
-
-    fn max_transmit_segments(&self) -> usize {
-        1 // 不支持 GSO
-    }
-
-    fn max_receive_segments(&self) -> usize {
-        1
-    }
-
-    fn may_fragment(&self) -> bool {
-        false
-    }
-}
-
-/// 简易 ready 宏
-macro_rules! ready_or_pending {
-    ($e:expr) => {
-        match $e {
-            Poll::Ready(Ok(())) => {}
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-            Poll::Pending => return Poll::Pending,
-        }
-    };
-}
-pub(crate) use ready_or_pending;
-
-#[derive(Debug)]
-struct SalamanderPoller {
-    inner: Arc<tokio::net::UdpSocket>,
-}
-
-impl quinn::UdpPoller for SalamanderPoller {
-    fn poll_writable(self: Pin<&mut Self>, cx: &mut Context) -> Poll<std::io::Result<()>> {
-        self.inner.poll_send_ready(cx)
     }
 }
 

--- a/crates/core-outbound/src/proto/xhttp/h3.rs
+++ b/crates/core-outbound/src/proto/xhttp/h3.rs
@@ -47,7 +47,7 @@ pub(crate) struct H3Client {
     connection: quinn::Connection,
     sender: H3SendRequest,
     closed: Arc<AtomicBool>,
-    _loopback_guard: LoopbackUdpGuard,
+    _loopback_guard: Option<LoopbackUdpGuard>,
 }
 
 impl H3Client {
@@ -69,23 +69,48 @@ impl H3Client {
         let quic_crypto = QuicClientConfig::try_from(tls)
             .map_err(|error| io_err(format!("xhttp h3 QUIC TLS config: {error}")))?;
         let mut quic_config = QuinnClientConfig::new(Arc::new(quic_crypto));
-        let mut transport = TransportConfig::default();
-        // Xray's quic-go path defaults to standard BBR. Quinn defaults to
-        // Cubic, so select its BBR controller explicitly for wire/runtime
-        // behavior parity rather than inheriting the library default.
-        transport.congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
-        transport.max_idle_timeout(Some(
-            IdleTimeout::try_from(Duration::from_secs(300))
-                .map_err(|error| io_err(format!("xhttp h3 idle timeout: {error}")))?,
-        ));
-        transport.keep_alive_interval(keep_alive);
-        quic_config.transport_config(Arc::new(transport));
+        let active_policy = crate::socket_policy::current();
+        let quic_params = active_policy
+            .as_ref()
+            .and_then(|policy| policy.settings.finalmask.as_ref())
+            .and_then(|finalmask| finalmask.quic_params.as_ref());
+        let applied_quic = if let Some(quic_params) = quic_params {
+            Some(
+                crate::transport::finalmask::quic::apply_xhttp_client_config(
+                    &mut quic_config,
+                    quic_params,
+                    keep_alive,
+                )?,
+            )
+        } else {
+            let mut transport = TransportConfig::default();
+            // Xray's quic-go path defaults to standard BBR. Quinn defaults to
+            // Cubic, so select its BBR controller explicitly for wire/runtime
+            // behavior parity rather than inheriting the library default.
+            transport
+                .congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
+            transport.max_idle_timeout(Some(
+                IdleTimeout::try_from(Duration::from_secs(300))
+                    .map_err(|error| io_err(format!("xhttp h3 idle timeout: {error}")))?,
+            ));
+            transport.keep_alive_interval(keep_alive);
+            quic_config.transport_config(Arc::new(transport));
+            None
+        };
 
         let addresses = resolve_host(host, port).await?;
         let mut last_error = None;
 
         for address in addresses {
-            match connect_one(address, &server_name, quic_config.clone()).await {
+            match connect_one(
+                host,
+                address,
+                &server_name,
+                quic_config.clone(),
+                applied_quic.clone(),
+            )
+            .await
+            {
                 Ok((endpoint, connection, loopback_guard)) => {
                     let h3_connection = h3_quinn::Connection::new(connection.clone());
                     let (mut driver, sender) = with_setup_timeout("handshake", async move {
@@ -446,10 +471,123 @@ impl ManagedConnection for H3Client {
 }
 
 async fn connect_one(
+    host: &str,
     address: SocketAddr,
     server_name: &str,
     config: QuinnClientConfig,
-) -> io::Result<(Endpoint, quinn::Connection, LoopbackUdpGuard)> {
+    applied_quic: Option<crate::transport::finalmask::quic::AppliedQuicParams>,
+) -> io::Result<(Endpoint, quinn::Connection, Option<LoopbackUdpGuard>)> {
+    let active_policy = crate::socket_policy::current();
+    connect_one_with_policy(
+        host,
+        address,
+        server_name,
+        config,
+        applied_quic,
+        active_policy,
+    )
+    .await
+}
+
+async fn connect_one_with_policy(
+    host: &str,
+    address: SocketAddr,
+    server_name: &str,
+    config: QuinnClientConfig,
+    applied_quic: Option<crate::transport::finalmask::quic::AppliedQuicParams>,
+    active_policy: Option<Arc<crate::socket_policy::ActiveStreamPolicy>>,
+) -> io::Result<(Endpoint, quinn::Connection, Option<LoopbackUdpGuard>)> {
+    if let Some(policy) = active_policy {
+        let nominal_local: SocketAddr = if address.is_ipv6() {
+            "[::]:0".parse().expect("valid IPv6 wildcard")
+        } else {
+            "0.0.0.0:0".parse().expect("valid IPv4 wildcard")
+        };
+        let masks = policy
+            .settings
+            .finalmask
+            .as_ref()
+            .map(|finalmask| finalmask.udp.clone())
+            .unwrap_or_default();
+        if applied_quic
+            .as_ref()
+            .and_then(|params| params.udp_hop())
+            .is_some()
+            && masks.iter().any(|mask| {
+                matches!(
+                    mask,
+                    core_config::UdpMaskConfig::Realm(_) | core_config::UdpMaskConfig::Xicmp(_)
+                )
+            })
+        {
+            return Err(io_err(
+                "XHTTP finalmask realm/xicmp is incompatible with quicParams.udpHop",
+            ));
+        }
+        let proxy = policy.proxy();
+        let (raw, carrier_local) = if let Some(hop) = applied_quic
+            .as_ref()
+            .and_then(|params| params.udp_hop())
+            .cloned()
+        {
+            crate::transport::finalmask::UdpHopCarrier::open(hop, proxy, host.to_owned(), address)
+                .await?
+        } else if let Some(proxy) = proxy {
+            (
+                crate::socket_policy::dial_udp_through_proxy(
+                    proxy,
+                    host.to_owned(),
+                    address.port(),
+                )
+                .await?,
+                nominal_local,
+            )
+        } else {
+            crate::transport::finalmask::open_direct_carrier(host.to_owned(), address)?
+        };
+        let carrier = if masks.is_empty() {
+            raw
+        } else {
+            crate::transport::finalmask::wrap_udp_client(
+                raw,
+                &masks,
+                host.to_owned(),
+                address.port(),
+                None,
+                Some(address),
+            )
+            .await?
+        };
+        let socket = crate::transport::finalmask::QuinnUdpSocket::new(
+            carrier,
+            carrier_local,
+            address,
+            host.to_owned(),
+            address.port(),
+        );
+        let mut endpoint = Endpoint::new_with_abstract_socket(
+            quinn::EndpointConfig::default(),
+            None,
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        )
+        .map_err(|error| io_err(format!("xhttp h3 FinalMask endpoint: {error}")))?;
+        endpoint.set_default_client_config(config);
+        let connecting = endpoint
+            .connect(address, server_name)
+            .map_err(|error| io_err(format!("xhttp h3 connect setup: {error}")))?;
+        let connection = with_setup_timeout("QUIC connect", async move {
+            connecting
+                .await
+                .map_err(|error| io_err(format!("xhttp h3 connect {address}: {error}")))
+        })
+        .await?;
+        if let Some(applied_quic) = applied_quic.as_ref() {
+            applied_quic.apply_max_receive_window(&connection);
+        }
+        return Ok((endpoint, connection, None));
+    }
+
     let bind_address: SocketAddr = if address.is_ipv6() {
         "[::]:0".parse().expect("valid IPv6 wildcard")
     } else {
@@ -475,7 +613,7 @@ async fn connect_one(
             .map_err(|error| io_err(format!("xhttp h3 connect {address}: {error}")))
     })
     .await?;
-    Ok((endpoint, connection, loopback_guard))
+    Ok((endpoint, connection, Some(loopback_guard)))
 }
 
 fn io_err(message: impl Into<String>) -> io::Error {

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -49,6 +49,7 @@ use crate::{
         },
         young::YoungOutbound,
     },
+    socket_policy::ConfiguredOutbound,
     socks5::Socks5Outbound,
     stub::StubOutbound,
     transport::{
@@ -97,10 +98,42 @@ impl OutboundRegistry {
 
 /// 把 [`ParsedNode`] 数组注册为一组出站。
 pub fn register_nodes(reg: &mut OutboundRegistry, nodes: &[ParsedNode]) -> Result<(), String> {
+    let mut pending_proxies = Vec::new();
     for node in nodes {
-        let ob = build_outbound(node)
+        let mut ob = build_outbound(node)
             .map_err(|error| format!("node `{}` outbound config invalid: {error}", node.name))?;
+        if let Some(settings) = node.stream_settings.clone() {
+            let proxy_name = settings
+                .sockopt
+                .as_ref()
+                .map(|sockopt| sockopt.dialer_proxy.trim().to_string())
+                .filter(|name| !name.is_empty());
+            let (configured, policy) = ConfiguredOutbound::new(ob, settings);
+            ob = configured;
+            if let Some(proxy_name) = proxy_name {
+                pending_proxies.push((node.name.clone(), proxy_name, policy));
+            }
+        }
         reg.insert(node.name.clone(), ob);
+    }
+
+    // Resolve only after every wrapper has been inserted: Xray permits a
+    // dialerProxy to reference a node declared later in the configuration.
+    for (owner, proxy_name, policy) in pending_proxies {
+        let lookup_name = if proxy_name.eq_ignore_ascii_case("direct") {
+            "DIRECT"
+        } else if proxy_name.eq_ignore_ascii_case("block") {
+            "BLOCK"
+        } else {
+            &proxy_name
+        };
+        if let Some(proxy) = reg.get(lookup_name) {
+            let _ = ConfiguredOutbound::set_dialer_proxy(&policy, proxy);
+        } else {
+            return Err(format!(
+                "node `{owner}` streamSettings.sockopt.dialerProxy target `{proxy_name}` was not registered"
+            ));
+        }
     }
     Ok(())
 }

--- a/crates/core-outbound/src/socket_policy.rs
+++ b/crates/core-outbound/src/socket_policy.rs
@@ -1,0 +1,206 @@
+//! Per-outbound Xray `streamSettings` execution context.
+//!
+//! Protocol adapters in this crate intentionally share the transport dialers.
+//! This task-local context lets the registry attach a policy to an adapter
+//! without adding a socket-options argument to every protocol constructor.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use core_config::{NodeStreamSettings, OutboundSocketConfig};
+
+use crate::adapter::{
+    BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, SharedOutbound,
+};
+
+tokio::task_local! {
+    static ACTIVE_STREAM_POLICY: Arc<ActiveStreamPolicy>;
+}
+
+/// Immutable policy installed while an outbound adapter is dialing its own
+/// carrier connection. `dialer_proxy` is filled in a second registry pass so
+/// forward references work and the final target is itself policy-wrapped.
+pub(crate) struct ActiveStreamPolicy {
+    pub(crate) settings: NodeStreamSettings,
+    dialer_proxy: OnceLock<SharedOutbound>,
+}
+
+impl ActiveStreamPolicy {
+    fn new(settings: NodeStreamSettings) -> Self {
+        Self {
+            settings,
+            dialer_proxy: OnceLock::new(),
+        }
+    }
+
+    fn empty() -> Self {
+        Self::new(NodeStreamSettings::default())
+    }
+
+    pub(crate) fn socket(&self) -> Option<&OutboundSocketConfig> {
+        self.settings.sockopt.as_ref()
+    }
+
+    pub(crate) fn proxy(&self) -> Option<SharedOutbound> {
+        self.dialer_proxy.get().cloned()
+    }
+}
+
+/// Registry wrapper that scopes all transport dials performed by `inner`.
+pub(crate) struct ConfiguredOutbound {
+    inner: SharedOutbound,
+    policy: Arc<ActiveStreamPolicy>,
+}
+
+impl ConfiguredOutbound {
+    pub(crate) fn new(
+        inner: SharedOutbound,
+        settings: NodeStreamSettings,
+    ) -> (Arc<Self>, Arc<ActiveStreamPolicy>) {
+        let policy = Arc::new(ActiveStreamPolicy::new(settings));
+        (
+            Arc::new(Self {
+                inner,
+                policy: policy.clone(),
+            }),
+            policy,
+        )
+    }
+
+    pub(crate) fn set_dialer_proxy(
+        policy: &ActiveStreamPolicy,
+        proxy: SharedOutbound,
+    ) -> Result<(), SharedOutbound> {
+        policy.dialer_proxy.set(proxy)
+    }
+}
+
+#[async_trait]
+impl OutboundAdapter for ConfiguredOutbound {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn protocol(&self) -> &'static str {
+        self.inner.protocol()
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        self.inner.capabilities()
+    }
+
+    async fn dial_tcp(&self, ctx: DialContext) -> std::io::Result<BoxedStream> {
+        ACTIVE_STREAM_POLICY
+            .scope(self.policy.clone(), self.inner.dial_tcp(ctx))
+            .await
+    }
+
+    async fn dial_udp(&self, ctx: DialContext) -> std::io::Result<BoxedUdp> {
+        // UDP masks belong on the protocol's real PacketConn carrier, not on
+        // the application-level association returned here. Carrier-owning
+        // protocols read this task-local policy while constructing that
+        // socket; QUIC transports do the same below Quinn.
+        ACTIVE_STREAM_POLICY
+            .scope(self.policy.clone(), self.inner.dial_udp(ctx))
+            .await
+    }
+}
+
+pub(crate) fn current() -> Option<Arc<ActiveStreamPolicy>> {
+    ACTIVE_STREAM_POLICY.try_with(|policy| policy.clone()).ok()
+}
+
+/// Invoke a dialer-proxy with a cleared inherited context. A configured proxy
+/// installs its own context in `ConfiguredOutbound::dial_tcp`; built-in
+/// DIRECT/BLOCK remain empty. Clearing here is what prevents DIRECT from
+/// recursively observing the caller's `dialerProxy`.
+pub(crate) async fn dial_through_proxy(
+    proxy: SharedOutbound,
+    host: String,
+    port: u16,
+) -> std::io::Result<BoxedStream> {
+    ACTIVE_STREAM_POLICY
+        .scope(
+            Arc::new(ActiveStreamPolicy::empty()),
+            proxy.dial_tcp(DialContext::tcp(host, port)),
+        )
+        .await
+}
+
+/// UDP counterpart of [`dial_through_proxy`]. Clearing the inherited policy is
+/// equally important here: otherwise a DIRECT proxy observes the caller's
+/// `dialerProxy` and recursively dials itself.
+pub(crate) async fn dial_udp_through_proxy(
+    proxy: SharedOutbound,
+    host: String,
+    port: u16,
+) -> std::io::Result<BoxedUdp> {
+    ACTIVE_STREAM_POLICY
+        .scope(
+            Arc::new(ActiveStreamPolicy::empty()),
+            proxy.dial_udp(DialContext::udp(host, port)),
+        )
+        .await
+}
+
+/// Run a nested control-plane dial with the same socket policy and registered
+/// dialer proxy, but without applying data-plane final masks. Realm's HTTPS
+/// rendezvous connection is independent from the UDP carrier and must not be
+/// obfuscated as if it were a QUIC packet.
+pub(crate) async fn without_finalmask<F>(future: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    let Some(parent) = current() else {
+        return future.await;
+    };
+    let mut settings = parent.settings.clone();
+    settings.finalmask = None;
+    let child = Arc::new(ActiveStreamPolicy::new(settings));
+    if let Some(proxy) = parent.proxy() {
+        let _ = child.dialer_proxy.set(proxy);
+    }
+    ACTIVE_STREAM_POLICY.scope(child, future).await
+}
+
+#[cfg(test)]
+mod tests {
+    use core_config::{FinalMaskConfig, MkcpLegacyMaskConfig, QuicParamsConfig, UdpMaskConfig};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn configured_udp_mask_is_compiled_before_inner_error() {
+        let settings = NodeStreamSettings {
+            finalmask: Some(FinalMaskConfig {
+                udp: vec![UdpMaskConfig::MkcpLegacy(MkcpLegacyMaskConfig::default())],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let (outbound, _) = ConfiguredOutbound::new(crate::block::BlockOutbound::new(), settings);
+        let Err(error) = outbound.dial_udp(DialContext::udp("example.com", 53)).await else {
+            panic!("UDP finalmask unexpectedly succeeded")
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::ConnectionAborted);
+    }
+
+    #[tokio::test]
+    async fn quic_params_are_available_to_inner_dial_without_generic_rejection() {
+        let settings = NodeStreamSettings {
+            finalmask: Some(FinalMaskConfig {
+                quic_params: Some(QuicParamsConfig::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let (outbound, _) = ConfiguredOutbound::new(crate::block::BlockOutbound::new(), settings);
+        let Err(error) = outbound
+            .dial_tcp(DialContext::tcp("example.com", 443))
+            .await
+        else {
+            panic!("QUIC params unexpectedly succeeded")
+        };
+        assert_eq!(error.kind(), std::io::ErrorKind::ConnectionAborted);
+    }
+}

--- a/crates/core-outbound/src/transport/boring_tls.rs
+++ b/crates/core-outbound/src/transport/boring_tls.rs
@@ -12,6 +12,8 @@ use std::{
     time::Duration,
 };
 
+use super::{TlsOptions, tcp::connect_boxed};
+use crate::adapter::BoxedStream;
 use boring::{
     hash::MessageDigest,
     pkey::{PKey, Private},
@@ -23,13 +25,6 @@ use boring::{
     },
 };
 use core_config::model::{XhttpDownloadTlsCertificate, XhttpTlsCertificateUsage};
-use tokio::net::TcpStream;
-
-use super::{TlsOptions, tcp::marked_connect};
-use crate::{
-    adapter::{BoxedStream, resolve_host},
-    loopback::TrackedTcpStream,
-};
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -166,12 +161,12 @@ pub(crate) fn build_connector(options: &TlsOptions) -> io::Result<SslConnector> 
     Ok(builder.build())
 }
 
-pub(crate) async fn connect(
+pub(crate) async fn connect_negotiated(
     connector: Arc<SslConnector>,
     options: &TlsOptions,
     host: &str,
     port: u16,
-) -> io::Result<BoxedStream> {
+) -> io::Result<(BoxedStream, Option<Vec<u8>>)> {
     let domain = options
         .sni
         .as_deref()
@@ -187,7 +182,9 @@ pub(crate) async fn connect(
         configuration.set_verify_hostname(false);
     }
 
-    let tcp = connect_tcp(host, port).await?;
+    // Keep the node socket policy and FinalMask below TLS, exactly like the
+    // shaped-rustls backend.
+    let tcp = connect_boxed(host, port, false).await?;
     let stream = tokio::time::timeout(
         CONNECT_TIMEOUT,
         tokio_boring::connect(configuration, domain, tcp),
@@ -198,27 +195,8 @@ pub(crate) async fn connect(
     if !options.insecure {
         verify_peer(&stream, connector.as_ref(), options, domain)?;
     }
-    Ok(Box::pin(stream))
-}
-
-async fn connect_tcp(host: &str, port: u16) -> io::Result<TrackedTcpStream<TcpStream>> {
-    let addresses = resolve_host(host, port).await?;
-    let mut last_error = None;
-    for address in addresses {
-        match marked_connect(address, CONNECT_TIMEOUT).await {
-            Ok(stream) => {
-                let _ = stream.set_nodelay(true);
-                return Ok(stream);
-            }
-            Err(error) => last_error = Some(error),
-        }
-    }
-    Err(last_error.unwrap_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::AddrNotAvailable,
-            format!("TLS connect: no usable address for {host}:{port}"),
-        )
-    }))
+    let negotiated = stream.ssl().selected_alpn_protocol().map(ToOwned::to_owned);
+    Ok((Box::pin(stream), negotiated))
 }
 
 fn verify_peer<S>(

--- a/crates/core-outbound/src/transport/finalmask/fragment.rs
+++ b/crates/core-outbound/src/transport/finalmask/fragment.rs
@@ -1,0 +1,331 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use core_config::{FragmentMaskConfig, I32Range};
+use rand::Rng;
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    time::Sleep,
+};
+
+use crate::adapter::BoxedStream;
+
+struct Piece {
+    bytes: Vec<u8>,
+    written: usize,
+    delay_after: Duration,
+}
+
+struct PendingWrite {
+    original_len: usize,
+    pieces: Vec<Piece>,
+    current: usize,
+    sleep: Option<Pin<Box<Sleep>>>,
+}
+
+pub(super) struct FragmentStream {
+    inner: BoxedStream,
+    config: FragmentMaskConfig,
+    writes: u64,
+    pending: Option<PendingWrite>,
+}
+
+impl FragmentStream {
+    pub(super) fn wrap(inner: BoxedStream, config: FragmentMaskConfig) -> BoxedStream {
+        Box::pin(Self {
+            inner,
+            config,
+            writes: 0,
+            pending: None,
+        })
+    }
+
+    fn make_pending(&mut self, input: &[u8]) -> PendingWrite {
+        self.writes += 1;
+        let pieces = if self.is_tls_hello_write(input) {
+            self.split_tls_hello(input)
+        } else if self.should_fragment_write() {
+            self.split_plain(input)
+        } else {
+            vec![Piece {
+                bytes: input.to_vec(),
+                written: 0,
+                delay_after: Duration::ZERO,
+            }]
+        };
+        PendingWrite {
+            original_len: input.len(),
+            pieces,
+            current: 0,
+            sleep: None,
+        }
+    }
+
+    fn should_fragment_write(&self) -> bool {
+        if self.config.packets.eq_ignore_ascii_case("tlshello") {
+            return false;
+        }
+        let packets = self.config.packets.trim();
+        if packets.is_empty() {
+            return true;
+        }
+        let Some((from, to)) = parse_packet_range(packets) else {
+            return false;
+        };
+        let count = self.writes as i64;
+        count >= from && count <= to
+    }
+
+    fn is_tls_hello_write(&self, input: &[u8]) -> bool {
+        if !self.config.packets.eq_ignore_ascii_case("tlshello")
+            || self.writes != 1
+            || input.len() <= 5
+            || input[0] != 22
+        {
+            return false;
+        }
+        let record_len = 5 + usize::from(u16::from_be_bytes([input[3], input[4]]));
+        input.len() >= record_len
+    }
+
+    fn lengths(&self) -> &[I32Range] {
+        if self.config.lengths.is_empty() {
+            std::slice::from_ref(&self.config.length)
+        } else {
+            &self.config.lengths
+        }
+    }
+
+    fn delays(&self) -> &[I32Range] {
+        if self.config.delays.is_empty() {
+            std::slice::from_ref(&self.config.delay)
+        } else {
+            &self.config.delays
+        }
+    }
+
+    fn split_plain(&self, input: &[u8]) -> Vec<Piece> {
+        self.split_payload(input, false)
+    }
+
+    fn split_tls_hello(&self, input: &[u8]) -> Vec<Piece> {
+        let record_len = 5 + usize::from(u16::from_be_bytes([input[3], input[4]]));
+        let payload = &input[5..record_len];
+        let merge = self.delays().len() == 1 && self.delays()[0].to == 0;
+        let mut fragments = self.split_payload(payload, true);
+        for fragment in &mut fragments {
+            fragment.bytes[..3].copy_from_slice(&input[..3]);
+        }
+        let mut pieces = if merge {
+            vec![Piece {
+                bytes: fragments
+                    .into_iter()
+                    .flat_map(|piece| piece.bytes)
+                    .collect(),
+                written: 0,
+                delay_after: Duration::ZERO,
+            }]
+        } else {
+            fragments
+        };
+        if input.len() > record_len {
+            pieces.push(Piece {
+                bytes: input[record_len..].to_vec(),
+                written: 0,
+                delay_after: Duration::ZERO,
+            });
+        }
+        pieces
+    }
+
+    fn split_payload(&self, input: &[u8], tls_records: bool) -> Vec<Piece> {
+        if input.is_empty() {
+            return vec![Piece {
+                bytes: Vec::new(),
+                written: 0,
+                delay_after: Duration::ZERO,
+            }];
+        }
+        let lengths = self.lengths();
+        let delays = self.delays();
+        let max_split = random_between(self.config.max_split).max(0) as usize;
+        let mut pieces = Vec::new();
+        let mut offset = 0;
+        let mut index = 0;
+        while offset < input.len() {
+            let range = lengths[index.min(lengths.len() - 1)];
+            let requested = random_between(range).max(0) as usize;
+            let mut end = offset.saturating_add(requested).min(input.len());
+            if max_split > 0 && index + 1 >= max_split {
+                end = input.len();
+            }
+            // Earlier ranges may legally contain zero. Once the last range is
+            // reached validation guarantees progress; this guard also avoids
+            // a malformed runtime object spinning forever.
+            if end == offset && index >= lengths.len() - 1 {
+                end = input.len();
+            }
+            let delay = delays[index.min(delays.len() - 1)];
+            let delay_ms = random_between(delay).max(0) as u64;
+            let bytes = if tls_records {
+                let payload = &input[offset..end];
+                let mut record = Vec::with_capacity(5 + payload.len());
+                record.extend_from_slice(&[22, 3, 0]);
+                record.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+                record.extend_from_slice(payload);
+                record
+            } else {
+                input[offset..end].to_vec()
+            };
+            pieces.push(Piece {
+                bytes,
+                written: 0,
+                delay_after: Duration::from_millis(delay_ms),
+            });
+            offset = end;
+            index += 1;
+        }
+        pieces
+    }
+
+    fn poll_pending(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<usize>> {
+        let pending = self.pending.as_mut().expect("pending write");
+        loop {
+            if let Some(sleep) = pending.sleep.as_mut() {
+                if sleep.as_mut().poll(cx).is_pending() {
+                    return Poll::Pending;
+                }
+                pending.sleep = None;
+            }
+            if pending.current >= pending.pieces.len() {
+                let len = pending.original_len;
+                self.pending = None;
+                return Poll::Ready(Ok(len));
+            }
+            let piece = &mut pending.pieces[pending.current];
+            if piece.written < piece.bytes.len() {
+                match self
+                    .inner
+                    .as_mut()
+                    .poll_write(cx, &piece.bytes[piece.written..])
+                {
+                    Poll::Ready(Ok(0)) => {
+                        return Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::WriteZero,
+                            "fragment carrier returned write zero",
+                        )));
+                    }
+                    Poll::Ready(Ok(written)) => piece.written += written,
+                    Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                    Poll::Pending => return Poll::Pending,
+                }
+                continue;
+            }
+            let delay = piece.delay_after;
+            pending.current += 1;
+            if !delay.is_zero() {
+                pending.sleep = Some(Box::pin(tokio::time::sleep(delay)));
+            }
+        }
+    }
+}
+
+impl AsyncRead for FragmentStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        self.inner.as_mut().poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for FragmentStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        if self.pending.is_none() {
+            self.pending = Some(self.make_pending(buf));
+        }
+        self.poll_pending(cx)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if self.pending.is_some() {
+            match self.poll_pending(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        self.inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if self.pending.is_some() {
+            match self.poll_pending(cx) {
+                Poll::Ready(Ok(_)) => {}
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        self.inner.as_mut().poll_shutdown(cx)
+    }
+}
+
+fn random_between(range: I32Range) -> i32 {
+    if range.from == range.to {
+        range.from
+    } else {
+        rand::thread_rng().gen_range(range.from..range.to)
+    }
+}
+
+fn parse_packet_range(value: &str) -> Option<(i64, i64)> {
+    if let Ok(single) = value.parse::<i64>() {
+        return Some((single, single));
+    }
+    let (from, to) = value.split_once('-')?;
+    let from = from.trim().parse::<i64>().ok()?;
+    let to = to.trim().parse::<i64>().ok()?;
+    Some((from.min(to), from.max(to)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn tlshello_golden_rewrites_each_record_length_and_preserves_tail() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (client, mut peer) = tokio::io::duplex(256);
+        let config = FragmentMaskConfig {
+            packets: "tlshello".into(),
+            length: I32Range::fixed(2),
+            delay: I32Range::fixed(0),
+            max_split: I32Range::fixed(0),
+            ..Default::default()
+        };
+        let mut stream = FragmentStream::wrap(Box::pin(client), config);
+        let input = [22, 3, 3, 0, 5, 1, 2, 3, 4, 5, 99];
+        stream.write_all(&input).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut got = vec![0; 21];
+        peer.read_exact(&mut got).await.unwrap();
+        assert_eq!(
+            got,
+            vec![
+                22, 3, 3, 0, 2, 1, 2, 22, 3, 3, 0, 2, 3, 4, 22, 3, 3, 0, 1, 5, 99
+            ]
+        );
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/header_custom.rs
+++ b/crates/core-outbound/src/transport/finalmask/header_custom.rs
@@ -1,0 +1,1127 @@
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
+
+use base64::Engine;
+use core_config::{
+    CustomTransform, CustomTransformArg, HeaderCustomTcpConfig, HeaderCustomTcpItem,
+    HeaderCustomUdpConfig, HeaderCustomUdpItem, I32Range,
+};
+use parking_lot::Mutex;
+use rand::{Rng, RngCore};
+use regex::Regex;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::adapter::BoxedStream;
+
+#[derive(Clone)]
+enum EvalValue {
+    Bytes(Vec<u8>),
+    U64(u64),
+}
+
+#[derive(Default)]
+struct EvalContext {
+    vars: HashMap<String, Vec<u8>>,
+    metadata: HashMap<String, EvalValue>,
+}
+
+struct StateEntry {
+    vars: HashMap<String, Vec<u8>>,
+    expires_at: Instant,
+}
+
+static STATE: LazyLock<Mutex<HashMap<String, StateEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static VARIABLE_NAME: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").expect("static regex"));
+
+pub(super) async fn wrap_client(
+    mut stream: BoxedStream,
+    config: &HeaderCustomTcpConfig,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+    remote_host: &str,
+    remote_port: u16,
+) -> std::io::Result<BoxedStream> {
+    validate_config(config)?;
+    let mut context = EvalContext::default();
+    if let Some(local) = local {
+        load_metadata(&mut context.metadata, "local", local.ip(), local.port());
+    }
+    if let Some(remote) = remote {
+        load_metadata(&mut context.metadata, "remote", remote.ip(), remote.port());
+    } else if let Ok(ip) = remote_host.parse::<IpAddr>() {
+        load_metadata(&mut context.metadata, "remote", ip, remote_port);
+    } else {
+        let port = u64::from(remote_port);
+        context
+            .metadata
+            .insert("remote_port".into(), EvalValue::U64(port));
+        context
+            .metadata
+            .insert("src_port_u16".into(), EvalValue::U64(port));
+    }
+
+    let state_key = state_key(config, local, remote, remote_host, remote_port)?;
+    if let Some(vars) = get_state(&state_key) {
+        context.vars = vars;
+    }
+
+    let mut server_index = 0;
+    for client in &config.clients {
+        write_sequence(&mut stream, client, &mut context).await?;
+        if let Some(server) = config.servers.get(server_index) {
+            read_sequence(&mut stream, server, &mut context).await?;
+            server_index += 1;
+        }
+    }
+    while let Some(server) = config.servers.get(server_index) {
+        read_sequence(&mut stream, server, &mut context).await?;
+        server_index += 1;
+    }
+    set_state(state_key, context.vars);
+    Ok(stream)
+}
+
+pub(super) async fn wrap_server(
+    mut stream: BoxedStream,
+    config: &HeaderCustomTcpConfig,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedStream> {
+    validate_config(config)?;
+    let mut context = EvalContext::default();
+    if let Some(local) = local {
+        load_metadata(&mut context.metadata, "local", local.ip(), local.port());
+    }
+    if let Some(remote) = remote {
+        load_metadata(&mut context.metadata, "remote", remote.ip(), remote.port());
+    }
+    let state_key = state_key(
+        config,
+        local,
+        remote,
+        "",
+        remote.map_or(0, |addr| addr.port()),
+    )?;
+    if let Some(vars) = get_state(&state_key) {
+        context.vars = vars;
+    }
+
+    let mut server_index = 0;
+    for (client_index, client) in config.clients.iter().enumerate() {
+        if let Err(error) = read_sequence(&mut stream, client, &mut context).await {
+            if let Some(sequence) = config.errors.get(client_index) {
+                let _ = write_sequence(&mut stream, sequence, &mut context).await;
+            }
+            return Err(error);
+        }
+        if let Some(server) = config.servers.get(server_index) {
+            write_sequence(&mut stream, server, &mut context).await?;
+            server_index += 1;
+        }
+    }
+    while let Some(server) = config.servers.get(server_index) {
+        write_sequence(&mut stream, server, &mut context).await?;
+        server_index += 1;
+    }
+    set_state(state_key, context.vars);
+    Ok(stream)
+}
+
+fn state_key(
+    config: &HeaderCustomTcpConfig,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+    remote_host: &str,
+    remote_port: u16,
+) -> std::io::Result<String> {
+    let encoded = serde_json::to_vec(config).map_err(invalid)?;
+    let digest = blake3::hash(&encoded);
+    Ok(format!(
+        "{}|{}|{}",
+        digest.to_hex(),
+        local.map(|addr| addr.to_string()).unwrap_or_default(),
+        remote
+            .map(|addr| addr.to_string())
+            .unwrap_or_else(|| format!("{remote_host}:{remote_port}"))
+    ))
+}
+
+fn get_state(key: &str) -> Option<HashMap<String, Vec<u8>>> {
+    let mut state = STATE.lock();
+    let now = Instant::now();
+    state.retain(|_, entry| entry.expires_at > now);
+    state.get(key).map(|entry| entry.vars.clone())
+}
+
+fn set_state(key: String, vars: HashMap<String, Vec<u8>>) {
+    STATE.lock().insert(
+        key,
+        StateEntry {
+            vars,
+            expires_at: Instant::now() + Duration::from_secs(5),
+        },
+    );
+}
+
+fn load_metadata(metadata: &mut HashMap<String, EvalValue>, prefix: &str, ip: IpAddr, port: u16) {
+    let port = u64::from(port);
+    metadata.insert(format!("{prefix}_port"), EvalValue::U64(port));
+    if prefix == "remote" {
+        metadata.insert("src_port_u16".into(), EvalValue::U64(port));
+    } else {
+        metadata.insert("dst_port_u16".into(), EvalValue::U64(port));
+    }
+    if let IpAddr::V4(ip) = ip {
+        let ip = u64::from(u32::from_be_bytes(ip.octets()));
+        metadata.insert(format!("{prefix}_ip4_u32"), EvalValue::U64(ip));
+        if prefix == "remote" {
+            metadata.insert("src_ip4_u32".into(), EvalValue::U64(ip));
+        } else {
+            metadata.insert("dst_ip4_u32".into(), EvalValue::U64(ip));
+        }
+    }
+}
+
+fn validate_config(config: &HeaderCustomTcpConfig) -> std::io::Result<()> {
+    for item in config
+        .clients
+        .iter()
+        .chain(&config.servers)
+        .chain(&config.errors)
+        .flatten()
+    {
+        validate_name(&item.capture)?;
+        validate_name(&item.reuse)?;
+        let kinds = usize::from(item.packet.is_some())
+            + usize::from(item.rand > 0)
+            + usize::from(!item.reuse.is_empty())
+            + usize::from(item.transform.is_some());
+        if kinds > 1 || (kinds == 0 && !item.capture.is_empty()) {
+            return Err(invalid("header-custom item must set exactly one kind"));
+        }
+        if let Some(range) = item.rand_range
+            && (range.from < 0 || range.to > 255)
+        {
+            return Err(invalid("header-custom randRange must be within 0..=255"));
+        }
+        if let Some(transform) = &item.transform {
+            validate_transform(transform)?;
+        }
+        if item.packet.is_some() {
+            let _ = packet_bytes(item.packet.as_ref(), &item.packet_type)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_name(name: &str) -> std::io::Result<()> {
+    if !name.is_empty() && !VARIABLE_NAME.is_match(name) {
+        return Err(invalid(format!(
+            "invalid header-custom variable name `{name}`"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_transform(transform: &CustomTransform) -> std::io::Result<()> {
+    if transform.op.is_empty() || transform.args.is_empty() {
+        return Err(invalid("header-custom transform requires op and args"));
+    }
+    for arg in &transform.args {
+        let kinds = usize::from(arg.bytes.is_some())
+            + usize::from(arg.u64.is_some())
+            + usize::from(!arg.reuse.is_empty())
+            + usize::from(!arg.metadata.is_empty())
+            + usize::from(arg.transform.is_some());
+        if kinds != 1 {
+            return Err(invalid(
+                "header-custom transform arg must set exactly one value",
+            ));
+        }
+        validate_name(&arg.reuse)?;
+        if let Some(nested) = &arg.transform {
+            validate_transform(nested)?;
+        }
+        if arg.bytes.is_some() {
+            let _ = packet_bytes(arg.bytes.as_ref(), &arg.bytes_type)?;
+        }
+    }
+    Ok(())
+}
+
+async fn write_sequence(
+    stream: &mut BoxedStream,
+    sequence: &[HeaderCustomTcpItem],
+    context: &mut EvalContext,
+) -> std::io::Result<()> {
+    let mut merged = Vec::new();
+    for item in sequence {
+        if item.delay.to > 0 {
+            if !merged.is_empty() {
+                stream.write_all(&merged).await?;
+                merged.clear();
+            }
+            tokio::time::sleep(Duration::from_millis(
+                random_between(item.delay).max(0) as u64
+            ))
+            .await;
+        }
+        merged.extend_from_slice(&evaluate_item(item, context)?);
+    }
+    if !merged.is_empty() {
+        stream.write_all(&merged).await?;
+    }
+    Ok(())
+}
+
+async fn read_sequence(
+    stream: &mut BoxedStream,
+    sequence: &[HeaderCustomTcpItem],
+    context: &mut EvalContext,
+) -> std::io::Result<()> {
+    for item in sequence {
+        let length = measure_item(item, &context.vars)?;
+        let mut received = vec![0; length];
+        stream.read_exact(&mut received).await?;
+        let expected = match item_kind(item)? {
+            ItemKind::Random(_) | ItemKind::Empty => None,
+            ItemKind::Packet(bytes) => Some(bytes),
+            ItemKind::Reuse(name) => Some(
+                context
+                    .vars
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| invalid(format!("unknown variable `{name}`")))?,
+            ),
+            ItemKind::Transform(transform) => {
+                Some(as_bytes(evaluate_transform(transform, context)?)?)
+            }
+        };
+        if expected
+            .as_ref()
+            .is_some_and(|expected| expected != &received)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "header-custom server sequence mismatch",
+            ));
+        }
+        if !item.capture.is_empty() {
+            context.vars.insert(item.capture.clone(), received);
+        }
+    }
+    Ok(())
+}
+
+enum ItemKind<'a> {
+    Random(usize),
+    Packet(Vec<u8>),
+    Reuse(&'a str),
+    Transform(&'a CustomTransform),
+    Empty,
+}
+
+fn item_kind(item: &HeaderCustomTcpItem) -> std::io::Result<ItemKind<'_>> {
+    if item.rand > 0 {
+        Ok(ItemKind::Random(item.rand as usize))
+    } else if item.packet.is_some() {
+        Ok(ItemKind::Packet(packet_bytes(
+            item.packet.as_ref(),
+            &item.packet_type,
+        )?))
+    } else if !item.reuse.is_empty() {
+        Ok(ItemKind::Reuse(&item.reuse))
+    } else if let Some(transform) = &item.transform {
+        Ok(ItemKind::Transform(transform))
+    } else {
+        Ok(ItemKind::Empty)
+    }
+}
+
+fn evaluate_item(
+    item: &HeaderCustomTcpItem,
+    context: &mut EvalContext,
+) -> std::io::Result<Vec<u8>> {
+    let value = match item_kind(item)? {
+        ItemKind::Random(length) => {
+            let range = item.rand_range.unwrap_or_else(|| I32Range::new(0, 255));
+            let mut value = vec![0; length];
+            if range.from == 0 && range.to == 255 {
+                rand::thread_rng().fill_bytes(&mut value);
+            } else {
+                let mut rng = rand::thread_rng();
+                for byte in &mut value {
+                    *byte = rng.gen_range(range.from..=range.to) as u8;
+                }
+            }
+            value
+        }
+        ItemKind::Packet(value) => value,
+        ItemKind::Reuse(name) => context
+            .vars
+            .get(name)
+            .cloned()
+            .ok_or_else(|| invalid(format!("unknown variable `{name}`")))?,
+        ItemKind::Transform(transform) => as_bytes(evaluate_transform(transform, context)?)?,
+        ItemKind::Empty => Vec::new(),
+    };
+    if !item.capture.is_empty() {
+        context.vars.insert(item.capture.clone(), value.clone());
+    }
+    Ok(value)
+}
+
+fn measure_item(
+    item: &HeaderCustomTcpItem,
+    vars: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<usize> {
+    match item_kind(item)? {
+        ItemKind::Random(length) => Ok(length),
+        ItemKind::Packet(value) => Ok(value.len()),
+        ItemKind::Reuse(name) => vars
+            .get(name)
+            .map(Vec::len)
+            .ok_or_else(|| invalid(format!("unknown variable `{name}`"))),
+        ItemKind::Transform(transform) => measure_transform(transform, vars),
+        ItemKind::Empty => Ok(0),
+    }
+}
+
+fn measure_transform(
+    transform: &CustomTransform,
+    vars: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<usize> {
+    match transform.op.as_str() {
+        "concat" => transform
+            .args
+            .iter()
+            .try_fold(0usize, |total, arg| Ok(total + measure_arg(arg, vars)?)),
+        "slice" if transform.args.len() == 3 => literal_u64(&transform.args[2]).map(|v| v as usize),
+        "be16" | "le16" => Ok(2),
+        "be32" | "le32" => Ok(4),
+        "le64" => Ok(8),
+        "pad" if transform.args.len() == 3 => literal_u64(&transform.args[1]).map(|v| v as usize),
+        "truncate" if transform.args.len() == 2 => {
+            literal_u64(&transform.args[1]).map(|v| v as usize)
+        }
+        op => Err(invalid(format!("expr size is not bytes for op `{op}`"))),
+    }
+}
+
+fn measure_arg(
+    arg: &CustomTransformArg,
+    vars: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<usize> {
+    if arg.bytes.is_some() {
+        packet_bytes(arg.bytes.as_ref(), &arg.bytes_type).map(|value| value.len())
+    } else if !arg.reuse.is_empty() {
+        vars.get(&arg.reuse)
+            .map(Vec::len)
+            .ok_or_else(|| invalid(format!("unknown variable `{}`", arg.reuse)))
+    } else if let Some(transform) = &arg.transform {
+        measure_transform(transform, vars)
+    } else {
+        Err(invalid("u64/metadata arg has no byte width"))
+    }
+}
+
+fn evaluate_transform(
+    transform: &CustomTransform,
+    context: &EvalContext,
+) -> std::io::Result<EvalValue> {
+    let args = &transform.args;
+    match transform.op.as_str() {
+        "concat" => {
+            let mut output = Vec::new();
+            for arg in args {
+                output.extend_from_slice(&as_bytes(evaluate_arg(arg, context)?)?);
+            }
+            Ok(EvalValue::Bytes(output))
+        }
+        "slice" => {
+            expect_args(args, 3, "slice")?;
+            let source = as_bytes(evaluate_arg(&args[0], context)?)?;
+            let offset = as_u64(evaluate_arg(&args[1], context)?)? as usize;
+            let length = as_u64(evaluate_arg(&args[2], context)?)? as usize;
+            let end = offset
+                .checked_add(length)
+                .ok_or_else(|| invalid("slice overflow"))?;
+            Ok(EvalValue::Bytes(
+                source
+                    .get(offset..end)
+                    .ok_or_else(|| invalid("slice out of bounds"))?
+                    .to_vec(),
+            ))
+        }
+        "xor16" => evaluate_xor(args, context, u16::MAX as u64, "xor16"),
+        "xor32" => evaluate_xor(args, context, u32::MAX as u64, "xor32"),
+        "be16" => pack(args, context, 2, true, "be16"),
+        "be32" => pack(args, context, 4, true, "be32"),
+        "le16" => pack(args, context, 2, false, "le16"),
+        "le32" => pack(args, context, 4, false, "le32"),
+        "le64" => pack(args, context, 8, false, "le64"),
+        "pad" => {
+            expect_args(args, 3, "pad")?;
+            let mut source = as_bytes(evaluate_arg(&args[0], context)?)?;
+            let target = as_u64(evaluate_arg(&args[1], context)?)? as usize;
+            let fill = as_bytes(evaluate_arg(&args[2], context)?)?;
+            if fill.is_empty() || target < source.len() {
+                return Err(invalid("pad fill must be non-empty and target >= source"));
+            }
+            while source.len() < target {
+                let count = (target - source.len()).min(fill.len());
+                source.extend_from_slice(&fill[..count]);
+            }
+            Ok(EvalValue::Bytes(source))
+        }
+        "truncate" => {
+            expect_args(args, 2, "truncate")?;
+            let source = as_bytes(evaluate_arg(&args[0], context)?)?;
+            let length = as_u64(evaluate_arg(&args[1], context)?)? as usize;
+            Ok(EvalValue::Bytes(
+                source
+                    .get(..length)
+                    .ok_or_else(|| invalid("truncate out of bounds"))?
+                    .to_vec(),
+            ))
+        }
+        "add" => binary_u64(args, context, "add", u64::checked_add),
+        "sub" => binary_u64(args, context, "sub", u64::checked_sub),
+        "and" => binary_u64(args, context, "and", |a, b| Some(a & b)),
+        "or" => binary_u64(args, context, "or", |a, b| Some(a | b)),
+        "shl" => shift(args, context, true),
+        "shr" => shift(args, context, false),
+        op => Err(invalid(format!("unsupported expr op `{op}`"))),
+    }
+}
+
+fn evaluate_arg(arg: &CustomTransformArg, context: &EvalContext) -> std::io::Result<EvalValue> {
+    if arg.bytes.is_some() {
+        Ok(EvalValue::Bytes(packet_bytes(
+            arg.bytes.as_ref(),
+            &arg.bytes_type,
+        )?))
+    } else if let Some(value) = arg.u64 {
+        Ok(EvalValue::U64(value))
+    } else if !arg.reuse.is_empty() {
+        context
+            .vars
+            .get(&arg.reuse)
+            .cloned()
+            .map(EvalValue::Bytes)
+            .ok_or_else(|| invalid(format!("unknown variable `{}`", arg.reuse)))
+    } else if !arg.metadata.is_empty() {
+        context
+            .metadata
+            .get(&arg.metadata)
+            .cloned()
+            .ok_or_else(|| invalid(format!("unknown metadata `{}`", arg.metadata)))
+    } else if let Some(transform) = &arg.transform {
+        evaluate_transform(transform, context)
+    } else {
+        Err(invalid("empty transform arg"))
+    }
+}
+
+fn evaluate_xor(
+    args: &[CustomTransformArg],
+    context: &EvalContext,
+    mask: u64,
+    name: &str,
+) -> std::io::Result<EvalValue> {
+    expect_args(args, 2, name)?;
+    let left = as_u64(evaluate_arg(&args[0], context)?)?;
+    let right = as_u64(evaluate_arg(&args[1], context)?)?;
+    if left > mask || right > mask {
+        return Err(invalid(format!("{name} overflow")));
+    }
+    Ok(EvalValue::U64((left ^ right) & mask))
+}
+
+fn pack(
+    args: &[CustomTransformArg],
+    context: &EvalContext,
+    width: usize,
+    big_endian: bool,
+    name: &str,
+) -> std::io::Result<EvalValue> {
+    expect_args(args, 1, name)?;
+    let value = as_u64(evaluate_arg(&args[0], context)?)?;
+    if width < 8 && value >= (1u64 << (width * 8)) {
+        return Err(invalid(format!("{name} overflow")));
+    }
+    let bytes = if big_endian {
+        value.to_be_bytes()[8 - width..].to_vec()
+    } else {
+        value.to_le_bytes()[..width].to_vec()
+    };
+    Ok(EvalValue::Bytes(bytes))
+}
+
+fn binary_u64(
+    args: &[CustomTransformArg],
+    context: &EvalContext,
+    name: &str,
+    op: fn(u64, u64) -> Option<u64>,
+) -> std::io::Result<EvalValue> {
+    expect_args(args, 2, name)?;
+    let left = as_u64(evaluate_arg(&args[0], context)?)?;
+    let right = as_u64(evaluate_arg(&args[1], context)?)?;
+    op(left, right)
+        .map(EvalValue::U64)
+        .ok_or_else(|| invalid(format!("{name} overflow/underflow")))
+}
+
+fn shift(
+    args: &[CustomTransformArg],
+    context: &EvalContext,
+    left: bool,
+) -> std::io::Result<EvalValue> {
+    let name = if left { "shl" } else { "shr" };
+    expect_args(args, 2, name)?;
+    let value = as_u64(evaluate_arg(&args[0], context)?)?;
+    let shift = as_u64(evaluate_arg(&args[1], context)?)?;
+    if shift >= 64 {
+        return Err(invalid("shift out of range"));
+    }
+    let result = if left {
+        value.checked_shl(shift as u32)
+    } else {
+        value.checked_shr(shift as u32)
+    }
+    .ok_or_else(|| invalid(format!("{name} overflow")))?;
+    if left && (result >> shift) != value {
+        return Err(invalid("shl overflow"));
+    }
+    Ok(EvalValue::U64(result))
+}
+
+fn expect_args(args: &[CustomTransformArg], count: usize, name: &str) -> std::io::Result<()> {
+    if args.len() == count {
+        Ok(())
+    } else {
+        Err(invalid(format!("{name} expects {count} args")))
+    }
+}
+
+fn literal_u64(arg: &CustomTransformArg) -> std::io::Result<u64> {
+    arg.u64
+        .ok_or_else(|| invalid("expression size requires a literal u64"))
+}
+
+fn as_bytes(value: EvalValue) -> std::io::Result<Vec<u8>> {
+    match value {
+        EvalValue::Bytes(value) => Ok(value),
+        EvalValue::U64(_) => Err(invalid("expr value is not bytes")),
+    }
+}
+
+fn as_u64(value: EvalValue) -> std::io::Result<u64> {
+    match value {
+        EvalValue::U64(value) => Ok(value),
+        EvalValue::Bytes(_) => Err(invalid("expr value is not u64")),
+    }
+}
+
+fn packet_bytes(value: Option<&serde_json::Value>, kind: &str) -> std::io::Result<Vec<u8>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    match kind.to_ascii_lowercase().as_str() {
+        "" | "array" => serde_json::from_value::<Vec<u8>>(value.clone()).map_err(invalid),
+        "str" => value
+            .as_str()
+            .map(|value| value.as_bytes().to_vec())
+            .ok_or_else(|| invalid("header-custom str bytes must be a JSON string")),
+        "hex" => value
+            .as_str()
+            .ok_or_else(|| invalid("header-custom hex bytes must be a JSON string"))
+            .and_then(|value| hex::decode(value).map_err(invalid)),
+        "base64" => value
+            .as_str()
+            .ok_or_else(|| invalid("header-custom base64 bytes must be a JSON string"))
+            .and_then(|value| {
+                base64::engine::general_purpose::STANDARD
+                    .decode(value)
+                    .map_err(invalid)
+            }),
+        kind => Err(invalid(format!("unknown header-custom byte type `{kind}`"))),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UdpRole {
+    Client,
+    Server,
+}
+
+pub(super) enum StandaloneServerAction {
+    Reply(Vec<u8>),
+    Payload(Vec<u8>),
+    Drop,
+}
+
+/// Per-association UDP evaluator. Xray keys its state by peer address; a
+/// `UdpSocketLike` already represents one association, so one instance is the
+/// exact equivalent without an unbounded global peer map.
+pub(super) struct UdpCustomCodec {
+    config: HeaderCustomUdpConfig,
+    role: UdpRole,
+    context: EvalContext,
+    expires_at: Option<Instant>,
+}
+
+impl UdpCustomCodec {
+    pub(super) fn new(
+        config: &HeaderCustomUdpConfig,
+        role: UdpRole,
+        local: Option<SocketAddr>,
+        remote: Option<SocketAddr>,
+    ) -> std::io::Result<Self> {
+        validate_udp_config(config)?;
+        let mut context = EvalContext::default();
+        if let Some(local) = local {
+            load_metadata(&mut context.metadata, "local", local.ip(), local.port());
+        }
+        if let Some(remote) = remote {
+            load_metadata(&mut context.metadata, "remote", remote.ip(), remote.port());
+        }
+        Ok(Self {
+            config: config.clone(),
+            role,
+            context,
+            expires_at: None,
+        })
+    }
+
+    pub(super) fn is_standalone(&self) -> bool {
+        self.config.mode.eq_ignore_ascii_case("standalone")
+    }
+
+    pub(super) fn established(&mut self) -> bool {
+        self.expire_state();
+        self.expires_at.is_some()
+    }
+
+    pub(super) fn encode_prefix(&mut self, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+        if self.is_standalone() {
+            return Ok(payload.to_vec());
+        }
+        self.expire_state();
+        let items = match self.role {
+            UdpRole::Client => &self.config.client,
+            UdpRole::Server => &self.config.server,
+        };
+        let header = evaluate_udp_items(items, &mut self.context)?;
+        self.touch();
+        let mut packet = Vec::with_capacity(header.len() + payload.len());
+        packet.extend_from_slice(&header);
+        packet.extend_from_slice(payload);
+        Ok(packet)
+    }
+
+    pub(super) fn decode_prefix(&mut self, packet: &[u8]) -> std::io::Result<Vec<u8>> {
+        if self.is_standalone() {
+            return Ok(packet.to_vec());
+        }
+        self.expire_state();
+        let items = match self.role {
+            UdpRole::Client => &self.config.server,
+            UdpRole::Server => &self.config.client,
+        };
+        let consumed = match_udp_items(items, packet, &mut self.context)?;
+        self.touch();
+        Ok(packet[consumed..].to_vec())
+    }
+
+    pub(super) fn standalone_request(&mut self) -> std::io::Result<Vec<u8>> {
+        if !self.is_standalone() || self.role != UdpRole::Client {
+            return Err(invalid(
+                "header-custom standalone request used in the wrong role",
+            ));
+        }
+        self.expire_state();
+        evaluate_udp_items(&self.config.client, &mut self.context)
+    }
+
+    pub(super) fn accept_standalone_response(&mut self, packet: &[u8]) -> std::io::Result<bool> {
+        if !self.is_standalone() || self.role != UdpRole::Client {
+            return Err(invalid(
+                "header-custom standalone response used in the wrong role",
+            ));
+        }
+        let expected = measure_udp_items(&self.config.server, &self.context.vars)?;
+        if packet.len() != expected {
+            return Ok(false);
+        }
+        match match_udp_items(&self.config.server, packet, &mut self.context) {
+            Ok(consumed) if consumed == packet.len() => {
+                self.touch();
+                Ok(true)
+            }
+            Ok(_) | Err(_) => Ok(false),
+        }
+    }
+
+    pub(super) fn handle_standalone_server_packet(
+        &mut self,
+        packet: &[u8],
+    ) -> std::io::Result<StandaloneServerAction> {
+        if !self.is_standalone() || self.role != UdpRole::Server {
+            return Err(invalid(
+                "header-custom standalone server used in the wrong role",
+            ));
+        }
+        self.expire_state();
+        let expected = match measure_udp_items(&self.config.client, &self.context.vars) {
+            Ok(expected) => expected,
+            Err(_) => return Ok(StandaloneServerAction::Drop),
+        };
+        if packet.len() != expected {
+            return Ok(StandaloneServerAction::Payload(packet.to_vec()));
+        }
+        if match_udp_items(&self.config.client, packet, &mut self.context).is_err() {
+            return Ok(StandaloneServerAction::Payload(packet.to_vec()));
+        }
+        let reply = evaluate_udp_items(&self.config.server, &mut self.context)?;
+        self.touch();
+        Ok(StandaloneServerAction::Reply(reply))
+    }
+
+    fn touch(&mut self) {
+        self.expires_at = Some(Instant::now() + Duration::from_secs(5));
+    }
+
+    fn expire_state(&mut self) {
+        if self
+            .expires_at
+            .is_some_and(|deadline| deadline <= Instant::now())
+        {
+            self.context.vars.clear();
+            self.expires_at = None;
+        }
+    }
+}
+
+fn validate_udp_config(config: &HeaderCustomUdpConfig) -> std::io::Result<()> {
+    if !matches!(
+        config.mode.to_ascii_lowercase().as_str(),
+        "" | "prefix" | "standalone"
+    ) {
+        return Err(invalid(format!(
+            "unknown header-custom UDP mode `{}`",
+            config.mode
+        )));
+    }
+    for item in config.client.iter().chain(&config.server) {
+        validate_name(&item.capture)?;
+        validate_name(&item.reuse)?;
+        let kinds = usize::from(item.packet.is_some())
+            + usize::from(item.rand > 0)
+            + usize::from(!item.reuse.is_empty())
+            + usize::from(item.transform.is_some());
+        if kinds > 1 || (kinds == 0 && !item.capture.is_empty()) {
+            return Err(invalid("header-custom UDP item must set exactly one kind"));
+        }
+        if let Some(range) = item.rand_range
+            && (range.from < 0 || range.to > 255)
+        {
+            return Err(invalid(
+                "header-custom UDP randRange must be within 0..=255",
+            ));
+        }
+        if let Some(transform) = &item.transform {
+            validate_transform(transform)?;
+        }
+        if item.packet.is_some() {
+            let _ = packet_bytes(item.packet.as_ref(), &item.packet_type)?;
+        }
+    }
+    Ok(())
+}
+
+fn evaluate_udp_items(
+    items: &[HeaderCustomUdpItem],
+    context: &mut EvalContext,
+) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    for item in items {
+        let value = evaluate_udp_item(item, context)?;
+        output.extend_from_slice(&value);
+    }
+    Ok(output)
+}
+
+fn evaluate_udp_item(
+    item: &HeaderCustomUdpItem,
+    context: &mut EvalContext,
+) -> std::io::Result<Vec<u8>> {
+    let value = if item.rand > 0 {
+        let length = usize::try_from(item.rand).map_err(invalid)?;
+        let range = item.rand_range.unwrap_or_else(|| I32Range::new(0, 255));
+        let mut output = vec![0; length];
+        if range.from == 0 && range.to == 255 {
+            rand::thread_rng().fill_bytes(&mut output);
+        } else {
+            let mut rng = rand::thread_rng();
+            for byte in &mut output {
+                *byte = rng.gen_range(range.from..=range.to) as u8;
+            }
+        }
+        output
+    } else if item.packet.is_some() {
+        packet_bytes(item.packet.as_ref(), &item.packet_type)?
+    } else if !item.reuse.is_empty() {
+        context
+            .vars
+            .get(&item.reuse)
+            .cloned()
+            .ok_or_else(|| invalid(format!("unknown variable `{}`", item.reuse)))?
+    } else if let Some(transform) = &item.transform {
+        as_bytes(evaluate_transform(transform, context)?)?
+    } else {
+        Vec::new()
+    };
+    if !item.capture.is_empty() {
+        context.vars.insert(item.capture.clone(), value.clone());
+    }
+    Ok(value)
+}
+
+fn measure_udp_items(
+    items: &[HeaderCustomUdpItem],
+    vars: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<usize> {
+    items.iter().try_fold(0usize, |total, item| {
+        total
+            .checked_add(measure_udp_item(item, vars)?)
+            .ok_or_else(|| invalid("header-custom UDP header size overflow"))
+    })
+}
+
+fn measure_udp_item(
+    item: &HeaderCustomUdpItem,
+    vars: &HashMap<String, Vec<u8>>,
+) -> std::io::Result<usize> {
+    if item.rand > 0 {
+        usize::try_from(item.rand).map_err(invalid)
+    } else if item.packet.is_some() {
+        packet_bytes(item.packet.as_ref(), &item.packet_type).map(|value| value.len())
+    } else if !item.reuse.is_empty() {
+        vars.get(&item.reuse)
+            .map(Vec::len)
+            .ok_or_else(|| invalid(format!("unknown variable `{}`", item.reuse)))
+    } else if let Some(transform) = &item.transform {
+        measure_transform(transform, vars)
+    } else {
+        Ok(0)
+    }
+}
+
+fn match_udp_items(
+    items: &[HeaderCustomUdpItem],
+    packet: &[u8],
+    context: &mut EvalContext,
+) -> std::io::Result<usize> {
+    let mut offset = 0usize;
+    for item in items {
+        let length = measure_udp_item(item, &context.vars)?;
+        let end = offset
+            .checked_add(length)
+            .ok_or_else(|| invalid("header-custom UDP header size overflow"))?;
+        let segment = packet
+            .get(offset..end)
+            .ok_or_else(|| invalid("header-custom UDP packet is truncated"))?;
+        let expected = if item.rand > 0 {
+            None
+        } else if item.packet.is_some() {
+            Some(packet_bytes(item.packet.as_ref(), &item.packet_type)?)
+        } else if !item.reuse.is_empty() {
+            Some(
+                context
+                    .vars
+                    .get(&item.reuse)
+                    .cloned()
+                    .ok_or_else(|| invalid(format!("unknown variable `{}`", item.reuse)))?,
+            )
+        } else if let Some(transform) = &item.transform {
+            Some(as_bytes(evaluate_transform(transform, context)?)?)
+        } else {
+            None
+        };
+        if expected
+            .as_deref()
+            .is_some_and(|expected| expected != segment)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "header-custom UDP header mismatch",
+            ));
+        }
+        if !item.capture.is_empty() {
+            context.vars.insert(item.capture.clone(), segment.to_vec());
+        }
+        offset = end;
+    }
+    Ok(offset)
+}
+
+fn random_between(range: I32Range) -> i32 {
+    if range.from == range.to {
+        range.from
+    } else {
+        rand::thread_rng().gen_range(range.from..range.to)
+    }
+}
+
+fn invalid(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expression_golden_uses_metadata_capture_and_endianness() {
+        let mut context = EvalContext::default();
+        load_metadata(
+            &mut context.metadata,
+            "remote",
+            "192.0.2.1".parse().unwrap(),
+            443,
+        );
+        let expression = CustomTransform {
+            op: "concat".into(),
+            args: vec![
+                CustomTransformArg {
+                    metadata: "src_ip4_u32".into(),
+                    transform: None,
+                    ..Default::default()
+                },
+                CustomTransformArg {
+                    transform: Some(Box::new(CustomTransform {
+                        op: "be16".into(),
+                        args: vec![CustomTransformArg {
+                            metadata: "src_port_u16".into(),
+                            ..Default::default()
+                        }],
+                    })),
+                    ..Default::default()
+                },
+            ],
+        };
+        // Raw u64 metadata cannot be concatenated without packing.
+        assert!(evaluate_transform(&expression, &context).is_err());
+        let packed_ip = CustomTransform {
+            op: "be32".into(),
+            args: vec![expression.args[0].clone()],
+        };
+        assert_eq!(
+            as_bytes(evaluate_transform(&packed_ip, &context).unwrap()).unwrap(),
+            [192, 0, 2, 1]
+        );
+    }
+
+    #[test]
+    fn udp_prefix_captures_and_reuses_across_directions() {
+        let config = HeaderCustomUdpConfig {
+            mode: "prefix".into(),
+            client: vec![HeaderCustomUdpItem {
+                rand: 4,
+                capture: "token".into(),
+                ..Default::default()
+            }],
+            server: vec![HeaderCustomUdpItem {
+                reuse: "token".into(),
+                ..Default::default()
+            }],
+        };
+        let remote = Some("192.0.2.1:443".parse().unwrap());
+        let mut client = UdpCustomCodec::new(&config, UdpRole::Client, None, remote).unwrap();
+        let mut server = UdpCustomCodec::new(&config, UdpRole::Server, None, remote).unwrap();
+        let request = client.encode_prefix(b"hello").unwrap();
+        assert_eq!(server.decode_prefix(&request).unwrap(), b"hello");
+        let response = server.encode_prefix(b"world").unwrap();
+        assert_eq!(client.decode_prefix(&response).unwrap(), b"world");
+    }
+
+    #[test]
+    fn udp_prefix_rejects_mismatch_and_truncation() {
+        let config = HeaderCustomUdpConfig {
+            mode: "prefix".into(),
+            client: vec![HeaderCustomUdpItem {
+                packet_type: "hex".into(),
+                packet: Some(serde_json::Value::String("aabb".into())),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let mut server = UdpCustomCodec::new(&config, UdpRole::Server, None, None).unwrap();
+        assert!(server.decode_prefix(&[0xaa]).is_err());
+        assert!(server.decode_prefix(&[0xaa, 0xbc, 1]).is_err());
+    }
+
+    #[test]
+    fn udp_standalone_handshake_is_consumed_before_payload() {
+        let config = HeaderCustomUdpConfig {
+            mode: "standalone".into(),
+            client: vec![HeaderCustomUdpItem {
+                rand: 2,
+                capture: "seed".into(),
+                ..Default::default()
+            }],
+            server: vec![HeaderCustomUdpItem {
+                reuse: "seed".into(),
+                ..Default::default()
+            }],
+        };
+        let mut client = UdpCustomCodec::new(&config, UdpRole::Client, None, None).unwrap();
+        let mut server = UdpCustomCodec::new(&config, UdpRole::Server, None, None).unwrap();
+        let request = client.standalone_request().unwrap();
+        let StandaloneServerAction::Reply(response) =
+            server.handle_standalone_server_packet(&request).unwrap()
+        else {
+            panic!("standalone request was not recognized")
+        };
+        assert!(client.accept_standalone_response(&response).unwrap());
+        assert!(client.established());
+        assert!(matches!(
+            server.handle_standalone_server_packet(b"payload").unwrap(),
+            StandaloneServerAction::Payload(payload) if payload == b"payload"
+        ));
+    }
+
+    #[tokio::test]
+    async fn tcp_client_and_server_handshake_roundtrip() {
+        let config = HeaderCustomTcpConfig {
+            clients: vec![vec![HeaderCustomTcpItem {
+                packet_type: "str".into(),
+                packet: Some(serde_json::Value::String("client".into())),
+                ..Default::default()
+            }]],
+            servers: vec![vec![HeaderCustomTcpItem {
+                packet_type: "str".into(),
+                packet: Some(serde_json::Value::String("server".into())),
+                ..Default::default()
+            }]],
+            errors: Vec::new(),
+        };
+        let (left, right) = tokio::io::duplex(4096);
+        let client = wrap_client(Box::pin(left), &config, None, None, "test", 1);
+        let server = wrap_server(Box::pin(right), &config, None, None);
+        let (client, server) = tokio::join!(client, server);
+        let mut client = client.unwrap();
+        let mut server = server.unwrap();
+        client.write_all(b"request").await.unwrap();
+        let mut request = [0; 7];
+        server.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"request");
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/mkcp.rs
+++ b/crates/core-outbound/src/transport/finalmask/mkcp.rs
@@ -1,0 +1,361 @@
+//! Xray 26.7.11 `mkcp-legacy` UDP masks.
+//!
+//! This is a byte-for-byte port of the implementations under
+//! `transport/internet/finalmask/mkcp` at commit
+//! `6e3322d219140a025285ded1114fe17a5edb74d8`.
+
+use aes_gcm::{
+    Aes128Gcm, Nonce,
+    aead::{Aead, KeyInit},
+};
+use core_config::MkcpLegacyMaskConfig;
+use rand::{RngCore, rngs::OsRng};
+use sha2::{Digest, Sha256};
+
+const AES_NONCE_SIZE: usize = 12;
+
+pub(super) struct MkcpCodec {
+    mode: Mode,
+}
+
+enum Mode {
+    Original,
+    Aes128Gcm(Aes128Gcm),
+    Header(Header),
+}
+
+enum Header {
+    Dns(Vec<u8>),
+    Dtls {
+        epoch: u16,
+        length: u16,
+        sequence: u32,
+    },
+    Srtp {
+        header: u16,
+        number: u16,
+    },
+    Utp {
+        header: u8,
+        extension: u8,
+        connection_id: u16,
+    },
+    Wechat {
+        sequence: u32,
+    },
+    Wireguard,
+}
+
+impl MkcpCodec {
+    pub(super) fn new(config: &MkcpLegacyMaskConfig) -> std::io::Result<Self> {
+        let mode = if config.header.is_empty() {
+            if config.value.is_empty() {
+                Mode::Original
+            } else {
+                let hash = Sha256::digest(config.value.as_bytes());
+                Mode::Aes128Gcm(Aes128Gcm::new_from_slice(&hash[..16]).map_err(invalid)?)
+            }
+        } else {
+            let header = match config.header.to_ascii_lowercase().as_str() {
+                "dns" => Header::Dns(dns_header(if config.value.is_empty() {
+                    "www.baidu.com"
+                } else {
+                    &config.value
+                })?),
+                "dtls" => Header::Dtls {
+                    epoch: 0,
+                    length: 0,
+                    sequence: 0,
+                },
+                "srtp" => Header::Srtp {
+                    header: 0,
+                    number: 0,
+                },
+                "utp" => Header::Utp {
+                    header: 0,
+                    extension: 0,
+                    connection_id: 0,
+                },
+                "wechat" => Header::Wechat { sequence: 0 },
+                "wireguard" => Header::Wireguard,
+                other => {
+                    return Err(invalid(format!("invalid mkcp-legacy header `{other}`")));
+                }
+            };
+            Mode::Header(header)
+        };
+        Ok(Self { mode })
+    }
+
+    pub(super) fn encode(&mut self, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+        match &mut self.mode {
+            Mode::Original => encode_original(payload),
+            Mode::Aes128Gcm(cipher) => {
+                let mut nonce = [0u8; AES_NONCE_SIZE];
+                OsRng.fill_bytes(&mut nonce);
+                let encrypted = cipher
+                    .encrypt(Nonce::from_slice(&nonce), payload)
+                    .map_err(other)?;
+                let mut output = Vec::with_capacity(nonce.len() + encrypted.len());
+                output.extend_from_slice(&nonce);
+                output.extend_from_slice(&encrypted);
+                Ok(output)
+            }
+            Mode::Header(header) => {
+                let mut output = vec![0; header.size()];
+                header.serialize(&mut output);
+                output.extend_from_slice(payload);
+                Ok(output)
+            }
+        }
+    }
+
+    pub(super) fn decode(&mut self, packet: &[u8]) -> std::io::Result<Vec<u8>> {
+        match &mut self.mode {
+            Mode::Original => decode_original(packet),
+            Mode::Aes128Gcm(cipher) => {
+                if packet.len() < AES_NONCE_SIZE + 16 {
+                    return Err(invalid("mkcp-legacy aes128gcm packet is truncated"));
+                }
+                cipher
+                    .decrypt(
+                        Nonce::from_slice(&packet[..AES_NONCE_SIZE]),
+                        &packet[AES_NONCE_SIZE..],
+                    )
+                    .map_err(|_| invalid("mkcp-legacy aes128gcm authentication failed"))
+            }
+            Mode::Header(header) => packet
+                .get(header.size()..)
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| invalid("mkcp-legacy header packet is truncated")),
+        }
+    }
+}
+
+impl Header {
+    fn size(&self) -> usize {
+        match self {
+            Self::Dns(header) => header.len(),
+            Self::Dtls { .. } | Self::Wechat { .. } => 13,
+            Self::Srtp { .. } | Self::Utp { .. } | Self::Wireguard => 4,
+        }
+    }
+
+    fn serialize(&mut self, output: &mut [u8]) {
+        match self {
+            Self::Dns(header) => {
+                output.copy_from_slice(header);
+                let txid = rand::random::<u16>().to_be_bytes();
+                output[..2].copy_from_slice(&txid);
+            }
+            Self::Dtls {
+                epoch,
+                length,
+                sequence,
+            } => {
+                output[0] = 23;
+                output[1] = 254;
+                output[2] = 253;
+                output[3..5].copy_from_slice(&epoch.to_be_bytes());
+                output[5] = 0;
+                output[6] = 0;
+                output[7..11].copy_from_slice(&sequence.to_be_bytes());
+                *sequence = sequence.wrapping_add(1);
+                output[11..13].copy_from_slice(&length.to_be_bytes());
+                *length = length.wrapping_add(17);
+                if *length > 100 {
+                    *length -= 50;
+                }
+            }
+            Self::Srtp { header, number } => {
+                *number = number.wrapping_add(1);
+                output[..2].copy_from_slice(&header.to_be_bytes());
+                output[2..4].copy_from_slice(&number.to_be_bytes());
+            }
+            Self::Utp {
+                header,
+                extension,
+                connection_id,
+            } => {
+                output[..2].copy_from_slice(&connection_id.to_be_bytes());
+                output[2] = *header;
+                output[3] = *extension;
+            }
+            Self::Wechat { sequence } => {
+                *sequence = sequence.wrapping_add(1);
+                output[0] = 0xa1;
+                output[1] = 0x08;
+                output[2..6].copy_from_slice(&sequence.to_be_bytes());
+                output[6..13].copy_from_slice(&[0x00, 0x10, 0x11, 0x18, 0x30, 0x22, 0x30]);
+            }
+            Self::Wireguard => output.copy_from_slice(&[0x04, 0x00, 0x00, 0x00]),
+        }
+    }
+}
+
+fn encode_original(payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    let length = u16::try_from(payload.len())
+        .map_err(|_| invalid("mkcp-legacy original payload exceeds 65535 bytes"))?;
+    let mut output = Vec::with_capacity(payload.len() + 9);
+    output.extend_from_slice(&[0; 4]);
+    output.extend_from_slice(&length.to_be_bytes());
+    output.extend_from_slice(payload);
+    let hash = fnv1a32(&output[4..]).to_be_bytes();
+    output[..4].copy_from_slice(&hash);
+    xor_forward_padded(&mut output);
+    Ok(output)
+}
+
+fn decode_original(packet: &[u8]) -> std::io::Result<Vec<u8>> {
+    if packet.len() < 6 {
+        return Err(invalid("mkcp-legacy original packet is truncated"));
+    }
+    let mut decoded = packet.to_vec();
+    xor_backward_padded(&mut decoded);
+    let expected = u32::from_be_bytes(decoded[..4].try_into().expect("four bytes"));
+    if fnv1a32(&decoded[4..]) != expected {
+        return Err(invalid("mkcp-legacy original authentication failed"));
+    }
+    let length = u16::from_be_bytes(decoded[4..6].try_into().expect("two bytes")) as usize;
+    if decoded.len() - 6 != length {
+        return Err(invalid("mkcp-legacy original length mismatch"));
+    }
+    Ok(decoded.split_off(6))
+}
+
+fn xor_forward_padded(bytes: &mut Vec<u8>) {
+    let original = bytes.len();
+    let padding = (4 - original % 4) % 4;
+    bytes.resize(original + padding, 0);
+    for index in 4..bytes.len() {
+        bytes[index] ^= bytes[index - 4];
+    }
+    bytes.truncate(original);
+}
+
+fn xor_backward_padded(bytes: &mut Vec<u8>) {
+    let original = bytes.len();
+    let padding = (4 - original % 4) % 4;
+    bytes.resize(original + padding, 0);
+    for index in (4..bytes.len()).rev() {
+        bytes[index] ^= bytes[index - 4];
+    }
+    bytes.truncate(original);
+}
+
+fn fnv1a32(bytes: &[u8]) -> u32 {
+    let mut hash = 0x811c_9dc5u32;
+    for &byte in bytes {
+        hash ^= u32::from(byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
+}
+
+fn dns_header(domain: &str) -> std::io::Result<Vec<u8>> {
+    let mut header = Vec::with_capacity(272);
+    header.extend_from_slice(&[0x00, 0x00, 0x01, 0x00, 0x00, 0x01]);
+    header.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    header.extend_from_slice(&pack_domain_name(&format!("{domain}."))?);
+    header.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]);
+    Ok(header)
+}
+
+fn pack_domain_name(domain: &str) -> std::io::Result<Vec<u8>> {
+    let mut labels = Vec::<Vec<u8>>::new();
+    let mut current = Vec::new();
+    let mut escaped = false;
+    for byte in domain.bytes() {
+        if escaped {
+            current.push(byte);
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'.' {
+            if current.len() >= 64 {
+                return Err(invalid("mkcp-legacy DNS label is too long"));
+            }
+            labels.push(std::mem::take(&mut current));
+        } else {
+            current.push(byte);
+        }
+    }
+    if escaped {
+        return Err(invalid("mkcp-legacy DNS name ends in an escape"));
+    }
+    if !current.is_empty() {
+        labels.push(current);
+    }
+    let mut output = Vec::new();
+    for label in labels {
+        output.push(label.len() as u8);
+        output.extend_from_slice(&label);
+    }
+    if output.last().copied() != Some(0) {
+        output.push(0);
+    }
+    if output.len() > 255 {
+        return Err(invalid("mkcp-legacy DNS name exceeds 255 bytes"));
+    }
+    Ok(output)
+}
+
+fn invalid(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn other(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn original_roundtrip_and_tamper_rejection() {
+        let mut codec = MkcpCodec::new(&MkcpLegacyMaskConfig::default()).unwrap();
+        let encoded = codec.encode(b"hello mkcp").unwrap();
+        assert_eq!(codec.decode(&encoded).unwrap(), b"hello mkcp");
+        let mut tampered = encoded;
+        tampered[5] ^= 1;
+        assert!(codec.decode(&tampered).is_err());
+    }
+
+    #[test]
+    fn aes128gcm_roundtrip_and_tamper_rejection() {
+        let config = MkcpLegacyMaskConfig {
+            value: "password".into(),
+            ..Default::default()
+        };
+        let mut codec = MkcpCodec::new(&config).unwrap();
+        let encoded = codec.encode(b"hello aes").unwrap();
+        assert_eq!(codec.decode(&encoded).unwrap(), b"hello aes");
+        let mut tampered = encoded;
+        *tampered.last_mut().unwrap() ^= 1;
+        assert!(codec.decode(&tampered).is_err());
+    }
+
+    #[test]
+    fn named_headers_match_pinned_wire_shapes() {
+        for (name, prefix) in [
+            ("wireguard", vec![4, 0, 0, 0]),
+            (
+                "wechat",
+                vec![
+                    0xa1, 0x08, 0, 0, 0, 1, 0, 0x10, 0x11, 0x18, 0x30, 0x22, 0x30,
+                ],
+            ),
+            ("dtls", vec![23, 254, 253, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        ] {
+            let mut codec = MkcpCodec::new(&MkcpLegacyMaskConfig {
+                header: name.into(),
+                ..Default::default()
+            })
+            .unwrap();
+            let packet = codec.encode(b"p").unwrap();
+            assert_eq!(&packet[..prefix.len()], prefix, "header={name}");
+            assert_eq!(codec.decode(&packet).unwrap(), b"p");
+        }
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/mod.rs
+++ b/crates/core-outbound/src/transport/finalmask/mod.rs
@@ -1,0 +1,334 @@
+//! Xray 26.7.11 final-mask composition.
+//!
+//! TCP masks are wrapped in reverse declaration order, exactly like
+//! `slices.Backward` in upstream. UDP has a separate compiled plan because
+//! packet headers must reserve their aggregate prefix once; applying each
+//! header as an ordinary nested socket corrupts offsets.
+
+use std::net::SocketAddr;
+
+use core_config::{TcpMaskConfig, UdpMaskConfig};
+
+use crate::adapter::{BoxedStream, BoxedUdp};
+
+mod fragment;
+mod header_custom;
+mod mkcp;
+pub mod quic;
+mod quic_socket;
+mod realm;
+mod salamander;
+mod sudoku;
+mod udp;
+mod udp_hop;
+mod xdns;
+#[cfg_attr(target_os = "linux", allow(unsafe_code))]
+mod xicmp;
+mod xmc;
+
+pub async fn wrap_tcp_client(
+    mut stream: BoxedStream,
+    masks: &[TcpMaskConfig],
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+    remote_host: &str,
+    remote_port: u16,
+) -> std::io::Result<BoxedStream> {
+    for mask in masks.iter().rev() {
+        stream = match mask {
+            TcpMaskConfig::HeaderCustom(config) => {
+                header_custom::wrap_client(stream, config, local, remote, remote_host, remote_port)
+                    .await?
+            }
+            TcpMaskConfig::Fragment(config) => {
+                fragment::FragmentStream::wrap(stream, config.clone())
+            }
+            TcpMaskConfig::Sudoku(config) => sudoku::wrap(stream, config)?,
+            TcpMaskConfig::Xmc(config) => {
+                xmc::wrap_client(stream, config, remote, remote_host, remote_port).await?
+            }
+        };
+    }
+    Ok(stream)
+}
+
+pub async fn wrap_tcp_server(
+    mut stream: BoxedStream,
+    masks: &[TcpMaskConfig],
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedStream> {
+    for mask in masks.iter().rev() {
+        stream = match mask {
+            TcpMaskConfig::HeaderCustom(config) => {
+                header_custom::wrap_server(stream, config, local, remote).await?
+            }
+            // Fragment is symmetric at the byte level. The upstream server
+            // wrapper retains it (and disables splice) even though servers
+            // normally only read first; keeping it here also handles server
+            // initiated writes exactly.
+            TcpMaskConfig::Fragment(config) => {
+                fragment::FragmentStream::wrap(stream, config.clone())
+            }
+            TcpMaskConfig::Sudoku(config) => sudoku::wrap_server(stream, config)?,
+            TcpMaskConfig::Xmc(config) => xmc::wrap_server(stream, config).await?,
+        };
+    }
+    Ok(stream)
+}
+
+pub async fn wrap_udp_client(
+    mut socket: BoxedUdp,
+    masks: &[UdpMaskConfig],
+    target: String,
+    port: u16,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedUdp> {
+    validate_udp_order(masks)?;
+    // Build the same wrapper nesting as Xray's reverse manager. Carrier masks
+    // such as xdns change the destination address, so they cannot be compiled
+    // into a payload-only plan with their neighbours.
+    for mask in masks.iter().rev() {
+        socket = match mask {
+            UdpMaskConfig::Xdns(config) => xdns::wrap_client(socket, config)?,
+            UdpMaskConfig::Xicmp(config) => xicmp::wrap_client(socket, config, remote)?,
+            UdpMaskConfig::Realm(config) => realm::wrap_client(socket, config, remote).await?,
+            ordinary => udp::wrap_client(
+                socket,
+                std::slice::from_ref(ordinary),
+                target.clone(),
+                port,
+                local,
+                remote,
+            )?,
+        };
+    }
+    Ok(socket)
+}
+
+pub async fn wrap_udp_server(
+    mut socket: BoxedUdp,
+    masks: &[UdpMaskConfig],
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedUdp> {
+    validate_udp_order(masks)?;
+    for mask in masks.iter().rev() {
+        socket = match mask {
+            UdpMaskConfig::Xdns(config) => xdns::wrap_server(socket, config)?,
+            UdpMaskConfig::Xicmp(config) => xicmp::wrap_server(socket, config)?,
+            UdpMaskConfig::Realm(config) => realm::wrap_server(socket, config).await?,
+            ordinary => udp::wrap_server(socket, std::slice::from_ref(ordinary), local, remote)?,
+        };
+    }
+    Ok(socket)
+}
+
+/// Open the real UDP packet carrier for a protocol such as Shadowsocks and
+/// apply the node's FinalMask policy below that protocol's own framing.  This
+/// is deliberately not an `OutboundAdapter::dial_udp` decorator: decorating
+/// there would mask application payloads before protocol encryption and would
+/// double-wrap QUIC transports that already execute FinalMask internally.
+pub(crate) async fn open_policy_udp_client_carrier(
+    target_host: String,
+    peer: SocketAddr,
+) -> std::io::Result<(BoxedUdp, SocketAddr)> {
+    let policy = crate::socket_policy::current();
+    let nominal_local: SocketAddr = if peer.is_ipv6() {
+        "[::]:0".parse().expect("valid IPv6 wildcard")
+    } else {
+        "0.0.0.0:0".parse().expect("valid IPv4 wildcard")
+    };
+    let (raw, local) = if let Some(proxy) = policy.as_ref().and_then(|policy| policy.proxy()) {
+        let raw =
+            crate::socket_policy::dial_udp_through_proxy(proxy, target_host.clone(), peer.port())
+                .await?;
+        let local = raw.local_addr()?.unwrap_or(nominal_local);
+        (raw, local)
+    } else {
+        open_direct_carrier(target_host.clone(), peer)?
+    };
+    let masks = policy
+        .as_ref()
+        .and_then(|policy| policy.settings.finalmask.as_ref())
+        .map(|finalmask| finalmask.udp.as_slice())
+        .unwrap_or_default();
+    if masks.is_empty() {
+        return Ok((raw, local));
+    }
+    let masked = wrap_udp_client(
+        raw,
+        masks,
+        target_host,
+        peer.port(),
+        Some(local),
+        Some(peer),
+    )
+    .await?;
+    Ok((masked, local))
+}
+
+fn validate_udp_order(masks: &[UdpMaskConfig]) -> std::io::Result<()> {
+    for (index, mask) in masks.iter().enumerate() {
+        if matches!(mask, UdpMaskConfig::Realm(_) | UdpMaskConfig::Xicmp(_))
+            && index + 1 != masks.len()
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "{} must be the last declared UDP finalmask (Xray outermost level 0)",
+                    udp_kind(mask)
+                ),
+            ));
+        }
+        if matches!(mask, UdpMaskConfig::Sudoku(_)) && index != 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "sudoku must be the first declared UDP finalmask (Xray innermost level)",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) use quic_socket::open_direct_carrier;
+pub use quic_socket::{QuinnUdpSocket, inbound_udp_carrier};
+pub(crate) use udp_hop::UdpHopCarrier;
+
+/// A packet-level execution plan. Header stages contain source indexes in the
+/// exact inner-to-outer evaluation order expected by Xray's header manager.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum UdpPlanStage {
+    HeaderAggregate(Vec<usize>),
+    Transform { index: usize, kind: &'static str },
+}
+
+pub(crate) fn compile_udp_plan(masks: &[UdpMaskConfig]) -> Vec<UdpPlanStage> {
+    let mut stages = Vec::new();
+    let mut headers = Vec::new();
+    let flush = |headers: &mut Vec<usize>, stages: &mut Vec<UdpPlanStage>| {
+        if !headers.is_empty() {
+            stages.push(UdpPlanStage::HeaderAggregate(std::mem::take(headers)));
+        }
+    };
+    for (index, mask) in masks.iter().enumerate().rev() {
+        if is_aggregate_header(mask) {
+            headers.push(index);
+            continue;
+        }
+        flush(&mut headers, &mut stages);
+        stages.push(UdpPlanStage::Transform {
+            index,
+            kind: udp_kind(mask),
+        });
+    }
+    flush(&mut headers, &mut stages);
+    stages
+}
+
+fn is_aggregate_header(mask: &UdpMaskConfig) -> bool {
+    matches!(
+        mask,
+        UdpMaskConfig::MkcpLegacy(_) | UdpMaskConfig::Salamander(_)
+    )
+}
+
+fn udp_kind(mask: &UdpMaskConfig) -> &'static str {
+    match mask {
+        UdpMaskConfig::HeaderCustom(_) => "header-custom",
+        UdpMaskConfig::MkcpLegacy(_) => "mkcp-legacy",
+        UdpMaskConfig::Noise(_) => "noise",
+        UdpMaskConfig::Salamander(_) => "salamander",
+        UdpMaskConfig::Sudoku(_) => "sudoku",
+        UdpMaskConfig::Xdns(_) => "xdns",
+        UdpMaskConfig::Xicmp(_) => "xicmp",
+        UdpMaskConfig::Realm(_) => "realm",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core_config::{
+        MkcpLegacyMaskConfig, NoiseMaskConfig, RealmMaskConfig, SalamanderMaskConfig,
+        SudokuMaskConfig, XicmpMaskConfig,
+    };
+
+    use super::*;
+
+    #[test]
+    fn tcp_declarations_are_applied_in_reverse_order() {
+        let masks = vec![
+            TcpMaskConfig::Fragment(Default::default()),
+            TcpMaskConfig::Sudoku(SudokuMaskConfig {
+                password: "p".into(),
+                ..Default::default()
+            }),
+        ];
+        let order = masks
+            .iter()
+            .rev()
+            .map(|mask| match mask {
+                TcpMaskConfig::Fragment(_) => "fragment",
+                TcpMaskConfig::Sudoku(_) => "sudoku",
+                TcpMaskConfig::HeaderCustom(_) => "header",
+                TcpMaskConfig::Xmc(_) => "xmc",
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(order, ["sudoku", "fragment"]);
+    }
+
+    #[test]
+    fn consecutive_udp_headers_are_aggregated_without_crossing_transforms() {
+        let masks = vec![
+            UdpMaskConfig::Noise(NoiseMaskConfig::default()),
+            UdpMaskConfig::MkcpLegacy(MkcpLegacyMaskConfig::default()),
+            UdpMaskConfig::Salamander(SalamanderMaskConfig::default()),
+            UdpMaskConfig::Sudoku(SudokuMaskConfig::default()),
+            UdpMaskConfig::MkcpLegacy(MkcpLegacyMaskConfig::default()),
+        ];
+        assert_eq!(
+            compile_udp_plan(&masks),
+            vec![
+                UdpPlanStage::HeaderAggregate(vec![4]),
+                UdpPlanStage::Transform {
+                    index: 3,
+                    kind: "sudoku"
+                },
+                UdpPlanStage::HeaderAggregate(vec![2, 1]),
+                UdpPlanStage::Transform {
+                    index: 0,
+                    kind: "noise"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn udp_carrier_and_sudoku_ordering_matches_xray_levels() {
+        let valid = vec![
+            UdpMaskConfig::Sudoku(SudokuMaskConfig::default()),
+            UdpMaskConfig::Noise(NoiseMaskConfig::default()),
+            UdpMaskConfig::Realm(RealmMaskConfig::default()),
+        ];
+        validate_udp_order(&valid).unwrap();
+
+        let realm_not_outermost = vec![
+            UdpMaskConfig::Realm(RealmMaskConfig::default()),
+            UdpMaskConfig::Noise(NoiseMaskConfig::default()),
+        ];
+        assert!(validate_udp_order(&realm_not_outermost).is_err());
+
+        let xicmp_not_outermost = vec![
+            UdpMaskConfig::Xicmp(XicmpMaskConfig::default()),
+            UdpMaskConfig::MkcpLegacy(MkcpLegacyMaskConfig::default()),
+        ];
+        assert!(validate_udp_order(&xicmp_not_outermost).is_err());
+
+        let sudoku_not_innermost = vec![
+            UdpMaskConfig::Noise(NoiseMaskConfig::default()),
+            UdpMaskConfig::Sudoku(SudokuMaskConfig::default()),
+        ];
+        assert!(validate_udp_order(&sudoku_not_innermost).is_err());
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/quic.rs
+++ b/crates/core-outbound/src/transport/finalmask/quic.rs
@@ -1,0 +1,885 @@
+//! Execution of Xray 26.7.11 `finalmask.quicParams` on Quinn.
+//!
+//! Xray source of truth:
+//! `transport/internet/hysteria/dialer.go` at
+//! `6e3322d219140a025285ded1114fe17a5edb74d8`.
+
+use std::{
+    any::Any,
+    io,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use core_config::{BandwidthValue, PortListValue, QuicParamsConfig};
+use quinn::{ClientConfig, IdleTimeout, ServerConfig, TransportConfig, VarInt};
+use quinn_proto::{
+    RttEstimator,
+    congestion::{BbrConfig, Controller, ControllerFactory, NewRenoConfig},
+};
+use rsteria2::BrutalFactory;
+
+const DEFAULT_STREAM_WINDOW: u64 = 8 * 1024 * 1024;
+const DEFAULT_CONNECTION_WINDOW: u64 = DEFAULT_STREAM_WINDOW * 5 / 2;
+const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_HOP_INTERVAL: Duration = Duration::from_secs(30);
+const MIN_BRUTAL_RATE: u64 = 65_536;
+
+/// Values Quinn needs after the endpoint has been created.
+#[derive(Debug, Clone)]
+pub struct AppliedQuicParams {
+    pub(crate) congestion: CongestionMode,
+    pub(crate) brutal_up: u64,
+    pub(crate) brutal_down: u64,
+    pub(crate) udp_hop: Option<UdpHopPlan>,
+    /// Quinn exposes a live connection-level receive window setter. The
+    /// configured maximum is applied after the handshake when it differs from
+    /// the initial transport parameter.
+    pub(crate) max_connection_receive_window: Option<VarInt>,
+    switch: Option<SwitchHandle>,
+    local_brutal_rate: u64,
+}
+
+impl AppliedQuicParams {
+    /// Complete Xray's `brutal` negotiation after Hysteria's auth response.
+    /// `server_rx` is the peer's advertised receive bandwidth in bytes/sec.
+    pub fn finish_hysteria_negotiation(&self, peer_rx: u64) {
+        let Some(switch) = &self.switch else {
+            return;
+        };
+        if self.local_brutal_rate == 0 || peer_rx == 0 {
+            switch.use_bbr.store(true, Ordering::Release);
+            return;
+        }
+        switch
+            .rate
+            .store(self.local_brutal_rate.min(peer_rx), Ordering::Release);
+        switch.use_bbr.store(false, Ordering::Release);
+    }
+
+    pub fn congestion_mode(&self) -> CongestionMode {
+        self.congestion
+    }
+
+    pub fn brutal_up(&self) -> u64 {
+        self.brutal_up
+    }
+
+    pub fn brutal_down(&self) -> u64 {
+        self.brutal_down
+    }
+
+    pub fn udp_hop(&self) -> Option<&UdpHopPlan> {
+        self.udp_hop.as_ref()
+    }
+
+    pub fn apply_max_receive_window(&self, connection: &quinn::Connection) {
+        if let Some(window) = self.max_connection_receive_window {
+            connection.set_receive_window(window);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CongestionMode {
+    Reno,
+    Bbr,
+    Brutal,
+    ForceBrutal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UdpHopPlan {
+    pub ports: Vec<u16>,
+    pub interval_min: Duration,
+    pub interval_max: Duration,
+}
+
+#[derive(Debug, Clone)]
+struct SwitchHandle {
+    rate: Arc<AtomicU64>,
+    use_bbr: Arc<AtomicBool>,
+}
+
+/// Apply every Quinn-representable field and return the carrier-level fields.
+pub fn apply_client_config(
+    client: &mut ClientConfig,
+    params: Option<&QuicParamsConfig>,
+) -> io::Result<AppliedQuicParams> {
+    let (transport, applied) = build_transport_config(params, false)?;
+    client.transport_config(Arc::new(transport));
+    Ok(applied)
+}
+
+/// Apply the same pinned Xray QUIC parameters to a Quinn server endpoint.
+/// Hysteria servers should call [`AppliedQuicParams::finish_hysteria_negotiation`]
+/// after authentication with the client's advertised receive rate.
+pub fn apply_server_config(
+    server: &mut ServerConfig,
+    params: Option<&QuicParamsConfig>,
+) -> io::Result<AppliedQuicParams> {
+    let (transport, applied) = build_transport_config(params, true)?;
+    server.transport_config(Arc::new(transport));
+    Ok(applied)
+}
+
+/// Apply the XHTTP/3 server interpretation of Xray's shared QUIC parameters.
+/// XHTTP has no Hysteria bandwidth negotiation: empty/`bbr` selects BBR and
+/// `force-brutal` uses `brutalUp` immediately, exactly like SplitHTTP's
+/// `QListener`.  Explicit `brutal` is rejected instead of reaching Xray's
+/// transport-specific panic branch.
+pub fn apply_xhttp_server_config(
+    server: &mut ServerConfig,
+    params: Option<&QuicParamsConfig>,
+    default_idle_timeout: Duration,
+    max_concurrent_streams: u32,
+) -> io::Result<AppliedQuicParams> {
+    let (mut transport, mut applied) = build_transport_config(params, true)?;
+    let owned_default;
+    let params = match params {
+        Some(params) => params,
+        None => {
+            owned_default = QuicParamsConfig::default();
+            &owned_default
+        }
+    };
+    match params.congestion.trim().to_ascii_lowercase().as_str() {
+        "reno" => {
+            applied.congestion = CongestionMode::Reno;
+            applied.switch = None;
+        }
+        "" | "bbr" => {
+            transport
+                .congestion_controller_factory(BbrProfile::parse(&params.bbr_profile)?.factory());
+            applied.congestion = CongestionMode::Bbr;
+            applied.switch = None;
+            applied.local_brutal_rate = 0;
+        }
+        "force-brutal" => {
+            let rate = parse_bandwidth(&params.brutal_up)?;
+            if rate < MIN_BRUTAL_RATE {
+                return Err(invalid(
+                    "XHTTP quicParams force-brutal requires brutalUp >= 65536 bytes/s",
+                ));
+            }
+            transport.congestion_controller_factory(Arc::new(BrutalFactory {
+                rate: Arc::new(AtomicU64::new(rate)),
+            }));
+            applied.congestion = CongestionMode::ForceBrutal;
+            applied.switch = None;
+            applied.local_brutal_rate = rate;
+        }
+        "brutal" => {
+            return Err(invalid(
+                "XHTTP/3 does not negotiate quicParams.congestion=brutal; use bbr, reno or force-brutal",
+            ));
+        }
+        other => return Err(invalid(format!("unknown QUIC congestion `{other}`"))),
+    }
+    if params.max_idle_timeout == 0 {
+        transport
+            .max_idle_timeout(Some(IdleTimeout::try_from(default_idle_timeout).map_err(
+                |_| invalid("XHTTP listener idle timeout exceeds QUIC's range"),
+            )?));
+    }
+    let configured_streams = if params.max_incoming_streams == 0 {
+        u64::from(max_concurrent_streams)
+    } else {
+        (params.max_incoming_streams as u64).min(u64::from(max_concurrent_streams))
+    };
+    transport
+        .max_concurrent_bidi_streams(varint(configured_streams, "XHTTP max incoming streams")?);
+    server.transport_config(Arc::new(transport));
+    Ok(applied)
+}
+
+/// Apply the client-side XHTTP/3 interpretation.  XHTTP uses a 300-second
+/// default idle timeout and its XMUX keepalive when quicParams leaves those
+/// values at zero; congestion selection otherwise mirrors the server path.
+pub fn apply_xhttp_client_config(
+    client: &mut ClientConfig,
+    params: &QuicParamsConfig,
+    default_keep_alive: Option<Duration>,
+) -> io::Result<AppliedQuicParams> {
+    let (mut transport, mut applied) = build_transport_config(Some(params), false)?;
+    match params.congestion.trim().to_ascii_lowercase().as_str() {
+        "reno" => {
+            applied.congestion = CongestionMode::Reno;
+            applied.switch = None;
+        }
+        "" | "bbr" => {
+            transport
+                .congestion_controller_factory(BbrProfile::parse(&params.bbr_profile)?.factory());
+            applied.congestion = CongestionMode::Bbr;
+            applied.switch = None;
+            applied.local_brutal_rate = 0;
+        }
+        "force-brutal" => {
+            let rate = parse_bandwidth(&params.brutal_up)?;
+            if rate < MIN_BRUTAL_RATE {
+                return Err(invalid(
+                    "XHTTP quicParams force-brutal requires brutalUp >= 65536 bytes/s",
+                ));
+            }
+            transport.congestion_controller_factory(Arc::new(BrutalFactory {
+                rate: Arc::new(AtomicU64::new(rate)),
+            }));
+            applied.congestion = CongestionMode::ForceBrutal;
+            applied.switch = None;
+            applied.local_brutal_rate = rate;
+        }
+        "brutal" => {
+            return Err(invalid(
+                "XHTTP/3 does not negotiate quicParams.congestion=brutal; use bbr, reno or force-brutal",
+            ));
+        }
+        other => return Err(invalid(format!("unknown QUIC congestion `{other}`"))),
+    }
+    if params.max_idle_timeout == 0 {
+        transport.max_idle_timeout(Some(
+            IdleTimeout::try_from(Duration::from_secs(300))
+                .expect("300 seconds is a valid QUIC idle timeout"),
+        ));
+    }
+    if params.keep_alive_period == 0 {
+        transport.keep_alive_interval(default_keep_alive);
+    }
+    if params.max_incoming_streams > 0 {
+        transport.max_concurrent_bidi_streams(varint(
+            params.max_incoming_streams as u64,
+            "XHTTP max incoming streams",
+        )?);
+    }
+    client.transport_config(Arc::new(transport));
+    Ok(applied)
+}
+
+fn build_transport_config(
+    params: Option<&QuicParamsConfig>,
+    server_side: bool,
+) -> io::Result<(TransportConfig, AppliedQuicParams)> {
+    let owned_default;
+    let params = match params {
+        Some(value) => value,
+        None => {
+            owned_default = QuicParamsConfig::default();
+            &owned_default
+        }
+    };
+    validate_params(params)?;
+
+    let brutal_up = parse_bandwidth(&params.brutal_up)?;
+    let brutal_down = parse_bandwidth(&params.brutal_down)?;
+    let local_brutal_rate = if server_side { brutal_down } else { brutal_up };
+    if (brutal_up != 0 && brutal_up < MIN_BRUTAL_RATE)
+        || (brutal_down != 0 && brutal_down < MIN_BRUTAL_RATE)
+    {
+        return Err(invalid(
+            "quicParams brutal bandwidth must be zero or at least 65536 bytes/s",
+        ));
+    }
+
+    let congestion = match params.congestion.trim().to_ascii_lowercase().as_str() {
+        "reno" => CongestionMode::Reno,
+        "bbr" => CongestionMode::Bbr,
+        "force-brutal" => {
+            if brutal_up == 0 {
+                return Err(invalid("quicParams force-brutal requires brutalUp"));
+            }
+            CongestionMode::ForceBrutal
+        }
+        "" | "brutal" => CongestionMode::Brutal,
+        other => return Err(invalid(format!("unknown QUIC congestion `{other}`"))),
+    };
+
+    let stream_initial = nonzero_or(params.init_stream_receive_window, DEFAULT_STREAM_WINDOW);
+    let stream_max = nonzero_or(params.max_stream_receive_window, DEFAULT_STREAM_WINDOW);
+    let connection_initial = nonzero_or(
+        params.init_connection_receive_window,
+        DEFAULT_CONNECTION_WINDOW,
+    );
+    let connection_max = nonzero_or(
+        params.max_connection_receive_window,
+        DEFAULT_CONNECTION_WINDOW,
+    );
+
+    let mut transport = TransportConfig::default();
+    // Quinn has one per-stream window rather than quic-go's initial+autotuned
+    // pair. Advertising the larger configured value preserves the declared
+    // maximum and prevents a smaller initial value from becoming a hard cap.
+    transport.stream_receive_window(varint(stream_initial.max(stream_max), "stream window")?);
+    transport.receive_window(varint(connection_initial, "connection window")?);
+    transport.max_idle_timeout(Some(
+        IdleTimeout::try_from(if params.max_idle_timeout == 0 {
+            DEFAULT_IDLE_TIMEOUT
+        } else {
+            Duration::from_secs(params.max_idle_timeout as u64)
+        })
+        .map_err(|_| invalid("quicParams maxIdleTimeout is too large"))?,
+    ));
+    transport.keep_alive_interval(
+        (!server_side && params.keep_alive_period > 0)
+            .then(|| Duration::from_secs(params.keep_alive_period as u64)),
+    );
+    if params.disable_path_mtu_discovery
+        || !cfg!(any(
+            target_os = "linux",
+            target_os = "windows",
+            target_os = "macos"
+        ))
+    {
+        transport.mtu_discovery_config(None);
+    }
+    if server_side {
+        transport.max_concurrent_bidi_streams(varint(
+            if params.max_incoming_streams == 0 {
+                1024
+            } else {
+                params.max_incoming_streams as u64
+            },
+            "max incoming streams",
+        )?);
+    }
+    // Hysteria uses QUIC datagrams. Match the existing implementation's
+    // bounded buffers while keeping this executor usable by H3/XHTTP.
+    transport
+        .datagram_receive_buffer_size(Some(16 * 1024 * 1024))
+        .datagram_send_buffer_size(16 * 1024 * 1024);
+
+    let profile = BbrProfile::parse(&params.bbr_profile)?;
+    let switch = match congestion {
+        CongestionMode::Reno => {
+            transport.congestion_controller_factory(Arc::new(NewRenoConfig::default()));
+            None
+        }
+        CongestionMode::Bbr => {
+            transport.congestion_controller_factory(profile.factory());
+            None
+        }
+        CongestionMode::ForceBrutal => {
+            let rate = Arc::new(AtomicU64::new(local_brutal_rate));
+            transport.congestion_controller_factory(Arc::new(BrutalFactory { rate }));
+            None
+        }
+        CongestionMode::Brutal => {
+            let rate = Arc::new(AtomicU64::new(local_brutal_rate.max(MIN_BRUTAL_RATE)));
+            let use_bbr = Arc::new(AtomicBool::new(local_brutal_rate == 0));
+            transport.congestion_controller_factory(Arc::new(SwitchableFactory {
+                rate: rate.clone(),
+                use_bbr: use_bbr.clone(),
+                bbr: profile.factory(),
+            }));
+            Some(SwitchHandle { rate, use_bbr })
+        }
+    };
+
+    if params.debug {
+        tracing::debug!(
+            ?congestion,
+            ?profile,
+            brutal_up,
+            brutal_down,
+            stream_initial,
+            stream_max,
+            connection_initial,
+            connection_max,
+            "finalmask QUIC debug enabled"
+        );
+    }
+
+    Ok((
+        transport,
+        AppliedQuicParams {
+            congestion,
+            brutal_up,
+            brutal_down,
+            udp_hop: build_udp_hop(params)?,
+            max_connection_receive_window: (connection_max != connection_initial)
+                .then(|| varint(connection_max, "max connection window"))
+                .transpose()?,
+            switch,
+            local_brutal_rate,
+        },
+    ))
+}
+
+fn build_udp_hop(params: &QuicParamsConfig) -> io::Result<Option<UdpHopPlan>> {
+    let ports = parse_ports(&params.udp_hop.ports)?;
+    if ports.is_empty() {
+        return Ok(None);
+    }
+    let min = if params.udp_hop.interval.from == 0 {
+        DEFAULT_HOP_INTERVAL.as_secs() as i32
+    } else {
+        params.udp_hop.interval.from
+    };
+    let max = if params.udp_hop.interval.to == 0 {
+        DEFAULT_HOP_INTERVAL.as_secs() as i32
+    } else {
+        params.udp_hop.interval.to
+    };
+    if min < 5 || max < min {
+        return Err(invalid(
+            "quicParams udpHop interval must be an ordered range >= 5s",
+        ));
+    }
+    Ok(Some(UdpHopPlan {
+        ports,
+        interval_min: Duration::from_secs(min as u64),
+        interval_max: Duration::from_secs(max as u64),
+    }))
+}
+
+fn validate_params(params: &QuicParamsConfig) -> io::Result<()> {
+    for (field, value) in [
+        ("initStreamReceiveWindow", params.init_stream_receive_window),
+        ("maxStreamReceiveWindow", params.max_stream_receive_window),
+        (
+            "initConnectionReceiveWindow",
+            params.init_connection_receive_window,
+        ),
+        (
+            "maxConnectionReceiveWindow",
+            params.max_connection_receive_window,
+        ),
+    ] {
+        if value != 0 && value < 16_384 {
+            return Err(invalid(format!(
+                "quicParams {field} must be zero or at least 16384"
+            )));
+        }
+    }
+    if params.max_idle_timeout != 0 && !(4..=120).contains(&params.max_idle_timeout) {
+        return Err(invalid(
+            "quicParams maxIdleTimeout must be zero or between 4 and 120 seconds",
+        ));
+    }
+    if params.keep_alive_period != 0 && !(2..=60).contains(&params.keep_alive_period) {
+        return Err(invalid(
+            "quicParams keepAlivePeriod must be zero or between 2 and 60 seconds",
+        ));
+    }
+    if params.max_incoming_streams != 0 && params.max_incoming_streams < 8 {
+        return Err(invalid(
+            "quicParams maxIncomingStreams must be zero or at least 8",
+        ));
+    }
+    for endpoint in [params.udp_hop.interval.from, params.udp_hop.interval.to] {
+        if endpoint != 0 && endpoint < 5 {
+            return Err(invalid(
+                "quicParams udpHop interval endpoints must be zero or at least 5 seconds",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_bandwidth(value: &BandwidthValue) -> io::Result<u64> {
+    match value {
+        BandwidthValue::Empty => Ok(0),
+        // serde's numeric alternative is the same textual value Xray feeds to
+        // Bandwidth.Bps: bare numbers are bits per second.
+        BandwidthValue::Number(value) => Ok(value / 8),
+        BandwidthValue::Text(value) => {
+            let input = value.trim().to_ascii_lowercase();
+            if input.is_empty() {
+                return Ok(0);
+            }
+            let split = input
+                .char_indices()
+                .find_map(|(index, ch)| (!ch.is_ascii_digit() && ch != '.').then_some(index))
+                .unwrap_or(input.len());
+            let number = input[..split]
+                .parse::<f64>()
+                .map_err(|_| invalid(format!("invalid bandwidth `{value}`")))?;
+            if !number.is_finite() || number.is_sign_negative() {
+                return Err(invalid(format!("invalid bandwidth `{value}`")));
+            }
+            let multiplier = match input[split..].trim() {
+                "" | "b" | "bps" => 1_u64,
+                "k" | "kb" | "kbps" => 1024,
+                "m" | "mb" | "mbps" => 1024 * 1024,
+                "g" | "gb" | "gbps" => 1024 * 1024 * 1024,
+                "t" | "tb" | "tbps" => 1024_u64.pow(4),
+                unit => return Err(invalid(format!("unsupported bandwidth unit `{unit}`"))),
+            };
+            let bits = number * multiplier as f64;
+            if bits > u64::MAX as f64 {
+                return Err(invalid("bandwidth overflows u64"));
+            }
+            Ok(bits as u64 / 8)
+        }
+    }
+}
+
+pub(crate) fn parse_ports(value: &PortListValue) -> io::Result<Vec<u16>> {
+    let raw = match value {
+        PortListValue::Empty => return Ok(Vec::new()),
+        PortListValue::Number(value) => {
+            if *value == 0 {
+                return Ok(Vec::new());
+            }
+            let port = u16::try_from(*value)
+                .ok()
+                .filter(|port| *port != 0)
+                .ok_or_else(|| invalid(format!("invalid UDP hop port `{value}`")))?;
+            return Ok(vec![port]);
+        }
+        PortListValue::Text(value) => value,
+    };
+    let mut ports = Vec::new();
+    for item in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+    {
+        let Some((left, right)) = item.split_once('-') else {
+            ports.push(parse_port(item)?);
+            continue;
+        };
+        let left = parse_port(left.trim())?;
+        let right = parse_port(right.trim())?;
+        if left > right {
+            return Err(invalid(format!("invalid UDP hop port range `{item}`")));
+        }
+        ports.extend(left..=right);
+    }
+    ports.sort_unstable();
+    ports.dedup();
+    Ok(ports)
+}
+
+fn parse_port(value: &str) -> io::Result<u16> {
+    value
+        .parse::<u16>()
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| invalid(format!("invalid UDP hop port `{value}`")))
+}
+
+fn nonzero_or(value: u64, default: u64) -> u64 {
+    if value == 0 { default } else { value }
+}
+
+fn varint(value: u64, field: &str) -> io::Result<VarInt> {
+    VarInt::from_u64(value).map_err(|_| invalid(format!("quicParams {field} exceeds QUIC varint")))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BbrProfile {
+    Conservative,
+    Standard,
+    Aggressive,
+}
+
+impl BbrProfile {
+    fn parse(input: &str) -> io::Result<Self> {
+        match input.trim().to_ascii_lowercase().as_str() {
+            "conservative" => Ok(Self::Conservative),
+            "" | "standard" => Ok(Self::Standard),
+            "aggressive" => Ok(Self::Aggressive),
+            other => Err(invalid(format!("unknown BBR profile `{other}`"))),
+        }
+    }
+
+    fn factory(self) -> Arc<dyn ControllerFactory + Send + Sync> {
+        let mut config = BbrConfig::default();
+        // Quinn's public BBR configuration exposes the initial window but not
+        // quic-go's internal gain knobs. Scale startup capacity according to
+        // Xray's three pinned profiles; the controller remains genuine BBR.
+        let packets = match self {
+            Self::Conservative => 9,
+            Self::Standard => 10,
+            Self::Aggressive => 13,
+        };
+        config.initial_window(packets * 1200);
+        Arc::new(config)
+    }
+}
+
+struct SwitchableFactory {
+    rate: Arc<AtomicU64>,
+    use_bbr: Arc<AtomicBool>,
+    bbr: Arc<dyn ControllerFactory + Send + Sync>,
+}
+
+impl ControllerFactory for SwitchableFactory {
+    fn build(self: Arc<Self>, now: Instant, current_mtu: u16) -> Box<dyn Controller> {
+        let brutal = Arc::new(BrutalFactory {
+            rate: self.rate.clone(),
+        })
+        .build(now, current_mtu);
+        let bbr = self.bbr.clone().build(now, current_mtu);
+        Box::new(SwitchableController {
+            brutal,
+            bbr,
+            use_bbr: self.use_bbr.clone(),
+        })
+    }
+}
+
+struct SwitchableController {
+    brutal: Box<dyn Controller>,
+    bbr: Box<dyn Controller>,
+    use_bbr: Arc<AtomicBool>,
+}
+
+impl Clone for SwitchableController {
+    fn clone(&self) -> Self {
+        Self {
+            brutal: self.brutal.clone_box(),
+            bbr: self.bbr.clone_box(),
+            use_bbr: self.use_bbr.clone(),
+        }
+    }
+}
+
+impl Controller for SwitchableController {
+    fn on_sent(&mut self, now: Instant, bytes: u64, packet: u64) {
+        self.brutal.on_sent(now, bytes, packet);
+        self.bbr.on_sent(now, bytes, packet);
+    }
+
+    fn on_ack(
+        &mut self,
+        now: Instant,
+        sent: Instant,
+        bytes: u64,
+        app_limited: bool,
+        rtt: &RttEstimator,
+    ) {
+        self.brutal.on_ack(now, sent, bytes, app_limited, rtt);
+        self.bbr.on_ack(now, sent, bytes, app_limited, rtt);
+    }
+
+    fn on_end_acks(
+        &mut self,
+        now: Instant,
+        in_flight: u64,
+        app_limited: bool,
+        largest_packet_num_acked: Option<u64>,
+    ) {
+        self.brutal
+            .on_end_acks(now, in_flight, app_limited, largest_packet_num_acked);
+        self.bbr
+            .on_end_acks(now, in_flight, app_limited, largest_packet_num_acked);
+    }
+
+    fn on_congestion_event(
+        &mut self,
+        now: Instant,
+        sent: Instant,
+        persistent: bool,
+        lost_bytes: u64,
+    ) {
+        self.brutal
+            .on_congestion_event(now, sent, persistent, lost_bytes);
+        self.bbr
+            .on_congestion_event(now, sent, persistent, lost_bytes);
+    }
+
+    fn on_mtu_update(&mut self, mtu: u16) {
+        self.brutal.on_mtu_update(mtu);
+        self.bbr.on_mtu_update(mtu);
+    }
+
+    fn window(&self) -> u64 {
+        self.active().window()
+    }
+
+    fn initial_window(&self) -> u64 {
+        self.active().initial_window()
+    }
+
+    fn clone_box(&self) -> Box<dyn Controller> {
+        Box::new(self.clone())
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+}
+
+impl SwitchableController {
+    fn active(&self) -> &dyn Controller {
+        if self.use_bbr.load(Ordering::Acquire) {
+            &*self.bbr
+        } else {
+            &*self.brutal
+        }
+    }
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use core_config::{I32Range, UdpHopConfig};
+
+    use super::*;
+
+    #[test]
+    fn bandwidth_matches_xray_binary_units_and_bits_to_bytes() {
+        assert_eq!(
+            parse_bandwidth(&BandwidthValue::Text("10 mbps".into())).unwrap(),
+            10 * 1024 * 1024 / 8
+        );
+        assert_eq!(
+            parse_bandwidth(&BandwidthValue::Text("1.5G".into())).unwrap(),
+            (1.5 * 1024.0 * 1024.0 * 1024.0) as u64 / 8
+        );
+        assert_eq!(parse_bandwidth(&BandwidthValue::Number(800)).unwrap(), 100);
+        assert!(parse_bandwidth(&BandwidthValue::Text("10 MiB/s".into())).is_err());
+    }
+
+    #[test]
+    fn port_list_expands_ranges_and_deduplicates() {
+        assert_eq!(
+            parse_ports(&PortListValue::Text("443, 2000-2002,443".into())).unwrap(),
+            [443, 2000, 2001, 2002]
+        );
+        assert!(parse_ports(&PortListValue::Text("4-2".into())).is_err());
+        assert!(parse_ports(&PortListValue::Number(0)).unwrap().is_empty());
+        let complete = parse_ports(&PortListValue::Text("1-65535".into())).unwrap();
+        assert_eq!(complete.len(), 65_535);
+        assert_eq!((complete[0], complete[65_534]), (1, 65_535));
+    }
+
+    #[test]
+    fn rejects_every_out_of_range_official_quic_parameter() {
+        for invalid_params in [
+            QuicParamsConfig {
+                init_stream_receive_window: 16_383,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                max_stream_receive_window: 1,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                init_connection_receive_window: 8_192,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                max_connection_receive_window: 12_000,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                max_idle_timeout: 121,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                keep_alive_period: 1,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                max_incoming_streams: 7,
+                ..Default::default()
+            },
+            QuicParamsConfig {
+                udp_hop: UdpHopConfig {
+                    ports: PortListValue::Empty,
+                    interval: I32Range::fixed(4),
+                },
+                ..Default::default()
+            },
+        ] {
+            assert!(
+                validate_params(&invalid_params).is_err(),
+                "{invalid_params:?}"
+            );
+        }
+        assert!(validate_params(&QuicParamsConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn all_transport_fields_compile_together() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let params = QuicParamsConfig {
+            congestion: "force-brutal".into(),
+            debug: true,
+            bbr_profile: "aggressive".into(),
+            brutal_up: BandwidthValue::Text("8 mbps".into()),
+            brutal_down: BandwidthValue::Text("16 mbps".into()),
+            udp_hop: UdpHopConfig {
+                ports: PortListValue::Text("2000-2002".into()),
+                interval: I32Range::new(5, 9),
+            },
+            init_stream_receive_window: 65_536,
+            max_stream_receive_window: 131_072,
+            init_connection_receive_window: 262_144,
+            max_connection_receive_window: 524_288,
+            max_idle_timeout: 20,
+            keep_alive_period: 5,
+            disable_path_mtu_discovery: true,
+            max_incoming_streams: 16,
+        };
+        let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        )
+        .unwrap();
+        let mut client = ClientConfig::new(Arc::new(crypto));
+        let applied = apply_client_config(&mut client, Some(&params)).unwrap();
+        assert_eq!(applied.congestion, CongestionMode::ForceBrutal);
+        assert_eq!(applied.brutal_up, 1024 * 1024);
+        assert_eq!(applied.brutal_down, 2 * 1024 * 1024);
+        let hop = applied.udp_hop.unwrap();
+        assert_eq!(hop.ports, [2000, 2001, 2002]);
+        assert_eq!(hop.interval_min, Duration::from_secs(5));
+        assert_eq!(hop.interval_max, Duration::from_secs(9));
+        assert_eq!(
+            applied.max_connection_receive_window.unwrap(),
+            VarInt::from_u32(524_288)
+        );
+    }
+
+    #[test]
+    fn client_and_server_use_the_correct_hysteria_send_bandwidth() {
+        let params = QuicParamsConfig {
+            congestion: "force-brutal".into(),
+            brutal_up: BandwidthValue::Text("8 mbps".into()),
+            brutal_down: BandwidthValue::Text("16 mbps".into()),
+            ..Default::default()
+        };
+        let (_, client) = build_transport_config(Some(&params), false).unwrap();
+        let (_, server) = build_transport_config(Some(&params), true).unwrap();
+        assert_eq!(client.local_brutal_rate, 1024 * 1024);
+        assert_eq!(server.local_brutal_rate, 2 * 1024 * 1024);
+
+        let _: fn(&mut ServerConfig, Option<&QuicParamsConfig>) -> io::Result<AppliedQuicParams> =
+            apply_server_config;
+    }
+
+    #[test]
+    fn xhttp_quic_uses_force_brutal_without_hysteria_negotiation() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_no_client_auth(),
+        )
+        .unwrap();
+        let mut client = ClientConfig::new(Arc::new(crypto));
+        let params = QuicParamsConfig {
+            congestion: "force-brutal".into(),
+            brutal_up: BandwidthValue::Text("8 mbps".into()),
+            ..Default::default()
+        };
+        let applied =
+            apply_xhttp_client_config(&mut client, &params, Some(Duration::from_secs(15))).unwrap();
+        assert_eq!(applied.congestion_mode(), CongestionMode::ForceBrutal);
+        assert_eq!(applied.local_brutal_rate, 1024 * 1024);
+        assert!(applied.switch.is_none());
+
+        let mut unsupported = params;
+        unsupported.congestion = "brutal".into();
+        assert!(apply_xhttp_client_config(&mut client, &unsupported, None).is_err());
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/quic_socket.rs
+++ b/crates/core-outbound/src/transport/finalmask/quic_socket.rs
@@ -1,0 +1,876 @@
+//! Bounded async bridge from the project's packet abstraction to Quinn.
+//!
+//! Quinn's socket API is readiness based and synchronous at `try_send`, while
+//! finalmask stages may expand a packet and await timers or carrier I/O. A
+//! bounded worker queue is therefore the only correct bridge: it keeps Quinn's
+//! reactor non-blocking, preserves datagram boundaries (including GSO input),
+//! and exposes backpressure through a dedicated `UdpPoller`.
+
+use std::{
+    collections::VecDeque,
+    fmt, io,
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll},
+};
+
+use parking_lot::Mutex;
+use quinn::{AsyncUdpSocket, UdpPoller, udp};
+use tokio::net::UdpSocket;
+use tokio::sync::{Notify, mpsc};
+
+use crate::adapter::{BoxedUdp, UdpSocketLike};
+
+const SEND_QUEUE_PACKETS: usize = 256;
+const RECEIVE_QUEUE_PACKETS: usize = 256;
+const MAX_DATAGRAM: usize = u16::MAX as usize;
+
+/// Open an endpoint-aware, unconnected UDP carrier. Unlike the public DIRECT
+/// association this deliberately accepts literal alternate destinations used
+/// by xdns and UDP hopping, while still mapping the configured hostname to its
+/// already-resolved address and applying the complete socket policy first.
+pub(crate) fn open_direct_carrier(
+    target_host: String,
+    peer: SocketAddr,
+) -> io::Result<(BoxedUdp, SocketAddr)> {
+    let bind_addr: SocketAddr = if peer.is_ipv4() {
+        "0.0.0.0:0".parse().expect("IPv4 wildcard")
+    } else {
+        "[::]:0".parse().expect("IPv6 wildcard")
+    };
+    let socket = std::net::UdpSocket::bind(bind_addr)?;
+    let guard = crate::adapter::prepare_outbound_udp_socket_for_addr(&socket, peer)?;
+    socket.set_nonblocking(true)?;
+    let local = socket.local_addr()?;
+    guard.observe_local_addr(local);
+    Ok((
+        Box::new(DirectCarrier {
+            socket: tokio::net::UdpSocket::from_std(socket)?,
+            peer,
+            target_host,
+            guard,
+        }),
+        local,
+    ))
+}
+
+struct DirectCarrier {
+    socket: tokio::net::UdpSocket,
+    peer: SocketAddr,
+    target_host: String,
+    guard: crate::loopback::LoopbackUdpGuard,
+}
+
+/// Adapt an already-bound inbound Tokio UDP socket to the packet abstraction
+/// consumed by the FinalMask manager.  Source endpoints are retained so a
+/// single QUIC listener can serve multiple clients.
+pub fn inbound_udp_carrier(socket: UdpSocket) -> BoxedUdp {
+    Box::new(InboundCarrier { socket })
+}
+
+struct InboundCarrier {
+    socket: UdpSocket,
+}
+
+#[async_trait::async_trait]
+impl UdpSocketLike for InboundCarrier {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        self.socket
+            .send_to(payload, (normalize_host(target), port))
+            .await
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        let (length, source) = self.socket.recv_from(output).await?;
+        Ok((length, Some(source)))
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.socket.local_addr().map(Some)
+    }
+}
+
+#[async_trait::async_trait]
+impl UdpSocketLike for DirectCarrier {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        let target = if normalize_host(target)
+            .eq_ignore_ascii_case(normalize_host(&self.target_host))
+            && port == self.peer.port()
+        {
+            self.peer
+        } else {
+            let ip = normalize_host(target).parse::<IpAddr>().map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "raw UDP carrier requires a resolved literal destination, got {target}"
+                    ),
+                )
+            })?;
+            let addr = SocketAddr::new(ip, port);
+            if addr.is_ipv4() != self.peer.is_ipv4() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "raw UDP carrier address family differs: peer={}, alternate={addr}",
+                        self.peer
+                    ),
+                ));
+            }
+            addr
+        };
+        let _ = &self.guard;
+        self.socket.send_to(payload, target).await
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        let (length, source) = self.socket.recv_from(output).await?;
+        Ok((length, Some(source)))
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.socket.local_addr().map(Some)
+    }
+}
+
+fn normalize_host(host: &str) -> &str {
+    host.trim()
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or_else(|| host.trim())
+        .trim_end_matches('.')
+}
+
+#[derive(Debug)]
+struct SendPacket {
+    payload: Vec<u8>,
+    destination: SocketAddr,
+}
+
+struct ReceivedPacket {
+    payload: Vec<u8>,
+    source: Option<SocketAddr>,
+}
+
+#[derive(Debug, Clone)]
+struct ErrorRecord {
+    kind: io::ErrorKind,
+    message: Arc<str>,
+}
+
+impl ErrorRecord {
+    fn from_error(error: io::Error) -> Self {
+        Self {
+            kind: error.kind(),
+            message: error.to_string().into(),
+        }
+    }
+
+    fn to_error(&self) -> io::Error {
+        io::Error::new(self.kind, self.message.to_string())
+    }
+}
+
+/// Quinn-compatible socket over a fully composed `UdpSocketLike` carrier.
+pub struct QuinnUdpSocket {
+    logical_peer: Option<SocketAddr>,
+    local_addr: SocketAddr,
+    target_host: Option<Arc<str>>,
+    target_port: u16,
+    send_queue: Arc<Mutex<VecDeque<SendPacket>>>,
+    send_work: Arc<Notify>,
+    send_ready: Arc<Notify>,
+    receive: Mutex<mpsc::Receiver<Result<ReceivedPacket, ErrorRecord>>>,
+    terminal: Arc<Mutex<Option<ErrorRecord>>>,
+    closed: Arc<AtomicBool>,
+    carrier_ready_notify: Arc<Notify>,
+}
+
+impl fmt::Debug for QuinnUdpSocket {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QuinnUdpSocket")
+            .field("logical_peer", &self.logical_peer)
+            .field("local_addr", &self.local_addr)
+            .field("target_host", &self.target_host)
+            .field("target_port", &self.target_port)
+            .field("send_queue_len", &self.send_queue.lock().len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl QuinnUdpSocket {
+    pub fn new(
+        inner: BoxedUdp,
+        local_addr: SocketAddr,
+        logical_peer: SocketAddr,
+        target_host: String,
+        target_port: u16,
+    ) -> Arc<Self> {
+        Self::build(
+            inner,
+            local_addr,
+            Some(logical_peer),
+            Some(target_host),
+            target_port,
+        )
+    }
+
+    /// Build a multi-peer Quinn socket for a FinalMask-wrapped server carrier.
+    /// Unlike the client association, each receive record retains its source
+    /// and each Quinn transmit supplies its own destination.
+    pub fn new_server(inner: BoxedUdp, local_addr: SocketAddr) -> Arc<Self> {
+        Self::build(inner, local_addr, None, None, 0)
+    }
+
+    fn build(
+        inner: BoxedUdp,
+        local_addr: SocketAddr,
+        logical_peer: Option<SocketAddr>,
+        target_host: Option<String>,
+        target_port: u16,
+    ) -> Arc<Self> {
+        let inner: Arc<dyn crate::adapter::UdpSocketLike> = Arc::from(inner);
+        let send_queue = Arc::new(Mutex::new(VecDeque::<SendPacket>::new()));
+        let send_work = Arc::new(Notify::new());
+        let send_ready = Arc::new(Notify::new());
+        let terminal = Arc::new(Mutex::new(None));
+        let closed = Arc::new(AtomicBool::new(false));
+        // Client standalone headers perform a request/reply exchange in the
+        // send path and must win the first read.  A server has no initiating
+        // write, so its receive worker must start immediately.
+        let carrier_ready = Arc::new(AtomicBool::new(logical_peer.is_none()));
+        let carrier_ready_notify = Arc::new(Notify::new());
+        let (receive_tx, receive_rx) = mpsc::channel(RECEIVE_QUEUE_PACKETS);
+
+        spawn_send_worker(
+            inner.clone(),
+            send_queue.clone(),
+            send_work.clone(),
+            send_ready.clone(),
+            terminal.clone(),
+            closed.clone(),
+            target_host.clone(),
+            target_port,
+            carrier_ready.clone(),
+            carrier_ready_notify.clone(),
+        );
+        spawn_receive_worker(
+            inner,
+            receive_tx,
+            terminal.clone(),
+            closed.clone(),
+            carrier_ready,
+            carrier_ready_notify.clone(),
+        );
+
+        Arc::new(Self {
+            logical_peer,
+            local_addr,
+            target_host: target_host.map(Into::into),
+            target_port,
+            send_queue,
+            send_work,
+            send_ready,
+            receive: Mutex::new(receive_rx),
+            terminal,
+            closed,
+            carrier_ready_notify,
+        })
+    }
+
+    fn terminal_error(&self) -> Option<io::Error> {
+        self.terminal.lock().as_ref().map(ErrorRecord::to_error)
+    }
+}
+
+impl Drop for QuinnUdpSocket {
+    fn drop(&mut self) {
+        self.closed.store(true, Ordering::Release);
+        self.send_work.notify_waiters();
+        self.send_ready.notify_waiters();
+        self.carrier_ready_notify.notify_waiters();
+    }
+}
+
+impl AsyncUdpSocket for QuinnUdpSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        Box::pin(SendPoller {
+            queue: self.send_queue.clone(),
+            notify: self.send_ready.clone(),
+            terminal: self.terminal.clone(),
+            waiter: None,
+        })
+    }
+
+    fn try_send(&self, transmit: &udp::Transmit<'_>) -> io::Result<()> {
+        if let Some(error) = self.terminal_error() {
+            return Err(error);
+        }
+        if self
+            .logical_peer
+            .is_some_and(|logical_peer| transmit.destination != logical_peer)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "QUIC finalmask association is bound to {}, got {}",
+                    self.logical_peer.expect("checked client peer"),
+                    transmit.destination
+                ),
+            ));
+        }
+        let segment = transmit
+            .segment_size
+            .unwrap_or(transmit.contents.len().max(1));
+        let count = transmit.contents.len().div_ceil(segment).max(1);
+        let mut queue = self.send_queue.lock();
+        if queue.len() + count > SEND_QUEUE_PACKETS {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        if transmit.contents.is_empty() {
+            queue.push_back(SendPacket {
+                payload: Vec::new(),
+                destination: transmit.destination,
+            });
+        } else {
+            for payload in transmit.contents.chunks(segment) {
+                queue.push_back(SendPacket {
+                    payload: payload.to_vec(),
+                    destination: transmit.destination,
+                });
+            }
+        }
+        drop(queue);
+        self.send_work.notify_one();
+        Ok(())
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context,
+        buffers: &mut [io::IoSliceMut<'_>],
+        metadata: &mut [udp::RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        let limit = buffers.len().min(metadata.len());
+        if limit == 0 {
+            return Poll::Ready(Ok(0));
+        }
+        let mut receive = self.receive.lock();
+        let mut count = 0;
+        loop {
+            match receive.poll_recv(cx) {
+                Poll::Ready(Some(Ok(packet))) => {
+                    if packet.payload.len() > buffers[count].len() {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "decoded finalmask datagram is {} bytes, Quinn supplied {}",
+                                packet.payload.len(),
+                                buffers[count].len()
+                            ),
+                        )));
+                    }
+                    let source = match self.logical_peer.or(packet.source) {
+                        Some(source) => source,
+                        None => {
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "server FinalMask carrier did not report a datagram source",
+                            )));
+                        }
+                    };
+                    buffers[count][..packet.payload.len()].copy_from_slice(&packet.payload);
+                    metadata[count] = udp::RecvMeta {
+                        addr: source,
+                        len: packet.payload.len(),
+                        stride: packet.payload.len(),
+                        ecn: None,
+                        dst_ip: local_ip(self.local_addr.ip()),
+                    };
+                    count += 1;
+                    if count == limit {
+                        return Poll::Ready(Ok(count));
+                    }
+                }
+                Poll::Ready(Some(Err(error))) => return Poll::Ready(Err(error.to_error())),
+                Poll::Ready(None) => {
+                    return Poll::Ready(match self.terminal_error() {
+                        Some(error) => Err(error),
+                        None if count > 0 => Ok(count),
+                        None => Err(io::ErrorKind::NotConnected.into()),
+                    });
+                }
+                Poll::Pending if count > 0 => return Poll::Ready(Ok(count)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        1
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        1
+    }
+
+    fn may_fragment(&self) -> bool {
+        false
+    }
+}
+
+fn spawn_send_worker(
+    inner: Arc<dyn crate::adapter::UdpSocketLike>,
+    queue: Arc<Mutex<VecDeque<SendPacket>>>,
+    work: Arc<Notify>,
+    ready: Arc<Notify>,
+    terminal: Arc<Mutex<Option<ErrorRecord>>>,
+    closed: Arc<AtomicBool>,
+    target: Option<String>,
+    port: u16,
+    carrier_ready: Arc<AtomicBool>,
+    carrier_ready_notify: Arc<Notify>,
+) {
+    tokio::spawn(async move {
+        loop {
+            loop {
+                let packet = { queue.lock().pop_front() };
+                let Some(packet) = packet else {
+                    break;
+                };
+                ready.notify_waiters();
+                let (target, port) = match target.as_deref() {
+                    Some(target) => (target.to_owned(), port),
+                    None => (
+                        packet.destination.ip().to_string(),
+                        packet.destination.port(),
+                    ),
+                };
+                if let Err(error) = inner.send_to(&packet.payload, &target, port).await {
+                    *terminal.lock() = Some(ErrorRecord::from_error(error));
+                    closed.store(true, Ordering::Release);
+                    ready.notify_waiters();
+                    carrier_ready_notify.notify_waiters();
+                    return;
+                }
+                // A standalone header-custom send performs its request/reply
+                // authentication inside `send_to`.  Do not let the receive
+                // worker race that exchange and hold MaskedUdp's receive gate.
+                if !carrier_ready.swap(true, Ordering::AcqRel) {
+                    carrier_ready_notify.notify_waiters();
+                }
+            }
+            if closed.load(Ordering::Acquire) {
+                let _ = inner.close().await;
+                return;
+            }
+            work.notified().await;
+        }
+    });
+}
+
+fn spawn_receive_worker(
+    inner: Arc<dyn crate::adapter::UdpSocketLike>,
+    output: mpsc::Sender<Result<ReceivedPacket, ErrorRecord>>,
+    terminal: Arc<Mutex<Option<ErrorRecord>>>,
+    closed: Arc<AtomicBool>,
+    carrier_ready: Arc<AtomicBool>,
+    carrier_ready_notify: Arc<Notify>,
+) {
+    tokio::spawn(async move {
+        while !carrier_ready.load(Ordering::Acquire) {
+            let notified = carrier_ready_notify.notified();
+            if carrier_ready.load(Ordering::Acquire) || closed.load(Ordering::Acquire) {
+                break;
+            }
+            notified.await;
+        }
+        if closed.load(Ordering::Acquire) {
+            return;
+        }
+        let mut buffer = vec![0; MAX_DATAGRAM];
+        loop {
+            if closed.load(Ordering::Acquire) {
+                return;
+            }
+            match inner.recv_from_endpoint(&mut buffer).await {
+                Ok((length, source)) if length <= buffer.len() => {
+                    if output
+                        .send(Ok(ReceivedPacket {
+                            payload: buffer[..length].to_vec(),
+                            source,
+                        }))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Ok((length, _)) => {
+                    let error = ErrorRecord {
+                        kind: io::ErrorKind::InvalidData,
+                        message: format!(
+                            "UDP carrier returned {length} bytes for a {} byte buffer",
+                            buffer.len()
+                        )
+                        .into(),
+                    };
+                    *terminal.lock() = Some(error.clone());
+                    let _ = output.send(Err(error)).await;
+                    return;
+                }
+                Err(error) => {
+                    let error = ErrorRecord::from_error(error);
+                    *terminal.lock() = Some(error.clone());
+                    let _ = output.send(Err(error)).await;
+                    return;
+                }
+            }
+        }
+    });
+}
+
+fn local_ip(ip: IpAddr) -> Option<IpAddr> {
+    (!ip.is_unspecified()).then_some(ip)
+}
+
+struct SendPoller {
+    queue: Arc<Mutex<VecDeque<SendPacket>>>,
+    notify: Arc<Notify>,
+    terminal: Arc<Mutex<Option<ErrorRecord>>>,
+    waiter: Option<Pin<Box<tokio::sync::futures::OwnedNotified>>>,
+}
+
+impl fmt::Debug for SendPoller {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FinalMaskSendPoller")
+            .field("queue_len", &self.queue.lock().len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl UdpPoller for SendPoller {
+    fn poll_writable(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        if let Some(error) = self.terminal.lock().as_ref() {
+            return Poll::Ready(Err(error.to_error()));
+        }
+        if self.waiter.is_none() {
+            self.waiter = Some(Box::pin(self.notify.clone().notified_owned()));
+        }
+        let pending = self.waiter.as_mut().expect("waiter initialized");
+        if pending.as_mut().poll(cx).is_ready() {
+            self.waiter = None;
+        }
+        // Check capacity only after registering the notification to avoid a
+        // lost wake if the worker pops between the check and registration.
+        if self.queue.lock().len() < SEND_QUEUE_PACKETS {
+            self.waiter = None;
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use futures::future::poll_fn;
+    use tokio::sync::mpsc;
+
+    use crate::adapter::UdpSocketLike;
+
+    use super::*;
+
+    struct EchoUdp {
+        tx: mpsc::UnboundedSender<Vec<u8>>,
+        rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
+    }
+
+    struct InlineHandshakeUdp {
+        tx: mpsc::UnboundedSender<Vec<u8>>,
+        rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
+        first: AtomicBool,
+    }
+
+    struct EndpointUdp {
+        sent: mpsc::UnboundedSender<(Vec<u8>, SocketAddr)>,
+        received: tokio::sync::Mutex<mpsc::UnboundedReceiver<(Vec<u8>, SocketAddr)>>,
+    }
+
+    #[async_trait]
+    impl UdpSocketLike for EndpointUdp {
+        async fn send_to(&self, packet: &[u8], target: &str, port: u16) -> io::Result<usize> {
+            let target = SocketAddr::new(
+                target
+                    .parse()
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?,
+                port,
+            );
+            self.sent
+                .send((packet.to_vec(), target))
+                .map_err(|_| io::ErrorKind::BrokenPipe)?;
+            Ok(packet.len())
+        }
+
+        async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+            self.recv_from_endpoint(output)
+                .await
+                .map(|(length, _)| length)
+        }
+
+        async fn recv_from_endpoint(
+            &self,
+            output: &mut [u8],
+        ) -> io::Result<(usize, Option<SocketAddr>)> {
+            let (packet, source) = self
+                .received
+                .lock()
+                .await
+                .recv()
+                .await
+                .ok_or(io::ErrorKind::UnexpectedEof)?;
+            output[..packet.len()].copy_from_slice(&packet);
+            Ok((packet.len(), Some(source)))
+        }
+    }
+
+    #[async_trait]
+    impl UdpSocketLike for InlineHandshakeUdp {
+        async fn send_to(&self, packet: &[u8], _: &str, _: u16) -> io::Result<usize> {
+            if !self.first.swap(true, Ordering::AcqRel) {
+                self.tx
+                    .send(b"standalone-ack".to_vec())
+                    .map_err(|_| io::ErrorKind::BrokenPipe)?;
+                let ack = tokio::time::timeout(
+                    std::time::Duration::from_millis(250),
+                    self.rx.lock().await.recv(),
+                )
+                .await
+                .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "handshake reply stolen"))?
+                .ok_or(io::ErrorKind::UnexpectedEof)?;
+                if ack != b"standalone-ack" {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "unexpected standalone acknowledgement",
+                    ));
+                }
+            }
+            self.tx
+                .send(packet.to_vec())
+                .map_err(|_| io::ErrorKind::BrokenPipe)?;
+            Ok(packet.len())
+        }
+
+        async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+            let packet = self
+                .rx
+                .lock()
+                .await
+                .recv()
+                .await
+                .ok_or(io::ErrorKind::UnexpectedEof)?;
+            output[..packet.len()].copy_from_slice(&packet);
+            Ok(packet.len())
+        }
+    }
+
+    #[async_trait]
+    impl UdpSocketLike for EchoUdp {
+        async fn send_to(&self, packet: &[u8], _: &str, _: u16) -> io::Result<usize> {
+            self.tx
+                .send(packet.to_vec())
+                .map_err(|_| io::ErrorKind::BrokenPipe)?;
+            Ok(packet.len())
+        }
+
+        async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+            let packet = self
+                .rx
+                .lock()
+                .await
+                .recv()
+                .await
+                .ok_or(io::ErrorKind::UnexpectedEof)?;
+            output[..packet.len()].copy_from_slice(&packet);
+            Ok(packet.len())
+        }
+    }
+
+    #[tokio::test]
+    async fn preserves_gso_datagram_boundaries_and_backpressure_bridge() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let peer: SocketAddr = "127.0.0.1:443".parse().unwrap();
+        let socket = QuinnUdpSocket::new(
+            Box::new(EchoUdp {
+                tx,
+                rx: tokio::sync::Mutex::new(rx),
+            }),
+            "127.0.0.1:12345".parse().unwrap(),
+            peer,
+            "127.0.0.1".into(),
+            443,
+        );
+        socket
+            .try_send(&udp::Transmit {
+                destination: peer,
+                ecn: None,
+                contents: b"aaaabbbb",
+                segment_size: Some(4),
+                src_ip: None,
+            })
+            .unwrap();
+
+        let mut first = [0; 16];
+        let mut second = [0; 16];
+        let mut buffers = [
+            io::IoSliceMut::new(&mut first),
+            io::IoSliceMut::new(&mut second),
+        ];
+        let mut meta = [udp::RecvMeta::default(), udp::RecvMeta::default()];
+        let count = poll_fn(|cx| socket.poll_recv(cx, &mut buffers, &mut meta))
+            .await
+            .unwrap();
+        assert!(count >= 1);
+        assert_eq!(&first[..meta[0].len], b"aaaa");
+        if count == 1 {
+            let mut buffer = [0; 16];
+            let mut buffers = [io::IoSliceMut::new(&mut buffer)];
+            let mut meta = [udp::RecvMeta::default()];
+            poll_fn(|cx| socket.poll_recv(cx, &mut buffers, &mut meta))
+                .await
+                .unwrap();
+            assert_eq!(&buffer[..meta[0].len], b"bbbb");
+        } else {
+            assert_eq!(&second[..meta[1].len], b"bbbb");
+        }
+    }
+
+    #[tokio::test]
+    async fn receive_worker_waits_for_inline_standalone_handshake() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let peer: SocketAddr = "127.0.0.1:443".parse().unwrap();
+        let socket = QuinnUdpSocket::new(
+            Box::new(InlineHandshakeUdp {
+                tx,
+                rx: tokio::sync::Mutex::new(rx),
+                first: AtomicBool::new(false),
+            }),
+            "127.0.0.1:12345".parse().unwrap(),
+            peer,
+            "127.0.0.1".into(),
+            443,
+        );
+        // Give the receive task a chance to race. It must remain parked until
+        // the first send (and its inline request/reply handshake) completes.
+        tokio::task::yield_now().await;
+        socket
+            .try_send(&udp::Transmit {
+                destination: peer,
+                ecn: None,
+                contents: b"quic-initial",
+                segment_size: None,
+                src_ip: None,
+            })
+            .unwrap();
+        let mut buffer = [0; 64];
+        let mut buffers = [io::IoSliceMut::new(&mut buffer)];
+        let mut metadata = [udp::RecvMeta::default()];
+        let count = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            poll_fn(|cx| socket.poll_recv(cx, &mut buffers, &mut metadata)),
+        )
+        .await
+        .expect("standalone carrier deadlocked")
+        .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(&buffer[..metadata[0].len], b"quic-initial");
+    }
+
+    #[tokio::test]
+    async fn server_bridge_preserves_each_peer_and_routes_replies() {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
+        let local: SocketAddr = "127.0.0.1:8443".parse().unwrap();
+        let first_peer: SocketAddr = "127.0.0.1:30001".parse().unwrap();
+        let second_peer: SocketAddr = "127.0.0.1:30002".parse().unwrap();
+        let socket = QuinnUdpSocket::new_server(
+            Box::new(EndpointUdp {
+                sent: outgoing_tx,
+                received: tokio::sync::Mutex::new(incoming_rx),
+            }),
+            local,
+        );
+        incoming_tx.send((b"one".to_vec(), first_peer)).unwrap();
+        incoming_tx.send((b"two".to_vec(), second_peer)).unwrap();
+
+        let mut observed = Vec::new();
+        while observed.len() < 2 {
+            let mut first = [0; 16];
+            let mut second = [0; 16];
+            let mut buffers = [
+                io::IoSliceMut::new(&mut first),
+                io::IoSliceMut::new(&mut second),
+            ];
+            let mut metadata = [udp::RecvMeta::default(), udp::RecvMeta::default()];
+            let count = tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                poll_fn(|cx| socket.poll_recv(cx, &mut buffers, &mut metadata)),
+            )
+            .await
+            .expect("server receive bridge stalled")
+            .unwrap();
+            for index in 0..count {
+                observed.push((
+                    metadata[index].addr,
+                    buffers[index][..metadata[index].len].to_vec(),
+                ));
+            }
+        }
+        assert_eq!(observed[0], (first_peer, b"one".to_vec()));
+        assert_eq!(observed[1], (second_peer, b"two".to_vec()));
+
+        socket
+            .try_send(&udp::Transmit {
+                destination: second_peer,
+                ecn: None,
+                contents: b"reply",
+                segment_size: None,
+                src_ip: None,
+            })
+            .unwrap();
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(1), outgoing_rx.recv())
+            .await
+            .expect("server send bridge stalled")
+            .expect("server send worker exited");
+        assert_eq!(sent, (b"reply".to_vec(), second_peer));
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/realm.rs
+++ b/crates/core-outbound/src/transport/finalmask/realm.rs
@@ -1,0 +1,1783 @@
+//! Xray 26.7.11 Realm UDP rendezvous and NAT traversal.
+//!
+//! This is wire-compatible with `transport/internet/finalmask/realm`: STUN
+//! discovery uses the carrier socket itself, the rendezvous control plane uses
+//! `/v1/{realm}/connect`, symmetric-NAT ports are expanded with Xray's bounds,
+//! and authenticated hello/ack packets use the exact SHA-256 XOR construction.
+
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    net::{IpAddr, SocketAddr},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use core_config::RealmMaskConfig;
+use http::{Method, Request, StatusCode, Uri};
+use http_body_util::{BodyExt, Full, Limited};
+use hyper::body::Incoming;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use percent_encoding::{NON_ALPHANUMERIC, percent_decode_str, utf8_percent_encode};
+use rand::{Rng, RngCore};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+use tokio::{sync::Mutex, task::JoinHandle};
+
+use crate::{
+    adapter::{BoxedUdp, UdpSocketLike, resolve_host},
+    transport::{TlsOptions, Transport, tcp::TcpTransport, tls::TlsTransport},
+};
+
+const STUN_TIMEOUT: Duration = Duration::from_secs(4);
+const PUNCH_TIMEOUT: Duration = Duration::from_secs(10);
+const PUNCH_INTERVAL: Duration = Duration::from_millis(100);
+const MAX_PUNCH_PADDING: usize = 1024;
+const PUNCH_SALT_LEN: usize = 8;
+const PUNCH_HEADER_LEN: usize = 25;
+const PUNCH_MIN_WIRE_LEN: usize = PUNCH_SALT_LEN + PUNCH_HEADER_LEN;
+const PUNCH_MAX_WIRE_LEN: usize = PUNCH_MIN_WIRE_LEN + MAX_PUNCH_PADDING;
+const MAX_CONTROL_BODY: usize = 1024 * 1024;
+const STUN_MAGIC: u32 = 0x2112_a442;
+const PUNCH_MAGIC: &[u8; 8] = b"HYRLMv1\0";
+
+pub(super) async fn wrap_client(
+    inner: BoxedUdp,
+    config: &RealmMaskConfig,
+    remote: Option<SocketAddr>,
+) -> io::Result<BoxedUdp> {
+    let parsed = ParsedRealm::parse(config)?;
+    let family = remote.map(|address| address.ip());
+    let stun_servers = resolve_stun_servers(&parsed.stun_servers, family).await?;
+    if stun_servers.is_empty() {
+        return Err(invalid(
+            "realm resolved no STUN servers for the carrier family",
+        ));
+    }
+    let locals = discover(&*inner, &stun_servers).await?;
+    if locals.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "realm STUN discovery returned no mapped addresses",
+        ));
+    }
+
+    let metadata = PunchMetadata::random();
+    let response = RealmHttpClient::new(&parsed)
+        .connect(
+            &parsed.realm_id,
+            &parsed.token,
+            ConnectRequest {
+                addresses: address_strings(&locals),
+                metadata: metadata.clone(),
+            },
+        )
+        .await?;
+    let peers = parse_addresses(&response.addresses);
+    let (candidates, mut seen) = candidate_punch_addresses(&locals, &peers);
+    let candidates = expand_symmetric_nat_candidates(candidates, &mut seen);
+    if candidates.is_empty() {
+        return Err(invalid(
+            "realm rendezvous returned no usable peer addresses",
+        ));
+    }
+    let peer = punch(&*inner, &metadata, &candidates).await?;
+    tracing::debug!(%peer, realm_id = %parsed.realm_id, "realm UDP peer established");
+    Ok(Box::new(RealmClient { inner, peer }))
+}
+
+/// Build the long-lived server side. It registers the discovered addresses,
+/// maintains heartbeat/SSE state, answers connect events and filters STUN and
+/// punch control packets out of the QUIC data stream.
+pub(super) async fn wrap_server(inner: BoxedUdp, config: &RealmMaskConfig) -> io::Result<BoxedUdp> {
+    let parsed = Arc::new(ParsedRealm::parse(config)?);
+    let inner: Arc<dyn UdpSocketLike> = Arc::from(inner);
+    let closed = Arc::new(AtomicBool::new(false));
+    let (data_tx, data_rx) = tokio::sync::mpsc::channel(1024);
+    let (stun_tx, stun_rx) = tokio::sync::mpsc::channel(16);
+    let punch_events = Arc::new(Mutex::new(HashMap::new()));
+    let dispatcher = tokio::spawn(dispatch_server_packets(
+        inner.clone(),
+        data_tx,
+        stun_tx,
+        punch_events.clone(),
+        closed.clone(),
+    ));
+    let control = tokio::spawn(run_server_control(
+        parsed,
+        inner.clone(),
+        stun_rx,
+        punch_events,
+        closed.clone(),
+    ));
+    Ok(Box::new(RealmServer {
+        inner,
+        data: Mutex::new(data_rx),
+        closed,
+        tasks: Mutex::new(vec![dispatcher, control]),
+    }))
+}
+
+struct ReceivedData {
+    bytes: Vec<u8>,
+    source: Option<SocketAddr>,
+}
+
+#[derive(Debug)]
+struct StunEvent {
+    transaction: [u8; 12],
+    mapped: SocketAddr,
+}
+
+#[derive(Debug)]
+struct PunchPacketEvent {
+    source: SocketAddr,
+    kind: PunchType,
+}
+
+type PunchRoutes = Arc<Mutex<HashMap<PunchMetadata, tokio::sync::mpsc::Sender<PunchPacketEvent>>>>;
+
+struct RealmServer {
+    inner: Arc<dyn UdpSocketLike>,
+    data: Mutex<tokio::sync::mpsc::Receiver<io::Result<ReceivedData>>>,
+    closed: Arc<AtomicBool>,
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+#[async_trait]
+impl UdpSocketLike for RealmServer {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        self.inner.send_to(payload, target, port).await
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        let packet = self
+            .data
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(io::ErrorKind::UnexpectedEof)??;
+        if packet.bytes.len() > output.len() {
+            return Err(invalid(format!(
+                "realm server datagram is {} bytes, buffer is {}",
+                packet.bytes.len(),
+                output.len()
+            )));
+        }
+        output[..packet.bytes.len()].copy_from_slice(&packet.bytes);
+        Ok((packet.bytes.len(), packet.source))
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner.local_addr()
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        let _ = self.inner.close().await;
+        for mut task in self.tasks.lock().await.drain(..) {
+            if tokio::time::timeout(Duration::from_secs(2), &mut task)
+                .await
+                .is_err()
+            {
+                task.abort();
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn dispatch_server_packets(
+    inner: Arc<dyn UdpSocketLike>,
+    data: tokio::sync::mpsc::Sender<io::Result<ReceivedData>>,
+    stun: tokio::sync::mpsc::Sender<StunEvent>,
+    punch_routes: PunchRoutes,
+    closed: Arc<AtomicBool>,
+) {
+    let mut buffer = vec![0; 4096];
+    while !closed.load(Ordering::Acquire) {
+        let received = tokio::select! {
+            value = inner.recv_from_endpoint(&mut buffer) => value,
+            () = wait_until_closed(closed.clone()) => return,
+        };
+        let (length, source) = match received {
+            Ok(value) => value,
+            Err(error) => {
+                let _ = data.send(Err(error)).await;
+                return;
+            }
+        };
+        let packet = &buffer[..length];
+        if let Ok((transaction, mapped)) = parse_stun_binding_response(packet) {
+            let _ = stun.try_send(StunEvent {
+                transaction,
+                mapped,
+            });
+            continue;
+        }
+        if let Some(source) = source {
+            let routes = punch_routes.lock().await;
+            let mut consumed = false;
+            for (metadata, route) in routes.iter() {
+                if let Ok(kind) = decode_punch(packet, metadata) {
+                    let _ = route.try_send(PunchPacketEvent { source, kind });
+                    consumed = true;
+                    break;
+                }
+            }
+            drop(routes);
+            if consumed {
+                continue;
+            }
+        }
+        if data
+            .send(Ok(ReceivedData {
+                bytes: packet.to_vec(),
+                source,
+            }))
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+async fn run_server_control(
+    config: Arc<ParsedRealm>,
+    inner: Arc<dyn UdpSocketLike>,
+    mut stun: tokio::sync::mpsc::Receiver<StunEvent>,
+    punch_routes: PunchRoutes,
+    closed: Arc<AtomicBool>,
+) {
+    let http = RealmHttpClient::new(&config);
+    let mut backoff = Duration::from_secs(1);
+    while !closed.load(Ordering::Acquire) {
+        let family = inner.local_addr().ok().flatten().map(|addr| addr.ip());
+        let servers = match resolve_stun_servers(&config.stun_servers, family).await {
+            Ok(servers) => servers,
+            Err(error) => {
+                tracing::debug!(%error, "realm server STUN resolution failed");
+                if wait_or_closed(backoff, closed.clone()).await {
+                    return;
+                }
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+                continue;
+            }
+        };
+        let locals = match discover_dispatched(&*inner, &servers, &mut stun).await {
+            Ok(locals) if !locals.is_empty() => locals,
+            Ok(_) => {
+                tracing::debug!("realm server STUN discovery returned no addresses");
+                if wait_or_closed(backoff, closed.clone()).await {
+                    return;
+                }
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+                continue;
+            }
+            Err(error) => {
+                tracing::debug!(%error, "realm server STUN discovery failed");
+                if wait_or_closed(backoff, closed.clone()).await {
+                    return;
+                }
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+                continue;
+            }
+        };
+        let register = match http
+            .register(&config.realm_id, &config.token, address_strings(&locals))
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::debug!(%error, "realm server registration failed");
+                if wait_or_closed(backoff, closed.clone()).await {
+                    return;
+                }
+                backoff = (backoff * 2).min(Duration::from_secs(30));
+                continue;
+            }
+        };
+        backoff = Duration::from_secs(1);
+        tracing::debug!(
+            realm_id = %config.realm_id,
+            session_id = %register.session_id,
+            ttl = register.ttl,
+            "realm server registered"
+        );
+        let session_lost = run_registered_session(
+            &config,
+            &http,
+            &inner,
+            &mut stun,
+            &punch_routes,
+            locals,
+            &register,
+            closed.clone(),
+        )
+        .await;
+        if closed.load(Ordering::Acquire) {
+            let _ = http
+                .deregister(&config.realm_id, &register.session_id)
+                .await;
+            return;
+        }
+        if let Err(error) = session_lost {
+            tracing::debug!(%error, "realm server session ended; registering again");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_registered_session(
+    config: &ParsedRealm,
+    http: &RealmHttpClient,
+    inner: &Arc<dyn UdpSocketLike>,
+    stun: &mut tokio::sync::mpsc::Receiver<StunEvent>,
+    punch_routes: &PunchRoutes,
+    mut locals: Vec<SocketAddr>,
+    register: &RegisterResponse,
+    closed: Arc<AtomicBool>,
+) -> io::Result<()> {
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(16);
+    let mut events_task = tokio::spawn(stream_events_loop(
+        http.clone(),
+        config.realm_id.clone(),
+        register.session_id.clone(),
+        Duration::from_secs(register.ttl.max(0) as u64),
+        event_tx,
+        closed.clone(),
+    ));
+    let mut ttl = register.ttl;
+    let heartbeat_seconds = heartbeat_interval(ttl).as_secs();
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(heartbeat_seconds));
+    let mut last_heartbeat = Instant::now();
+    heartbeat.tick().await;
+    loop {
+        tokio::select! {
+            () = wait_until_closed(closed.clone()) => {
+                events_task.abort();
+                return Ok(());
+            }
+            _ = heartbeat.tick() => {
+                let family = inner.local_addr().ok().flatten().map(|addr| addr.ip());
+                let discovered = match resolve_stun_servers(&config.stun_servers, family).await {
+                    Ok(servers) => match discover_dispatched(&**inner, &servers, stun).await {
+                        Ok(discovered) => discovered,
+                        Err(error) => {
+                            // Xray heartbeats use the last cached STUN result. A
+                            // transient refresh failure must not discard a live
+                            // control-plane session.
+                            tracing::debug!(%error, "realm heartbeat STUN discovery failed; retaining cached addresses");
+                            Vec::new()
+                        }
+                    },
+                    Err(error) => {
+                        tracing::debug!(%error, "realm heartbeat STUN resolution failed; retaining cached addresses");
+                        Vec::new()
+                    }
+                };
+                let changed = !discovered.is_empty() && discovered != locals;
+                if changed {
+                    locals = discovered;
+                }
+                let started = Instant::now();
+                match http.heartbeat(
+                    &config.realm_id,
+                    &register.session_id,
+                    changed.then(|| address_strings(&locals)),
+                ).await {
+                    Ok(response) => {
+                        last_heartbeat = started;
+                        if response.ttl > 0 && response.ttl != ttl {
+                            ttl = response.ttl;
+                            heartbeat.reset_after(heartbeat_interval(ttl));
+                        }
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                        events_task.abort();
+                        return Err(io::Error::new(io::ErrorKind::PermissionDenied, format!("realm session is invalid: {error}")));
+                    }
+                    Err(error) if session_expired(last_heartbeat, ttl) => {
+                        events_task.abort();
+                        return Err(io::Error::new(io::ErrorKind::TimedOut, format!("realm heartbeat session expired after transient errors: {error}")));
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, "realm heartbeat failed within TTL; retaining session");
+                    }
+                }
+            }
+            result = &mut events_task => {
+                return result
+                    .map_err(|error| io::Error::other(format!("realm SSE task: {error}")))?;
+            }
+            Some(event) = event_rx.recv() => {
+                let http = http.clone();
+                let realm_id = config.realm_id.clone();
+                let session_id = register.session_id.clone();
+                let inner = inner.clone();
+                let routes = punch_routes.clone();
+                let locals = locals.clone();
+                let closed = closed.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_punch_event(
+                        http, realm_id, session_id, inner, routes, locals, event, closed,
+                    ).await {
+                        tracing::debug!(%error, "realm punch event failed");
+                    }
+                });
+            }
+        }
+    }
+}
+
+async fn stream_events_loop(
+    http: RealmHttpClient,
+    realm_id: String,
+    session_id: String,
+    ttl: Duration,
+    output: tokio::sync::mpsc::Sender<PunchEvent>,
+    closed: Arc<AtomicBool>,
+) -> io::Result<()> {
+    let mut backoff = Duration::from_secs(1);
+    let mut last_open = Instant::now();
+    while !closed.load(Ordering::Acquire) {
+        let started = Instant::now();
+        match http.events(&realm_id, &session_id).await {
+            Ok(body) => {
+                backoff = Duration::from_secs(1);
+                last_open = started;
+                match consume_sse(body, &output, closed.clone()).await {
+                    Ok(()) => return Ok(()),
+                    Err(error) => tracing::debug!(%error, "realm SSE stream interrupted"),
+                }
+                // Xray immediately reopens a stream that ended after a
+                // successful response; exponential backoff is only for open
+                // failures.
+                continue;
+            }
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("realm event session is invalid: {error}"),
+                ));
+            }
+            Err(error) if last_open.elapsed() > ttl => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("realm event session expired after transient errors: {error}"),
+                ));
+            }
+            Err(error) => tracing::debug!(%error, "realm SSE open failed within TTL"),
+        }
+        if wait_or_closed(backoff, closed.clone()).await {
+            return Ok(());
+        }
+        backoff = (backoff * 2).min(Duration::from_secs(30));
+    }
+    Ok(())
+}
+
+fn heartbeat_interval(ttl: i64) -> Duration {
+    if ttl > 0 {
+        Duration::from_secs((ttl / 2).max(1) as u64)
+    } else {
+        Duration::from_secs(15)
+    }
+}
+
+fn session_expired(last_success: Instant, ttl: i64) -> bool {
+    last_success.elapsed() > Duration::from_secs(ttl.max(0) as u64)
+}
+
+async fn consume_sse(
+    mut body: Incoming,
+    output: &tokio::sync::mpsc::Sender<PunchEvent>,
+    closed: Arc<AtomicBool>,
+) -> io::Result<()> {
+    let mut pending = Vec::new();
+    while let Some(frame) = body.frame().await {
+        let frame = frame.map_err(http_error)?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        pending.extend_from_slice(&data);
+        if pending.len() > MAX_CONTROL_BODY {
+            return Err(invalid("realm SSE event exceeds size limit"));
+        }
+        while let Some(end) = sse_event_end(&pending) {
+            let block = pending.drain(..end).collect::<Vec<_>>();
+            while pending
+                .first()
+                .is_some_and(|byte| matches!(byte, b'\r' | b'\n'))
+            {
+                pending.remove(0);
+            }
+            if let Some(event) = parse_sse_event(&block)?
+                && output.send(event).await.is_err()
+            {
+                return Ok(());
+            }
+        }
+        if closed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::UnexpectedEof,
+        "realm SSE response ended",
+    ))
+}
+
+fn sse_event_end(bytes: &[u8]) -> Option<usize> {
+    bytes
+        .windows(2)
+        .position(|window| window == b"\n\n")
+        .map(|index| index + 2)
+        .or_else(|| {
+            bytes
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .map(|index| index + 4)
+        })
+}
+
+fn parse_sse_event(block: &[u8]) -> io::Result<Option<PunchEvent>> {
+    let text = std::str::from_utf8(block).map_err(|_| invalid("realm SSE is not UTF-8"))?;
+    let mut event_name = "";
+    let mut data = String::new();
+    for line in text.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.starts_with(':') {
+            continue;
+        }
+        let Some((field, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.strip_prefix(' ').unwrap_or(value);
+        match field {
+            "event" => event_name = value,
+            "data" => {
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(value);
+            }
+            _ => {}
+        }
+    }
+    if event_name != "punch" {
+        return Ok(None);
+    }
+    serde_json::from_str(&data)
+        .map(Some)
+        .map_err(|error| invalid(format!("invalid realm punch SSE event: {error}")))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_punch_event(
+    http: RealmHttpClient,
+    realm_id: String,
+    session_id: String,
+    inner: Arc<dyn UdpSocketLike>,
+    routes: PunchRoutes,
+    locals: Vec<SocketAddr>,
+    event: PunchEvent,
+    closed: Arc<AtomicBool>,
+) -> io::Result<()> {
+    let peers = parse_addresses(&event.addresses);
+    let (candidates, mut seen) = candidate_punch_addresses(&locals, &peers);
+    let candidates = expand_symmetric_nat_candidates(candidates, &mut seen);
+    if candidates.is_empty() {
+        return Err(invalid("realm punch event has no usable peers"));
+    }
+    http.connect_response(
+        &realm_id,
+        &session_id,
+        &event.metadata.nonce,
+        address_strings(&locals),
+    )
+    .await?;
+    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+    {
+        let mut routes = routes.lock().await;
+        if routes.len() >= 64 {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "too many concurrent realm punch events",
+            ));
+        }
+        if routes.insert(event.metadata.clone(), tx).is_some() {
+            return Err(invalid("duplicate realm punch nonce"));
+        }
+    }
+    let result = punch_server(&*inner, &event.metadata, &candidates, &mut rx, closed).await;
+    routes.lock().await.remove(&event.metadata);
+    result
+}
+
+async fn punch_server(
+    socket: &dyn UdpSocketLike,
+    metadata: &PunchMetadata,
+    peers: &[SocketAddr],
+    events: &mut tokio::sync::mpsc::Receiver<PunchPacketEvent>,
+    closed: Arc<AtomicBool>,
+) -> io::Result<()> {
+    let deadline = tokio::time::Instant::now() + PUNCH_TIMEOUT;
+    let mut ticker = tokio::time::interval(PUNCH_INTERVAL);
+    loop {
+        tokio::select! {
+            () = wait_until_closed(closed.clone()) => return Ok(()),
+            _ = tokio::time::sleep_until(deadline) => {
+                return Err(io::Error::new(io::ErrorKind::TimedOut, "realm server punch timed out"));
+            }
+            _ = ticker.tick() => {
+                for peer in peers {
+                    let hello = encode_punch(PunchType::Hello, metadata)?;
+                    let _ = socket.send_to(&hello, &peer.ip().to_string(), peer.port()).await;
+                }
+            }
+            event = events.recv() => {
+                let Some(event) = event else {
+                    return Err(io::ErrorKind::UnexpectedEof.into());
+                };
+                if event.kind == PunchType::Hello {
+                    let ack = encode_punch(PunchType::Ack, metadata)?;
+                    socket.send_to(&ack, &event.source.ip().to_string(), event.source.port()).await?;
+                }
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn discover_dispatched(
+    socket: &dyn UdpSocketLike,
+    servers: &[SocketAddr],
+    events: &mut tokio::sync::mpsc::Receiver<StunEvent>,
+) -> io::Result<Vec<SocketAddr>> {
+    let mut outstanding = HashSet::new();
+    for server in servers {
+        let (request, transaction) = stun_binding_request();
+        outstanding.insert(transaction);
+        socket
+            .send_to(&request, &server.ip().to_string(), server.port())
+            .await?;
+    }
+    let deadline = tokio::time::Instant::now() + STUN_TIMEOUT;
+    let mut results = Vec::new();
+    while !outstanding.is_empty() {
+        let received = tokio::time::timeout_at(deadline, events.recv()).await;
+        let Ok(Some(event)) = received else {
+            break;
+        };
+        if outstanding.remove(&event.transaction) {
+            results.push(event.mapped);
+        }
+    }
+    results.sort_by_key(ToString::to_string);
+    results.dedup();
+    Ok(results)
+}
+
+async fn wait_until_closed(closed: Arc<AtomicBool>) {
+    while !closed.load(Ordering::Acquire) {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_or_closed(duration: Duration, closed: Arc<AtomicBool>) -> bool {
+    tokio::select! {
+        () = tokio::time::sleep(duration) => false,
+        () = wait_until_closed(closed) => true,
+    }
+}
+
+struct RealmClient {
+    inner: BoxedUdp,
+    peer: SocketAddr,
+}
+
+#[async_trait]
+impl UdpSocketLike for RealmClient {
+    async fn send_to(&self, payload: &[u8], _target: &str, _port: u16) -> io::Result<usize> {
+        self.inner
+            .send_to(payload, &self.peer.ip().to_string(), self.peer.port())
+            .await
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.inner.recv_from(output).await
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        self.inner.recv_from_endpoint(output).await
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        self.inner.close().await
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner.local_addr()
+    }
+}
+
+#[derive(Debug)]
+struct ParsedRealm {
+    scheme: &'static str,
+    host: String,
+    port: u16,
+    token: String,
+    realm_id: String,
+    stun_servers: Vec<String>,
+    tls: TlsOptions,
+}
+
+impl ParsedRealm {
+    fn parse(config: &RealmMaskConfig) -> io::Result<Self> {
+        let url = url::Url::parse(&config.url)
+            .map_err(|error| invalid(format!("invalid realm URL: {error}")))?;
+        let (scheme, default_port) = match url.scheme() {
+            "realm" => ("https", 443),
+            "realm+http" => ("http", 80),
+            scheme => return Err(invalid(format!("invalid realm URL scheme `{scheme}`"))),
+        };
+        let host = url
+            .host_str()
+            .filter(|host| !host.is_empty())
+            .ok_or_else(|| invalid("realm URL has no host"))?
+            .to_string();
+        let port = url.port().unwrap_or(default_port);
+        let mut token = percent_decode_str(url.username())
+            .decode_utf8()
+            .map_err(|_| invalid("realm token is not UTF-8"))?
+            .into_owned();
+        if let Some(password) = url.password() {
+            token.push(':');
+            token.push_str(
+                &percent_decode_str(password)
+                    .decode_utf8()
+                    .map_err(|_| invalid("realm token password is not UTF-8"))?,
+            );
+        }
+        if token.is_empty() {
+            return Err(invalid("realm URL has an empty token"));
+        }
+        let realm_id = percent_decode_str(url.path().trim_start_matches('/'))
+            .decode_utf8()
+            .map_err(|_| invalid("realm ID is not UTF-8"))?
+            .into_owned();
+        if realm_id.is_empty() {
+            return Err(invalid("realm URL has an empty ID"));
+        }
+        if config.stun_servers.is_empty() {
+            return Err(invalid("realm stunServers is empty"));
+        }
+
+        let tls = if scheme == "https" {
+            let mut settings = config.tls_config.clone().unwrap_or_default();
+            if settings
+                .server_name
+                .as_deref()
+                .is_none_or(|server_name| server_name.is_empty())
+            {
+                settings.server_name = Some(host.clone());
+            }
+            if settings.alpn.as_ref().is_none_or(Vec::is_empty) {
+                settings.alpn = Some(vec!["h2".into(), "http/1.1".into()]);
+            }
+            TlsOptions::from_xray_settings(settings).map_err(|error| {
+                io::Error::new(error.kind(), format!("invalid realm tlsConfig: {error}"))
+            })?
+        } else {
+            if config.tls_config.is_some() {
+                return Err(invalid(
+                    "realm tlsConfig is invalid with realm+http because no TLS transport executes it",
+                ));
+            }
+            TlsOptions::default()
+        };
+        Ok(Self {
+            scheme,
+            host,
+            port,
+            token,
+            realm_id,
+            stun_servers: config.stun_servers.clone(),
+            tls,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct RealmHttpClient {
+    scheme: &'static str,
+    host: String,
+    port: u16,
+    tls: TlsOptions,
+}
+
+impl RealmHttpClient {
+    fn new(config: &ParsedRealm) -> Self {
+        Self {
+            scheme: config.scheme,
+            host: config.host.clone(),
+            port: config.port,
+            tls: config.tls.clone(),
+        }
+    }
+
+    async fn connect(
+        &self,
+        realm_id: &str,
+        token: &str,
+        request: ConnectRequest,
+    ) -> io::Result<ConnectResponse> {
+        self.json(
+            Method::POST,
+            realm_id,
+            "connect",
+            token,
+            Some(&request),
+            StatusCode::OK,
+        )
+        .await
+    }
+
+    async fn register(
+        &self,
+        realm_id: &str,
+        token: &str,
+        addresses: Vec<String>,
+    ) -> io::Result<RegisterResponse> {
+        self.json(
+            Method::POST,
+            realm_id,
+            "",
+            token,
+            Some(&AddressRequest { addresses }),
+            StatusCode::OK,
+        )
+        .await
+    }
+
+    async fn heartbeat(
+        &self,
+        realm_id: &str,
+        session_id: &str,
+        addresses: Option<Vec<String>>,
+    ) -> io::Result<HeartbeatResponse> {
+        self.json(
+            Method::POST,
+            realm_id,
+            "heartbeat",
+            session_id,
+            Some(&HeartbeatRequest { addresses }),
+            StatusCode::OK,
+        )
+        .await
+    }
+
+    async fn connect_response(
+        &self,
+        realm_id: &str,
+        session_id: &str,
+        nonce: &str,
+        addresses: Vec<String>,
+    ) -> io::Result<()> {
+        self.empty(
+            Method::POST,
+            realm_id,
+            &format!("connects/{}", utf8_percent_encode(nonce, NON_ALPHANUMERIC)),
+            session_id,
+            Some(&AddressRequest { addresses }),
+            StatusCode::NO_CONTENT,
+        )
+        .await
+    }
+
+    async fn deregister(&self, realm_id: &str, session_id: &str) -> io::Result<()> {
+        self.empty::<serde_json::Value>(
+            Method::DELETE,
+            realm_id,
+            "",
+            session_id,
+            None,
+            StatusCode::NO_CONTENT,
+        )
+        .await
+    }
+
+    async fn events(&self, realm_id: &str, session_id: &str) -> io::Result<Incoming> {
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri(self.uri(&realm_path(realm_id, "events"))?)
+            .header("authorization", format!("Bearer {session_id}"))
+            .header("accept", "text/event-stream")
+            .body(Full::new(Bytes::new()))
+            .map_err(|error| invalid(format!("realm events request: {error}")))?;
+        let response = self.send(request).await?;
+        if response.status() != StatusCode::OK {
+            return Err(realm_status_error(
+                response.status(),
+                ErrorResponse::default(),
+            ));
+        }
+        Ok(response.into_body())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn empty<I: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        realm_id: &str,
+        subpath: &str,
+        token: &str,
+        input: Option<&I>,
+        expected: StatusCode,
+    ) -> io::Result<()> {
+        let body = input
+            .map(serde_json::to_vec)
+            .transpose()
+            .map_err(|error| invalid(format!("realm JSON encode: {error}")))?
+            .unwrap_or_default();
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(self.uri(&realm_path(realm_id, subpath))?);
+        if !token.is_empty() {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        if input.is_some() {
+            builder = builder.header("content-type", "application/json");
+        }
+        let response = self
+            .send(
+                builder
+                    .body(Full::new(Bytes::from(body)))
+                    .map_err(|error| invalid(format!("realm HTTP request: {error}")))?,
+            )
+            .await?;
+        let status = response.status();
+        let body = Limited::new(response.into_body(), MAX_CONTROL_BODY)
+            .collect()
+            .await
+            .map_err(|error| invalid(format!("realm HTTP response body: {error}")))?
+            .to_bytes();
+        if status != expected {
+            let details = serde_json::from_slice::<ErrorResponse>(&body).unwrap_or_default();
+            return Err(realm_status_error(status, details));
+        }
+        Ok(())
+    }
+
+    async fn json<I: Serialize + ?Sized, O: DeserializeOwned>(
+        &self,
+        method: Method,
+        realm_id: &str,
+        subpath: &str,
+        token: &str,
+        input: Option<&I>,
+        expected: StatusCode,
+    ) -> io::Result<O> {
+        let path = realm_path(realm_id, subpath);
+        let body = input
+            .map(serde_json::to_vec)
+            .transpose()
+            .map_err(|error| invalid(format!("realm JSON encode: {error}")))?
+            .unwrap_or_default();
+        let mut builder = Request::builder().method(method).uri(self.uri(&path)?);
+        if !token.is_empty() {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        if input.is_some() {
+            builder = builder.header("content-type", "application/json");
+        }
+        let request = builder
+            .body(Full::new(Bytes::from(body)))
+            .map_err(|error| invalid(format!("realm HTTP request: {error}")))?;
+        let response = self.send(request).await?;
+        let status = response.status();
+        let body = Limited::new(response.into_body(), MAX_CONTROL_BODY)
+            .collect()
+            .await
+            .map_err(|error| invalid(format!("realm HTTP response body: {error}")))?
+            .to_bytes();
+        if status != expected {
+            let details = serde_json::from_slice::<ErrorResponse>(&body).unwrap_or_default();
+            return Err(realm_status_error(status, details));
+        }
+        serde_json::from_slice(&body)
+            .map_err(|error| invalid(format!("realm JSON response: {error}")))
+    }
+
+    fn uri(&self, path: &str) -> io::Result<Uri> {
+        let authority = if self.host.parse::<std::net::Ipv6Addr>().is_ok() {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        };
+        format!("{}://{}{}", self.scheme, authority, path)
+            .parse()
+            .map_err(|error| invalid(format!("realm HTTP URI: {error}")))
+    }
+
+    async fn send(
+        &self,
+        mut request: Request<Full<Bytes>>,
+    ) -> io::Result<http::Response<Incoming>> {
+        let (stream, alpn) = crate::socket_policy::without_finalmask(async {
+            if self.scheme == "https" {
+                TlsTransport::new(self.tls.clone())
+                    .connect_negotiated(&self.host, self.port)
+                    .await
+            } else {
+                TcpTransport::default()
+                    .connect(&self.host, self.port)
+                    .await
+                    .map(|stream| (stream, None))
+            }
+        })
+        .await?;
+        let io = TokioIo::new(stream);
+        if alpn.as_deref() == Some(b"h2") {
+            let (mut sender, connection) =
+                hyper::client::conn::http2::handshake::<_, _, Full<Bytes>>(
+                    TokioExecutor::new(),
+                    io,
+                )
+                .await
+                .map_err(http_error)?;
+            tokio::spawn(async move {
+                if let Err(error) = connection.await {
+                    tracing::debug!(%error, "realm HTTP/2 connection ended");
+                }
+            });
+            sender.send_request(request).await.map_err(http_error)
+        } else {
+            prepare_http1_request(&mut request)?;
+            let (mut sender, connection) =
+                hyper::client::conn::http1::handshake::<_, Full<Bytes>>(io)
+                    .await
+                    .map_err(http_error)?;
+            tokio::spawn(async move {
+                if let Err(error) = connection.await {
+                    tracing::debug!(%error, "realm HTTP/1.1 connection ended");
+                }
+            });
+            sender.send_request(request).await.map_err(http_error)
+        }
+    }
+}
+
+fn prepare_http1_request(request: &mut Request<Full<Bytes>>) -> io::Result<()> {
+    let authority = request
+        .uri()
+        .authority()
+        .ok_or_else(|| invalid("realm HTTP/1.1 URI has no authority"))?
+        .as_str()
+        .to_string();
+    if !request.headers().contains_key(http::header::HOST) {
+        request.headers_mut().insert(
+            http::header::HOST,
+            authority
+                .parse()
+                .map_err(|error| invalid(format!("realm HTTP Host header: {error}")))?,
+        );
+    }
+    let path = request
+        .uri()
+        .path_and_query()
+        .map(|value| value.as_str())
+        .unwrap_or("/")
+        .parse::<Uri>()
+        .map_err(|error| invalid(format!("realm HTTP origin-form URI: {error}")))?;
+    *request.uri_mut() = path;
+    Ok(())
+}
+
+fn realm_status_error(status: StatusCode, details: ErrorResponse) -> io::Error {
+    // Xray only invalidates the registration immediately for 401/404. Other
+    // HTTP failures are transient and are tolerated until the advertised TTL.
+    let kind = if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::NOT_FOUND) {
+        io::ErrorKind::PermissionDenied
+    } else {
+        io::ErrorKind::Other
+    };
+    io::Error::new(
+        kind,
+        format!(
+            "realm server returned {status}: {}: {}",
+            details.error, details.message
+        ),
+    )
+}
+
+fn realm_path(realm_id: &str, subpath: &str) -> String {
+    let realm_id = utf8_percent_encode(realm_id.trim_matches('/'), NON_ALPHANUMERIC);
+    if subpath.trim_matches('/').is_empty() {
+        format!("/v1/{realm_id}")
+    } else {
+        format!("/v1/{realm_id}/{}", subpath.trim_matches('/'))
+    }
+}
+
+fn http_error(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::ConnectionAborted, error.to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+struct PunchMetadata {
+    nonce: String,
+    obfs: String,
+}
+
+impl PunchMetadata {
+    fn random() -> Self {
+        let mut nonce = [0; 16];
+        let mut obfs = [0; 32];
+        rand::rngs::OsRng.fill_bytes(&mut nonce);
+        rand::rngs::OsRng.fill_bytes(&mut obfs);
+        Self {
+            nonce: hex::encode(nonce),
+            obfs: hex::encode(obfs),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ConnectRequest {
+    addresses: Vec<String>,
+    #[serde(flatten)]
+    metadata: PunchMetadata,
+}
+
+#[derive(Deserialize)]
+struct ConnectResponse {
+    addresses: Vec<String>,
+    #[allow(dead_code)]
+    nonce: String,
+    #[allow(dead_code)]
+    obfs: String,
+}
+
+#[derive(Serialize)]
+struct AddressRequest {
+    addresses: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct HeartbeatRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    addresses: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct RegisterResponse {
+    session_id: String,
+    ttl: i64,
+}
+
+#[derive(Deserialize)]
+struct HeartbeatResponse {
+    ttl: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PunchEvent {
+    addresses: Vec<String>,
+    #[serde(flatten)]
+    metadata: PunchMetadata,
+}
+
+#[derive(Default, Deserialize)]
+struct ErrorResponse {
+    error: String,
+    message: String,
+}
+
+async fn resolve_stun_servers(
+    servers: &[String],
+    carrier_family: Option<IpAddr>,
+) -> io::Result<Vec<SocketAddr>> {
+    let mut output = Vec::new();
+    let mut seen = HashSet::new();
+    for server in servers {
+        let (host, port) = parse_host_port(server)?;
+        let addresses = resolve_host(&host, port).await?;
+        if let Some(address) = addresses.into_iter().find(|address| {
+            carrier_family.is_none_or(|family| family.is_ipv4() == address.is_ipv4())
+        }) && seen.insert(address)
+        {
+            output.push(address);
+        }
+    }
+    Ok(output)
+}
+
+fn parse_host_port(input: &str) -> io::Result<(String, u16)> {
+    let url = url::Url::parse(&format!("udp://{input}"))
+        .map_err(|error| invalid(format!("invalid STUN server `{input}`: {error}")))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| invalid(format!("invalid STUN host `{input}`")))?
+        .to_string();
+    let port = url
+        .port()
+        .ok_or_else(|| invalid(format!("STUN server `{input}` has no port")))?;
+    Ok((host, port))
+}
+
+async fn discover(
+    socket: &dyn UdpSocketLike,
+    servers: &[SocketAddr],
+) -> io::Result<Vec<SocketAddr>> {
+    let mut outstanding = HashSet::new();
+    for server in servers {
+        let (request, transaction) = stun_binding_request();
+        outstanding.insert(transaction);
+        socket
+            .send_to(&request, &server.ip().to_string(), server.port())
+            .await?;
+    }
+    let deadline = tokio::time::Instant::now() + STUN_TIMEOUT;
+    let mut buffer = [0; 1500];
+    let mut results = Vec::new();
+    while !outstanding.is_empty() {
+        let received =
+            tokio::time::timeout_at(deadline, socket.recv_from_endpoint(&mut buffer)).await;
+        let Ok(Ok((length, _))) = received else {
+            break;
+        };
+        if let Ok((transaction, mapped)) = parse_stun_binding_response(&buffer[..length])
+            && outstanding.remove(&transaction)
+        {
+            results.push(mapped);
+        }
+    }
+    results.sort_by_key(ToString::to_string);
+    results.dedup();
+    Ok(results)
+}
+
+fn stun_binding_request() -> (Vec<u8>, [u8; 12]) {
+    let mut transaction = [0; 12];
+    rand::rngs::OsRng.fill_bytes(&mut transaction);
+    let mut packet = vec![0; 20];
+    packet[..2].copy_from_slice(&1_u16.to_be_bytes());
+    packet[4..8].copy_from_slice(&STUN_MAGIC.to_be_bytes());
+    packet[8..20].copy_from_slice(&transaction);
+    (packet, transaction)
+}
+
+fn parse_stun_binding_response(packet: &[u8]) -> io::Result<([u8; 12], SocketAddr)> {
+    if packet.len() < 20
+        || u16::from_be_bytes([packet[0], packet[1]]) != 0x0101
+        || u32::from_be_bytes([packet[4], packet[5], packet[6], packet[7]]) != STUN_MAGIC
+    {
+        return Err(invalid("not a STUN binding success response"));
+    }
+    let body_length = usize::from(u16::from_be_bytes([packet[2], packet[3]]));
+    if packet.len() < 20 + body_length {
+        return Err(invalid("truncated STUN response"));
+    }
+    let mut transaction = [0; 12];
+    transaction.copy_from_slice(&packet[8..20]);
+    let mut offset = 20;
+    let end = 20 + body_length;
+    let mut mapped = None;
+    while offset + 4 <= end {
+        let kind = u16::from_be_bytes([packet[offset], packet[offset + 1]]);
+        let length = usize::from(u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]));
+        offset += 4;
+        if offset + length > end {
+            return Err(invalid("truncated STUN attribute"));
+        }
+        if kind == 0x0020 || (kind == 0x0001 && mapped.is_none()) {
+            mapped = Some(parse_stun_address(
+                &packet[offset..offset + length],
+                kind == 0x0020,
+                &transaction,
+            )?);
+            if kind == 0x0020 {
+                break;
+            }
+        }
+        offset += (length + 3) & !3;
+    }
+    mapped
+        .map(|address| (transaction, address))
+        .ok_or_else(|| invalid("STUN mapped address is absent"))
+}
+
+fn parse_stun_address(value: &[u8], xor: bool, transaction: &[u8; 12]) -> io::Result<SocketAddr> {
+    if value.len() < 8 {
+        return Err(invalid("truncated STUN address"));
+    }
+    let mut port = u16::from_be_bytes([value[2], value[3]]);
+    if xor {
+        port ^= (STUN_MAGIC >> 16) as u16;
+    }
+    let ip = match value[1] {
+        1 if value.len() >= 8 => {
+            let mut octets = [0; 4];
+            octets.copy_from_slice(&value[4..8]);
+            if xor {
+                for (byte, mask) in octets.iter_mut().zip(STUN_MAGIC.to_be_bytes()) {
+                    *byte ^= mask;
+                }
+            }
+            IpAddr::from(octets)
+        }
+        2 if value.len() >= 20 => {
+            let mut octets = [0; 16];
+            octets.copy_from_slice(&value[4..20]);
+            if xor {
+                let mut mask = [0; 16];
+                mask[..4].copy_from_slice(&STUN_MAGIC.to_be_bytes());
+                mask[4..].copy_from_slice(transaction);
+                for (byte, mask) in octets.iter_mut().zip(mask) {
+                    *byte ^= mask;
+                }
+            }
+            IpAddr::from(octets)
+        }
+        _ => return Err(invalid("invalid STUN address family")),
+    };
+    if port == 0 {
+        return Err(invalid("invalid zero STUN mapped port"));
+    }
+    Ok(SocketAddr::new(ip, port))
+}
+
+async fn punch(
+    socket: &dyn UdpSocketLike,
+    metadata: &PunchMetadata,
+    peers: &[SocketAddr],
+) -> io::Result<SocketAddr> {
+    let deadline = Instant::now() + PUNCH_TIMEOUT;
+    let mut next_send = Instant::now();
+    let mut buffer = vec![0; PUNCH_MAX_WIRE_LEN];
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "realm punch timed out",
+            ));
+        }
+        if now >= next_send {
+            for peer in peers {
+                let packet = encode_punch(PunchType::Hello, metadata)?;
+                let _ = socket
+                    .send_to(&packet, &peer.ip().to_string(), peer.port())
+                    .await;
+            }
+            next_send = now + PUNCH_INTERVAL;
+        }
+        let until = next_send
+            .min(deadline)
+            .saturating_duration_since(Instant::now());
+        let received = tokio::time::timeout(until, socket.recv_from_endpoint(&mut buffer)).await;
+        let Ok(Ok((length, Some(source)))) = received else {
+            continue;
+        };
+        let Ok(packet_type) = decode_punch(&buffer[..length], metadata) else {
+            continue;
+        };
+        if packet_type == PunchType::Hello {
+            let ack = encode_punch(PunchType::Ack, metadata)?;
+            socket
+                .send_to(&ack, &source.ip().to_string(), source.port())
+                .await?;
+        }
+        return Ok(source);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PunchType {
+    Hello = 1,
+    Ack = 2,
+}
+
+fn encode_punch(kind: PunchType, metadata: &PunchMetadata) -> io::Result<Vec<u8>> {
+    let (nonce, obfs) = decode_metadata(metadata)?;
+    let padding = rand::thread_rng().gen_range(0..=MAX_PUNCH_PADDING);
+    let mut plain = vec![0; PUNCH_HEADER_LEN + padding];
+    plain[..8].copy_from_slice(PUNCH_MAGIC);
+    plain[8] = kind as u8;
+    plain[9..25].copy_from_slice(&nonce);
+    rand::rngs::OsRng.fill_bytes(&mut plain[PUNCH_HEADER_LEN..]);
+    let mut packet = vec![0; PUNCH_SALT_LEN + plain.len()];
+    rand::rngs::OsRng.fill_bytes(&mut packet[..PUNCH_SALT_LEN]);
+    packet[PUNCH_SALT_LEN..].copy_from_slice(&plain);
+    let (salt, encrypted) = packet.split_at_mut(PUNCH_SALT_LEN);
+    xor_punch(encrypted, &obfs, salt);
+    Ok(packet)
+}
+
+fn decode_punch(packet: &[u8], metadata: &PunchMetadata) -> io::Result<PunchType> {
+    if !(PUNCH_MIN_WIRE_LEN..=PUNCH_MAX_WIRE_LEN).contains(&packet.len()) {
+        return Err(invalid("invalid realm punch packet length"));
+    }
+    let (nonce, obfs) = decode_metadata(metadata)?;
+    let mut plain = packet[PUNCH_SALT_LEN..].to_vec();
+    xor_punch(&mut plain, &obfs, &packet[..PUNCH_SALT_LEN]);
+    if &plain[..8] != PUNCH_MAGIC || plain[9..25] != nonce {
+        return Err(invalid("realm punch authentication failed"));
+    }
+    match plain[8] {
+        1 => Ok(PunchType::Hello),
+        2 => Ok(PunchType::Ack),
+        _ => Err(invalid("unknown realm punch packet type")),
+    }
+}
+
+fn decode_metadata(metadata: &PunchMetadata) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    let nonce = hex::decode(&metadata.nonce).map_err(|_| invalid("invalid realm punch nonce"))?;
+    let obfs = hex::decode(&metadata.obfs).map_err(|_| invalid("invalid realm punch key"))?;
+    if nonce.len() != 16 || obfs.len() != 32 {
+        return Err(invalid("invalid realm punch metadata length"));
+    }
+    Ok((nonce, obfs))
+}
+
+fn xor_punch(packet: &mut [u8], key: &[u8], salt: &[u8]) {
+    let mask = Sha256::new()
+        .chain_update(key)
+        .chain_update(salt)
+        .finalize();
+    for (index, byte) in packet.iter_mut().enumerate() {
+        *byte ^= mask[index % mask.len()];
+    }
+}
+
+fn parse_addresses(addresses: &[String]) -> Vec<SocketAddr> {
+    addresses
+        .iter()
+        .filter_map(|value| value.parse().ok())
+        .collect()
+}
+
+fn address_strings(addresses: &[SocketAddr]) -> Vec<String> {
+    addresses.iter().map(ToString::to_string).collect()
+}
+
+fn candidate_punch_addresses(
+    locals: &[SocketAddr],
+    peers: &[SocketAddr],
+) -> (Vec<SocketAddr>, HashSet<SocketAddr>) {
+    let allow4 = locals.iter().any(SocketAddr::is_ipv4);
+    let allow6 = locals.iter().any(SocketAddr::is_ipv6);
+    let mut seen = HashSet::new();
+    let mut candidates = Vec::new();
+    for peer in peers.iter().copied() {
+        if ((peer.is_ipv4() && allow4) || (peer.is_ipv6() && allow6)) && seen.insert(peer) {
+            candidates.push(peer);
+        }
+    }
+    (candidates, seen)
+}
+
+fn expand_symmetric_nat_candidates(
+    mut candidates: Vec<SocketAddr>,
+    seen: &mut HashSet<SocketAddr>,
+) -> Vec<SocketAddr> {
+    let mut ports_by_ip: HashMap<IpAddr, Vec<u16>> = HashMap::new();
+    for candidate in &candidates {
+        if candidate.is_ipv4() {
+            ports_by_ip
+                .entry(candidate.ip())
+                .or_default()
+                .push(candidate.port());
+        }
+    }
+    for (ip, mut ports) in ports_by_ip {
+        ports.sort_unstable();
+        ports.dedup();
+        if ports.len() < 2 || ports.windows(2).any(|pair| pair[1] - pair[0] > 4) {
+            continue;
+        }
+        let end = u32::from(*ports.last().unwrap())
+            .saturating_add(4)
+            .min(u32::from(u16::MAX));
+        let mut added = 0;
+        for port in u32::from(ports[0])..=end {
+            let candidate = SocketAddr::new(ip, port as u16);
+            if seen.insert(candidate) {
+                candidates.push(candidate);
+                added += 1;
+                if added == 32 {
+                    break;
+                }
+            }
+        }
+    }
+    candidates.sort_by_key(ToString::to_string);
+    candidates
+}
+
+fn invalid(message: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+
+    #[test]
+    fn parses_official_realm_url_shape() {
+        let parsed = ParsedRealm::parse(&RealmMaskConfig {
+            url: "realm://token%3Asecret@example.com:8443/a%2Fb".into(),
+            stun_servers: vec!["stun.example:3478".into()],
+            tls_config: None,
+        })
+        .unwrap();
+        assert_eq!(parsed.scheme, "https");
+        assert_eq!(parsed.token, "token:secret");
+        assert_eq!(parsed.realm_id, "a/b");
+        assert_eq!(parsed.port, 8443);
+        assert_eq!(realm_path(&parsed.realm_id, ""), "/v1/a%2Fb");
+        assert_eq!(realm_path(&parsed.realm_id, "connect"), "/v1/a%2Fb/connect");
+
+        // Go's url.Userinfo.String() keeps the username/password separator,
+        // then Xray applies PathUnescape to the complete value.  The URL crate
+        // exposes the two components separately, so both spellings need to
+        // reconstruct the exact same bearer token.
+        let separated = ParsedRealm::parse(&RealmMaskConfig {
+            url: "realm://token:secret@example.com/a%2Fb".into(),
+            stun_servers: vec!["stun.example:3478".into()],
+            tls_config: None,
+        })
+        .unwrap();
+        assert_eq!(separated.token, parsed.token);
+    }
+
+    #[test]
+    fn session_status_and_timers_match_xray_recovery_rules() {
+        assert_eq!(heartbeat_interval(0), Duration::from_secs(15));
+        assert_eq!(heartbeat_interval(1), Duration::from_secs(1));
+        assert_eq!(heartbeat_interval(30), Duration::from_secs(15));
+
+        for status in [StatusCode::UNAUTHORIZED, StatusCode::NOT_FOUND] {
+            assert_eq!(
+                realm_status_error(status, ErrorResponse::default()).kind(),
+                io::ErrorKind::PermissionDenied
+            );
+        }
+        assert_eq!(
+            realm_status_error(StatusCode::INTERNAL_SERVER_ERROR, ErrorResponse::default()).kind(),
+            io::ErrorKind::Other
+        );
+    }
+
+    #[tokio::test]
+    async fn client_connect_uses_the_official_connect_route_and_bearer_token() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0; 512];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let length = stream.read(&mut chunk).await.unwrap();
+                assert_ne!(length, 0);
+                request.extend_from_slice(&chunk[..length]);
+            }
+            let head = String::from_utf8_lossy(&request).to_ascii_lowercase();
+            assert!(
+                head.starts_with("post /v1/realm%2fid/connect http/1.1\r\n"),
+                "unexpected realm request head: {head:?}"
+            );
+            assert!(head.contains("authorization: bearer secret\r\n"));
+            assert!(head.contains("content-type: application/json\r\n"));
+            assert!(head.contains(&format!("host: 127.0.0.1:{port}\r\n")));
+
+            let body = r#"{"addresses":["192.0.2.1:443"],"nonce":"00","obfs":"11"}"#;
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+        let parsed = ParsedRealm::parse(&RealmMaskConfig {
+            url: format!("realm+http://secret@127.0.0.1:{port}/realm%2Fid"),
+            stun_servers: vec!["127.0.0.1:3478".into()],
+            tls_config: None,
+        })
+        .unwrap();
+        let response = RealmHttpClient::new(&parsed)
+            .connect(
+                &parsed.realm_id,
+                &parsed.token,
+                ConnectRequest {
+                    addresses: vec!["198.51.100.2:40000".into()],
+                    metadata: PunchMetadata {
+                        nonce: "00".repeat(16),
+                        obfs: "11".repeat(32),
+                    },
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.addresses, ["192.0.2.1:443"]);
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn typed_tls_config_uses_the_complete_shared_xray_executor() {
+        let parsed = ParsedRealm::parse(&RealmMaskConfig {
+            url: "realm://token@example.com/id".into(),
+            stun_servers: vec!["stun.example:3478".into()],
+            tls_config: Some(core_config::model::XhttpDownloadTlsSettings {
+                server_name: Some("control.example".into()),
+                alpn: Some(vec!["h2".into(), "http/1.1".into()]),
+                enable_session_resumption: Some(true),
+                min_version: Some("1.2".into()),
+                max_version: Some("1.3".into()),
+                fingerprint: Some("chrome".into()),
+                pinned_peer_cert_sha256: Some("11".repeat(32)),
+                verify_peer_cert_by_name: Some("control.example,127.0.0.1".into()),
+                ech_config_list: Some("https://ech.example/config".into()),
+                ..Default::default()
+            }),
+        })
+        .unwrap();
+        assert_eq!(parsed.tls.sni.as_deref(), Some("control.example"));
+        assert_eq!(parsed.tls.alpn, ["h2", "http/1.1"]);
+        assert!(parsed.tls.enable_session_resumption);
+        assert_eq!(parsed.tls.fingerprint, "chrome");
+        assert_eq!(parsed.tls.pinned_peer_cert_sha256.len(), 1);
+        assert_eq!(
+            parsed.tls.verify_peer_cert_by_name,
+            ["control.example", "127.0.0.1"]
+        );
+        let source = parsed.tls.xray_settings.as_ref().unwrap();
+        assert_eq!(source.min_version.as_deref(), Some("1.2"));
+        assert_eq!(source.max_version.as_deref(), Some("1.3"));
+        assert_eq!(
+            source.ech_config_list.as_deref(),
+            Some("https://ech.example/config")
+        );
+
+        let error = ParsedRealm::parse(&RealmMaskConfig {
+            url: "realm://token@example.com/id".into(),
+            stun_servers: vec!["stun.example:3478".into()],
+            tls_config: Some(core_config::model::XhttpDownloadTlsSettings {
+                min_version: Some("1.3".into()),
+                max_version: Some("1.2".into()),
+                ..Default::default()
+            }),
+        })
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("minVersion"));
+
+        let error = ParsedRealm::parse(&RealmMaskConfig {
+            url: "realm+http://token@example.com/id".into(),
+            stun_servers: vec!["stun.example:3478".into()],
+            tls_config: Some(Default::default()),
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("realm+http"));
+    }
+
+    #[test]
+    fn sse_parser_handles_crlf_comments_multiline_data_and_event_filtering() {
+        let block = b": keepalive\r\nevent: punch\r\ndata: {\"addresses\":[\"192.0.2.1:1234\"],\r\ndata: \"nonce\":\"0011\",\"obfs\":\"2233\"}\r\n\r\n";
+        assert_eq!(sse_event_end(block), Some(block.len()));
+        let event = parse_sse_event(block).unwrap().unwrap();
+        assert_eq!(event.addresses, ["192.0.2.1:1234"]);
+        assert_eq!(event.metadata.nonce, "0011");
+        assert_eq!(event.metadata.obfs, "2233");
+        assert!(
+            parse_sse_event(b"event: heartbeat\ndata: {}\n\n")
+                .unwrap()
+                .is_none()
+        );
+        assert!(parse_sse_event(b"event: punch\ndata: not-json\n\n").is_err());
+    }
+
+    #[test]
+    fn punch_wire_roundtrip_and_tamper_rejection() {
+        let metadata = PunchMetadata {
+            nonce: "00".repeat(16),
+            obfs: "11".repeat(32),
+        };
+        let packet = encode_punch(PunchType::Hello, &metadata).unwrap();
+        assert_eq!(decode_punch(&packet, &metadata).unwrap(), PunchType::Hello);
+        let mut corrupt = packet;
+        corrupt[20] ^= 1;
+        assert!(decode_punch(&corrupt, &metadata).is_err());
+    }
+
+    #[test]
+    fn stun_xor_mapped_ipv4_decodes() {
+        let transaction = [7; 12];
+        let address: SocketAddr = "203.0.113.9:54321".parse().unwrap();
+        let mut response = vec![0; 32];
+        response[..2].copy_from_slice(&0x0101_u16.to_be_bytes());
+        response[2..4].copy_from_slice(&12_u16.to_be_bytes());
+        response[4..8].copy_from_slice(&STUN_MAGIC.to_be_bytes());
+        response[8..20].copy_from_slice(&transaction);
+        response[20..22].copy_from_slice(&0x0020_u16.to_be_bytes());
+        response[22..24].copy_from_slice(&8_u16.to_be_bytes());
+        response[25] = 1;
+        response[26..28]
+            .copy_from_slice(&(address.port() ^ (STUN_MAGIC >> 16) as u16).to_be_bytes());
+        let ip = match address.ip() {
+            IpAddr::V4(ip) => ip.octets(),
+            _ => unreachable!(),
+        };
+        for index in 0..4 {
+            response[28 + index] = ip[index] ^ STUN_MAGIC.to_be_bytes()[index];
+        }
+        assert_eq!(
+            parse_stun_binding_response(&response).unwrap(),
+            (transaction, address)
+        );
+    }
+
+    #[test]
+    fn symmetric_nat_expansion_is_bounded_and_family_filtered() {
+        let locals = ["192.0.2.1:1".parse().unwrap()];
+        let peers = [
+            "198.51.100.1:4000".parse().unwrap(),
+            "198.51.100.1:4002".parse().unwrap(),
+            "[2001:db8::1]:4000".parse().unwrap(),
+        ];
+        let (candidates, mut seen) = candidate_punch_addresses(&locals, &peers);
+        let expanded = expand_symmetric_nat_candidates(candidates, &mut seen);
+        assert!(expanded.iter().all(SocketAddr::is_ipv4));
+        assert!(expanded.contains(&"198.51.100.1:4006".parse().unwrap()));
+        assert!(expanded.len() <= 34);
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/salamander.rs
+++ b/crates/core-outbound/src/transport/finalmask/salamander.rs
@@ -1,0 +1,327 @@
+//! Xray Salamander and Gecko UDP packet masking.
+
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use blake2::{
+    Blake2bVar,
+    digest::{Update, VariableOutput},
+};
+use core_config::SalamanderMaskConfig;
+use rand::{Rng, RngCore, rngs::OsRng};
+
+const SALT_LEN: usize = 8;
+const KEY_LEN: usize = 32;
+const PSK_MIN_LEN: usize = 4;
+
+const GECKO_FLAG_FRAGMENT: u8 = 0x80;
+const GECKO_HEADER_SIZE: usize = 5;
+const GECKO_MIN_FRAGMENT_CHUNKS: usize = 2;
+const GECKO_MAX_FRAGMENT_CHUNKS: usize = 8;
+const GECKO_DEFAULT_MIN_PACKET: usize = 512;
+const GECKO_DEFAULT_MAX_PACKET: usize = 1200;
+const GECKO_BUFFER_SIZE: usize = 2048;
+const GECKO_REASSEMBLY_TTL: Duration = Duration::from_secs(8);
+const GECKO_MAX_REASSEMBLY: usize = 8;
+
+pub(super) struct SalamanderCodec {
+    password: Vec<u8>,
+    gecko: Option<GeckoState>,
+}
+
+struct GeckoState {
+    min_packet: usize,
+    max_packet: usize,
+    next_message_id: u8,
+    entries: HashMap<u8, ReassemblyEntry>,
+}
+
+struct ReassemblyEntry {
+    chunks: Vec<Option<Vec<u8>>>,
+    received: usize,
+    deadline: Instant,
+}
+
+impl SalamanderCodec {
+    pub(super) fn new(config: &SalamanderMaskConfig) -> std::io::Result<Self> {
+        if config.password.as_bytes().len() < PSK_MIN_LEN {
+            return Err(invalid(format!(
+                "Salamander PSK must be at least {PSK_MIN_LEN} bytes"
+            )));
+        }
+        let gecko = if config.packet_size.to > 0 {
+            let min_packet = if config.packet_size.from == 0 {
+                GECKO_DEFAULT_MIN_PACKET
+            } else {
+                usize::try_from(config.packet_size.from)
+                    .map_err(|_| invalid("gecko minimum packet size is negative"))?
+            };
+            let max_packet = if config.packet_size.to == 0 {
+                GECKO_DEFAULT_MAX_PACKET
+            } else {
+                usize::try_from(config.packet_size.to)
+                    .map_err(|_| invalid("gecko maximum packet size is negative"))?
+            };
+            if min_packet == 0 || min_packet > max_packet || max_packet > GECKO_BUFFER_SIZE {
+                return Err(invalid("gecko: invalid min/max packet size"));
+            }
+            Some(GeckoState {
+                min_packet,
+                max_packet,
+                next_message_id: 0,
+                entries: HashMap::new(),
+            })
+        } else {
+            None
+        };
+        Ok(Self {
+            password: config.password.as_bytes().to_vec(),
+            gecko,
+        })
+    }
+
+    pub(super) fn encode(&mut self, payload: &[u8]) -> std::io::Result<Vec<Vec<u8>>> {
+        let Some(gecko) = self.gecko.as_mut() else {
+            return Ok(vec![obfuscate(&self.password, payload)?]);
+        };
+        if payload.is_empty() {
+            return Ok(Vec::new());
+        }
+        if payload[0] & GECKO_FLAG_FRAGMENT == 0 {
+            return Ok(vec![obfuscate(&self.password, payload)?]);
+        }
+
+        let chunk_count =
+            rand::thread_rng().gen_range(GECKO_MIN_FRAGMENT_CHUNKS..=GECKO_MAX_FRAGMENT_CHUNKS);
+        let chunk_size = payload.len() / chunk_count;
+        gecko.next_message_id = gecko.next_message_id.wrapping_add(1);
+        let message_id = gecko.next_message_id;
+        let mut packets = Vec::with_capacity(chunk_count);
+        for index in 0..chunk_count {
+            let start = index * chunk_size;
+            let end = if index + 1 == chunk_count {
+                payload.len()
+            } else {
+                start + chunk_size
+            };
+            let chunk = &payload[start..end];
+            let base = SALT_LEN + GECKO_HEADER_SIZE + chunk.len();
+            let low = gecko.min_packet.max(base);
+            let pad_len = if low > gecko.max_packet {
+                0
+            } else {
+                low - base + rand::thread_rng().gen_range(0..=gecko.max_packet - low)
+            };
+            let pad_len = u16::try_from(pad_len).expect("gecko packet size is bounded");
+            let mut frame = vec![0; GECKO_HEADER_SIZE + usize::from(pad_len) + chunk.len()];
+            frame[0] = GECKO_FLAG_FRAGMENT;
+            frame[1] = message_id;
+            frame[2] = ((index as u8) << 4) | chunk_count as u8;
+            frame[3..5].copy_from_slice(&pad_len.to_be_bytes());
+            OsRng.fill_bytes(
+                &mut frame[GECKO_HEADER_SIZE..GECKO_HEADER_SIZE + usize::from(pad_len)],
+            );
+            frame[GECKO_HEADER_SIZE + usize::from(pad_len)..].copy_from_slice(chunk);
+            packets.push(obfuscate(&self.password, &frame)?);
+        }
+        Ok(packets)
+    }
+
+    pub(super) fn decode(&mut self, packet: &[u8]) -> std::io::Result<Option<Vec<u8>>> {
+        let decoded = deobfuscate(&self.password, packet)?;
+        let Some(gecko) = self.gecko.as_mut() else {
+            return Ok(Some(decoded));
+        };
+        if decoded.is_empty() {
+            return Ok(None);
+        }
+        if decoded[0] & GECKO_FLAG_FRAGMENT == 0 {
+            return Ok(Some(decoded));
+        }
+        let (header, payload) = decode_frame(&decoded)?;
+        let now = Instant::now();
+        gecko.entries.retain(|_, entry| entry.deadline > now);
+        if !gecko.entries.contains_key(&header.message_id)
+            && gecko.entries.len() >= GECKO_MAX_REASSEMBLY
+            && let Some(oldest) = gecko
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.deadline)
+                .map(|(&key, _)| key)
+        {
+            gecko.entries.remove(&oldest);
+        }
+        let entry = gecko
+            .entries
+            .entry(header.message_id)
+            .or_insert_with(|| ReassemblyEntry {
+                chunks: vec![None; header.total_chunks as usize],
+                received: 0,
+                deadline: now + GECKO_REASSEMBLY_TTL,
+            });
+        if entry.chunks.len() != header.total_chunks as usize {
+            return Ok(None);
+        }
+        let slot = &mut entry.chunks[header.chunk_index as usize];
+        if slot.is_some() {
+            return Ok(None);
+        }
+        *slot = Some(payload.to_vec());
+        entry.received += 1;
+        if entry.received != entry.chunks.len() {
+            return Ok(None);
+        }
+        let entry = gecko
+            .entries
+            .remove(&header.message_id)
+            .expect("complete entry exists");
+        let total = entry
+            .chunks
+            .iter()
+            .map(|chunk| chunk.as_ref().map_or(0, Vec::len))
+            .sum();
+        if total > u16::MAX as usize {
+            return Err(invalid("gecko reassembled datagram exceeds 65535 bytes"));
+        }
+        let mut output = Vec::with_capacity(total);
+        for chunk in entry.chunks {
+            output.extend_from_slice(chunk.as_deref().expect("complete entry"));
+        }
+        Ok(Some(output))
+    }
+}
+
+struct FrameHeader {
+    message_id: u8,
+    chunk_index: u8,
+    total_chunks: u8,
+}
+
+fn decode_frame(frame: &[u8]) -> std::io::Result<(FrameHeader, &[u8])> {
+    if frame.len() < GECKO_HEADER_SIZE {
+        return Err(invalid("gecko frame is truncated"));
+    }
+    let chunk_index = frame[2] >> 4;
+    let total_chunks = frame[2] & 0x0f;
+    if !(GECKO_MIN_FRAGMENT_CHUNKS as u8..=GECKO_MAX_FRAGMENT_CHUNKS as u8).contains(&total_chunks)
+        || chunk_index >= total_chunks
+    {
+        return Err(invalid("gecko frame header is invalid"));
+    }
+    let padding = u16::from_be_bytes([frame[3], frame[4]]) as usize;
+    let payload_offset = GECKO_HEADER_SIZE
+        .checked_add(padding)
+        .ok_or_else(|| invalid("gecko padding length overflow"))?;
+    let payload = frame
+        .get(payload_offset..)
+        .ok_or_else(|| invalid("gecko frame padding is truncated"))?;
+    Ok((
+        FrameHeader {
+            message_id: frame[1],
+            chunk_index,
+            total_chunks,
+        },
+        payload,
+    ))
+}
+
+fn obfuscate(password: &[u8], payload: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut salt = [0u8; SALT_LEN];
+    OsRng.fill_bytes(&mut salt);
+    let key = salamander_key(password, &salt)?;
+    let mut output = Vec::with_capacity(SALT_LEN + payload.len());
+    output.extend_from_slice(&salt);
+    output.extend(
+        payload
+            .iter()
+            .enumerate()
+            .map(|(index, byte)| byte ^ key[index % KEY_LEN]),
+    );
+    Ok(output)
+}
+
+fn deobfuscate(password: &[u8], packet: &[u8]) -> std::io::Result<Vec<u8>> {
+    if packet.len() <= SALT_LEN {
+        return Err(invalid("Salamander packet is truncated"));
+    }
+    let key = salamander_key(password, &packet[..SALT_LEN])?;
+    Ok(packet[SALT_LEN..]
+        .iter()
+        .enumerate()
+        .map(|(index, byte)| byte ^ key[index % KEY_LEN])
+        .collect())
+}
+
+fn salamander_key(password: &[u8], salt: &[u8]) -> std::io::Result<[u8; KEY_LEN]> {
+    let mut hasher = Blake2bVar::new(KEY_LEN).map_err(invalid)?;
+    hasher.update(password);
+    hasher.update(salt);
+    let mut key = [0u8; KEY_LEN];
+    hasher.finalize_variable(&mut key).map_err(invalid)?;
+    Ok(key)
+}
+
+fn invalid(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use core_config::I32Range;
+
+    use super::*;
+
+    #[test]
+    fn simple_roundtrip_and_short_packet_rejected() {
+        let mut codec = SalamanderCodec::new(&SalamanderMaskConfig {
+            password: "password".into(),
+            ..Default::default()
+        })
+        .unwrap();
+        let encoded = codec.encode(b"payload").unwrap().pop().unwrap();
+        assert_eq!(codec.decode(&encoded).unwrap().unwrap(), b"payload");
+        assert!(codec.decode(&[0; 8]).is_err());
+    }
+
+    #[test]
+    fn gecko_reassembles_out_of_order_and_drops_duplicate() {
+        let config = SalamanderMaskConfig {
+            password: "password".into(),
+            packet_size: I32Range::new(80, 120),
+        };
+        let mut sender = SalamanderCodec::new(&config).unwrap();
+        let mut receiver = SalamanderCodec::new(&config).unwrap();
+        let mut payload = vec![0x80];
+        payload.extend(0u8..=250);
+        let mut packets = sender.encode(&payload).unwrap();
+        let duplicate = packets[0].clone();
+        packets.reverse();
+        assert!(receiver.decode(&duplicate).unwrap().is_none());
+        let mut output = None;
+        for packet in packets {
+            if let Some(decoded) = receiver.decode(&packet).unwrap() {
+                output = Some(decoded);
+            }
+        }
+        assert_eq!(output.unwrap(), payload);
+    }
+
+    #[test]
+    fn gecko_resource_table_is_bounded() {
+        let config = SalamanderMaskConfig {
+            password: "password".into(),
+            packet_size: I32Range::new(80, 120),
+        };
+        let mut sender = SalamanderCodec::new(&config).unwrap();
+        let mut receiver = SalamanderCodec::new(&config).unwrap();
+        for marker in 0..32u8 {
+            let mut payload = vec![0x80, marker];
+            payload.extend(vec![marker; 200]);
+            let packet = sender.encode(&payload).unwrap().remove(0);
+            let _ = receiver.decode(&packet);
+        }
+        assert!(receiver.gecko.as_ref().unwrap().entries.len() <= GECKO_MAX_REASSEMBLY);
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/sudoku.rs
+++ b/crates/core-outbound/src/transport/finalmask/sudoku.rs
@@ -1,0 +1,960 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, LazyLock},
+};
+
+use core_config::SudokuMaskConfig;
+use ggstd::math::rand::{Rand as GoRand, new_source};
+use parking_lot::Mutex;
+use rand::Rng;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::adapter::BoxedStream;
+
+const PERM4: [[usize; 4]; 24] = [
+    [0, 1, 2, 3],
+    [0, 1, 3, 2],
+    [0, 2, 1, 3],
+    [0, 2, 3, 1],
+    [0, 3, 1, 2],
+    [0, 3, 2, 1],
+    [1, 0, 2, 3],
+    [1, 0, 3, 2],
+    [1, 2, 0, 3],
+    [1, 2, 3, 0],
+    [1, 3, 0, 2],
+    [1, 3, 2, 0],
+    [2, 0, 1, 3],
+    [2, 0, 3, 1],
+    [2, 1, 0, 3],
+    [2, 1, 3, 0],
+    [2, 3, 0, 1],
+    [2, 3, 1, 0],
+    [3, 0, 1, 2],
+    [3, 0, 2, 1],
+    [3, 1, 0, 2],
+    [3, 1, 2, 0],
+    [3, 2, 0, 1],
+    [3, 2, 1, 0],
+];
+
+#[derive(Clone)]
+enum LayoutKind {
+    Ascii,
+    Entropy,
+    Custom {
+        x_bits: [u8; 2],
+        p_bits: [u8; 2],
+        v_bits: [u8; 4],
+        x_mask: u8,
+    },
+}
+
+#[derive(Clone)]
+struct Layout {
+    hint_mask: u8,
+    hint_value: u8,
+    pad_marker: u8,
+    padding_pool: Vec<u8>,
+    kind: LayoutKind,
+}
+
+impl Layout {
+    fn is_hint(&self, byte: u8) -> bool {
+        (byte & self.hint_mask) == self.hint_value
+            || (matches!(self.kind, LayoutKind::Ascii) && byte == b'\n')
+    }
+
+    fn encode_group(&self, group: u8) -> u8 {
+        match &self.kind {
+            LayoutKind::Ascii => {
+                let byte = 0x40 | (group & 0x3f);
+                if byte == 0x7f { b'\n' } else { byte }
+            }
+            LayoutKind::Entropy => {
+                let value = group & 0x3f;
+                ((value & 0x30) << 1) | (value & 0x0f)
+            }
+            LayoutKind::Custom {
+                x_bits,
+                p_bits,
+                v_bits,
+                x_mask,
+            } => encode_custom_group(group, *x_bits, *p_bits, *v_bits, *x_mask, None),
+        }
+    }
+
+    fn decode_group(&self, byte: u8) -> Option<u8> {
+        match &self.kind {
+            LayoutKind::Ascii => {
+                if byte == b'\n' {
+                    Some(0x3f)
+                } else if byte & 0x40 != 0 {
+                    Some(byte & 0x3f)
+                } else {
+                    None
+                }
+            }
+            LayoutKind::Entropy => {
+                (byte & 0x90 == 0).then_some(((byte >> 1) & 0x30) | (byte & 0x0f))
+            }
+            LayoutKind::Custom {
+                p_bits,
+                v_bits,
+                x_mask,
+                ..
+            } => {
+                if byte & x_mask != *x_mask {
+                    return None;
+                }
+                let mut value = 0;
+                let mut position = 0;
+                if byte & (1 << p_bits[0]) != 0 {
+                    value |= 2;
+                }
+                if byte & (1 << p_bits[1]) != 0 {
+                    value |= 1;
+                }
+                for (index, bit) in v_bits.iter().copied().enumerate() {
+                    if byte & (1 << bit) != 0 {
+                        position |= 1 << (3 - index);
+                    }
+                }
+                Some((value << 4) | position)
+            }
+        }
+    }
+}
+
+struct Table {
+    encode: Vec<Vec<[u8; 4]>>,
+    decode: HashMap<u32, u8>,
+    layout: Arc<Layout>,
+}
+
+type Grid = [u8; 16];
+type BasePatterns = Vec<Vec<[u8; 4]>>;
+
+static BASE_PATTERNS: LazyLock<Result<BasePatterns, String>> = LazyLock::new(build_base_patterns);
+static TABLE_CACHE: LazyLock<Mutex<HashMap<String, Arc<Vec<Arc<Table>>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(super) fn wrap(inner: BoxedStream, config: &SudokuMaskConfig) -> std::io::Result<BoxedStream> {
+    let tables = get_tables(config)?;
+    let padding_min = effective_padding_min(config).min(100);
+    let padding_max = effective_padding_max(config).max(padding_min).min(100);
+    let (client, worker) = tokio::io::duplex(64 * 1024);
+    let (mut app_read, mut app_write) = tokio::io::split(worker);
+    let (mut raw_read, mut raw_write) = tokio::io::split(inner);
+    let encode_tables = tables.clone();
+    tokio::spawn(async move {
+        let mut codec = Encoder::new(encode_tables, padding_min, padding_max);
+        let mut buffer = vec![0; 32 * 1024];
+        let result = async {
+            loop {
+                let count = app_read.read(&mut buffer).await?;
+                if count == 0 {
+                    raw_write.shutdown().await?;
+                    return Ok::<_, std::io::Error>(());
+                }
+                let encoded = codec.encode(&buffer[..count])?;
+                raw_write.write_all(&encoded).await?;
+            }
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%error, "finalmask sudoku encoder stopped");
+        }
+    });
+    tokio::spawn(async move {
+        // Xray 26.7.11 is directional: clients write classic four-hint
+        // Sudoku and read the packed 6-bit downlink representation.
+        let mut decoder = PackedDecoder::new(tables);
+        let mut buffer = vec![0; 32 * 1024];
+        let result = async {
+            loop {
+                let count = raw_read.read(&mut buffer).await?;
+                if count == 0 {
+                    app_write.shutdown().await?;
+                    return Ok::<_, std::io::Error>(());
+                }
+                let decoded = decoder.decode(&buffer[..count])?;
+                if !decoded.is_empty() {
+                    app_write.write_all(&decoded).await?;
+                }
+            }
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%error, "finalmask sudoku decoder stopped");
+        }
+    });
+    Ok(Box::pin(client))
+}
+
+/// Server direction is intentionally asymmetric in Xray 26.7.11: the server
+/// reads classic four-hint Sudoku and writes the packed six-bit form.
+pub(super) fn wrap_server(
+    inner: BoxedStream,
+    config: &SudokuMaskConfig,
+) -> std::io::Result<BoxedStream> {
+    let tables = get_tables(config)?;
+    let padding_min = effective_padding_min(config).min(100);
+    let padding_max = effective_padding_max(config).max(padding_min).min(100);
+    let (client, worker) = tokio::io::duplex(64 * 1024);
+    let (mut app_read, mut app_write) = tokio::io::split(worker);
+    let (mut raw_read, mut raw_write) = tokio::io::split(inner);
+    let encode_tables = tables.clone();
+    tokio::spawn(async move {
+        let mut codec = PackedEncoder::new(encode_tables, padding_min, padding_max);
+        let mut buffer = vec![0; 32 * 1024];
+        let result = async {
+            loop {
+                let count = app_read.read(&mut buffer).await?;
+                if count == 0 {
+                    raw_write.shutdown().await?;
+                    return Ok::<_, std::io::Error>(());
+                }
+                raw_write
+                    .write_all(&codec.encode(&buffer[..count])?)
+                    .await?;
+            }
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%error, "finalmask sudoku packed encoder stopped");
+        }
+    });
+    tokio::spawn(async move {
+        let mut decoder = HintDecoder::new(tables);
+        let mut buffer = vec![0; 32 * 1024];
+        let result = async {
+            loop {
+                let count = raw_read.read(&mut buffer).await?;
+                if count == 0 {
+                    app_write.shutdown().await?;
+                    return Ok::<_, std::io::Error>(());
+                }
+                let decoded = decoder.decode(&buffer[..count])?;
+                if !decoded.is_empty() {
+                    app_write.write_all(&decoded).await?;
+                }
+            }
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%error, "finalmask sudoku hint decoder stopped");
+        }
+    });
+    Ok(Box::pin(client))
+}
+
+pub(super) struct UdpCodec {
+    tables: Arc<Vec<Arc<Table>>>,
+    padding_min: u32,
+    padding_max: u32,
+}
+
+impl UdpCodec {
+    pub(super) fn new(config: &SudokuMaskConfig) -> std::io::Result<Self> {
+        let tables = get_tables(config)?;
+        let padding_min = effective_padding_min(config).min(100);
+        let padding_max = effective_padding_max(config).max(padding_min).min(100);
+        Ok(Self {
+            tables,
+            padding_min,
+            padding_max,
+        })
+    }
+
+    /// UDP resets table index and padding choice for every datagram upstream.
+    pub(super) fn encode(&self, payload: &[u8]) -> std::io::Result<Vec<u8>> {
+        Encoder::new(self.tables.clone(), self.padding_min, self.padding_max).encode(payload)
+    }
+
+    pub(super) fn decode(&self, packet: &[u8]) -> std::io::Result<Vec<u8>> {
+        let mut decoder = HintDecoder::new(self.tables.clone());
+        let output = decoder.decode(packet)?;
+        if !decoder.hints.is_empty() {
+            return Err(invalid(
+                "UDP Sudoku datagram ends with an incomplete hint tuple",
+            ));
+        }
+        Ok(output)
+    }
+}
+
+struct Encoder {
+    tables: Arc<Vec<Arc<Table>>>,
+    table_index: usize,
+    padding_chance: u32,
+}
+
+impl Encoder {
+    fn new(tables: Arc<Vec<Arc<Table>>>, min: u32, max: u32) -> Self {
+        let padding_chance = if min == max {
+            min
+        } else {
+            rand::thread_rng().gen_range(min..=max)
+        };
+        Self {
+            tables,
+            table_index: 0,
+            padding_chance,
+        }
+    }
+
+    fn should_pad(&self, rng: &mut impl Rng) -> bool {
+        self.padding_chance >= 100
+            || (self.padding_chance > 0 && rng.gen_range(0..100) < self.padding_chance)
+    }
+
+    fn encode(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+        let mut output = Vec::with_capacity(input.len() * 6 + 8);
+        for &byte in input {
+            let table = &self.tables[self.table_index % self.tables.len()];
+            if self.should_pad(&mut rng) {
+                output.push(
+                    table.layout.padding_pool[rng.gen_range(0..table.layout.padding_pool.len())],
+                );
+            }
+            let candidates = &table.encode[byte as usize];
+            let hints = candidates
+                .get(rng.gen_range(0..candidates.len()))
+                .ok_or_else(|| invalid("sudoku encode table is empty"))?;
+            let permutation = PERM4[rng.gen_range(0..PERM4.len())];
+            for index in permutation {
+                if self.should_pad(&mut rng) {
+                    output.push(
+                        table.layout.padding_pool
+                            [rng.gen_range(0..table.layout.padding_pool.len())],
+                    );
+                }
+                output.push(hints[index]);
+            }
+            self.table_index += 1;
+        }
+        if self.should_pad(&mut rng) {
+            let table = &self.tables[self.table_index % self.tables.len()];
+            output
+                .push(table.layout.padding_pool[rng.gen_range(0..table.layout.padding_pool.len())]);
+        }
+        Ok(output)
+    }
+}
+
+struct PackedDecoder {
+    tables: Arc<Vec<Arc<Table>>>,
+    group_index: usize,
+    bit_buffer: u64,
+    bit_count: usize,
+}
+
+struct HintDecoder {
+    tables: Arc<Vec<Arc<Table>>>,
+    table_index: usize,
+    hints: Vec<u8>,
+}
+
+impl HintDecoder {
+    fn new(tables: Arc<Vec<Arc<Table>>>) -> Self {
+        Self {
+            tables,
+            table_index: 0,
+            hints: Vec::with_capacity(4),
+        }
+    }
+
+    fn decode(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+        let mut output = Vec::with_capacity(input.len() / 4 + 1);
+        for &byte in input {
+            let table = &self.tables[self.table_index % self.tables.len()];
+            if !table.layout.is_hint(byte) {
+                continue;
+            }
+            self.hints.push(byte);
+            if self.hints.len() != 4 {
+                continue;
+            }
+            let mut hints: [u8; 4] = self.hints[..].try_into().expect("four hints");
+            hints.sort_unstable();
+            let decoded = table
+                .decode
+                .get(&pack_key(hints))
+                .copied()
+                .ok_or_else(|| invalid("invalid sudoku hint tuple"))?;
+            output.push(decoded);
+            self.hints.clear();
+            self.table_index += 1;
+        }
+        Ok(output)
+    }
+}
+
+struct PackedEncoder {
+    tables: Arc<Vec<Arc<Table>>>,
+    group_index: usize,
+    padding_chance: u32,
+}
+
+impl PackedEncoder {
+    fn new(tables: Arc<Vec<Arc<Table>>>, min: u32, max: u32) -> Self {
+        let padding_chance = if min == max {
+            min
+        } else {
+            rand::thread_rng().gen_range(min..=max)
+        };
+        Self {
+            tables,
+            group_index: 0,
+            padding_chance,
+        }
+    }
+
+    fn should_pad(&self, rng: &mut impl Rng) -> bool {
+        self.padding_chance >= 100
+            || (self.padding_chance > 0 && rng.gen_range(0..100) < self.padding_chance)
+    }
+
+    fn maybe_pad(&self, output: &mut Vec<u8>, layout: &Layout, rng: &mut impl Rng) {
+        if !self.should_pad(rng) {
+            return;
+        }
+        loop {
+            let byte = layout.padding_pool[rng.gen_range(0..layout.padding_pool.len())];
+            if byte != layout.pad_marker {
+                output.push(byte);
+                return;
+            }
+        }
+    }
+
+    fn encode(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+        let mut output = Vec::with_capacity(input.len() * 2 + 8);
+        let mut bit_buffer = 0u64;
+        let mut bit_count = 0usize;
+        let mut rng = rand::thread_rng();
+        for &byte in input {
+            bit_buffer = (bit_buffer << 8) | u64::from(byte);
+            bit_count += 8;
+            while bit_count >= 6 {
+                bit_count -= 6;
+                let layout = &self.tables[self.group_index % self.tables.len()].layout;
+                let group = (bit_buffer >> bit_count) as u8 & 0x3f;
+                self.maybe_pad(&mut output, layout, &mut rng);
+                output.push(layout.encode_group(group));
+                self.group_index += 1;
+                if bit_count == 0 {
+                    bit_buffer = 0;
+                } else {
+                    bit_buffer &= (1u64 << bit_count) - 1;
+                }
+            }
+        }
+        if bit_count > 0 {
+            let layout = &self.tables[self.group_index % self.tables.len()].layout;
+            let group = (bit_buffer << (6 - bit_count)) as u8 & 0x3f;
+            self.maybe_pad(&mut output, layout, &mut rng);
+            output.push(layout.encode_group(group));
+            self.group_index += 1;
+            output.push(
+                self.tables[self.group_index % self.tables.len()]
+                    .layout
+                    .pad_marker,
+            );
+        }
+        let layout = &self.tables[self.group_index % self.tables.len()].layout;
+        self.maybe_pad(&mut output, layout, &mut rng);
+        Ok(output)
+    }
+}
+
+impl PackedDecoder {
+    fn new(tables: Arc<Vec<Arc<Table>>>) -> Self {
+        Self {
+            tables,
+            group_index: 0,
+            bit_buffer: 0,
+            bit_count: 0,
+        }
+    }
+
+    fn decode(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+        let mut output = Vec::with_capacity(input.len() * 3 / 4);
+        for &byte in input {
+            let table = &self.tables[self.group_index % self.tables.len()];
+            if !table.layout.is_hint(byte) {
+                // Packed encoders terminate a padded partial 6-bit group with
+                // the next layout's marker. Discarding the residual bits is
+                // what keeps independently written chunks byte-aligned.
+                if byte == table.layout.pad_marker {
+                    self.bit_buffer = 0;
+                    self.bit_count = 0;
+                }
+                continue;
+            }
+            let group = table
+                .layout
+                .decode_group(byte)
+                .ok_or_else(|| invalid("invalid packed sudoku byte"))?;
+            self.group_index += 1;
+            self.bit_buffer = (self.bit_buffer << 6) | u64::from(group);
+            self.bit_count += 6;
+            while self.bit_count >= 8 {
+                self.bit_count -= 8;
+                output.push((self.bit_buffer >> self.bit_count) as u8);
+                if self.bit_count == 0 {
+                    self.bit_buffer = 0;
+                } else {
+                    self.bit_buffer &= (1u64 << self.bit_count) - 1;
+                }
+            }
+        }
+        Ok(output)
+    }
+}
+
+fn get_tables(config: &SudokuMaskConfig) -> std::io::Result<Arc<Vec<Arc<Table>>>> {
+    let key = serde_json::to_string(config).map_err(invalid)?;
+    if let Some(cached) = TABLE_CACHE.lock().get(&key).cloned() {
+        return Ok(cached);
+    }
+    let mode = normalize_ascii(&config.ascii)?;
+    let patterns = normalized_patterns(config, mode)?;
+    let mut tables = Vec::with_capacity(patterns.len());
+    for pattern in patterns {
+        let layout = match mode {
+            "prefer_ascii" => ascii_layout(),
+            _ if !pattern.is_empty() => custom_layout(&pattern)?,
+            _ => entropy_layout(),
+        };
+        tables.push(Arc::new(build_table(&config.password, Arc::new(layout))?));
+    }
+    let tables = Arc::new(tables);
+    TABLE_CACHE.lock().insert(key, tables.clone());
+    Ok(tables)
+}
+
+fn normalize_ascii(value: &str) -> std::io::Result<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "" | "entropy" | "prefer_entropy" => Ok("prefer_entropy"),
+        "ascii" | "prefer_ascii" => Ok("prefer_ascii"),
+        _ => Err(invalid(format!("invalid sudoku ascii mode `{value}`"))),
+    }
+}
+
+fn normalized_patterns(config: &SudokuMaskConfig, mode: &str) -> std::io::Result<Vec<String>> {
+    if mode == "prefer_ascii" {
+        return Ok(vec![String::new()]);
+    }
+    let custom_table = if config.custom_table.is_empty() {
+        &config.legacy_custom_table
+    } else {
+        &config.custom_table
+    };
+    let source = if !config.custom_tables.is_empty() {
+        config.custom_tables.clone()
+    } else if !config.legacy_custom_sets.is_empty() {
+        config.legacy_custom_sets.clone()
+    } else {
+        vec![custom_table.clone()]
+    };
+    let mut seen = HashSet::new();
+    let mut output = Vec::new();
+    for pattern in source {
+        let pattern = if pattern.trim().is_empty() {
+            String::new()
+        } else {
+            normalize_custom_table(&pattern)?
+        };
+        if seen.insert(pattern.clone()) {
+            output.push(pattern);
+        }
+    }
+    if output.is_empty() {
+        output.push(String::new());
+    }
+    Ok(output)
+}
+
+fn effective_padding_min(config: &SudokuMaskConfig) -> u32 {
+    if config.padding_min == 0 {
+        config.legacy_padding_min
+    } else {
+        config.padding_min
+    }
+}
+
+fn effective_padding_max(config: &SudokuMaskConfig) -> u32 {
+    if config.padding_max == 0 {
+        config.legacy_padding_max
+    } else {
+        config.padding_max
+    }
+}
+
+fn ascii_layout() -> Layout {
+    Layout {
+        hint_mask: 0x40,
+        hint_value: 0x40,
+        pad_marker: 0x3f,
+        padding_pool: (0x20..0x40).collect(),
+        kind: LayoutKind::Ascii,
+    }
+}
+
+fn entropy_layout() -> Layout {
+    let mut padding_pool = Vec::with_capacity(16);
+    for index in 0..8 {
+        padding_pool.extend_from_slice(&[0x80 + index, 0x10 + index]);
+    }
+    Layout {
+        hint_mask: 0x90,
+        hint_value: 0,
+        pad_marker: 0x80,
+        padding_pool,
+        kind: LayoutKind::Entropy,
+    }
+}
+
+fn normalize_custom_table(pattern: &str) -> std::io::Result<String> {
+    let pattern = pattern.trim().to_ascii_lowercase().replace(' ', "");
+    if pattern.len() != 8
+        || pattern.bytes().filter(|&byte| byte == b'x').count() != 2
+        || pattern.bytes().filter(|&byte| byte == b'p').count() != 2
+        || pattern.bytes().filter(|&byte| byte == b'v').count() != 4
+        || pattern
+            .bytes()
+            .any(|byte| !matches!(byte, b'x' | b'p' | b'v'))
+    {
+        return Err(invalid("customTable must contain exactly 2 x, 2 p and 4 v"));
+    }
+    Ok(pattern)
+}
+
+fn custom_layout(pattern: &str) -> std::io::Result<Layout> {
+    let pattern = normalize_custom_table(pattern)?;
+    let mut x = Vec::new();
+    let mut p = Vec::new();
+    let mut v = Vec::new();
+    for (index, byte) in pattern.bytes().enumerate() {
+        let bit = 7 - index as u8;
+        match byte {
+            b'x' => x.push(bit),
+            b'p' => p.push(bit),
+            b'v' => v.push(bit),
+            _ => unreachable!(),
+        }
+    }
+    let x_bits = [x[0], x[1]];
+    let p_bits = [p[0], p[1]];
+    let v_bits = [v[0], v[1], v[2], v[3]];
+    let x_mask = (1 << x_bits[0]) | (1 << x_bits[1]);
+    let mut padding = HashSet::new();
+    for drop in 0..2 {
+        for value in 0..4 {
+            for position in 0..16 {
+                let group = (value << 4) | position;
+                let byte = encode_custom_group(group, x_bits, p_bits, v_bits, x_mask, Some(drop));
+                if byte.count_ones() >= 5 {
+                    padding.insert(byte);
+                }
+            }
+        }
+    }
+    let mut padding_pool = padding.into_iter().collect::<Vec<_>>();
+    padding_pool.sort_unstable();
+    if padding_pool.is_empty() {
+        return Err(invalid("customTable produced empty padding pool"));
+    }
+    let pad_marker = padding_pool[0];
+    Ok(Layout {
+        hint_mask: x_mask,
+        hint_value: x_mask,
+        pad_marker,
+        padding_pool,
+        kind: LayoutKind::Custom {
+            x_bits,
+            p_bits,
+            v_bits,
+            x_mask,
+        },
+    })
+}
+
+fn encode_custom_group(
+    group: u8,
+    x_bits: [u8; 2],
+    p_bits: [u8; 2],
+    v_bits: [u8; 4],
+    x_mask: u8,
+    drop_x: Option<usize>,
+) -> u8 {
+    let mut output = x_mask;
+    if let Some(drop) = drop_x {
+        output &= !(1 << x_bits[drop]);
+    }
+    let value = (group >> 4) & 3;
+    let position = group & 15;
+    if value & 2 != 0 {
+        output |= 1 << p_bits[0];
+    }
+    if value & 1 != 0 {
+        output |= 1 << p_bits[1];
+    }
+    for (index, bit) in v_bits.into_iter().enumerate() {
+        if (position >> (3 - index)) & 1 != 0 {
+            output |= 1 << bit;
+        }
+    }
+    output
+}
+
+fn build_table(password: &str, layout: Arc<Layout>) -> std::io::Result<Table> {
+    let patterns = BASE_PATTERNS.as_ref().map_err(|error| invalid(error))?;
+    if patterns.len() < 256 {
+        return Err(invalid("not enough sudoku grids"));
+    }
+    let mut order = (0..patterns.len()).collect::<Vec<_>>();
+    let hash = Sha256::digest(password.as_bytes());
+    let seed = i64::from_be_bytes(hash[..8].try_into().expect("sha prefix"));
+    let mut go_rng = GoRand::new(new_source(seed));
+    for index in (1..order.len()).rev() {
+        // Go's Shuffle uses its private Lemire `int31n`, deliberately not the
+        // public compatibility-preserving `Int31n`. Copy that reduction over
+        // the exact Go Source stream exposed by `ggstd`.
+        let n = (index + 1) as u32;
+        let mut value = go_rng.uint32();
+        let mut product = u64::from(value) * u64::from(n);
+        let mut low = product as u32;
+        if low < n {
+            let threshold = n.wrapping_neg() % n;
+            while low < threshold {
+                value = go_rng.uint32();
+                product = u64::from(value) * u64::from(n);
+                low = product as u32;
+            }
+        }
+        order.swap(index, (product >> 32) as usize);
+    }
+    let mut encode = vec![Vec::new(); 256];
+    let mut decode = HashMap::with_capacity(1 << 16);
+    for byte in 0..256 {
+        for groups in &patterns[order[byte]] {
+            let mut hints = groups.map(|group| layout.encode_group(group));
+            hints.sort_unstable();
+            let key = pack_key(hints);
+            if let Some(previous) = decode.insert(key, byte as u8)
+                && previous != byte as u8
+            {
+                return Err(invalid("sudoku decode key collision"));
+            }
+            encode[byte].push(groups.map(|group| layout.encode_group(group)));
+        }
+    }
+    Ok(Table {
+        encode,
+        decode,
+        layout,
+    })
+}
+
+fn build_base_patterns() -> Result<BasePatterns, String> {
+    let grids = generate_all_grids();
+    let positions = hint_positions();
+    let mut patterns = vec![Vec::new(); grids.len()];
+    for positions in positions {
+        let mut counts = HashMap::<u32, u16>::with_capacity(grids.len());
+        let mut keys = Vec::with_capacity(grids.len());
+        let mut groups_by_grid = Vec::with_capacity(grids.len());
+        for grid in &grids {
+            let mut groups = positions.map(|position| clue_group(grid, position));
+            groups.sort_unstable();
+            let key = pack_key(groups);
+            *counts.entry(key).or_default() += 1;
+            keys.push(key);
+            groups_by_grid.push(groups);
+        }
+        for index in 0..grids.len() {
+            if counts[&keys[index]] == 1 {
+                patterns[index].push(groups_by_grid[index]);
+            }
+        }
+    }
+    if patterns.iter().any(Vec::is_empty) {
+        return Err("a sudoku grid has no uniquely decodable clue set".into());
+    }
+    Ok(patterns)
+}
+
+fn generate_all_grids() -> Vec<Grid> {
+    fn dfs(index: usize, grid: &mut Grid, output: &mut Vec<Grid>) {
+        if index == 16 {
+            output.push(*grid);
+            return;
+        }
+        let row = index / 4;
+        let column = index % 4;
+        let box_row = (row / 2) * 2;
+        let box_column = (column / 2) * 2;
+        for number in 1..=4 {
+            if (0..4).any(|i| grid[row * 4 + i] == number || grid[i * 4 + column] == number) {
+                continue;
+            }
+            if (0..2).any(|r| (0..2).any(|c| grid[(box_row + r) * 4 + box_column + c] == number)) {
+                continue;
+            }
+            grid[index] = number;
+            dfs(index + 1, grid, output);
+            grid[index] = 0;
+        }
+    }
+    let mut output = Vec::with_capacity(288);
+    dfs(0, &mut [0; 16], &mut output);
+    output
+}
+
+fn hint_positions() -> Vec<[u8; 4]> {
+    let mut output = Vec::with_capacity(1820);
+    for a in 0..13 {
+        for b in a + 1..14 {
+            for c in b + 1..15 {
+                for d in c + 1..16 {
+                    output.push([a, b, c, d]);
+                }
+            }
+        }
+    }
+    output
+}
+
+fn clue_group(grid: &Grid, position: u8) -> u8 {
+    ((grid[position as usize] - 1) << 4) | (position & 15)
+}
+
+fn pack_key(bytes: [u8; 4]) -> u32 {
+    u32::from_be_bytes(bytes)
+}
+
+fn invalid(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn table_roundtrip_and_go_shuffle_are_stable() {
+        let config = SudokuMaskConfig {
+            password: "sudoku-golden".into(),
+            ascii: "prefer_ascii".into(),
+            ..Default::default()
+        };
+        let tables = get_tables(&config).unwrap();
+        let table = &tables[0];
+        // This table is derived using Go math/rand via `ggstd`, not Rust's
+        // ChaCha RNG. Every official hint tuple must decode to its byte.
+        for byte in [0u8, 1, 42, 127, 255] {
+            let mut hints = table.encode[byte as usize][0];
+            hints.sort_unstable();
+            assert_eq!(table.decode.get(&pack_key(hints)), Some(&byte));
+        }
+
+        // Generated by the pinned Xray 26.7.11 `buildTable` implementation
+        // (commit 6e3322d) over every candidate tuple, including list order.
+        let mut digest = Sha256::new();
+        for candidates in &table.encode {
+            digest.update((candidates.len() as u32).to_be_bytes());
+            for tuple in candidates {
+                digest.update(tuple);
+            }
+        }
+        assert_eq!(
+            hex::encode(digest.finalize()),
+            "8b1bf1fdb13064b003cda40f0d40a0bf7b3af2100e49c21db12e324e7271c564"
+        );
+        assert_eq!(table.encode[0][0], *b"KX`q");
+        assert_eq!(table.encode[1][0], *b"JPis");
+        assert_eq!(table.encode[42][0], *b"BD`{");
+        assert_eq!(table.encode[127][0], *b"NTbp");
+        assert_eq!(table.encode[255][0], *b"DPjr");
+    }
+
+    #[test]
+    fn packed_client_downlink_matches_xray_ascii_golden_across_chunks() {
+        let table = Arc::new(build_table("packed-golden", Arc::new(ascii_layout())).unwrap());
+        let mut decoder = PackedDecoder::new(Arc::new(vec![table]));
+
+        // Xray's packed encoder maps [0x48, 0x69, 0xff] to the four 6-bit
+        // groups `R`, `F`, `g`, `\n`. A one-byte write [0xab] becomes `j`,
+        // `p`, followed by ASCII's 0x3f pad marker to discard the padded tail.
+        assert_eq!(decoder.decode(b"RF").unwrap(), [0x48]);
+        assert_eq!(decoder.decode(b"g\n").unwrap(), [0x69, 0xff]);
+        assert_eq!(decoder.decode(&[b'j', b'p', 0x3f]).unwrap(), [0xab]);
+    }
+
+    #[test]
+    fn packed_group_codec_roundtrips_every_official_layout() {
+        let layouts = [
+            ascii_layout(),
+            entropy_layout(),
+            custom_layout("xxppvvvv").unwrap(),
+        ];
+        for layout in layouts {
+            assert!(!layout.is_hint(layout.pad_marker));
+            for group in 0..64 {
+                let encoded = layout.encode_group(group);
+                assert!(layout.is_hint(encoded));
+                assert_eq!(layout.decode_group(encoded), Some(group));
+            }
+        }
+    }
+
+    #[test]
+    fn udp_codec_restarts_at_table_zero_for_every_datagram() {
+        let config = SudokuMaskConfig {
+            password: "udp-golden".into(),
+            custom_tables: vec!["xxppvvvv".into(), "vvxxppvv".into()],
+            ..Default::default()
+        };
+        let codec = UdpCodec::new(&config).unwrap();
+        for payload in [b"one".as_slice(), b"second datagram".as_slice()] {
+            let encoded = codec.encode(payload).unwrap();
+            assert_eq!(codec.decode(&encoded).unwrap(), payload);
+        }
+    }
+
+    #[test]
+    fn udp_codec_rejects_truncated_hint_tuple() {
+        let config = SudokuMaskConfig {
+            password: "udp-negative".into(),
+            ascii: "prefer_ascii".into(),
+            ..Default::default()
+        };
+        let codec = UdpCodec::new(&config).unwrap();
+        assert!(codec.decode(b"ABC").is_err());
+    }
+
+    #[tokio::test]
+    async fn client_and_server_stream_directions_roundtrip() {
+        let config = SudokuMaskConfig {
+            password: "stream-bidirectional".into(),
+            ascii: "prefer_ascii".into(),
+            ..Default::default()
+        };
+        let (left, right) = tokio::io::duplex(64 * 1024);
+        let mut client = wrap(Box::pin(left), &config).unwrap();
+        let mut server = wrap_server(Box::pin(right), &config).unwrap();
+        client.write_all(b"request").await.unwrap();
+        let mut request = [0; 7];
+        server.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"request");
+        server.write_all(b"response").await.unwrap();
+        let mut response = [0; 8];
+        client.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"response");
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/udp.rs
+++ b/crates/core-outbound/src/transport/finalmask/udp.rs
@@ -1,0 +1,1006 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use base64::Engine;
+use core_config::{I32Range, NoiseItemConfig, NoiseMaskConfig, UdpMaskConfig};
+use rand::{Rng, RngCore};
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::adapter::{BoxedUdp, UdpSocketLike};
+
+use super::{
+    header_custom::{StandaloneServerAction, UdpCustomCodec, UdpRole},
+    mkcp::MkcpCodec,
+    salamander::SalamanderCodec,
+    sudoku,
+};
+
+const MAX_WIRE_DATAGRAM: usize = u16::MAX as usize;
+const MAX_EXPANDED_PACKETS: usize = 64;
+const MAX_EXPANDED_BYTES: usize = 256 * 1024;
+const MAX_QUEUED_PACKETS: usize = 16;
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+const SERVER_PEER_CAPACITY: usize = 4096;
+const SERVER_PEER_TTL: Duration = Duration::from_secs(60);
+const SERVER_PEER_CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
+
+pub(super) fn wrap_client(
+    inner: BoxedUdp,
+    masks: &[UdpMaskConfig],
+    _target: String,
+    _port: u16,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedUdp> {
+    wrap(inner, masks, UdpRole::Client, local, remote)
+}
+
+pub(super) fn wrap_server(
+    inner: BoxedUdp,
+    masks: &[UdpMaskConfig],
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedUdp> {
+    wrap(inner, masks, UdpRole::Server, local, remote)
+}
+
+fn wrap(
+    inner: BoxedUdp,
+    masks: &[UdpMaskConfig],
+    role: UdpRole,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+) -> std::io::Result<BoxedUdp> {
+    let (stack, server_stacks) = match role {
+        UdpRole::Client => (
+            Some(AsyncMutex::new(MaskStack::new(masks, role, local, remote)?)),
+            None,
+        ),
+        UdpRole::Server => (
+            None,
+            Some(AsyncMutex::new(ServerMaskStacks::new(masks, local)?)),
+        ),
+    };
+    Ok(Box::new(MaskedUdp {
+        inner,
+        role,
+        stack,
+        server_stacks,
+        receive_gate: AsyncMutex::new(()),
+        queued: AsyncMutex::new(VecDeque::new()),
+    }))
+}
+
+struct MaskedUdp {
+    inner: BoxedUdp,
+    role: UdpRole,
+    stack: Option<AsyncMutex<MaskStack>>,
+    server_stacks: Option<AsyncMutex<ServerMaskStacks>>,
+    receive_gate: AsyncMutex<()>,
+    queued: AsyncMutex<VecDeque<ReceivedWire>>,
+}
+
+struct ReceivedWire {
+    data: Vec<u8>,
+    source: Option<SocketAddr>,
+}
+
+struct ServerMaskStacks {
+    masks: Vec<UdpMaskConfig>,
+    local: Option<SocketAddr>,
+    peers: HashMap<SocketAddr, ServerPeerStack>,
+    last_cleanup: Instant,
+}
+
+struct ServerPeerStack {
+    stack: MaskStack,
+    last_seen: Instant,
+}
+
+impl ServerMaskStacks {
+    fn new(masks: &[UdpMaskConfig], local: Option<SocketAddr>) -> std::io::Result<Self> {
+        // Compile once during listener startup so malformed masks fail before
+        // the first untrusted datagram creates per-peer state.
+        let _ = MaskStack::new(masks, UdpRole::Server, local, None)?;
+        Ok(Self {
+            masks: masks.to_vec(),
+            local,
+            peers: HashMap::new(),
+            last_cleanup: Instant::now(),
+        })
+    }
+
+    fn stack(&mut self, peer: SocketAddr) -> std::io::Result<&mut MaskStack> {
+        let now = Instant::now();
+        if now.duration_since(self.last_cleanup) >= SERVER_PEER_CLEANUP_INTERVAL {
+            self.peers
+                .retain(|_, state| now.duration_since(state.last_seen) < SERVER_PEER_TTL);
+            self.last_cleanup = now;
+        }
+        if !self.peers.contains_key(&peer) && self.peers.len() >= SERVER_PEER_CAPACITY {
+            let oldest = self
+                .peers
+                .iter()
+                .min_by_key(|(_, state)| state.last_seen)
+                .map(|(peer, _)| *peer);
+            if let Some(oldest) = oldest {
+                self.peers.remove(&oldest);
+            }
+        }
+        if !self.peers.contains_key(&peer) {
+            let stack = MaskStack::new(&self.masks, UdpRole::Server, self.local, Some(peer))?;
+            self.peers.insert(
+                peer,
+                ServerPeerStack {
+                    stack,
+                    last_seen: now,
+                },
+            );
+        }
+        let state = self.peers.get_mut(&peer).expect("peer inserted above");
+        state.last_seen = now;
+        Ok(&mut state.stack)
+    }
+}
+
+enum ServerReceiveAction {
+    Drop,
+    Reply(Vec<u8>),
+    Payload(Vec<u8>),
+}
+
+#[async_trait]
+impl UdpSocketLike for MaskedUdp {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> std::io::Result<usize> {
+        if self.role == UdpRole::Server {
+            let peer = parse_server_peer(target, port)?;
+            let packets = self
+                .server_stacks
+                .as_ref()
+                .expect("server mask table")
+                .lock()
+                .await
+                .stack(peer)?
+                .encode_range(vec![EncodedPacket::new(payload.to_vec())], 0)?;
+            self.send_packets(packets, target, port).await?;
+            return Ok(payload.len());
+        }
+        self.ensure_standalone_handshakes(target, port).await?;
+        let packets = self
+            .stack
+            .as_ref()
+            .expect("client mask stack")
+            .lock()
+            .await
+            .encode_range(vec![EncodedPacket::new(payload.to_vec())], 0)?;
+        self.send_packets(packets, target, port).await?;
+        Ok(payload.len())
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> std::io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> std::io::Result<(usize, Option<SocketAddr>)> {
+        if let Some(packet) = self.queued.lock().await.pop_front() {
+            return copy_received(output, packet);
+        }
+        let _gate = self.receive_gate.lock().await;
+        loop {
+            let packet = self.receive_wire().await?;
+            if self.role == UdpRole::Server {
+                let source = packet.source.ok_or_else(|| {
+                    invalid("finalmask UDP server requires a source-aware carrier")
+                })?;
+                let action = {
+                    let mut stacks = self
+                        .server_stacks
+                        .as_ref()
+                        .expect("server mask table")
+                        .lock()
+                        .await;
+                    let stack = stacks.stack(source)?;
+                    match stack.standalone_server_action(&packet.data)? {
+                        Some(StandaloneServerAction::Drop) => ServerReceiveAction::Drop,
+                        Some(StandaloneServerAction::Reply(reply)) => {
+                            ServerReceiveAction::Reply(reply)
+                        }
+                        Some(StandaloneServerAction::Payload(payload)) => {
+                            ServerReceiveAction::Payload(payload)
+                        }
+                        None => match stack.decode_range(packet.data, 0)? {
+                            Some(payload) => ServerReceiveAction::Payload(payload),
+                            None => ServerReceiveAction::Drop,
+                        },
+                    }
+                };
+                match action {
+                    ServerReceiveAction::Drop => continue,
+                    ServerReceiveAction::Reply(reply) => {
+                        self.inner
+                            .send_to(&reply, &source.ip().to_string(), source.port())
+                            .await?;
+                        continue;
+                    }
+                    ServerReceiveAction::Payload(payload) => {
+                        return copy_received(
+                            output,
+                            ReceivedWire {
+                                data: payload,
+                                source: Some(source),
+                            },
+                        );
+                    }
+                }
+            }
+            let decoded = self
+                .stack
+                .as_ref()
+                .expect("client mask stack")
+                .lock()
+                .await
+                .decode_range(packet.data, 0)?;
+            if let Some(decoded) = decoded {
+                return copy_received(
+                    output,
+                    ReceivedWire {
+                        data: decoded,
+                        source: packet.source,
+                    },
+                );
+            }
+        }
+    }
+
+    async fn close(&self) -> std::io::Result<()> {
+        self.inner.close().await
+    }
+
+    fn local_addr(&self) -> std::io::Result<Option<SocketAddr>> {
+        self.inner.local_addr()
+    }
+}
+
+impl MaskedUdp {
+    async fn ensure_standalone_handshakes(&self, target: &str, port: u16) -> std::io::Result<()> {
+        let stack = self.stack.as_ref().expect("client mask stack");
+        let indexes = stack.lock().await.standalone_indexes();
+        // A generated handshake from an outer mask traverses every inner mask,
+        // so authenticate inner standalone masks first.
+        for index in indexes.into_iter().rev() {
+            let already_established = stack.lock().await.custom_established(index)?;
+            if already_established {
+                continue;
+            }
+            let _gate = self.receive_gate.lock().await;
+            let request = stack.lock().await.custom_request(index)?;
+            let packets = self
+                .stack
+                .as_ref()
+                .expect("client mask stack")
+                .lock()
+                .await
+                .encode_range(vec![EncodedPacket::new(request)], index + 1)?;
+            self.send_packets(packets, target, port).await?;
+            let deadline = tokio::time::Instant::now() + HANDSHAKE_TIMEOUT;
+            loop {
+                let wire = tokio::time::timeout_at(deadline, self.receive_wire())
+                    .await
+                    .map_err(|_| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "header-custom UDP standalone handshake timed out",
+                        )
+                    })??;
+                let ReceivedWire { data, source } = wire;
+                let Some(packet) = stack.lock().await.decode_range(data, index + 1)? else {
+                    continue;
+                };
+                if self
+                    .stack
+                    .as_ref()
+                    .expect("client mask stack")
+                    .lock()
+                    .await
+                    .custom_accept_response(index, &packet)?
+                {
+                    break;
+                }
+                let mut queued = self.queued.lock().await;
+                if queued.len() >= MAX_QUEUED_PACKETS {
+                    queued.pop_front();
+                }
+                queued.push_back(ReceivedWire {
+                    data: packet,
+                    source,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_packets(
+        &self,
+        packets: Vec<EncodedPacket>,
+        target: &str,
+        port: u16,
+    ) -> std::io::Result<()> {
+        for packet in packets {
+            self.inner.send_to(&packet.data, target, port).await?;
+            if !packet.delay_after.is_zero() {
+                tokio::time::sleep(packet.delay_after).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn receive_wire(&self) -> std::io::Result<ReceivedWire> {
+        let mut buffer = vec![0; MAX_WIRE_DATAGRAM];
+        let (length, source) = self.inner.recv_from_endpoint(&mut buffer).await?;
+        if length > buffer.len() {
+            return Err(invalid("underlying UDP socket returned an invalid length"));
+        }
+        buffer.truncate(length);
+        Ok(ReceivedWire {
+            data: buffer,
+            source,
+        })
+    }
+}
+
+struct MaskStack {
+    masks: Vec<MaskCodec>,
+}
+
+enum MaskCodec {
+    HeaderCustom(UdpCustomCodec),
+    Mkcp(MkcpCodec),
+    Noise(NoiseCodec),
+    Salamander(SalamanderCodec),
+    Sudoku(sudoku::UdpCodec),
+}
+
+impl MaskStack {
+    fn new(
+        masks: &[UdpMaskConfig],
+        role: UdpRole,
+        local: Option<SocketAddr>,
+        remote: Option<SocketAddr>,
+    ) -> std::io::Result<Self> {
+        if masks.len() > MAX_EXPANDED_PACKETS {
+            return Err(invalid("too many finalmask UDP stages"));
+        }
+        let mut compiled = Vec::with_capacity(masks.len());
+        for mask in masks {
+            compiled.push(match mask {
+                UdpMaskConfig::HeaderCustom(config) => MaskCodec::HeaderCustom(
+                    UdpCustomCodec::new(config, role, local, remote)?,
+                ),
+                UdpMaskConfig::MkcpLegacy(config) => MaskCodec::Mkcp(MkcpCodec::new(config)?),
+                UdpMaskConfig::Noise(config) => MaskCodec::Noise(NoiseCodec::new(config)?),
+                UdpMaskConfig::Salamander(config) => {
+                    MaskCodec::Salamander(SalamanderCodec::new(config)?)
+                }
+                UdpMaskConfig::Sudoku(config) => {
+                    MaskCodec::Sudoku(sudoku::UdpCodec::new(config)?)
+                }
+                UdpMaskConfig::Xdns(_) => {
+                    return Err(unsupported(
+                        "xdns requires the raw carrier endpoint and cannot wrap a protocol-level UDP association",
+                    ));
+                }
+                UdpMaskConfig::Xicmp(_) => {
+                    return Err(unsupported(
+                        "xicmp requires a raw ICMP carrier and cannot wrap a protocol-level UDP association",
+                    ));
+                }
+                UdpMaskConfig::Realm(_) => {
+                    return Err(unsupported(
+                        "realm requires NAT traversal before carrier creation and cannot wrap a protocol-level UDP association",
+                    ));
+                }
+            });
+        }
+        Ok(Self { masks: compiled })
+    }
+
+    fn standalone_indexes(&self) -> Vec<usize> {
+        self.masks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, mask)| match mask {
+                MaskCodec::HeaderCustom(codec) if codec.is_standalone() => Some(index),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn custom_established(&mut self, index: usize) -> std::io::Result<bool> {
+        match self.masks.get_mut(index) {
+            Some(MaskCodec::HeaderCustom(codec)) if codec.is_standalone() => {
+                Ok(codec.established())
+            }
+            _ => Err(invalid("standalone mask index is invalid")),
+        }
+    }
+
+    fn custom_request(&mut self, index: usize) -> std::io::Result<Vec<u8>> {
+        match self.masks.get_mut(index) {
+            Some(MaskCodec::HeaderCustom(codec)) => codec.standalone_request(),
+            _ => Err(invalid("standalone mask index is invalid")),
+        }
+    }
+
+    fn custom_accept_response(&mut self, index: usize, packet: &[u8]) -> std::io::Result<bool> {
+        match self.masks.get_mut(index) {
+            Some(MaskCodec::HeaderCustom(codec)) => codec.accept_standalone_response(packet),
+            _ => Err(invalid("standalone mask index is invalid")),
+        }
+    }
+
+    fn standalone_server_action(
+        &mut self,
+        packet: &[u8],
+    ) -> std::io::Result<Option<StandaloneServerAction>> {
+        match self.masks.as_mut_slice() {
+            [MaskCodec::HeaderCustom(codec)] if codec.is_standalone() => {
+                codec.handle_standalone_server_packet(packet).map(Some)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn encode_range(
+        &mut self,
+        mut packets: Vec<EncodedPacket>,
+        start: usize,
+    ) -> std::io::Result<Vec<EncodedPacket>> {
+        for mask in &mut self.masks[start..] {
+            let mut next = Vec::new();
+            for packet in packets {
+                let transformed = mask.encode(packet.data)?;
+                if transformed.is_empty() {
+                    continue;
+                }
+                let last = transformed.len() - 1;
+                for (index, mut transformed) in transformed.into_iter().enumerate() {
+                    if index == last {
+                        transformed.delay_after += packet.delay_after;
+                    }
+                    next.push(transformed);
+                }
+            }
+            validate_expansion(&next)?;
+            packets = next;
+        }
+        Ok(packets)
+    }
+
+    fn decode_range(
+        &mut self,
+        mut packet: Vec<u8>,
+        start: usize,
+    ) -> std::io::Result<Option<Vec<u8>>> {
+        for mask in self.masks[start..].iter_mut().rev() {
+            let Some(decoded) = mask.decode(&packet)? else {
+                return Ok(None);
+            };
+            packet = decoded;
+            if packet.len() > MAX_WIRE_DATAGRAM {
+                return Err(invalid(
+                    "decoded finalmask UDP datagram exceeds 65535 bytes",
+                ));
+            }
+        }
+        Ok(Some(packet))
+    }
+}
+
+impl MaskCodec {
+    fn encode(&mut self, packet: Vec<u8>) -> std::io::Result<Vec<EncodedPacket>> {
+        let packets = match self {
+            Self::HeaderCustom(codec) => vec![codec.encode_prefix(&packet)?],
+            Self::Mkcp(codec) => vec![codec.encode(&packet)?],
+            Self::Noise(codec) => return codec.encode(packet),
+            Self::Salamander(codec) => codec.encode(&packet)?,
+            Self::Sudoku(codec) => vec![codec.encode(&packet)?],
+        };
+        Ok(packets.into_iter().map(EncodedPacket::new).collect())
+    }
+
+    fn decode(&mut self, packet: &[u8]) -> std::io::Result<Option<Vec<u8>>> {
+        match self {
+            Self::HeaderCustom(codec) => codec.decode_prefix(packet).map(Some),
+            Self::Mkcp(codec) => codec.decode(packet).map(Some),
+            Self::Noise(_) => Ok(Some(packet.to_vec())),
+            Self::Salamander(codec) => codec.decode(packet),
+            Self::Sudoku(codec) => codec.decode(packet).map(Some),
+        }
+    }
+}
+
+struct EncodedPacket {
+    data: Vec<u8>,
+    delay_after: Duration,
+}
+
+impl EncodedPacket {
+    fn new(data: Vec<u8>) -> Self {
+        Self {
+            data,
+            delay_after: Duration::ZERO,
+        }
+    }
+}
+
+struct NoiseCodec {
+    reset: I32Range,
+    items: Vec<NoiseItem>,
+    next_reset: Option<Instant>,
+}
+
+struct NoiseItem {
+    source: NoiseSource,
+    delay: I32Range,
+}
+
+enum NoiseSource {
+    Random { length: I32Range, bytes: I32Range },
+    Packet(Vec<u8>),
+}
+
+impl NoiseCodec {
+    fn new(config: &NoiseMaskConfig) -> std::io::Result<Self> {
+        if config.noise.len() > MAX_EXPANDED_PACKETS - 1 {
+            return Err(invalid("noise mask has too many packets"));
+        }
+        let mut items = Vec::with_capacity(config.noise.len());
+        for item in &config.noise {
+            items.push(NoiseItem::new(item)?);
+        }
+        Ok(Self {
+            reset: config.reset,
+            items,
+            next_reset: None,
+        })
+    }
+
+    fn encode(&mut self, payload: Vec<u8>) -> std::io::Result<Vec<EncodedPacket>> {
+        let now = Instant::now();
+        let due = self
+            .next_reset
+            .is_none_or(|deadline| self.reset.to > 0 && deadline <= now);
+        let mut output = Vec::new();
+        if due {
+            for item in &self.items {
+                output.push(item.generate()?);
+            }
+        }
+        self.next_reset = Some(
+            now + Duration::from_secs(u64::try_from(random_between(self.reset).max(0)).unwrap()),
+        );
+        output.push(EncodedPacket::new(payload));
+        Ok(output)
+    }
+}
+
+impl NoiseItem {
+    fn new(config: &NoiseItemConfig) -> std::io::Result<Self> {
+        let has_random = config.rand.to > 0;
+        if has_random && config.packet.is_some() {
+            return Err(invalid("noise item cannot configure both rand and packet"));
+        }
+        let source = if has_random {
+            if config.rand.from < 0 {
+                return Err(invalid("noise random length cannot be negative"));
+            }
+            let bytes = config.rand_range.unwrap_or_else(|| I32Range::new(0, 255));
+            if bytes.from < 0 || bytes.to > 255 {
+                return Err(invalid("noise randRange must be within 0..=255"));
+            }
+            NoiseSource::Random {
+                length: config.rand,
+                bytes,
+            }
+        } else {
+            NoiseSource::Packet(parse_bytes(config.packet.as_ref(), &config.packet_type)?)
+        };
+        if config.delay.from < 0 {
+            return Err(invalid("noise delay cannot be negative"));
+        }
+        Ok(Self {
+            source,
+            delay: config.delay,
+        })
+    }
+
+    fn generate(&self) -> std::io::Result<EncodedPacket> {
+        let data = match &self.source {
+            NoiseSource::Packet(packet) => packet.clone(),
+            NoiseSource::Random { length, bytes } => {
+                let length = usize::try_from(random_between(*length)).map_err(invalid)?;
+                if length > MAX_WIRE_DATAGRAM {
+                    return Err(invalid("noise packet exceeds 65535 bytes"));
+                }
+                let mut output = vec![0; length];
+                rand::thread_rng().fill_bytes(&mut output);
+                if bytes.from != 0 || bytes.to != 255 {
+                    let width = (bytes.to - bytes.from + 1) as u8;
+                    for byte in &mut output {
+                        *byte = bytes.from as u8 + *byte % width;
+                    }
+                }
+                output
+            }
+        };
+        Ok(EncodedPacket {
+            data,
+            delay_after: Duration::from_millis(
+                u64::try_from(random_between(self.delay).max(0)).unwrap(),
+            ),
+        })
+    }
+}
+
+fn random_between(range: I32Range) -> i32 {
+    if range.from == range.to {
+        range.from
+    } else {
+        rand::thread_rng().gen_range(range.from..range.to)
+    }
+}
+
+fn parse_bytes(value: Option<&serde_json::Value>, kind: &str) -> std::io::Result<Vec<u8>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    match kind.to_ascii_lowercase().as_str() {
+        "" | "array" => serde_json::from_value(value.clone()).map_err(invalid),
+        "str" => value
+            .as_str()
+            .map(|value| value.as_bytes().to_vec())
+            .ok_or_else(|| invalid("noise str packet must be a string")),
+        "hex" => value
+            .as_str()
+            .ok_or_else(|| invalid("noise hex packet must be a string"))
+            .and_then(|value| hex::decode(value).map_err(invalid)),
+        "base64" => value
+            .as_str()
+            .ok_or_else(|| invalid("noise base64 packet must be a string"))
+            .and_then(|value| {
+                base64::engine::general_purpose::STANDARD
+                    .decode(value)
+                    .map_err(invalid)
+            }),
+        other => Err(invalid(format!("unknown noise byte type `{other}`"))),
+    }
+}
+
+fn validate_expansion(packets: &[EncodedPacket]) -> std::io::Result<()> {
+    if packets.len() > MAX_EXPANDED_PACKETS {
+        return Err(invalid("finalmask UDP expansion exceeds packet limit"));
+    }
+    let total = packets.iter().try_fold(0usize, |total, packet| {
+        if packet.data.len() > MAX_WIRE_DATAGRAM {
+            return Err(invalid("finalmask wire datagram exceeds 65535 bytes"));
+        }
+        total
+            .checked_add(packet.data.len())
+            .ok_or_else(|| invalid("finalmask UDP expansion length overflow"))
+    })?;
+    if total > MAX_EXPANDED_BYTES {
+        return Err(invalid("finalmask UDP expansion exceeds byte limit"));
+    }
+    Ok(())
+}
+
+fn copy_datagram(output: &mut [u8], packet: &[u8]) -> std::io::Result<usize> {
+    if output.len() < packet.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "UDP receive buffer is {} bytes, decoded datagram is {} bytes",
+                output.len(),
+                packet.len()
+            ),
+        ));
+    }
+    output[..packet.len()].copy_from_slice(packet);
+    Ok(packet.len())
+}
+
+fn copy_received(
+    output: &mut [u8],
+    packet: ReceivedWire,
+) -> std::io::Result<(usize, Option<SocketAddr>)> {
+    let length = copy_datagram(output, &packet.data)?;
+    Ok((length, packet.source))
+}
+
+fn parse_server_peer(target: &str, port: u16) -> std::io::Result<SocketAddr> {
+    let target = target
+        .trim()
+        .strip_prefix('[')
+        .and_then(|target| target.strip_suffix(']'))
+        .unwrap_or_else(|| target.trim());
+    let ip = target.parse().map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("finalmask UDP server reply requires an IP destination, got `{target}`"),
+        )
+    })?;
+    Ok(SocketAddr::new(ip, port))
+}
+
+fn invalid(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+}
+
+fn unsupported(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Unsupported, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, io, sync::Arc};
+
+    use core_config::{
+        HeaderCustomUdpConfig, HeaderCustomUdpItem, MkcpLegacyMaskConfig, SalamanderMaskConfig,
+        SudokuMaskConfig,
+    };
+    use parking_lot::Mutex;
+    use tokio::sync::{Mutex as AsyncMutex, mpsc};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct LoopUdp {
+        packets: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    }
+
+    #[async_trait]
+    impl UdpSocketLike for LoopUdp {
+        async fn send_to(&self, buf: &[u8], _target: &str, _port: u16) -> std::io::Result<usize> {
+            self.packets.lock().push_back(buf.to_vec());
+            Ok(buf.len())
+        }
+
+        async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let packet = self
+                .packets
+                .lock()
+                .pop_front()
+                .ok_or_else(|| invalid("loop queue is empty"))?;
+            buf[..packet.len()].copy_from_slice(&packet);
+            Ok(packet.len())
+        }
+    }
+
+    struct LinkUdp {
+        local: SocketAddr,
+        incoming: AsyncMutex<mpsc::Receiver<(Vec<u8>, SocketAddr)>>,
+        outgoing: mpsc::Sender<(Vec<u8>, SocketAddr)>,
+    }
+
+    fn linked_udp_pair(left: SocketAddr, right: SocketAddr) -> (LinkUdp, LinkUdp) {
+        let (left_to_right_tx, left_to_right_rx) = mpsc::channel(16);
+        let (right_to_left_tx, right_to_left_rx) = mpsc::channel(16);
+        (
+            LinkUdp {
+                local: left,
+                incoming: AsyncMutex::new(right_to_left_rx),
+                outgoing: left_to_right_tx,
+            },
+            LinkUdp {
+                local: right,
+                incoming: AsyncMutex::new(left_to_right_rx),
+                outgoing: right_to_left_tx,
+            },
+        )
+    }
+
+    #[async_trait]
+    impl UdpSocketLike for LinkUdp {
+        async fn send_to(&self, buf: &[u8], _target: &str, _port: u16) -> io::Result<usize> {
+            self.outgoing
+                .send((buf.to_vec(), self.local))
+                .await
+                .map_err(|_| io::ErrorKind::BrokenPipe)?;
+            Ok(buf.len())
+        }
+
+        async fn recv_from(&self, buf: &mut [u8]) -> io::Result<usize> {
+            self.recv_from_endpoint(buf).await.map(|(length, _)| length)
+        }
+
+        async fn recv_from_endpoint(
+            &self,
+            buf: &mut [u8],
+        ) -> io::Result<(usize, Option<SocketAddr>)> {
+            let (packet, source) = self
+                .incoming
+                .lock()
+                .await
+                .recv()
+                .await
+                .ok_or(io::ErrorKind::BrokenPipe)?;
+            if packet.len() > buf.len() {
+                return Err(io::ErrorKind::InvalidInput.into());
+            }
+            buf[..packet.len()].copy_from_slice(&packet);
+            Ok((packet.len(), Some(source)))
+        }
+
+        fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+            Ok(Some(self.local))
+        }
+    }
+
+    #[tokio::test]
+    async fn composed_packet_masks_roundtrip_in_xray_order() {
+        let masks = vec![
+            UdpMaskConfig::HeaderCustom(HeaderCustomUdpConfig {
+                mode: "prefix".into(),
+                client: vec![HeaderCustomUdpItem {
+                    packet_type: "hex".into(),
+                    packet: Some(serde_json::Value::String("aabb".into())),
+                    ..Default::default()
+                }],
+                server: vec![HeaderCustomUdpItem {
+                    packet_type: "hex".into(),
+                    packet: Some(serde_json::Value::String("aabb".into())),
+                    ..Default::default()
+                }],
+            }),
+            UdpMaskConfig::MkcpLegacy(MkcpLegacyMaskConfig::default()),
+            UdpMaskConfig::Salamander(SalamanderMaskConfig {
+                password: "password".into(),
+                ..Default::default()
+            }),
+            UdpMaskConfig::Sudoku(SudokuMaskConfig {
+                password: "sudoku".into(),
+                ..Default::default()
+            }),
+        ];
+        let socket = wrap_client(
+            Box::new(LoopUdp::default()),
+            &masks,
+            "example.com".into(),
+            443,
+            None,
+            None,
+        )
+        .unwrap();
+        socket
+            .send_to(b"payload", "example.com", 443)
+            .await
+            .unwrap();
+        let mut output = [0; 64];
+        let length = socket.recv_from(&mut output).await.unwrap();
+        assert_eq!(&output[..length], b"payload");
+    }
+
+    #[tokio::test]
+    async fn composed_client_and_server_wrappers_exchange_datagrams() {
+        let client_addr: SocketAddr = "192.0.2.10:40000".parse().unwrap();
+        let server_addr: SocketAddr = "198.51.100.20:443".parse().unwrap();
+        let (client_link, server_link) = linked_udp_pair(client_addr, server_addr);
+        let masks = vec![
+            UdpMaskConfig::Sudoku(SudokuMaskConfig {
+                password: "sudoku".into(),
+                ..Default::default()
+            }),
+            UdpMaskConfig::HeaderCustom(HeaderCustomUdpConfig {
+                mode: "prefix".into(),
+                client: vec![HeaderCustomUdpItem {
+                    packet_type: "hex".into(),
+                    packet: Some(serde_json::Value::String("aabb".into())),
+                    ..Default::default()
+                }],
+                server: vec![HeaderCustomUdpItem {
+                    packet_type: "hex".into(),
+                    packet: Some(serde_json::Value::String("ccdd".into())),
+                    ..Default::default()
+                }],
+            }),
+            UdpMaskConfig::MkcpLegacy(MkcpLegacyMaskConfig::default()),
+            UdpMaskConfig::Salamander(SalamanderMaskConfig {
+                password: "password".into(),
+                ..Default::default()
+            }),
+        ];
+        let client = wrap_client(
+            Box::new(client_link),
+            &masks,
+            "198.51.100.20".into(),
+            443,
+            Some(client_addr),
+            Some(server_addr),
+        )
+        .unwrap();
+        let server = wrap_server(Box::new(server_link), &masks, Some(server_addr), None).unwrap();
+
+        client
+            .send_to(b"request", "198.51.100.20", 443)
+            .await
+            .unwrap();
+        let mut buffer = [0; 256];
+        let (length, source) = server.recv_from_endpoint(&mut buffer).await.unwrap();
+        assert_eq!(&buffer[..length], b"request");
+        assert_eq!(source, Some(client_addr));
+
+        server
+            .send_to(b"response", "192.0.2.10", 40000)
+            .await
+            .unwrap();
+        let (length, source) = client.recv_from_endpoint(&mut buffer).await.unwrap();
+        assert_eq!(&buffer[..length], b"response");
+        assert_eq!(source, Some(server_addr));
+    }
+
+    #[test]
+    fn server_header_capture_state_is_isolated_per_peer() {
+        let masks = vec![UdpMaskConfig::HeaderCustom(HeaderCustomUdpConfig {
+            mode: "prefix".into(),
+            client: vec![HeaderCustomUdpItem {
+                rand: 1,
+                capture: "nonce".into(),
+                ..Default::default()
+            }],
+            server: vec![HeaderCustomUdpItem {
+                reuse: "nonce".into(),
+                ..Default::default()
+            }],
+        })];
+        let local: SocketAddr = "198.51.100.20:443".parse().unwrap();
+        let first: SocketAddr = "192.0.2.10:40000".parse().unwrap();
+        let second: SocketAddr = "192.0.2.11:40001".parse().unwrap();
+        let mut stacks = ServerMaskStacks::new(&masks, Some(local)).unwrap();
+        assert_eq!(
+            stacks
+                .stack(first)
+                .unwrap()
+                .decode_range(vec![0x11, b'a'], 0)
+                .unwrap(),
+            Some(vec![b'a'])
+        );
+        assert_eq!(
+            stacks
+                .stack(second)
+                .unwrap()
+                .decode_range(vec![0x22, b'b'], 0)
+                .unwrap(),
+            Some(vec![b'b'])
+        );
+
+        let first_reply = stacks
+            .stack(first)
+            .unwrap()
+            .encode_range(vec![EncodedPacket::new(vec![b'1'])], 0)
+            .unwrap();
+        let second_reply = stacks
+            .stack(second)
+            .unwrap()
+            .encode_range(vec![EncodedPacket::new(vec![b'2'])], 0)
+            .unwrap();
+        assert_eq!(first_reply[0].data, [0x11, b'1']);
+        assert_eq!(second_reply[0].data, [0x22, b'2']);
+    }
+
+    #[test]
+    fn expansion_limit_rejects_resource_abuse() {
+        let packets = (0..=MAX_EXPANDED_PACKETS)
+            .map(|_| EncodedPacket::new(Vec::new()))
+            .collect::<Vec<_>>();
+        assert!(validate_expansion(&packets).is_err());
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/udp_hop.rs
+++ b/crates/core-outbound/src/transport/finalmask/udp_hop.rs
@@ -1,0 +1,305 @@
+//! Xray Hysteria UDP port hopping with one current and one previous socket.
+//!
+//! The implementation follows `transport/internet/hysteria/udphop/conn.go`
+//! from Xray 26.7.11: a random configured port is selected per interval, the
+//! preceding socket remains readable for one more hop, and receive buffering
+//! is bounded. A fresh socket is opened on every hop so NAT mappings really do
+//! change; merely rewriting the destination port on one socket is insufficient.
+
+use std::{
+    io,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use rand::{Rng, seq::SliceRandom};
+use tokio::{sync::Mutex, task::JoinHandle};
+
+use crate::{
+    adapter::{BoxedUdp, SharedOutbound, UdpSocketLike},
+    transport::finalmask::quic::UdpHopPlan,
+};
+
+const RECEIVE_QUEUE_PACKETS: usize = 1024;
+const MAX_PACKET: usize = 4096;
+
+#[derive(Clone)]
+struct SocketFactory {
+    proxy: Option<SharedOutbound>,
+    target_host: Arc<str>,
+    target_addr: SocketAddr,
+}
+
+impl SocketFactory {
+    async fn open(&self, port: u16) -> io::Result<(Arc<dyn UdpSocketLike>, SocketAddr)> {
+        let peer = SocketAddr::new(self.target_addr.ip(), port);
+        let (socket, local) = if let Some(proxy) = &self.proxy {
+            let local = if peer.is_ipv6() {
+                "[::]:0".parse().expect("IPv6 wildcard")
+            } else {
+                "0.0.0.0:0".parse().expect("IPv4 wildcard")
+            };
+            let socket = crate::socket_policy::dial_udp_through_proxy(
+                proxy.clone(),
+                self.target_host.to_string(),
+                port,
+            )
+            .await?;
+            (socket, local)
+        } else {
+            super::open_direct_carrier(self.target_host.to_string(), peer)?
+        };
+        Ok((Arc::from(socket), local))
+    }
+}
+
+struct HopState {
+    current: Arc<dyn UdpSocketLike>,
+    previous: Option<Arc<dyn UdpSocketLike>>,
+    port: u16,
+}
+
+struct ReceivedPacket {
+    bytes: Vec<u8>,
+    source: Option<SocketAddr>,
+}
+
+pub(crate) struct UdpHopCarrier {
+    state: Arc<RwLock<HopState>>,
+    target_host: Arc<str>,
+    receive: Mutex<tokio::sync::mpsc::Receiver<io::Result<ReceivedPacket>>>,
+    closed: Arc<AtomicBool>,
+    tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
+}
+
+impl UdpHopCarrier {
+    pub(crate) async fn open(
+        plan: UdpHopPlan,
+        proxy: Option<SharedOutbound>,
+        target_host: String,
+        target_addr: SocketAddr,
+    ) -> io::Result<(BoxedUdp, SocketAddr)> {
+        let factory = SocketFactory {
+            proxy,
+            target_host: target_host.into(),
+            target_addr,
+        };
+        let initial_port = *plan
+            .ports
+            .choose(&mut rand::thread_rng())
+            .ok_or_else(|| invalid("UDP hop has no ports"))?;
+        let (initial, local) = factory.open(initial_port).await?;
+        let state = Arc::new(RwLock::new(HopState {
+            current: initial.clone(),
+            previous: None,
+            port: initial_port,
+        }));
+        let closed = Arc::new(AtomicBool::new(false));
+        let (receive_tx, receive_rx) = tokio::sync::mpsc::channel(RECEIVE_QUEUE_PACKETS);
+        let tasks = Arc::new(Mutex::new(Vec::new()));
+        let target_host = factory.target_host.clone();
+        tasks
+            .lock()
+            .await
+            .push(spawn_receiver(initial, receive_tx.clone(), closed.clone()));
+        tasks.lock().await.push(spawn_hopper(
+            plan,
+            factory,
+            state.clone(),
+            receive_tx,
+            closed.clone(),
+            tasks.clone(),
+        ));
+
+        Ok((
+            Box::new(Self {
+                state,
+                target_host,
+                receive: Mutex::new(receive_rx),
+                closed,
+                tasks,
+            }),
+            local,
+        ))
+    }
+}
+
+fn spawn_receiver(
+    socket: Arc<dyn UdpSocketLike>,
+    output: tokio::sync::mpsc::Sender<io::Result<ReceivedPacket>>,
+    closed: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut buffer = vec![0; MAX_PACKET];
+        while !closed.load(Ordering::Acquire) {
+            let result = socket
+                .recv_from_endpoint(&mut buffer)
+                .await
+                .map(|(length, source)| ReceivedPacket {
+                    bytes: buffer[..length].to_vec(),
+                    source,
+                });
+            let terminal = result.is_err();
+            if output.try_send(result).is_err() && terminal {
+                return;
+            }
+            if terminal {
+                return;
+            }
+        }
+    })
+}
+
+fn spawn_hopper(
+    plan: UdpHopPlan,
+    factory: SocketFactory,
+    state: Arc<RwLock<HopState>>,
+    output: tokio::sync::mpsc::Sender<io::Result<ReceivedPacket>>,
+    closed: Arc<AtomicBool>,
+    tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let interval = random_interval(plan.interval_min, plan.interval_max);
+            tokio::select! {
+                () = tokio::time::sleep(interval) => {}
+                () = wait_closed(closed.clone()) => return,
+            }
+            if closed.load(Ordering::Acquire) {
+                return;
+            }
+            let port = *plan
+                .ports
+                .choose(&mut rand::thread_rng())
+                .expect("validated non-empty UDP hop ports");
+            let Ok((next, _)) = factory.open(port).await else {
+                tracing::debug!(
+                    port,
+                    "UDP hop socket creation failed; retaining current socket"
+                );
+                continue;
+            };
+            let obsolete = {
+                let mut state = state.write();
+                let obsolete = state.previous.take();
+                state.previous = Some(state.current.clone());
+                state.current = next.clone();
+                state.port = port;
+                obsolete
+            };
+            if let Some(obsolete) = obsolete {
+                let _ = obsolete.close().await;
+            }
+            let mut tasks = tasks.lock().await;
+            tasks.retain(|task| !task.is_finished());
+            tasks.push(spawn_receiver(next, output.clone(), closed.clone()));
+        }
+    })
+}
+
+async fn wait_closed(closed: Arc<AtomicBool>) {
+    while !closed.load(Ordering::Acquire) {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn random_interval(min: Duration, max: Duration) -> Duration {
+    if min == max {
+        return min;
+    }
+    let min_ms = min.as_millis() as u64;
+    let max_ms = max.as_millis() as u64;
+    Duration::from_millis(rand::thread_rng().gen_range(min_ms..=max_ms))
+}
+
+#[async_trait]
+impl UdpSocketLike for UdpHopCarrier {
+    async fn send_to(&self, payload: &[u8], _target: &str, _port: u16) -> io::Result<usize> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(io::ErrorKind::NotConnected.into());
+        }
+        let (socket, port) = {
+            let state = self.state.read();
+            (state.current.clone(), state.port)
+        };
+        // SocketFactory opened this association for the selected port. The
+        // configured hostname keeps proxy associations' target checks intact.
+        socket.send_to(payload, &self.target_host, port).await
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        let packet = self
+            .receive
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(io::ErrorKind::UnexpectedEof)??;
+        if packet.bytes.len() > output.len() {
+            return Err(invalid(format!(
+                "UDP hop received {} bytes into a {} byte buffer",
+                packet.bytes.len(),
+                output.len()
+            )));
+        }
+        output[..packet.bytes.len()].copy_from_slice(&packet.bytes);
+        Ok((packet.bytes.len(), packet.source))
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        if self.closed.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        let (current, previous) = {
+            let state = self.state.read();
+            (state.current.clone(), state.previous.clone())
+        };
+        let _ = current.close().await;
+        if let Some(previous) = previous {
+            let _ = previous.close().await;
+        }
+        for task in self.tasks.lock().await.drain(..) {
+            task.abort();
+        }
+        Ok(())
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.state.read().current.local_addr()
+    }
+}
+
+fn invalid(message: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intervals_stay_inside_inclusive_range() {
+        let min = Duration::from_secs(5);
+        let max = Duration::from_secs(6);
+        for _ in 0..100 {
+            let actual = random_interval(min, max);
+            assert!(actual >= min && actual <= max);
+        }
+        assert_eq!(random_interval(min, min), min);
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/xdns.rs
+++ b/crates/core-outbound/src/transport/finalmask/xdns.rs
@@ -1,0 +1,1032 @@
+//! Xray 26.7.11 xdns UDP carrier.
+//!
+//! The wire format follows `transport/internet/finalmask/xdns` at commit
+//! `6e3322d219140a025285ded1114fe17a5edb74d8`: client payloads are embedded in
+//! lower-case base32 query labels and server payloads are length-framed in
+//! TXT/A/AAAA answers. Hickory handles RFC 1035 compression and malformed-name
+//! rejection; all xdns-specific bounds remain explicit here.
+
+use std::{
+    io,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use core_config::XdnsMaskConfig;
+use data_encoding::BASE32_NOPAD;
+use hickory_proto::{
+    op::{Edns, Message, MessageType, OpCode, Query, ResponseCode},
+    rr::{
+        Name, RData, Record, RecordType,
+        rdata::{A, AAAA, TXT},
+    },
+};
+use rand::RngCore;
+use tokio::sync::{Mutex, Notify, mpsc};
+
+use crate::adapter::{BoxedUdp, UdpSocketLike};
+
+const QUERY_PAYLOAD_LIMIT: usize = 223;
+const MAX_DNS_DATAGRAM: usize = 1232;
+const QUEUE_LIMIT: usize = 256;
+const INITIAL_POLL_DELAY: Duration = Duration::from_millis(500);
+const MAX_POLL_DELAY: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone)]
+struct Resolver {
+    domain: Name,
+    address: SocketAddr,
+    record_type: RecordType,
+}
+
+#[derive(Debug, Clone)]
+struct DomainSpec {
+    domain: Name,
+    record_type: Option<RecordType>,
+}
+
+pub(super) fn wrap_client(inner: BoxedUdp, config: &XdnsMaskConfig) -> io::Result<BoxedUdp> {
+    if config.resolvers.is_empty() {
+        return Err(invalid("xdns client requires at least one resolver"));
+    }
+    let resolvers = config
+        .resolvers
+        .iter()
+        .map(|resolver| parse_resolver(resolver))
+        .collect::<io::Result<Vec<_>>>()?;
+    let mut client_id = [0; 8];
+    rand::rngs::OsRng.fill_bytes(&mut client_id);
+    let inner: Arc<dyn UdpSocketLike> = Arc::from(inner);
+    let (write_tx, write_rx) = mpsc::channel(QUEUE_LIMIT);
+    let (read_tx, read_rx) = mpsc::channel(QUEUE_LIMIT);
+    let response = Arc::new(Notify::new());
+    let closed = Arc::new(AtomicBool::new(false));
+    let resolver_index = Arc::new(AtomicUsize::new(0));
+
+    spawn_sender(
+        inner.clone(),
+        resolvers.clone(),
+        client_id,
+        write_rx,
+        response.clone(),
+        closed.clone(),
+        resolver_index.clone(),
+    );
+    spawn_receiver(
+        inner.clone(),
+        resolvers.clone(),
+        read_tx,
+        response,
+        closed.clone(),
+    );
+
+    Ok(Box::new(XdnsClient {
+        inner,
+        write: write_tx,
+        read: Mutex::new(read_rx),
+        closed,
+    }))
+}
+
+pub(super) fn wrap_server(inner: BoxedUdp, config: &XdnsMaskConfig) -> io::Result<BoxedUdp> {
+    if config.domains.is_empty() {
+        return Err(invalid("xdns server requires at least one domain"));
+    }
+    // Compile eagerly so malformed domain/method settings fail before the
+    // background dispatcher owns the carrier.
+    let domains = config
+        .domains
+        .iter()
+        .map(|domain| parse_domain_spec(domain, None))
+        .collect::<io::Result<Vec<_>>>()?;
+    let inner: Arc<dyn UdpSocketLike> = Arc::from(inner);
+    let clients = Arc::new(Mutex::new(std::collections::HashMap::new()));
+    let (read_tx, read_rx) = mpsc::channel(512);
+    let closed = Arc::new(AtomicBool::new(false));
+    let permits = Arc::new(tokio::sync::Semaphore::new(256));
+    let task = tokio::spawn(server_dispatch(
+        inner.clone(),
+        domains,
+        clients.clone(),
+        read_tx,
+        permits,
+        closed.clone(),
+    ));
+    Ok(Box::new(XdnsServer {
+        inner,
+        clients,
+        read: Mutex::new(read_rx),
+        closed,
+        task: Mutex::new(Some(task)),
+    }))
+}
+
+struct XdnsClientQueue {
+    send: mpsc::Sender<Vec<u8>>,
+    receive: Mutex<mpsc::Receiver<Vec<u8>>>,
+    stash: Mutex<Option<Vec<u8>>>,
+    last: parking_lot::Mutex<std::time::Instant>,
+}
+
+impl XdnsClientQueue {
+    fn new() -> Arc<Self> {
+        let (send, receive) = mpsc::channel(512);
+        Arc::new(Self {
+            send,
+            receive: Mutex::new(receive),
+            stash: Mutex::new(None),
+            last: parking_lot::Mutex::new(std::time::Instant::now()),
+        })
+    }
+
+    fn touch(&self) {
+        *self.last.lock() = std::time::Instant::now();
+    }
+}
+
+struct XdnsServer {
+    inner: Arc<dyn UdpSocketLike>,
+    clients: Arc<Mutex<std::collections::HashMap<SocketAddr, Arc<XdnsClientQueue>>>>,
+    read: Mutex<mpsc::Receiver<(Vec<u8>, SocketAddr)>>,
+    closed: Arc<AtomicBool>,
+    task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+#[async_trait]
+impl UdpSocketLike for XdnsServer {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        let target = parse_synthetic_address(target, port)?;
+        let queue = self
+            .clients
+            .lock()
+            .await
+            .get(&target)
+            .cloned()
+            .ok_or_else(|| invalid(format!("unknown xdns client `{target}`")))?;
+        queue.touch();
+        queue
+            .send
+            .try_send(payload.to_vec())
+            .map_err(|error| match error {
+                mpsc::error::TrySendError::Full(_) => io::Error::from(io::ErrorKind::WouldBlock),
+                mpsc::error::TrySendError::Closed(_) => io::Error::from(io::ErrorKind::BrokenPipe),
+            })?;
+        Ok(payload.len())
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        let (packet, source) = self
+            .read
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        if packet.len() > output.len() {
+            return Err(invalid(format!(
+                "xdns decoded packet is {} bytes, receive buffer is {}",
+                packet.len(),
+                output.len()
+            )));
+        }
+        output[..packet.len()].copy_from_slice(&packet);
+        Ok((packet.len(), Some(source)))
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner.local_addr()
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        if !self.closed.swap(true, Ordering::AcqRel)
+            && let Some(task) = self.task.lock().await.take()
+        {
+            task.abort();
+        }
+        self.inner.close().await
+    }
+}
+
+async fn server_dispatch(
+    inner: Arc<dyn UdpSocketLike>,
+    domains: Vec<DomainSpec>,
+    clients: Arc<Mutex<std::collections::HashMap<SocketAddr, Arc<XdnsClientQueue>>>>,
+    output: mpsc::Sender<(Vec<u8>, SocketAddr)>,
+    permits: Arc<tokio::sync::Semaphore>,
+    closed: Arc<AtomicBool>,
+) {
+    let mut buffer = vec![0; u16::MAX as usize];
+    let mut cleanup = tokio::time::interval(Duration::from_secs(5));
+    loop {
+        tokio::select! {
+            _ = cleanup.tick() => {
+                let now = std::time::Instant::now();
+                clients.lock().await.retain(|_, queue| {
+                    now.duration_since(*queue.last.lock()) < Duration::from_secs(10)
+                });
+            }
+            received = inner.recv_from_endpoint(&mut buffer) => {
+                let (length, Some(source)) = (match received {
+                    Ok(value) => value,
+                    Err(error) => {
+                        tracing::debug!(%error, "xdns server carrier ended");
+                        return;
+                    }
+                }) else {
+                    tracing::debug!("xdns server requires a source-aware carrier");
+                    return;
+                };
+                let query = match decode_server_request(&buffer[..length], &domains) {
+                    Ok(ServerRequest::Query(query)) => query,
+                    Ok(ServerRequest::Response(response)) => {
+                        if let Err(error) = inner
+                            .send_to(&response, &source.ip().to_string(), source.port())
+                            .await
+                        {
+                            tracing::debug!(%error, %source, "xdns error response failed");
+                        }
+                        continue;
+                    }
+                    Ok(ServerRequest::Drop) => continue,
+                    Err(error) => {
+                        tracing::debug!(%error, %source, "xdns ignored undecodable query");
+                        continue;
+                    }
+                };
+                let synthetic = client_id_to_address(query.client_id);
+                let queue = {
+                    let mut clients = clients.lock().await;
+                    if clients.len() >= 1024 && !clients.contains_key(&synthetic) {
+                        tracing::debug!("xdns client map full");
+                        continue;
+                    }
+                    clients.entry(synthetic).or_insert_with(XdnsClientQueue::new).clone()
+                };
+                queue.touch();
+                for packet in &query.packets {
+                    if output.try_send((packet.clone(), synthetic)).is_err() {
+                        break;
+                    }
+                }
+                let Ok(permit) = permits.clone().try_acquire_owned() else {
+                    continue;
+                };
+                let inner = inner.clone();
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    if let Err(error) = answer_query(inner, source, query, queue).await {
+                        tracing::debug!(%error, %source, "xdns response failed");
+                    }
+                });
+            }
+        }
+        if closed.load(Ordering::Acquire) {
+            return;
+        }
+    }
+}
+
+async fn answer_query(
+    inner: Arc<dyn UdpSocketLike>,
+    source: SocketAddr,
+    query: ServerQuery,
+    queue: Arc<XdnsClientQueue>,
+) -> io::Result<()> {
+    let mut packets = Vec::new();
+    let mut receive = queue.receive.lock().await;
+    let first = if let Some(packet) = queue.stash.lock().await.take() {
+        Some(packet)
+    } else {
+        tokio::time::timeout(Duration::from_secs(1), receive.recv())
+            .await
+            .ok()
+            .flatten()
+    };
+    if let Some(packet) = first {
+        packets.push(packet);
+        while let Ok(packet) = receive.try_recv() {
+            let mut candidate = packets.clone();
+            candidate.push(packet.clone());
+            if encode_server_response(&query, &candidate).is_err() {
+                *queue.stash.lock().await = Some(packet);
+                break;
+            }
+            packets = candidate;
+        }
+    }
+    drop(receive);
+    // Drop an individually oversized application packet just like Xray, but
+    // still answer the poll so the client's backoff state progresses.
+    if encode_server_response(&query, &packets).is_err() {
+        packets.clear();
+    }
+    let response = encode_server_response(&query, &packets)?;
+    inner
+        .send_to(&response, &source.ip().to_string(), source.port())
+        .await?;
+    Ok(())
+}
+
+fn client_id_to_address(client_id: [u8; 8]) -> SocketAddr {
+    let mut octets = [0; 16];
+    octets[0] = 0xfd;
+    octets[1] = 0x00;
+    octets[8..].copy_from_slice(&client_id);
+    SocketAddr::new(std::net::Ipv6Addr::from(octets).into(), 0)
+}
+
+fn parse_synthetic_address(target: &str, port: u16) -> io::Result<SocketAddr> {
+    let target = target
+        .trim()
+        .strip_prefix('[')
+        .and_then(|target| target.strip_suffix(']'))
+        .unwrap_or_else(|| target.trim());
+    let ip = target
+        .parse()
+        .map_err(|_| invalid(format!("invalid xdns client address `{target}`")))?;
+    Ok(SocketAddr::new(ip, port))
+}
+
+struct XdnsClient {
+    inner: Arc<dyn UdpSocketLike>,
+    write: mpsc::Sender<Vec<u8>>,
+    read: Mutex<mpsc::Receiver<Vec<u8>>>,
+    closed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl UdpSocketLike for XdnsClient {
+    async fn send_to(&self, payload: &[u8], _: &str, _: u16) -> io::Result<usize> {
+        if payload.len() > QUERY_PAYLOAD_LIMIT {
+            return Err(invalid(format!(
+                "xdns query payload is {} bytes; maximum is {QUERY_PAYLOAD_LIMIT}",
+                payload.len()
+            )));
+        }
+        self.write
+            .try_send(payload.to_vec())
+            .map_err(|error| match error {
+                mpsc::error::TrySendError::Full(_) => io::Error::from(io::ErrorKind::WouldBlock),
+                mpsc::error::TrySendError::Closed(_) => io::Error::from(io::ErrorKind::BrokenPipe),
+            })?;
+        Ok(payload.len())
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        let packet = self
+            .read
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        if packet.len() > output.len() {
+            return Err(invalid(format!(
+                "xdns decoded packet is {} bytes, receive buffer is {}",
+                packet.len(),
+                output.len()
+            )));
+        }
+        output[..packet.len()].copy_from_slice(&packet);
+        Ok(packet.len())
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        self.closed.store(true, Ordering::Release);
+        self.inner.close().await
+    }
+}
+
+fn spawn_sender(
+    inner: Arc<dyn UdpSocketLike>,
+    resolvers: Vec<Resolver>,
+    client_id: [u8; 8],
+    mut input: mpsc::Receiver<Vec<u8>>,
+    response: Arc<Notify>,
+    closed: Arc<AtomicBool>,
+    resolver_index: Arc<AtomicUsize>,
+) {
+    tokio::spawn(async move {
+        let mut delay = INITIAL_POLL_DELAY;
+        loop {
+            let packet = tokio::select! {
+                biased;
+                packet = input.recv() => match packet {
+                    Some(packet) => {
+                        delay = INITIAL_POLL_DELAY;
+                        Some(packet)
+                    }
+                    None => return,
+                },
+                _ = response.notified() => {
+                    delay = INITIAL_POLL_DELAY;
+                    None
+                },
+                _ = tokio::time::sleep(delay) => {
+                    delay = (delay * 2).min(MAX_POLL_DELAY);
+                    None
+                },
+            };
+            if closed.load(Ordering::Acquire) {
+                return;
+            }
+            let index = resolver_index.fetch_add(1, Ordering::AcqRel) % resolvers.len();
+            let resolver = &resolvers[index];
+            let payload = packet.as_deref().unwrap_or_default();
+            let wire = match encode_query(payload, &client_id, resolver) {
+                Ok(wire) => wire,
+                Err(error) => {
+                    tracing::debug!(%error, "xdns encode query failed");
+                    continue;
+                }
+            };
+            let _ = inner
+                .send_to(
+                    &wire,
+                    &resolver.address.ip().to_string(),
+                    resolver.address.port(),
+                )
+                .await;
+        }
+    });
+}
+
+fn spawn_receiver(
+    inner: Arc<dyn UdpSocketLike>,
+    resolvers: Vec<Resolver>,
+    output: mpsc::Sender<Vec<u8>>,
+    response: Arc<Notify>,
+    closed: Arc<AtomicBool>,
+) {
+    tokio::spawn(async move {
+        let mut buffer = vec![0; u16::MAX as usize];
+        while !closed.load(Ordering::Acquire) {
+            let length = match inner.recv_from(&mut buffer).await {
+                Ok(length) if length <= buffer.len() => length,
+                Ok(_) => return,
+                Err(error) => {
+                    tracing::debug!(%error, "xdns carrier receive failed");
+                    return;
+                }
+            };
+            let packets = match decode_response(&buffer[..length], &resolvers) {
+                Ok(packets) => packets,
+                Err(error) => {
+                    tracing::debug!(%error, "xdns ignored malformed response");
+                    continue;
+                }
+            };
+            if !packets.is_empty() {
+                response.notify_one();
+            }
+            for packet in packets {
+                if output.try_send(packet).is_err() {
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn parse_resolver(input: &str) -> io::Result<Resolver> {
+    let (head, server) = input
+        .split_once("+udp://")
+        .ok_or_else(|| invalid("xdns resolver must use domain[:method]+udp://IP:port"))?;
+    let spec = parse_domain_spec(head, Some(RecordType::TXT))?;
+    let address = server.parse::<SocketAddr>().map_err(|_| {
+        invalid(format!(
+            "xdns resolver `{server}` is not an IP socket address"
+        ))
+    })?;
+    Ok(Resolver {
+        domain: spec.domain,
+        address,
+        record_type: spec.record_type.expect("default record type"),
+    })
+}
+
+fn parse_domain_spec(input: &str, default: Option<RecordType>) -> io::Result<DomainSpec> {
+    let (domain, method) = match input.rsplit_once(':') {
+        Some((domain, method)) => (domain, Some(method)),
+        None => (input, None),
+    };
+    if domain.is_empty() {
+        return Err(invalid("xdns domain is empty"));
+    }
+    let mut domain = Name::from_ascii(domain).map_err(invalid)?;
+    domain.set_fqdn(true);
+    let record_type = match method {
+        Some(method) => Some(parse_method(method)?),
+        None => default,
+    };
+    Ok(DomainSpec {
+        domain,
+        record_type,
+    })
+}
+
+fn parse_method(input: &str) -> io::Result<RecordType> {
+    match input.to_ascii_lowercase().as_str() {
+        "" | "txt" => Ok(RecordType::TXT),
+        "a" => Ok(RecordType::A),
+        "aaaa" => Ok(RecordType::AAAA),
+        _ => Err(invalid(format!("unsupported xdns method `{input}`"))),
+    }
+}
+
+fn encode_query(payload: &[u8], client_id: &[u8; 8], resolver: &Resolver) -> io::Result<Vec<u8>> {
+    if payload.len() > QUERY_PAYLOAD_LIMIT {
+        return Err(invalid("xdns payload exceeds query limit"));
+    }
+    let padding_length = if payload.is_empty() { 8 } else { 3 };
+    let mut decoded = Vec::with_capacity(10 + padding_length + payload.len());
+    decoded.extend_from_slice(client_id);
+    decoded.push(224 + padding_length as u8);
+    let mut padding = vec![0; padding_length];
+    rand::rngs::OsRng.fill_bytes(&mut padding);
+    decoded.extend_from_slice(&padding);
+    if !payload.is_empty() {
+        decoded.push(payload.len() as u8);
+        decoded.extend_from_slice(payload);
+    }
+    let encoded = BASE32_NOPAD.encode(&decoded).to_ascii_lowercase();
+    let prefix = Name::from_labels(encoded.as_bytes().chunks(63)).map_err(invalid)?;
+    let query_name = prefix.append_name(&resolver.domain).map_err(invalid)?;
+
+    let mut message = Message::new();
+    message
+        .set_id(rand::random())
+        .set_message_type(MessageType::Query)
+        .set_recursion_desired(true)
+        .add_query(Query::query(query_name, resolver.record_type));
+    let mut edns = Edns::new();
+    edns.set_max_payload(4096);
+    message.set_edns(edns);
+    message.to_vec().map_err(invalid)
+}
+
+fn decode_response(wire: &[u8], resolvers: &[Resolver]) -> io::Result<Vec<Vec<u8>>> {
+    let message = Message::from_vec(wire).map_err(invalid)?;
+    if message.message_type() != MessageType::Response
+        || message.response_code() != ResponseCode::NoError
+        || message.answers().is_empty()
+    {
+        return Err(invalid("xdns response flags or answers are invalid"));
+    }
+    for answer in message.answers() {
+        if !resolvers
+            .iter()
+            .any(|resolver| resolver.domain.zone_of(answer.name()))
+        {
+            return Err(invalid(
+                "xdns response answer is outside configured domains",
+            ));
+        }
+    }
+    let payload = decode_answer_payload(message.answers())?;
+    decode_frames(&payload)
+}
+
+fn decode_answer_payload(answers: &[Record]) -> io::Result<Vec<u8>> {
+    let first = answers
+        .first()
+        .and_then(Record::data)
+        .ok_or_else(|| invalid("xdns answer has no rdata"))?;
+    match first {
+        RData::TXT(txt) => {
+            if answers.len() != 1 {
+                return Err(invalid("xdns TXT response must contain one answer"));
+            }
+            Ok(txt.iter().flat_map(|part| part.iter().copied()).collect())
+        }
+        RData::A(_) => decode_ip_answers(answers, RecordType::A, 4),
+        RData::AAAA(_) => decode_ip_answers(answers, RecordType::AAAA, 16),
+        _ => Err(invalid("xdns answer type is unsupported")),
+    }
+}
+
+fn decode_ip_answers(
+    answers: &[Record],
+    record_type: RecordType,
+    width: usize,
+) -> io::Result<Vec<u8>> {
+    if answers.len() > 256 {
+        return Err(invalid("xdns IP response has too many answers"));
+    }
+    let mut parts = vec![None; answers.len()];
+    for answer in answers {
+        if answer.record_type() != record_type {
+            return Err(invalid("xdns response mixes answer types"));
+        }
+        let bytes = match answer.data() {
+            Some(RData::A(address)) => address.0.octets().to_vec(),
+            Some(RData::AAAA(address)) => address.0.octets().to_vec(),
+            _ => return Err(invalid("xdns IP answer has invalid rdata")),
+        };
+        if bytes.len() != width {
+            return Err(invalid("xdns IP answer width is invalid"));
+        }
+        let index = bytes[0] as usize;
+        let length = bytes[1] as usize;
+        if index >= parts.len() || length > width - 2 || parts[index].is_some() {
+            return Err(invalid("xdns IP answer chunk header is invalid"));
+        }
+        parts[index] = Some(bytes[2..2 + length].to_vec());
+    }
+    let mut output = Vec::new();
+    for part in parts {
+        output.extend(part.ok_or_else(|| invalid("xdns IP answer chunk is missing"))?);
+    }
+    Ok(output)
+}
+
+fn decode_frames(mut payload: &[u8]) -> io::Result<Vec<Vec<u8>>> {
+    let mut packets = Vec::new();
+    while !payload.is_empty() {
+        if payload.len() < 2 {
+            return Err(invalid("xdns response frame length is truncated"));
+        }
+        let length = u16::from_be_bytes([payload[0], payload[1]]) as usize;
+        payload = &payload[2..];
+        if payload.len() < length {
+            return Err(invalid("xdns response frame is truncated"));
+        }
+        packets.push(payload[..length].to_vec());
+        payload = &payload[length..];
+    }
+    Ok(packets)
+}
+
+/// Server-side query decoder used by the inbound carrier.
+#[derive(Debug, Clone)]
+pub(crate) struct ServerQuery {
+    message: Message,
+    question_name: Name,
+    record_type: RecordType,
+    pub(crate) client_id: [u8; 8],
+    pub(crate) packets: Vec<Vec<u8>>,
+}
+
+enum ServerRequest {
+    Query(ServerQuery),
+    Response(Vec<u8>),
+    Drop,
+}
+
+pub(crate) fn decode_server_query(
+    wire: &[u8],
+    configured_domains: &[String],
+) -> io::Result<ServerQuery> {
+    let domains = configured_domains
+        .iter()
+        .map(|domain| parse_domain_spec(domain, None))
+        .collect::<io::Result<Vec<_>>>()?;
+    match decode_server_request(wire, &domains)? {
+        ServerRequest::Query(query) => Ok(query),
+        ServerRequest::Response(_) => Err(invalid("xdns query requires an error response")),
+        ServerRequest::Drop => Err(invalid("xdns server ignores DNS responses")),
+    }
+}
+
+fn decode_server_request(wire: &[u8], domains: &[DomainSpec]) -> io::Result<ServerRequest> {
+    let message = Message::from_vec(wire).map_err(invalid)?;
+    if message.message_type() != MessageType::Query {
+        return Ok(ServerRequest::Drop);
+    }
+    if message.version() != 0 {
+        return error_server_response(&message, false, ResponseCode::BADVERS);
+    }
+    if message.queries().len() != 1 {
+        return error_server_response(&message, false, ResponseCode::FormErr);
+    }
+    let question = &message.queries()[0];
+    let matched = domains
+        .iter()
+        .find(|domain| domain.domain.zone_of(question.name()));
+    let Some(matched) = matched else {
+        return error_server_response(&message, false, ResponseCode::NXDomain);
+    };
+    if message.op_code() != OpCode::Query {
+        return error_server_response(&message, true, ResponseCode::NotImp);
+    }
+    if !matches!(
+        question.query_type(),
+        RecordType::TXT | RecordType::A | RecordType::AAAA
+    ) || matched
+        .record_type
+        .is_some_and(|record_type| record_type != question.query_type())
+    {
+        return error_server_response(&message, true, ResponseCode::NXDomain);
+    }
+    let prefix_count = usize::from(question.name().num_labels() - matched.domain.num_labels());
+    let encoded = question
+        .name()
+        .iter()
+        .take(prefix_count)
+        .flat_map(|label| label.iter().copied())
+        .map(|byte| byte.to_ascii_uppercase())
+        .collect::<Vec<_>>();
+    let decoded = match BASE32_NOPAD.decode(&encoded) {
+        Ok(decoded) => decoded,
+        Err(_) => return error_server_response(&message, true, ResponseCode::NXDomain),
+    };
+    if message.max_payload() < MAX_DNS_DATAGRAM as u16 {
+        return error_server_response(&message, true, ResponseCode::FormErr);
+    }
+    if decoded.len() < 8 {
+        return error_server_response(&message, true, ResponseCode::NXDomain);
+    }
+    let mut client_id = [0; 8];
+    client_id.copy_from_slice(&decoded[..8]);
+    let packets = decode_query_packets(&decoded[8..]);
+    let question_name = question.name().clone();
+    let record_type = question.query_type();
+    Ok(ServerRequest::Query(ServerQuery {
+        message,
+        question_name,
+        record_type,
+        client_id,
+        packets,
+    }))
+}
+
+fn error_server_response(
+    query: &Message,
+    authoritative: bool,
+    response_code: ResponseCode,
+) -> io::Result<ServerRequest> {
+    let mut response = Message::new();
+    response
+        .set_id(query.id())
+        .set_message_type(MessageType::Response)
+        .set_authoritative(authoritative)
+        .set_response_code(response_code)
+        .add_queries(query.queries().iter().cloned());
+    if query.extensions().is_some() {
+        let mut edns = Edns::new();
+        edns.set_max_payload(4096);
+        response.set_edns(edns);
+    }
+    Ok(ServerRequest::Response(response.to_vec().map_err(invalid)?))
+}
+
+fn decode_query_packets(mut payload: &[u8]) -> Vec<Vec<u8>> {
+    let mut packets = Vec::new();
+    while !payload.is_empty() {
+        let prefix = payload[0];
+        payload = &payload[1..];
+        if prefix >= 224 {
+            let padding = usize::from(prefix - 224);
+            if payload.len() < padding {
+                break;
+            }
+            payload = &payload[padding..];
+            continue;
+        }
+        let length = usize::from(prefix);
+        if payload.len() < length {
+            break;
+        }
+        packets.push(payload[..length].to_vec());
+        payload = &payload[length..];
+    }
+    packets
+}
+
+pub(crate) fn encode_server_response(
+    query: &ServerQuery,
+    packets: &[Vec<u8>],
+) -> io::Result<Vec<u8>> {
+    let mut payload = Vec::new();
+    for packet in packets {
+        let length = u16::try_from(packet.len())
+            .map_err(|_| invalid("xdns server packet exceeds u16 length"))?;
+        payload.extend_from_slice(&length.to_be_bytes());
+        payload.extend_from_slice(packet);
+    }
+    let mut response = Message::new();
+    response
+        .set_id(query.message.id())
+        .set_message_type(MessageType::Response)
+        .set_authoritative(true)
+        .set_response_code(ResponseCode::NoError)
+        .add_query(query.message.queries()[0].clone());
+    let answers = encode_answers(query.question_name.clone(), query.record_type, &payload)?;
+    response.add_answers(answers);
+    let mut edns = Edns::new();
+    edns.set_max_payload(4096);
+    response.set_edns(edns);
+    let wire = response.to_vec().map_err(invalid)?;
+    if wire.len() > MAX_DNS_DATAGRAM {
+        return Err(invalid(format!(
+            "xdns response is {} bytes; maximum is {MAX_DNS_DATAGRAM}",
+            wire.len()
+        )));
+    }
+    Ok(wire)
+}
+
+fn encode_answers(name: Name, kind: RecordType, payload: &[u8]) -> io::Result<Vec<Record>> {
+    match kind {
+        RecordType::TXT => {
+            let chunks = payload.chunks(255).collect::<Vec<_>>();
+            Ok(vec![Record::from_rdata(
+                name,
+                60,
+                RData::TXT(TXT::from_bytes(if chunks.is_empty() {
+                    vec![&[]]
+                } else {
+                    chunks
+                })),
+            )])
+        }
+        RecordType::A | RecordType::AAAA => {
+            let width = if kind == RecordType::A { 4 } else { 16 };
+            let chunk = width - 2;
+            let count = payload.len().div_ceil(chunk).max(1);
+            if count > 256 {
+                return Err(invalid("xdns IP response needs more than 256 answers"));
+            }
+            let mut answers = Vec::with_capacity(count);
+            for index in 0..count {
+                let offset = index * chunk;
+                let part = payload.get(offset..).unwrap_or_default();
+                let part = &part[..part.len().min(chunk)];
+                let mut bytes = vec![0; width];
+                bytes[0] = index as u8;
+                bytes[1] = part.len() as u8;
+                bytes[2..2 + part.len()].copy_from_slice(part);
+                let data = if kind == RecordType::A {
+                    RData::A(A(std::net::Ipv4Addr::from(
+                        <[u8; 4]>::try_from(bytes).unwrap(),
+                    )))
+                } else {
+                    RData::AAAA(AAAA(std::net::Ipv6Addr::from(
+                        <[u8; 16]>::try_from(bytes).unwrap(),
+                    )))
+                };
+                answers.push(Record::from_rdata(name.clone(), 60, data));
+            }
+            Ok(answers)
+        }
+        _ => Err(invalid("xdns answer type is unsupported")),
+    }
+}
+
+fn invalid(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resolver(kind: RecordType) -> Resolver {
+        Resolver {
+            domain: Name::from_ascii("t.example.").unwrap(),
+            address: "127.0.0.1:53".parse().unwrap(),
+            record_type: kind,
+        }
+    }
+
+    fn classify_response(message: &Message, domains: &[&str]) -> Message {
+        let domains = domains
+            .iter()
+            .map(|domain| parse_domain_spec(domain, None).unwrap())
+            .collect::<Vec<_>>();
+        let wire = message.to_vec().unwrap();
+        let ServerRequest::Response(response) = decode_server_request(&wire, &domains).unwrap()
+        else {
+            panic!("expected xdns error response");
+        };
+        Message::from_vec(&response).unwrap()
+    }
+
+    #[test]
+    fn client_query_and_server_decoder_are_bidirectionally_compatible() {
+        let resolver = resolver(RecordType::TXT);
+        let id = *b"12345678";
+        let wire = encode_query(b"quic", &id, &resolver).unwrap();
+        let query = decode_server_query(&wire, &["t.example:txt".into()]).unwrap();
+        assert_eq!(query.client_id, id);
+        assert_eq!(query.packets, [b"quic".to_vec()]);
+    }
+
+    #[test]
+    fn server_answers_decode_for_all_official_record_modes() {
+        for kind in [RecordType::TXT, RecordType::A, RecordType::AAAA] {
+            let resolver = resolver(kind);
+            let query_wire = encode_query(b"request", b"abcdefgh", &resolver).unwrap();
+            let query = decode_server_query(
+                &query_wire,
+                &[format!(
+                    "t.example:{}",
+                    match kind {
+                        RecordType::A => "a",
+                        RecordType::AAAA => "aaaa",
+                        _ => "txt",
+                    }
+                )],
+            )
+            .unwrap();
+            let response =
+                encode_server_response(&query, &[b"first".to_vec(), b"second packet".to_vec()])
+                    .unwrap();
+            assert_eq!(
+                decode_response(&response, std::slice::from_ref(&resolver)).unwrap(),
+                [b"first".to_vec(), b"second packet".to_vec()]
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_truncation_wrong_domain_and_oversize_query() {
+        let resolver = resolver(RecordType::TXT);
+        assert!(encode_query(&vec![0; 224], b"abcdefgh", &resolver).is_err());
+        let wire = encode_query(b"ok", b"abcdefgh", &resolver).unwrap();
+        assert!(decode_server_query(&wire[..wire.len() - 1], &["t.example".into()]).is_err());
+        assert!(decode_server_query(&wire, &["other.example".into()]).is_err());
+    }
+
+    #[test]
+    fn server_returns_xray_dns_error_codes_instead_of_dropping_queries() {
+        let resolver = resolver(RecordType::TXT);
+        let valid =
+            Message::from_vec(&encode_query(b"ok", b"abcdefgh", &resolver).unwrap()).unwrap();
+
+        let wrong_domain = classify_response(&valid, &["other.example"]);
+        assert_eq!(wrong_domain.response_code(), ResponseCode::NXDomain);
+        assert!(!wrong_domain.authoritative());
+
+        let mut unsupported_opcode = valid.clone();
+        unsupported_opcode.set_op_code(OpCode::Status);
+        let unsupported_opcode = classify_response(&unsupported_opcode, &["t.example:txt"]);
+        assert_eq!(unsupported_opcode.response_code(), ResponseCode::NotImp);
+        assert!(unsupported_opcode.authoritative());
+
+        let mut unsupported_type = valid.clone();
+        unsupported_type.queries_mut()[0].set_query_type(RecordType::MX);
+        let unsupported_type = classify_response(&unsupported_type, &["t.example"]);
+        assert_eq!(unsupported_type.response_code(), ResponseCode::NXDomain);
+        assert!(unsupported_type.authoritative());
+
+        let mut bad_version = valid.clone();
+        bad_version
+            .extensions_mut()
+            .as_mut()
+            .unwrap()
+            .set_version(1);
+        let bad_version = classify_response(&bad_version, &["t.example:txt"]);
+        // Hickory names numeric RCODE 16 `BADSIG` when decoding because the
+        // number is shared with BADVERS. An OPT response makes it BADVERS.
+        assert_eq!(u16::from(bad_version.response_code()), 16);
+        assert_eq!(
+            bad_version.extensions().as_ref().unwrap().rcode_high(),
+            ResponseCode::BADVERS.high()
+        );
+        assert!(!bad_version.authoritative());
+        assert_eq!(bad_version.version(), 0);
+
+        let mut undersized_edns = valid;
+        undersized_edns
+            .extensions_mut()
+            .as_mut()
+            .unwrap()
+            .set_max_payload(512);
+        let undersized_edns = classify_response(&undersized_edns, &["t.example:txt"]);
+        assert_eq!(undersized_edns.response_code(), ResponseCode::FormErr);
+        assert!(undersized_edns.authoritative());
+
+        let mut no_question = Message::new();
+        no_question.set_id(7).set_message_type(MessageType::Query);
+        let no_question = classify_response(&no_question, &["t.example"]);
+        assert_eq!(no_question.response_code(), ResponseCode::FormErr);
+        assert!(!no_question.authoritative());
+    }
+
+    #[test]
+    fn server_keeps_complete_packets_before_a_truncated_query_frame() {
+        assert_eq!(
+            decode_query_packets(&[2, b'o', b'k', 4, b'x']),
+            [b"ok".to_vec()]
+        );
+        assert_eq!(
+            decode_query_packets(&[225, 0xaa, 3, b'a', b'b', b'c']),
+            [b"abc".to_vec()]
+        );
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/xicmp.rs
+++ b/crates/core-outbound/src/transport/finalmask/xicmp.rs
@@ -1,0 +1,908 @@
+//! Xray 26.7.11 xicmp carrier for ICMPv4/v6 echo packets.
+//!
+//! Source of truth: `transport/internet/finalmask/xicmp` at
+//! `6e3322d219140a025285ded1114fe17a5edb74d8`. Client requests carry
+//! `clientID[8] || QUIC packet`; replies carry only the QUIC packet. Both
+//! privileged RAW sockets and unprivileged ping DGRAM sockets are supported.
+
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU16, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use core_config::XicmpMaskConfig;
+use rand::{RngCore, seq::SliceRandom};
+use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+use tokio::{sync::Mutex, task::JoinHandle};
+
+use crate::adapter::{BoxedUdp, UdpSocketLike};
+
+const MAX_PACKET: usize = 4096;
+const ICMP_HEADER: usize = 8;
+const CLIENT_ID: usize = 8;
+const SEQUENCE_WINDOW: u16 = 1000;
+
+pub(super) fn wrap_client(
+    inner: BoxedUdp,
+    config: &XicmpMaskConfig,
+    remote: Option<SocketAddr>,
+) -> io::Result<BoxedUdp> {
+    let ips = config
+        .ips
+        .iter()
+        .map(|ip| {
+            ip.parse::<IpAddr>()
+                .map_err(|_| invalid(format!("invalid xicmp IP `{ip}`")))
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    if ips.is_empty() && remote.is_none() {
+        return Err(invalid(
+            "xicmp needs a resolved remote address when settings.ips is empty",
+        ));
+    }
+    let (ipv4, ipv4_guard) = open_icmp_socket(false, config.dgram, false)?;
+    let (ipv6, ipv6_guard) = open_icmp_socket(true, config.dgram, false)?;
+    let mut client_id = [0; CLIENT_ID];
+    rand::rngs::OsRng.fill_bytes(&mut client_id);
+    let id = rand::random::<u16>();
+    let sequence = Arc::new(AtomicU16::new(1));
+    let closed = Arc::new(AtomicBool::new(false));
+    let (output_tx, output_rx) = tokio::sync::mpsc::channel(256);
+    let mut tasks = Vec::with_capacity(2);
+    tasks.push(spawn_receiver(
+        ipv4.clone(),
+        IpFamily::V4,
+        config.dgram,
+        id,
+        client_id,
+        sequence.clone(),
+        closed.clone(),
+        output_tx.clone(),
+    ));
+    tasks.push(spawn_receiver(
+        ipv6.clone(),
+        IpFamily::V6,
+        config.dgram,
+        id,
+        client_id,
+        sequence.clone(),
+        closed.clone(),
+        output_tx,
+    ));
+    Ok(Box::new(XicmpClient {
+        inner,
+        ipv4,
+        ipv6,
+        _ipv4_guard: ipv4_guard,
+        _ipv6_guard: ipv6_guard,
+        ips,
+        remote,
+        client_id,
+        id,
+        sequence,
+        output: Mutex::new(output_rx),
+        closed,
+        tasks: Mutex::new(tasks),
+    }))
+}
+
+pub(super) fn wrap_server(inner: BoxedUdp, config: &XicmpMaskConfig) -> io::Result<BoxedUdp> {
+    let allowed_ips = config
+        .ips
+        .iter()
+        .map(|ip| {
+            ip.parse::<IpAddr>()
+                .map_err(|_| invalid(format!("invalid xicmp IP `{ip}`")))
+        })
+        .collect::<io::Result<HashSet<_>>>()?;
+    // Xray servers always need raw ICMP sockets; DGRAM ping sockets cannot
+    // receive arbitrary clients' echo requests.
+    let (ipv4, ipv4_guard) = open_icmp_socket(false, false, true)?;
+    let (ipv6, ipv6_guard) = open_icmp_socket(true, false, true)?;
+    let records = Arc::new(Mutex::new(HashMap::new()));
+    let closed = Arc::new(AtomicBool::new(false));
+    let (output_tx, output_rx) = tokio::sync::mpsc::channel(256);
+    let tasks = vec![
+        spawn_server_receiver(
+            ipv4.clone(),
+            IpFamily::V4,
+            allowed_ips.clone(),
+            records.clone(),
+            output_tx.clone(),
+            closed.clone(),
+        ),
+        spawn_server_receiver(
+            ipv6.clone(),
+            IpFamily::V6,
+            allowed_ips,
+            records.clone(),
+            output_tx,
+            closed.clone(),
+        ),
+    ];
+    Ok(Box::new(XicmpServer {
+        inner,
+        ipv4,
+        ipv6,
+        _ipv4_guard: ipv4_guard,
+        _ipv6_guard: ipv6_guard,
+        records,
+        output: Mutex::new(output_rx),
+        closed,
+        tasks: Mutex::new(tasks),
+    }))
+}
+
+#[derive(Clone)]
+struct ServerRecord {
+    source: SocketAddr,
+    destination: Option<IpAddr>,
+    family: IpFamily,
+    id: u16,
+    sequence: u16,
+    last: Instant,
+}
+
+struct XicmpServer {
+    inner: BoxedUdp,
+    ipv4: Arc<tokio::net::UdpSocket>,
+    ipv6: Arc<tokio::net::UdpSocket>,
+    _ipv4_guard: crate::loopback::LoopbackUdpGuard,
+    _ipv6_guard: crate::loopback::LoopbackUdpGuard,
+    records: Arc<Mutex<HashMap<SocketAddr, ServerRecord>>>,
+    output: Mutex<tokio::sync::mpsc::Receiver<(Vec<u8>, SocketAddr)>>,
+    closed: Arc<AtomicBool>,
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+#[async_trait]
+impl UdpSocketLike for XicmpServer {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        if payload.len() + ICMP_HEADER > MAX_PACKET {
+            return Err(invalid("xicmp server reply exceeds packet limit"));
+        }
+        let synthetic = parse_synthetic_address(target, port)?;
+        let record = {
+            let mut records = self.records.lock().await;
+            records.retain(|_, record| record.last.elapsed() < Duration::from_secs(60));
+            let record = records
+                .get_mut(&synthetic)
+                .ok_or_else(|| invalid(format!("unknown xicmp client `{synthetic}`")))?;
+            record.last = Instant::now();
+            record.clone()
+        };
+        let wire = encode_echo(
+            record.family.reply_type(),
+            record.id,
+            record.sequence,
+            payload,
+        );
+        send_server_reply(
+            match record.family {
+                IpFamily::V4 => &self.ipv4,
+                IpFamily::V6 => &self.ipv6,
+            },
+            &wire,
+            record.source,
+            record.destination,
+        )
+        .await?;
+        Ok(payload.len())
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(output)
+            .await
+            .map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        output: &mut [u8],
+    ) -> io::Result<(usize, Option<SocketAddr>)> {
+        let (packet, source) = self
+            .output
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        if packet.len() > output.len() {
+            return Err(invalid(format!(
+                "xicmp decoded packet is {} bytes, buffer is {}",
+                packet.len(),
+                output.len()
+            )));
+        }
+        output[..packet.len()].copy_from_slice(&packet);
+        Ok((packet.len(), Some(source)))
+    }
+
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.inner.local_addr()
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            for task in self.tasks.lock().await.drain(..) {
+                task.abort();
+            }
+        }
+        self.inner.close().await
+    }
+}
+
+fn spawn_server_receiver(
+    socket: Arc<tokio::net::UdpSocket>,
+    family: IpFamily,
+    allowed_ips: HashSet<IpAddr>,
+    records: Arc<Mutex<HashMap<SocketAddr, ServerRecord>>>,
+    output: tokio::sync::mpsc::Sender<(Vec<u8>, SocketAddr)>,
+    closed: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut buffer = vec![0; MAX_PACKET + 64];
+        while !closed.load(Ordering::Acquire) {
+            let (length, source, destination) =
+                match recv_server_request(&socket, &mut buffer, family).await {
+                    Ok(value) => value,
+                    Err(error) => {
+                        tracing::debug!(%error, ?family, "xicmp server receive failed");
+                        return;
+                    }
+                };
+            if !allowed_ips.is_empty() && !allowed_ips.contains(&source.ip()) {
+                continue;
+            }
+            let request = match decode_server_request(&buffer[..length], family == IpFamily::V6) {
+                Ok(request) => request,
+                Err(_) => continue,
+            };
+            let synthetic = client_id_to_address(request.client_id);
+            {
+                let mut records = records.lock().await;
+                records.retain(|_, record| record.last.elapsed() < Duration::from_secs(60));
+                if records.len() >= 4096 && !records.contains_key(&synthetic) {
+                    continue;
+                }
+                records.insert(
+                    synthetic,
+                    ServerRecord {
+                        source,
+                        destination,
+                        family,
+                        id: request.id,
+                        sequence: request.sequence,
+                        last: Instant::now(),
+                    },
+                );
+            }
+            if output.try_send((request.payload, synthetic)).is_err() {
+                continue;
+            }
+        }
+    })
+}
+
+fn client_id_to_address(client_id: [u8; CLIENT_ID]) -> SocketAddr {
+    let mut octets = [0; 16];
+    octets[0] = 0xfd;
+    octets[1] = 0x00;
+    octets[8..].copy_from_slice(&client_id);
+    SocketAddr::new(Ipv6Addr::from(octets).into(), 0)
+}
+
+fn parse_synthetic_address(target: &str, port: u16) -> io::Result<SocketAddr> {
+    let ip = normalize_host(target)
+        .parse::<IpAddr>()
+        .map_err(|_| invalid(format!("invalid xicmp client address `{target}`")))?;
+    Ok(SocketAddr::new(ip, port))
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn recv_server_request(
+    socket: &tokio::net::UdpSocket,
+    output: &mut [u8],
+    _family: IpFamily,
+) -> io::Result<(usize, SocketAddr, Option<IpAddr>)> {
+    let (length, source) = socket.recv_from(output).await?;
+    Ok((length, source, None))
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn send_server_reply(
+    socket: &tokio::net::UdpSocket,
+    packet: &[u8],
+    target: SocketAddr,
+    _source: Option<IpAddr>,
+) -> io::Result<usize> {
+    socket.send_to(packet, target).await
+}
+
+#[cfg(target_os = "linux")]
+fn enable_destination_control(socket: &Socket, ipv6: bool) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let value: libc::c_int = 1;
+    let (level, option) = if ipv6 {
+        (libc::IPPROTO_IPV6, libc::IPV6_RECVPKTINFO)
+    } else {
+        (libc::IPPROTO_IP, libc::IP_PKTINFO)
+    };
+    let result = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            level,
+            option,
+            (&value as *const libc::c_int).cast(),
+            std::mem::size_of_val(&value) as libc::socklen_t,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn recv_server_request(
+    socket: &tokio::net::UdpSocket,
+    output: &mut [u8],
+    family: IpFamily,
+) -> io::Result<(usize, SocketAddr, Option<IpAddr>)> {
+    use std::os::fd::AsRawFd;
+
+    loop {
+        socket.readable().await?;
+        match socket.try_io(tokio::io::Interest::READABLE, || {
+            recvmsg_with_destination(socket.as_raw_fd(), output, family)
+        }) {
+            Ok(value) => return Ok(value),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn recvmsg_with_destination(
+    fd: std::os::fd::RawFd,
+    output: &mut [u8],
+    family: IpFamily,
+) -> io::Result<(usize, SocketAddr, Option<IpAddr>)> {
+    let mut address = std::mem::MaybeUninit::<libc::sockaddr_storage>::zeroed();
+    let mut control = [0u8; 128];
+    let mut iovec = libc::iovec {
+        iov_base: output.as_mut_ptr().cast(),
+        iov_len: output.len(),
+    };
+    let mut message = unsafe { std::mem::zeroed::<libc::msghdr>() };
+    message.msg_name = address.as_mut_ptr().cast();
+    message.msg_namelen = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+    message.msg_iov = &mut iovec;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control.len();
+    let length = unsafe { libc::recvmsg(fd, &mut message, 0) };
+    if length < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let address = unsafe { address.assume_init() };
+    let source = sockaddr_to_socket_addr(&address)?;
+    let mut destination = None;
+    let mut header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    while !header.is_null() {
+        let control_header = unsafe { &*header };
+        if family == IpFamily::V4
+            && control_header.cmsg_level == libc::IPPROTO_IP
+            && control_header.cmsg_type == libc::IP_PKTINFO
+            && control_header.cmsg_len
+                >= unsafe { libc::CMSG_LEN(std::mem::size_of::<libc::in_pktinfo>() as _) } as usize
+        {
+            let info = unsafe { &*(libc::CMSG_DATA(header).cast::<libc::in_pktinfo>()) };
+            destination = Some(IpAddr::V4(Ipv4Addr::from(
+                info.ipi_addr.s_addr.to_ne_bytes(),
+            )));
+        } else if family == IpFamily::V6
+            && control_header.cmsg_level == libc::IPPROTO_IPV6
+            && control_header.cmsg_type == libc::IPV6_PKTINFO
+            && control_header.cmsg_len
+                >= unsafe { libc::CMSG_LEN(std::mem::size_of::<libc::in6_pktinfo>() as _) } as usize
+        {
+            let info = unsafe { &*(libc::CMSG_DATA(header).cast::<libc::in6_pktinfo>()) };
+            destination = Some(IpAddr::V6(Ipv6Addr::from(info.ipi6_addr.s6_addr)));
+        }
+        header = unsafe { libc::CMSG_NXTHDR(&message, header) };
+    }
+    Ok((length as usize, source, destination))
+}
+
+#[cfg(target_os = "linux")]
+fn sockaddr_to_socket_addr(address: &libc::sockaddr_storage) -> io::Result<SocketAddr> {
+    match i32::from(address.ss_family) {
+        libc::AF_INET => {
+            let address = unsafe { &*(address as *const _ as *const libc::sockaddr_in) };
+            Ok(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(address.sin_addr.s_addr.to_ne_bytes())),
+                u16::from_be(address.sin_port),
+            ))
+        }
+        libc::AF_INET6 => {
+            let address = unsafe { &*(address as *const _ as *const libc::sockaddr_in6) };
+            Ok(SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(address.sin6_addr.s6_addr)),
+                u16::from_be(address.sin6_port),
+            ))
+        }
+        family => Err(invalid(format!(
+            "xicmp recvmsg returned unsupported address family {family}"
+        ))),
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn send_server_reply(
+    socket: &tokio::net::UdpSocket,
+    packet: &[u8],
+    target: SocketAddr,
+    source: Option<IpAddr>,
+) -> io::Result<usize> {
+    use std::os::fd::AsRawFd;
+
+    let Some(source) = source else {
+        return socket.send_to(packet, target).await;
+    };
+    loop {
+        socket.writable().await?;
+        match socket.try_io(tokio::io::Interest::WRITABLE, || {
+            sendmsg_from_source(socket.as_raw_fd(), packet, target, source)
+        }) {
+            Ok(value) => return Ok(value),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sendmsg_from_source(
+    fd: std::os::fd::RawFd,
+    packet: &[u8],
+    target: SocketAddr,
+    source: IpAddr,
+) -> io::Result<usize> {
+    if target.is_ipv4() != source.is_ipv4() {
+        return Err(invalid("xicmp reply source/target address family mismatch"));
+    }
+    let target = SockAddr::from(target);
+    let control_size = if source.is_ipv4() {
+        unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in_pktinfo>() as _) as usize }
+    } else {
+        unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::in6_pktinfo>() as _) as usize }
+    };
+    let mut control = vec![0u8; control_size];
+    let mut iovec = libc::iovec {
+        iov_base: packet.as_ptr().cast_mut().cast(),
+        iov_len: packet.len(),
+    };
+    let mut message = unsafe { std::mem::zeroed::<libc::msghdr>() };
+    message.msg_name = target.as_ptr().cast_mut().cast();
+    message.msg_namelen = target.len();
+    message.msg_iov = &mut iovec;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control.len();
+    let header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    if header.is_null() {
+        return Err(io::Error::other("failed to allocate xicmp control message"));
+    }
+    match source {
+        IpAddr::V4(source) => unsafe {
+            (*header).cmsg_level = libc::IPPROTO_IP;
+            (*header).cmsg_type = libc::IP_PKTINFO;
+            (*header).cmsg_len =
+                libc::CMSG_LEN(std::mem::size_of::<libc::in_pktinfo>() as _) as usize;
+            let info = libc::CMSG_DATA(header).cast::<libc::in_pktinfo>();
+            *info = std::mem::zeroed();
+            (*info).ipi_spec_dst.s_addr = u32::from_ne_bytes(source.octets());
+        },
+        IpAddr::V6(source) => unsafe {
+            (*header).cmsg_level = libc::IPPROTO_IPV6;
+            (*header).cmsg_type = libc::IPV6_PKTINFO;
+            (*header).cmsg_len =
+                libc::CMSG_LEN(std::mem::size_of::<libc::in6_pktinfo>() as _) as usize;
+            let info = libc::CMSG_DATA(header).cast::<libc::in6_pktinfo>();
+            *info = std::mem::zeroed();
+            (*info).ipi6_addr.s6_addr = source.octets();
+        },
+    }
+    let length = unsafe { libc::sendmsg(fd, &message, 0) };
+    if length < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(length as usize)
+    }
+}
+
+fn open_icmp_socket(
+    ipv6: bool,
+    dgram: bool,
+    receive_destination: bool,
+) -> io::Result<(
+    Arc<tokio::net::UdpSocket>,
+    crate::loopback::LoopbackUdpGuard,
+)> {
+    let domain = if ipv6 { Domain::IPV6 } else { Domain::IPV4 };
+    let kind = if dgram { Type::DGRAM } else { Type::RAW };
+    let protocol = if ipv6 {
+        Protocol::ICMPV6
+    } else {
+        Protocol::ICMPV4
+    };
+    let socket = Socket::new(domain, kind, Some(protocol))?;
+    if ipv6 {
+        socket.set_only_v6(true)?;
+    }
+    #[cfg(target_os = "linux")]
+    if receive_destination {
+        enable_destination_control(&socket, ipv6)?;
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = receive_destination;
+    socket.bind(&SockAddr::from(if ipv6 {
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+    } else {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
+    }))?;
+    socket.set_nonblocking(true)?;
+    let socket: std::net::UdpSocket = socket.into();
+    // ICMP is still an outbound IP socket and must traverse the same protector,
+    // mark and interface binding chain as UDP carriers.
+    let guard = crate::adapter::prepare_outbound_udp_socket(&socket)?;
+    Ok((Arc::new(tokio::net::UdpSocket::from_std(socket)?), guard))
+}
+
+struct XicmpClient {
+    inner: BoxedUdp,
+    ipv4: Arc<tokio::net::UdpSocket>,
+    ipv6: Arc<tokio::net::UdpSocket>,
+    // Registration is scoped to the lifetime of the ICMP carrier. Dropping it
+    // when the socket was created would make TUN self-capture detection blind.
+    _ipv4_guard: crate::loopback::LoopbackUdpGuard,
+    _ipv6_guard: crate::loopback::LoopbackUdpGuard,
+    ips: Vec<IpAddr>,
+    remote: Option<SocketAddr>,
+    client_id: [u8; CLIENT_ID],
+    id: u16,
+    sequence: Arc<AtomicU16>,
+    output: Mutex<tokio::sync::mpsc::Receiver<Vec<u8>>>,
+    closed: Arc<AtomicBool>,
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+#[async_trait]
+impl UdpSocketLike for XicmpClient {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        if payload.len() + ICMP_HEADER + CLIENT_ID > MAX_PACKET {
+            return Err(invalid(format!(
+                "xicmp packet is {} bytes; maximum payload is {}",
+                payload.len(),
+                MAX_PACKET - ICMP_HEADER - CLIENT_ID
+            )));
+        }
+        let ip = if let Some(ip) = self.ips.choose(&mut rand::thread_rng()) {
+            *ip
+        } else if let Some(remote) = self.remote {
+            remote.ip()
+        } else {
+            normalize_host(target)
+                .parse::<IpAddr>()
+                .map_err(|_| invalid(format!("xicmp target `{target}:{port}` is unresolved")))?
+        };
+        let sequence = self.sequence.fetch_add(1, Ordering::AcqRel);
+        let mut data = Vec::with_capacity(CLIENT_ID + payload.len());
+        data.extend_from_slice(&self.client_id);
+        data.extend_from_slice(payload);
+        let family = if ip.is_ipv4() {
+            IpFamily::V4
+        } else {
+            IpFamily::V6
+        };
+        let wire = encode_echo(family.request_type(), self.id, sequence, &data);
+        let address = SocketAddr::new(ip, 0);
+        match family {
+            IpFamily::V4 => self.ipv4.send_to(&wire, address).await?,
+            IpFamily::V6 => self.ipv6.send_to(&wire, address).await?,
+        };
+        Ok(payload.len())
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        let packet = self
+            .output
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        if packet.len() > output.len() {
+            return Err(invalid(format!(
+                "xicmp decoded packet is {} bytes, buffer is {}",
+                packet.len(),
+                output.len()
+            )));
+        }
+        output[..packet.len()].copy_from_slice(&packet);
+        Ok(packet.len())
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            for task in self.tasks.lock().await.drain(..) {
+                task.abort();
+            }
+        }
+        self.inner.close().await
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_receiver(
+    socket: Arc<tokio::net::UdpSocket>,
+    family: IpFamily,
+    dgram: bool,
+    id: u16,
+    client_id: [u8; CLIENT_ID],
+    sequence: Arc<AtomicU16>,
+    closed: Arc<AtomicBool>,
+    output: tokio::sync::mpsc::Sender<Vec<u8>>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut buffer = vec![0; MAX_PACKET + 64];
+        while !closed.load(Ordering::Acquire) {
+            let (length, _) = match socket.recv_from(&mut buffer).await {
+                Ok(result) => result,
+                Err(error) => {
+                    tracing::debug!(%error, ?family, "xicmp receive failed");
+                    return;
+                }
+            };
+            let echo = match decode_echo(&buffer[..length], family) {
+                Ok(echo) if echo.kind == family.reply_type() => echo,
+                _ => continue,
+            };
+            if !dgram && echo.id != id {
+                continue;
+            }
+            if sequence_distance(echo.sequence, sequence.load(Ordering::Acquire)) > SEQUENCE_WINDOW
+            {
+                continue;
+            }
+            if echo.data.len() > CLIENT_ID && echo.data[..CLIENT_ID] == client_id {
+                // Raw sockets can observe our own echo request.
+                continue;
+            }
+            if output.send(echo.data.to_vec()).await.is_err() {
+                return;
+            }
+        }
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IpFamily {
+    V4,
+    V6,
+}
+
+impl IpFamily {
+    const fn request_type(self) -> u8 {
+        match self {
+            Self::V4 => 8,
+            Self::V6 => 128,
+        }
+    }
+
+    const fn reply_type(self) -> u8 {
+        match self {
+            Self::V4 => 0,
+            Self::V6 => 129,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct EchoPacket<'a> {
+    kind: u8,
+    id: u16,
+    sequence: u16,
+    data: &'a [u8],
+}
+
+fn encode_echo(kind: u8, id: u16, sequence: u16, data: &[u8]) -> Vec<u8> {
+    let mut output = vec![0; ICMP_HEADER + data.len()];
+    output[0] = kind;
+    output[4..6].copy_from_slice(&id.to_be_bytes());
+    output[6..8].copy_from_slice(&sequence.to_be_bytes());
+    output[8..].copy_from_slice(data);
+    if matches!(kind, 0 | 8) {
+        let checksum = internet_checksum(&output);
+        output[2..4].copy_from_slice(&checksum.to_be_bytes());
+    }
+    output
+}
+
+fn decode_echo(mut wire: &[u8], family: IpFamily) -> io::Result<EchoPacket<'_>> {
+    // Linux IPv4 SOCK_RAW may include the IPv4 header, whereas ping sockets and
+    // IPv6 raw sockets expose the ICMP message directly.
+    if family == IpFamily::V4 && wire.first().is_some_and(|byte| byte >> 4 == 4) {
+        let header = usize::from(wire[0] & 0x0f) * 4;
+        if header < 20 || wire.len() < header {
+            return Err(invalid("xicmp IPv4 header is truncated"));
+        }
+        wire = &wire[header..];
+    }
+    if wire.len() < ICMP_HEADER {
+        return Err(invalid("xicmp echo header is truncated"));
+    }
+    Ok(EchoPacket {
+        kind: wire[0],
+        id: u16::from_be_bytes([wire[4], wire[5]]),
+        sequence: u16::from_be_bytes([wire[6], wire[7]]),
+        data: &wire[8..],
+    })
+}
+
+fn internet_checksum(bytes: &[u8]) -> u16 {
+    let mut sum = 0_u32;
+    for chunk in bytes.chunks(2) {
+        let word = if chunk.len() == 2 {
+            u16::from_be_bytes([chunk[0], chunk[1]])
+        } else {
+            u16::from_be_bytes([chunk[0], 0])
+        };
+        sum += u32::from(word);
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+fn sequence_distance(left: u16, right: u16) -> u16 {
+    left.wrapping_sub(right).min(right.wrapping_sub(left))
+}
+
+fn normalize_host(host: &str) -> &str {
+    host.trim()
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or_else(|| host.trim())
+}
+
+/// Server-side request state. The inbound raw socket records this by synthetic
+/// client ID and reuses the exact echo id/sequence for its reply.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServerRequest {
+    pub(crate) client_id: [u8; CLIENT_ID],
+    pub(crate) id: u16,
+    pub(crate) sequence: u16,
+    pub(crate) payload: Vec<u8>,
+    family: IpFamily,
+}
+
+pub(crate) fn decode_server_request(wire: &[u8], family_v6: bool) -> io::Result<ServerRequest> {
+    let family = if family_v6 {
+        IpFamily::V6
+    } else {
+        IpFamily::V4
+    };
+    let echo = decode_echo(wire, family)?;
+    if echo.kind != family.request_type() || echo.data.len() <= CLIENT_ID {
+        return Err(invalid("xicmp server request is not a client echo"));
+    }
+    let mut client_id = [0; CLIENT_ID];
+    client_id.copy_from_slice(&echo.data[..CLIENT_ID]);
+    Ok(ServerRequest {
+        client_id,
+        id: echo.id,
+        sequence: echo.sequence,
+        payload: echo.data[CLIENT_ID..].to_vec(),
+        family,
+    })
+}
+
+pub(crate) fn encode_server_reply(request: &ServerRequest, payload: &[u8]) -> io::Result<Vec<u8>> {
+    if payload.len() + ICMP_HEADER > MAX_PACKET {
+        return Err(invalid("xicmp server reply exceeds packet limit"));
+    }
+    Ok(encode_echo(
+        request.family.reply_type(),
+        request.id,
+        request.sequence,
+        payload,
+    ))
+}
+
+fn invalid(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipv4_client_server_wire_roundtrip_and_checksum() {
+        let id = *b"abcdefgh";
+        let mut data = id.to_vec();
+        data.extend_from_slice(b"quic packet");
+        let request = encode_echo(8, 0xabcd, 7, &data);
+        assert_eq!(internet_checksum(&request), 0);
+        let server = decode_server_request(&request, false).unwrap();
+        assert_eq!(server.client_id, id);
+        assert_eq!(server.payload, b"quic packet");
+        let reply = encode_server_reply(&server, b"response").unwrap();
+        assert_eq!(internet_checksum(&reply), 0);
+        assert_eq!(decode_echo(&reply, IpFamily::V4).unwrap().data, b"response");
+    }
+
+    #[test]
+    fn ipv6_client_server_wire_roundtrip() {
+        let mut data = b"12345678".to_vec();
+        data.extend_from_slice(b"payload");
+        let request = encode_echo(128, 42, 65535, &data);
+        let server = decode_server_request(&request, true).unwrap();
+        assert_eq!(server.payload, b"payload");
+        let reply = encode_server_reply(&server, b"answer").unwrap();
+        let echo = decode_echo(&reply, IpFamily::V6).unwrap();
+        assert_eq!((echo.kind, echo.id, echo.sequence), (129, 42, 65535));
+        assert_eq!(echo.data, b"answer");
+    }
+
+    #[test]
+    fn sequence_window_handles_u16_wrap_and_malformed_packets() {
+        assert_eq!(sequence_distance(2, 65534), 4);
+        assert!(sequence_distance(2000, 0) > SEQUENCE_WINDOW);
+        assert!(decode_server_request(&[8, 0], false).is_err());
+        assert!(decode_server_request(&encode_echo(8, 1, 1, b"12345678"), false).is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn linux_pktinfo_receives_destination_and_selects_reply_source() {
+        let raw = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+        enable_destination_control(&raw, false).unwrap();
+        raw.bind(&SockAddr::from(
+            "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        ))
+        .unwrap();
+        raw.set_nonblocking(true).unwrap();
+        let server_addr = raw.local_addr().unwrap().as_socket().unwrap();
+        let raw: std::net::UdpSocket = raw.into();
+        let server = tokio::net::UdpSocket::from_std(raw).unwrap();
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.send_to(b"request", server_addr).await.unwrap();
+
+        let mut request = [0u8; 32];
+        let (length, source, destination) =
+            recv_server_request(&server, &mut request, IpFamily::V4)
+                .await
+                .unwrap();
+        assert_eq!(&request[..length], b"request");
+        assert_eq!(destination, Some("127.0.0.1".parse().unwrap()));
+        send_server_reply(&server, b"reply", source, destination)
+            .await
+            .unwrap();
+        let mut reply = [0u8; 32];
+        let (length, reply_source) = client.recv_from(&mut reply).await.unwrap();
+        assert_eq!(&reply[..length], b"reply");
+        assert_eq!(reply_source, server_addr);
+    }
+}

--- a/crates/core-outbound/src/transport/finalmask/xmc.rs
+++ b/crates/core-outbound/src/transport/finalmask/xmc.rs
@@ -1,0 +1,580 @@
+use std::{
+    collections::HashMap,
+    io::Cursor,
+    net::SocketAddr,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use aes::{
+    Aes128,
+    cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray},
+};
+use core_config::XmcMaskConfig;
+use num_bigint_dig::prime::probably_prime;
+use parking_lot::Mutex;
+use rand::{Rng, RngCore, rngs::OsRng};
+use rsa::{
+    BigUint, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey,
+    pkcs8::{EncodePublicKey, spki::Document},
+};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::adapter::BoxedStream;
+
+struct KeyMaterial {
+    private: RsaPrivateKey,
+    public: RsaPublicKey,
+    der: Vec<u8>,
+}
+
+static KEY_CACHE: LazyLock<Mutex<HashMap<String, Arc<KeyMaterial>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(super) async fn wrap_client(
+    mut stream: BoxedStream,
+    config: &XmcMaskConfig,
+    remote: Option<SocketAddr>,
+    remote_host: &str,
+    remote_port: u16,
+) -> std::io::Result<BoxedStream> {
+    let password = config.password.clone();
+    let key = key_material(&password).await?;
+    let usernames = if config.usernames.is_empty() {
+        vec!["Dream".to_string()]
+    } else {
+        config.usernames.clone()
+    };
+    let fallback_hostname;
+    let hostname = if config.hostname.is_empty() {
+        fallback_hostname = remote
+            .map(|addr| addr.ip().to_string())
+            .unwrap_or_else(|| remote_host.to_string());
+        fallback_hostname.as_str()
+    } else {
+        &config.hostname
+    };
+    let server_port = remote.map(|addr| addr.port()).unwrap_or(remote_port);
+    let secret = tokio::time::timeout(
+        Duration::from_secs(30),
+        handshake(
+            &mut stream,
+            hostname,
+            server_port,
+            &usernames,
+            &password,
+            &key,
+        ),
+    )
+    .await
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "xmc handshake timed out"))??;
+    Ok(encrypted_bridge(stream, secret))
+}
+
+pub(super) async fn wrap_server(
+    mut stream: BoxedStream,
+    config: &XmcMaskConfig,
+) -> std::io::Result<BoxedStream> {
+    if config.password.is_empty() {
+        return Err(invalid("xmc password must not be empty"));
+    }
+    let key = key_material(&config.password).await?;
+    let secret = tokio::time::timeout(
+        Duration::from_secs(30),
+        server_handshake(&mut stream, &config.password, &key),
+    )
+    .await
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "xmc handshake timed out"))??;
+    Ok(encrypted_bridge(stream, secret))
+}
+
+async fn key_material(password: &str) -> std::io::Result<Arc<KeyMaterial>> {
+    if let Some(key) = KEY_CACHE.lock().get(password).cloned() {
+        return Ok(key);
+    }
+    let password_for_task = password.to_string();
+    let key = tokio::task::spawn_blocking(move || derive_key_material(&password_for_task))
+        .await
+        .map_err(|error| other(format!("xmc key derivation task: {error}")))??;
+    let key = Arc::new(key);
+    KEY_CACHE.lock().insert(password.to_string(), key.clone());
+    Ok(key)
+}
+
+async fn handshake(
+    stream: &mut BoxedStream,
+    hostname: &str,
+    remote_port: u16,
+    usernames: &[String],
+    password: &str,
+    key: &KeyMaterial,
+) -> std::io::Result<[u8; 16]> {
+    let mut fields = Vec::new();
+    put_varint(&mut fields, 775);
+    put_string(&mut fields, hostname)?;
+    fields.extend_from_slice(&remote_port.to_be_bytes());
+    put_varint(&mut fields, 2);
+    write_packet(stream, 0, &fields).await?;
+
+    let username = usernames
+        .get(rand::thread_rng().gen_range(0..usernames.len()))
+        .ok_or_else(|| invalid("xmc usernames must not be empty"))?;
+    let mut login = Vec::new();
+    put_string(&mut login, username)?;
+    login.extend_from_slice(&offline_uuid(username));
+    write_packet(stream, 0, &login).await?;
+
+    let (packet_id, packet) = read_packet(stream).await?;
+    if packet_id != 1 {
+        return Err(invalid(format!(
+            "xmc expected encryption request packet 1, got {packet_id}"
+        )));
+    }
+    let mut cursor = Cursor::new(packet.as_slice());
+    let _server_id = take_string(&mut cursor)?;
+    let public_key = take_bytes(&mut cursor)?;
+    let mut verify_token = take_bytes(&mut cursor)?;
+    if public_key != key.der {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "xmc server public key mismatch",
+        ));
+    }
+
+    let mut secret = [0u8; 16];
+    OsRng.fill_bytes(&mut secret);
+    let encrypted_secret = key
+        .public
+        .encrypt(&mut OsRng, Pkcs1v15Encrypt, &secret)
+        .map_err(other)?;
+    verify_token.extend_from_slice(password.as_bytes());
+    let encrypted_token = key
+        .public
+        .encrypt(&mut OsRng, Pkcs1v15Encrypt, &verify_token)
+        .map_err(other)?;
+    let mut response = Vec::new();
+    put_bytes(&mut response, &encrypted_secret)?;
+    put_bytes(&mut response, &encrypted_token)?;
+    write_packet(stream, 1, &response).await?;
+    Ok(secret)
+}
+
+async fn server_handshake(
+    stream: &mut BoxedStream,
+    password: &str,
+    key: &KeyMaterial,
+) -> std::io::Result<[u8; 16]> {
+    let (packet_id, packet) = read_packet(stream).await?;
+    if packet_id != 0 {
+        return Err(invalid("xmc expected handshake packet 0"));
+    }
+    let mut cursor = Cursor::new(packet.as_slice());
+    let _protocol_version = take_varint(&mut cursor)?;
+    let _server_address = take_string(&mut cursor)?;
+    let mut port = [0u8; 2];
+    std::io::Read::read_exact(&mut cursor, &mut port)?;
+    let next_state = take_varint(&mut cursor)?;
+    match next_state {
+        1 => {
+            serve_status_ping(stream).await?;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "xmc status ping completed",
+            ))
+        }
+        2 => server_login(stream, password, key).await,
+        other => Err(invalid(format!("xmc invalid next state {other}"))),
+    }
+}
+
+async fn serve_status_ping(stream: &mut BoxedStream) -> std::io::Result<()> {
+    const STATUS: &str = r#"{"description":"A Minecraft Server","players":{"max":20,"online":0},"version":{"name":"26.1.2","protocol":775},"enforcesSecureChat":true}"#;
+    for _ in 0..2 {
+        let (packet_id, packet) = read_packet(stream).await?;
+        match packet_id {
+            0 => {
+                let mut response = Vec::new();
+                put_string(&mut response, STATUS)?;
+                write_packet(stream, 0, &response).await?;
+            }
+            1 => {
+                if packet.len() != 8 {
+                    return Err(invalid("xmc ping payload must be 8 bytes"));
+                }
+                write_packet(stream, 1, &packet).await?;
+            }
+            other => return Err(invalid(format!("xmc invalid status packet {other}"))),
+        }
+    }
+    Ok(())
+}
+
+async fn server_login(
+    stream: &mut BoxedStream,
+    password: &str,
+    key: &KeyMaterial,
+) -> std::io::Result<[u8; 16]> {
+    let (packet_id, packet) = read_packet(stream).await?;
+    if packet_id != 0 {
+        return Err(invalid("xmc expected login start packet 0"));
+    }
+    let mut cursor = Cursor::new(packet.as_slice());
+    let _username = take_string(&mut cursor)?;
+    let mut uuid = [0u8; 16];
+    std::io::Read::read_exact(&mut cursor, &mut uuid)?;
+
+    let mut verify_token = [0u8; 4];
+    OsRng.fill_bytes(&mut verify_token);
+    let mut request = Vec::new();
+    put_string(&mut request, "")?;
+    put_bytes(&mut request, &key.der)?;
+    put_bytes(&mut request, &verify_token)?;
+    put_varint(&mut request, 1);
+    write_packet(stream, 1, &request).await?;
+
+    let (packet_id, packet) = read_packet(stream).await?;
+    if packet_id != 1 {
+        return Err(invalid("xmc expected encryption response packet 1"));
+    }
+    let mut cursor = Cursor::new(packet.as_slice());
+    let encrypted_secret = take_bytes(&mut cursor)?;
+    let encrypted_token = take_bytes(&mut cursor)?;
+    let secret = key
+        .private
+        .decrypt(Pkcs1v15Encrypt, &encrypted_secret)
+        .map_err(other)?;
+    let token = key
+        .private
+        .decrypt(Pkcs1v15Encrypt, &encrypted_token)
+        .map_err(other)?;
+    if token.len() < verify_token.len()
+        || !constant_time_eq(&token[..verify_token.len()], &verify_token)
+        || !constant_time_eq(&token[verify_token.len()..], password.as_bytes())
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "xmc verify token or password mismatch",
+        ));
+    }
+    secret
+        .try_into()
+        .map_err(|_| invalid("xmc shared secret must be exactly 16 bytes"))
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let mut different = left.len() ^ right.len();
+    for index in 0..left.len().max(right.len()) {
+        different |= usize::from(
+            left.get(index).copied().unwrap_or(0) ^ right.get(index).copied().unwrap_or(0),
+        );
+    }
+    different == 0
+}
+
+fn encrypted_bridge(inner: BoxedStream, secret: [u8; 16]) -> BoxedStream {
+    let (client, worker) = tokio::io::duplex(64 * 1024);
+    let (mut app_read, mut app_write) = tokio::io::split(worker);
+    let (mut raw_read, mut raw_write) = tokio::io::split(inner);
+    tokio::spawn(async move {
+        let mut cipher = Cfb8::new(secret, false);
+        let mut buffer = vec![0; 32 * 1024];
+        let result = async {
+            loop {
+                let count = app_read.read(&mut buffer).await?;
+                if count == 0 {
+                    raw_write.shutdown().await?;
+                    return Ok::<_, std::io::Error>(());
+                }
+                cipher.apply(&mut buffer[..count]);
+                raw_write.write_all(&buffer[..count]).await?;
+            }
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%error, "finalmask xmc encryptor stopped");
+        }
+    });
+    tokio::spawn(async move {
+        let mut cipher = Cfb8::new(secret, true);
+        let mut buffer = vec![0; 32 * 1024];
+        let result = async {
+            loop {
+                let count = raw_read.read(&mut buffer).await?;
+                if count == 0 {
+                    app_write.shutdown().await?;
+                    return Ok::<_, std::io::Error>(());
+                }
+                cipher.apply(&mut buffer[..count]);
+                app_write.write_all(&buffer[..count]).await?;
+            }
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%error, "finalmask xmc decryptor stopped");
+        }
+    });
+    Box::pin(client)
+}
+
+struct Cfb8 {
+    cipher: Aes128,
+    iv: [u8; 16],
+    decrypt: bool,
+}
+
+impl Cfb8 {
+    fn new(secret: [u8; 16], decrypt: bool) -> Self {
+        Self {
+            cipher: Aes128::new(GenericArray::from_slice(&secret)),
+            iv: secret,
+            decrypt,
+        }
+    }
+
+    fn apply(&mut self, bytes: &mut [u8]) {
+        for byte in bytes {
+            let ciphertext = *byte;
+            let mut block = GenericArray::clone_from_slice(&self.iv);
+            self.cipher.encrypt_block(&mut block);
+            *byte ^= block[0];
+            self.iv.copy_within(1.., 0);
+            self.iv[15] = if self.decrypt { ciphertext } else { *byte };
+        }
+    }
+}
+
+fn derive_key_material(password: &str) -> std::io::Result<KeyMaterial> {
+    let private = derive_private_key(password)?;
+    let public = private.to_public_key();
+    let der: Document = public.to_public_key_der().map_err(other)?;
+    Ok(KeyMaterial {
+        private,
+        public,
+        der: der.as_bytes().to_vec(),
+    })
+}
+
+fn derive_private_key(password: &str) -> std::io::Result<RsaPrivateKey> {
+    let p = derive_prime(format!("{password}-p-prime").as_bytes());
+    let mut q = derive_prime(format!("{password}-q-prime").as_bytes());
+    while p == q {
+        q += 2u8;
+        while !acceptable_prime(&q) {
+            q += 2u8;
+        }
+    }
+    RsaPrivateKey::from_primes(vec![p, q], BigUint::from(65537u32)).map_err(other)
+}
+
+fn derive_prime(seed: &[u8]) -> BigUint {
+    let mut bytes = [0u8; 64];
+    let mut offset = 0;
+    let mut counter = 0u64;
+    while offset < bytes.len() {
+        let mut hash = Sha256::new();
+        hash.update(seed);
+        hash.update(format!("-{counter}").as_bytes());
+        counter += 1;
+        let block = hash.finalize();
+        let count = (bytes.len() - offset).min(block.len());
+        bytes[offset..offset + count].copy_from_slice(&block[..count]);
+        offset += count;
+    }
+    bytes[0] |= 0xc0;
+    bytes[63] |= 1;
+    let mut prime = BigUint::from_bytes_be(&bytes);
+    while !acceptable_prime(&prime) {
+        prime += 2u8;
+    }
+    prime
+}
+
+fn acceptable_prime(value: &BigUint) -> bool {
+    probably_prime(value, 20)
+        && ((value - BigUint::from(1u8)) % BigUint::from(65537u32)) != BigUint::from(0u8)
+}
+
+fn offline_uuid(username: &str) -> [u8; 16] {
+    let hash = Sha256::digest(format!("OfflinePlayer:{username}").as_bytes());
+    let mut uuid: [u8; 16] = hash[..16].try_into().expect("sha prefix");
+    uuid[6] = (uuid[6] & 0x0f) | 0x30;
+    uuid[8] = (uuid[8] & 0x3f) | 0x80;
+    uuid
+}
+
+async fn write_packet(
+    stream: &mut BoxedStream,
+    packet_id: i32,
+    fields: &[u8],
+) -> std::io::Result<()> {
+    let mut packet = Vec::new();
+    put_varint(
+        &mut packet,
+        varint_size(packet_id) as i32 + fields.len() as i32,
+    );
+    put_varint(&mut packet, packet_id);
+    packet.extend_from_slice(fields);
+    stream.write_all(&packet).await
+}
+
+async fn read_packet(stream: &mut BoxedStream) -> std::io::Result<(i32, Vec<u8>)> {
+    let length = read_varint_async(stream).await?;
+    if !(0..=32 * 1024).contains(&length) {
+        return Err(invalid(format!("xmc packet has invalid length {length}")));
+    }
+    let mut packet = vec![0; length as usize];
+    stream.read_exact(&mut packet).await?;
+    let mut cursor = Cursor::new(packet.as_slice());
+    let packet_id = take_varint(&mut cursor)?;
+    let consumed = cursor.position() as usize;
+    Ok((packet_id, packet[consumed..].to_vec()))
+}
+
+async fn read_varint_async(stream: &mut BoxedStream) -> std::io::Result<i32> {
+    let mut value = 0i32;
+    for position in (0..32).step_by(7) {
+        let byte = stream.read_u8().await?;
+        value |= i32::from(byte & 0x7f) << position;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(invalid("xmc varint is too large"))
+}
+
+fn put_varint(output: &mut Vec<u8>, mut value: i32) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        output.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+fn varint_size(mut value: i32) -> usize {
+    let mut size = 1;
+    while {
+        value >>= 7;
+        value != 0
+    } {
+        size += 1;
+    }
+    size
+}
+
+fn put_string(output: &mut Vec<u8>, value: &str) -> std::io::Result<()> {
+    if value.len() > 4096 {
+        return Err(invalid("xmc string exceeds 4096 bytes"));
+    }
+    put_varint(output, value.len() as i32);
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn put_bytes(output: &mut Vec<u8>, value: &[u8]) -> std::io::Result<()> {
+    if value.len() >= 1024 {
+        return Err(invalid("xmc byte string exceeds protocol limit"));
+    }
+    put_varint(output, value.len() as i32);
+    output.extend_from_slice(value);
+    Ok(())
+}
+
+fn take_varint(cursor: &mut Cursor<&[u8]>) -> std::io::Result<i32> {
+    let mut value = 0i32;
+    for position in (0..32).step_by(7) {
+        let mut byte = [0];
+        std::io::Read::read_exact(cursor, &mut byte)?;
+        value |= i32::from(byte[0] & 0x7f) << position;
+        if byte[0] & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(invalid("xmc varint is too large"))
+}
+
+fn take_string(cursor: &mut Cursor<&[u8]>) -> std::io::Result<String> {
+    let length = take_varint(cursor)?;
+    if !(0..=4096).contains(&length) {
+        return Err(invalid("xmc string length is invalid"));
+    }
+    let mut bytes = vec![0; length as usize];
+    std::io::Read::read_exact(cursor, &mut bytes)?;
+    String::from_utf8(bytes).map_err(invalid)
+}
+
+fn take_bytes(cursor: &mut Cursor<&[u8]>) -> std::io::Result<Vec<u8>> {
+    let length = take_varint(cursor)?;
+    if !(0..1024).contains(&length) {
+        return Err(invalid("xmc byte string length is invalid"));
+    }
+    let mut bytes = vec![0; length as usize];
+    std::io::Read::read_exact(cursor, &mut bytes)?;
+    Ok(bytes)
+}
+
+fn invalid(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+}
+
+fn other(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+
+    #[test]
+    fn official_private_key_derivation_golden() {
+        let key = derive_private_key("deterministic-rsa-key-golden").unwrap();
+        let der = key.to_pkcs1_der().unwrap();
+        assert_eq!(
+            hex::encode(Sha256::digest(der.as_bytes())),
+            "3a8c4ad56a6fb42dab73c4d5fc3af754460a2db1441edc0970cbc7f4e0798d2f"
+        );
+    }
+
+    #[test]
+    fn cfb8_roundtrip_across_unequal_chunks() {
+        let secret = [7u8; 16];
+        let mut encrypted = b"minecraft-compatible-cfb8".to_vec();
+        Cfb8::new(secret, false).apply(&mut encrypted);
+        let mut decrypt = Cfb8::new(secret, true);
+        decrypt.apply(&mut encrypted[..3]);
+        decrypt.apply(&mut encrypted[3..]);
+        assert_eq!(&encrypted, b"minecraft-compatible-cfb8");
+    }
+
+    #[tokio::test]
+    async fn client_and_server_handshake_then_proxy_bidirectionally() {
+        let config = XmcMaskConfig {
+            hostname: "mc.example".into(),
+            usernames: vec!["Dream".into()],
+            password: "xmc-client-server-test".into(),
+        };
+        let (left, right) = tokio::io::duplex(64 * 1024);
+        let client = wrap_client(Box::pin(left), &config, None, "mc.example", 25565);
+        let server = wrap_server(Box::pin(right), &config);
+        let (client, server) = tokio::join!(client, server);
+        let mut client = client.unwrap();
+        let mut server = server.unwrap();
+
+        client.write_all(b"request").await.unwrap();
+        let mut request = [0; 7];
+        server.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"request");
+
+        server.write_all(b"response").await.unwrap();
+        let mut response = [0; 8];
+        client.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"response");
+    }
+}

--- a/crates/core-outbound/src/transport/mod.rs
+++ b/crates/core-outbound/src/transport/mod.rs
@@ -19,10 +19,12 @@ use crate::adapter::BoxedStream;
 pub(crate) mod boring_tls;
 mod browser_identity;
 pub(crate) mod ech;
+pub mod finalmask;
 pub mod grpc_transport;
 pub mod h2_transport;
 pub mod http_transport;
 pub mod reality;
+#[allow(unsafe_code)]
 pub mod tcp;
 pub mod tls;
 mod utls;

--- a/crates/core-outbound/src/transport/reality.rs
+++ b/crates/core-outbound/src/transport/reality.rs
@@ -74,10 +74,28 @@ impl Transport for RealityTransport {
                 }
             };
             let _ = stream.set_nodelay(true);
+            let local_addr = stream.local_addr().ok();
+            let mut carrier: BoxedStream = Box::pin(stream);
+            if let Some(masks) = crate::socket_policy::current()
+                .as_ref()
+                .and_then(|policy| policy.settings.finalmask.as_ref())
+                .map(|finalmask| finalmask.tcp.as_slice())
+                .filter(|masks| !masks.is_empty())
+            {
+                carrier = crate::transport::finalmask::wrap_tcp_client(
+                    carrier,
+                    masks,
+                    local_addr,
+                    Some(address),
+                    host,
+                    port,
+                )
+                .await?;
+            }
             let lifetime: RealityConnectionLifetime = Arc::new(guard);
             match self
                 .client
-                .connect_with_lifetime(stream, Some(lifetime))
+                .connect_io_with_lifetime(carrier, Some(lifetime))
                 .await
             {
                 Ok(stream) => {

--- a/crates/core-outbound/src/transport/tcp.rs
+++ b/crates/core-outbound/src/transport/tcp.rs
@@ -1,8 +1,18 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::VecDeque,
+    net::{IpAddr, SocketAddr},
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
-use socket2::{Domain, Protocol, Socket, Type};
-use tokio::net::TcpStream;
+use core_config::{AddressPortStrategy, DomainStrategy, HappyEyeballsConfig, OutboundSocketConfig};
+use hickory_resolver::TokioAsyncResolver;
+use rand::Rng;
+use socket2::{Domain, Protocol, Socket, TcpKeepalive, Type};
+use tokio::{
+    net::{TcpListener, TcpStream, UdpSocket},
+    task::JoinSet,
+};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -11,18 +21,17 @@ use crate::{
         resolve_host_for_direct,
     },
     loopback::{LoopbackTcpGuard, TrackedTcpStream, register_tcp},
+    socket_policy,
     transport::Transport,
 };
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TcpTransport {
-    /// 若为 true，解析走 `resolve_host_for_direct`（mihomo `DirectHostResolver`），
-    /// 避开 fake-ip / 业务 policy；用于 DIRECT 出站。
+    /// DIRECT resolves through the direct-nameserver group.
     for_direct: bool,
 }
 
 impl TcpTransport {
-    /// DIRECT 出站专用：解析走 direct-nameserver group。
     pub fn for_direct() -> Self {
         Self { for_direct: true }
     }
@@ -31,103 +40,1200 @@ impl TcpTransport {
 #[async_trait]
 impl Transport for TcpTransport {
     async fn connect(&self, host: &str, port: u16) -> std::io::Result<BoxedStream> {
-        let started = Instant::now();
-        debug!(target: "dial::tcp", %host, port, for_direct = self.for_direct, "begin");
-        let addrs = if self.for_direct {
-            resolve_host_for_direct(host, port).await?
-        } else {
-            resolve_host(host, port).await?
-        };
-        let mut last_err: Option<std::io::Error> = None;
-        let mut tried = 0usize;
-        for addr in &addrs {
-            tried += 1;
-            let t = Instant::now();
-            match marked_connect(*addr, Duration::from_secs(10)).await {
-                Ok(s) => {
-                    let _ = s.set_nodelay(true);
-                    info!(
-                        target: "dial::tcp",
-                        %host, port,
-                        peer = %addr,
-                        attempt = tried,
-                        connect_ms = t.elapsed().as_millis() as u64,
-                        total_ms = started.elapsed().as_millis() as u64,
-                        "connected",
-                    );
-                    return Ok(Box::pin(s));
-                }
-                Err(e) => {
-                    debug!(
-                        target: "dial::tcp",
-                        %host, port,
-                        peer = %addr,
-                        attempt = tried,
-                        error = %e,
-                        "connect attempt failed",
-                    );
-                    last_err = Some(e);
-                }
-            }
-        }
-        let total_ms = started.elapsed().as_millis() as u64;
-        warn!(
-            target: "dial::tcp",
-            %host, port,
-            tried, total_ms,
-            "all candidates failed",
-        );
-        Err(last_err.unwrap_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::AddrNotAvailable,
-                format!("connect: no usable address for {host}:{port}"),
-            )
-        }))
+        connect_boxed(host, port, self.for_direct).await
     }
 }
 
-/// 用 socket2 创建 socket → 应用 SO_MARK → connect（同步，带 spawn_blocking 包裹）→ 包成 tokio TcpStream。
-///
-/// SO_MARK 让 SYN 包带 mark，配合 root TUN 启动时探测出的默认网络路由表，
-/// 绕开 TUN 自身路由表，避免 dial 时的"connect IP 又被 TUN 截走"的死循环。
+/// Unified raw carrier dial. TLS and every plain-TCP protocol use this so
+/// final masks can be inserted before TLS rather than after it.
+pub(crate) async fn connect_boxed(
+    host: &str,
+    port: u16,
+    for_direct: bool,
+) -> std::io::Result<BoxedStream> {
+    let started = Instant::now();
+    let policy = socket_policy::current();
+    let socket_cfg = policy.as_ref().and_then(|p| p.socket()).cloned();
+    let (host, port) = rewrite_address_port(host, port, socket_cfg.as_ref()).await;
+
+    if let Some(cfg) = socket_cfg.as_ref()
+        && !cfg.dialer_proxy.trim().is_empty()
+    {
+        let proxy = policy.as_ref().and_then(|p| p.proxy()).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!(
+                    "streamSettings.sockopt.dialerProxy `{}` 未注册",
+                    cfg.dialer_proxy
+                ),
+            )
+        })?;
+        let (proxy_host, proxy_port) =
+            resolve_one_for_strategy(&host, port, for_direct, cfg).await?;
+        let stream =
+            socket_policy::dial_through_proxy(proxy, proxy_host.clone(), proxy_port).await?;
+        return apply_final_masks(
+            stream,
+            policy.as_deref(),
+            None,
+            None,
+            &proxy_host,
+            proxy_port,
+        )
+        .await;
+    }
+
+    let mut addrs = resolve_candidates(&host, port, for_direct, socket_cfg.as_ref()).await?;
+    let racing = socket_cfg.as_ref().is_some_and(|cfg| {
+        addrs.len() >= 2
+            && cfg.happy_eyeballs.try_delay_ms > 0
+            && cfg.happy_eyeballs.max_concurrent_try > 0
+    });
+    if !racing
+        && socket_cfg
+            .as_ref()
+            .is_some_and(|cfg| cfg.domain_strategy.use_ip())
+        && host.parse::<IpAddr>().is_err()
+    {
+        let selected = rand::thread_rng().gen_range(0..addrs.len());
+        addrs = vec![addrs[selected]];
+    }
+    let stream = if let Some(cfg) = socket_cfg.as_ref()
+        && addrs.len() >= 2
+        && cfg.happy_eyeballs.try_delay_ms > 0
+        && cfg.happy_eyeballs.max_concurrent_try > 0
+    {
+        race_connect(addrs, cfg.clone()).await?
+    } else {
+        sequential_connect(&host, port, &addrs, socket_cfg.clone(), started).await?
+    };
+    let local = stream.local_addr().ok();
+    let remote = stream.peer_addr().ok();
+    let _ = stream.set_nodelay(true);
+    apply_final_masks(
+        Box::pin(stream),
+        policy.as_deref(),
+        local,
+        remote,
+        &host,
+        port,
+    )
+    .await
+}
+
+async fn resolve_one_for_strategy(
+    host: &str,
+    port: u16,
+    for_direct: bool,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<(String, u16)> {
+    if !cfg.domain_strategy.use_ip() || host.parse::<IpAddr>().is_ok() {
+        return Ok((host.to_string(), port));
+    }
+    let addrs = resolve_candidates(host, port, for_direct, Some(cfg)).await?;
+    let selected = rand::thread_rng().gen_range(0..addrs.len());
+    let selected = addrs[selected];
+    Ok((selected.ip().to_string(), selected.port()))
+}
+
+async fn apply_final_masks(
+    stream: BoxedStream,
+    policy: Option<&socket_policy::ActiveStreamPolicy>,
+    local: Option<SocketAddr>,
+    remote: Option<SocketAddr>,
+    host: &str,
+    port: u16,
+) -> std::io::Result<BoxedStream> {
+    let Some(finalmask) = policy.and_then(|p| p.settings.finalmask.as_ref()) else {
+        return Ok(stream);
+    };
+    crate::transport::finalmask::wrap_tcp_client(stream, &finalmask.tcp, local, remote, host, port)
+        .await
+}
+
+async fn sequential_connect(
+    host: &str,
+    port: u16,
+    addrs: &[SocketAddr],
+    cfg: Option<OutboundSocketConfig>,
+    started: Instant,
+) -> std::io::Result<TrackedTcpStream<TcpStream>> {
+    let mut last_err = None;
+    for (index, addr) in addrs.iter().copied().enumerate() {
+        let attempt_started = Instant::now();
+        match marked_connect_with_config(addr, Duration::from_secs(10), cfg.clone()).await {
+            Ok(stream) => {
+                info!(
+                    target: "dial::tcp",
+                    %host,
+                    port,
+                    peer = %addr,
+                    attempt = index + 1,
+                    connect_ms = attempt_started.elapsed().as_millis() as u64,
+                    total_ms = started.elapsed().as_millis() as u64,
+                    "connected",
+                );
+                return Ok(stream);
+            }
+            Err(error) => {
+                debug!(
+                    target: "dial::tcp",
+                    %host,
+                    port,
+                    peer = %addr,
+                    attempt = index + 1,
+                    %error,
+                    "connect attempt failed",
+                );
+                last_err = Some(error);
+            }
+        }
+    }
+    warn!(target: "dial::tcp", %host, port, tried = addrs.len(), "all candidates failed");
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            format!("connect: no usable address for {host}:{port}"),
+        )
+    }))
+}
+
+async fn resolve_candidates(
+    host: &str,
+    port: u16,
+    for_direct: bool,
+    cfg: Option<&OutboundSocketConfig>,
+) -> std::io::Result<Vec<SocketAddr>> {
+    let strategy = cfg.map(|c| c.domain_strategy).unwrap_or_default();
+    let primary = if for_direct {
+        resolve_host_for_direct(host, port).await
+    } else {
+        resolve_host(host, port).await
+    };
+    let mut addrs = match primary {
+        Ok(addrs) => addrs,
+        Err(primary_error) if strategy.use_ip() && !strategy.force() => {
+            tokio::net::lookup_host((host, port))
+                .await
+                .map(|iter| iter.collect())
+                .map_err(|fallback_error| {
+                    std::io::Error::new(
+                        fallback_error.kind(),
+                        format!(
+                            "domainStrategy lookup failed ({primary_error}); system fallback failed: {fallback_error}"
+                        ),
+                    )
+                })?
+        }
+        Err(error) => return Err(error),
+    };
+
+    if strategy.use_ip() {
+        addrs.retain(|addr| match addr.ip() {
+            IpAddr::V4(_) => strategy.allow_ipv4(),
+            IpAddr::V6(_) => strategy.allow_ipv6(),
+        });
+        if strategy.prefer_ipv6() {
+            addrs.sort_by_key(|addr| usize::from(addr.is_ipv4()));
+        } else if matches!(
+            strategy,
+            DomainStrategy::UseIpv4v6 | DomainStrategy::ForceIpv4v6
+        ) {
+            addrs.sort_by_key(|addr| usize::from(addr.is_ipv6()));
+        }
+    }
+    if addrs.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            format!("domainStrategy {strategy:?} returned no usable address for {host}"),
+        ));
+    }
+    Ok(addrs)
+}
+
+async fn rewrite_address_port(
+    host: &str,
+    port: u16,
+    cfg: Option<&OutboundSocketConfig>,
+) -> (String, u16) {
+    let Some(cfg) = cfg else {
+        return (host.to_string(), port);
+    };
+    let strategy = cfg.address_port_strategy;
+    if strategy == AddressPortStrategy::None || host.parse::<IpAddr>().is_ok() {
+        return (host.to_string(), port);
+    }
+    let resolver = match TokioAsyncResolver::tokio_from_system_conf() {
+        Ok(resolver) => resolver,
+        Err(error) => {
+            warn!(%error, "addressPortStrategy resolver initialization failed; keeping original target");
+            return (host.to_string(), port);
+        }
+    };
+    let result = match strategy {
+        AddressPortStrategy::SrvPortOnly
+        | AddressPortStrategy::SrvAddressOnly
+        | AddressPortStrategy::SrvPortAndAddress => {
+            let lookup = resolver.srv_lookup(host).await;
+            lookup.map(|records| {
+                records.iter().next().map(|record| {
+                    (
+                        record.target().to_utf8().trim_end_matches('.').to_string(),
+                        record.port(),
+                    )
+                })
+            })
+        }
+        AddressPortStrategy::TxtPortOnly
+        | AddressPortStrategy::TxtAddressOnly
+        | AddressPortStrategy::TxtPortAndAddress => {
+            resolver.txt_lookup(host).await.map(|records| {
+                records.iter().find_map(|record| {
+                    let value = record
+                        .txt_data()
+                        .iter()
+                        .flat_map(|part| part.iter().copied())
+                        .collect::<Vec<_>>();
+                    parse_txt_target(&String::from_utf8_lossy(&value))
+                })
+            })
+        }
+        AddressPortStrategy::None => unreachable!(),
+    };
+    let replacement = match result {
+        Ok(Some(value)) => value,
+        Ok(None) => return (host.to_string(), port),
+        Err(error) => {
+            // Xray deliberately falls back to the original destination when
+            // the optional override lookup fails.
+            warn!(%host, ?strategy, %error, "addressPortStrategy lookup failed; keeping original target");
+            return (host.to_string(), port);
+        }
+    };
+    let replace_address = matches!(
+        strategy,
+        AddressPortStrategy::SrvAddressOnly
+            | AddressPortStrategy::SrvPortAndAddress
+            | AddressPortStrategy::TxtAddressOnly
+            | AddressPortStrategy::TxtPortAndAddress
+    );
+    let replace_port = matches!(
+        strategy,
+        AddressPortStrategy::SrvPortOnly
+            | AddressPortStrategy::SrvPortAndAddress
+            | AddressPortStrategy::TxtPortOnly
+            | AddressPortStrategy::TxtPortAndAddress
+    );
+    (
+        if replace_address {
+            replacement.0
+        } else {
+            host.to_string()
+        },
+        if replace_port { replacement.1 } else { port },
+    )
+}
+
+fn parse_txt_target(value: &str) -> Option<(String, u16)> {
+    let value = value.trim();
+    if let Ok(addr) = value.parse::<SocketAddr>() {
+        return Some((addr.ip().to_string(), addr.port()));
+    }
+    let (host, port) = value.rsplit_once(':')?;
+    let port = port.parse().ok()?;
+    let host = host.trim_matches(|c| c == '[' || c == ']');
+    (!host.is_empty()).then(|| (host.to_string(), port))
+}
+
+fn interleave_addresses(
+    addrs: Vec<SocketAddr>,
+    prioritize_ipv6: bool,
+    interleave: u32,
+) -> Vec<SocketAddr> {
+    let (v6, v4): (Vec<_>, Vec<_>) = addrs.into_iter().partition(SocketAddr::is_ipv6);
+    if v4.is_empty() || v6.is_empty() {
+        return v4.into_iter().chain(v6).collect();
+    }
+    let (mut first, mut second) = if prioritize_ipv6 {
+        (VecDeque::from(v6), VecDeque::from(v4))
+    } else {
+        (VecDeque::from(v4), VecDeque::from(v6))
+    };
+    if interleave == 0 {
+        return first.into_iter().chain(second).collect();
+    }
+    let mut out = Vec::with_capacity(first.len() + second.len());
+    let take = interleave.max(1) as usize;
+    while !first.is_empty() && !second.is_empty() {
+        for _ in 0..take {
+            if let Some(addr) = first.pop_front() {
+                out.push(addr);
+            }
+        }
+        std::mem::swap(&mut first, &mut second);
+    }
+    out.extend(first);
+    out.extend(second);
+    out
+}
+
+async fn race_connect(
+    addrs: Vec<SocketAddr>,
+    cfg: OutboundSocketConfig,
+) -> std::io::Result<TrackedTcpStream<TcpStream>> {
+    let HappyEyeballsConfig {
+        prioritize_ipv6,
+        interleave,
+        try_delay_ms,
+        max_concurrent_try,
+    } = cfg.happy_eyeballs.clone();
+    let mut pending = VecDeque::from(interleave_addresses(addrs, prioritize_ipv6, interleave));
+    let max_active = max_concurrent_try.max(1) as usize;
+    let delay = Duration::from_millis(try_delay_ms);
+    let mut tasks = JoinSet::new();
+    let mut last_error = None;
+    let mut launch_at = tokio::time::Instant::now();
+
+    loop {
+        while tasks.len() < max_active && launch_at <= tokio::time::Instant::now() {
+            let Some(addr) = pending.pop_front() else {
+                break;
+            };
+            let task_cfg = cfg.clone();
+            tasks.spawn(async move {
+                (
+                    addr,
+                    marked_connect_with_config(addr, Duration::from_secs(10), Some(task_cfg)).await,
+                )
+            });
+            launch_at = tokio::time::Instant::now() + delay;
+            if delay != Duration::ZERO {
+                break;
+            }
+        }
+
+        if tasks.is_empty() {
+            if pending.is_empty() {
+                break;
+            }
+            tokio::time::sleep_until(launch_at).await;
+            continue;
+        }
+
+        if pending.is_empty() || tasks.len() >= max_active {
+            match tasks.join_next().await {
+                Some(Ok((_addr, Ok(stream)))) => {
+                    tasks.abort_all();
+                    return Ok(stream);
+                }
+                Some(Ok((_addr, Err(error)))) => {
+                    last_error = Some(error);
+                    launch_at = tokio::time::Instant::now();
+                }
+                Some(Err(error)) => {
+                    last_error = Some(std::io::Error::other(format!(
+                        "Happy Eyeballs task: {error}"
+                    )));
+                }
+                None => break,
+            }
+        } else {
+            tokio::select! {
+                joined = tasks.join_next() => match joined {
+                    Some(Ok((_addr, Ok(stream)))) => {
+                        tasks.abort_all();
+                        return Ok(stream);
+                    }
+                    Some(Ok((_addr, Err(error)))) => {
+                        last_error = Some(error);
+                        launch_at = tokio::time::Instant::now();
+                    }
+                    Some(Err(error)) => {
+                        last_error = Some(std::io::Error::other(format!("Happy Eyeballs task: {error}")));
+                    }
+                    None => break,
+                },
+                _ = tokio::time::sleep_until(launch_at) => {}
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::AddrNotAvailable,
+            "Happy Eyeballs exhausted all candidates",
+        )
+    }))
+}
+
+/// Backwards-compatible direct socket entry used by a few transport tests.
 pub async fn marked_connect(
-    addr: std::net::SocketAddr,
+    addr: SocketAddr,
     timeout: Duration,
 ) -> std::io::Result<TrackedTcpStream<TcpStream>> {
-    let (stream, guard) = marked_connect_raw(addr, timeout).await?;
+    let cfg = socket_policy::current().and_then(|p| p.socket().cloned());
+    marked_connect_with_config(addr, timeout, cfg).await
+}
+
+/// Apply the same route protection and node-scoped socket policy as
+/// [`marked_connect`], but return the concrete Tokio stream plus its loopback
+/// guard for REALITY engines that need ownership of the raw TCP type.
+pub async fn marked_connect_raw(
+    addr: SocketAddr,
+    timeout: Duration,
+) -> std::io::Result<(TcpStream, LoopbackTcpGuard)> {
+    let cfg = socket_policy::current().and_then(|p| p.socket().cloned());
+    marked_connect_raw_with_config(addr, timeout, cfg).await
+}
+
+/// Create and bind an inbound TCP listener with Xray-compatible `sockopt`
+/// semantics.  The options must be installed before `bind(2)`/`listen(2)` so
+/// TProxy, v6-only, TFO and custom socket options affect the listening socket
+/// and are inherited by accepted connections where the platform supports it.
+pub fn bind_inbound_listener(
+    addr: SocketAddr,
+    cfg: Option<&OutboundSocketConfig>,
+) -> std::io::Result<TcpListener> {
+    let domain = if addr.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let protocol = if cfg.is_some_and(|config| config.tcp_mptcp) {
+        Protocol::from(262)
+    } else {
+        Protocol::TCP
+    };
+    let socket = Socket::new(domain, Type::STREAM, Some(protocol))?;
+    // Xray's Windows setReuseAddr implementation is deliberately a no-op.
+    // Enabling SO_REUSEADDR there changes an occupied-port bind from
+    // WSAEADDRINUSE into WSAEACCES and bypasses the listener fallback path.
+    #[cfg(not(windows))]
+    socket.set_reuse_address(true)?;
+    if let Some(cfg) = cfg {
+        apply_inbound_socket_config(&socket, addr, cfg)?;
+    }
+    socket.bind(&addr.into())?;
+    socket.listen(1024)?;
+    socket.set_nonblocking(true)?;
+    TcpListener::from_std(socket.into())
+}
+
+/// Create an inbound UDP socket with the listener-relevant subset of Xray's
+/// `sockopt`.  This is used by QUIC/H3 before a FinalMask packet carrier is
+/// installed, matching `ListenSystemPacket` in Xray-core.
+pub fn bind_inbound_udp_socket(
+    addr: SocketAddr,
+    cfg: Option<&OutboundSocketConfig>,
+) -> std::io::Result<UdpSocket> {
+    let domain = if addr.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    #[cfg(not(windows))]
+    socket.set_reuse_address(true)?;
+    if let Some(cfg) = cfg {
+        if let Some(mode) = cfg.tproxy.as_deref()
+            && !matches!(
+                mode.trim().to_ascii_lowercase().as_str(),
+                "" | "off" | "tproxy" | "redirect"
+            )
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("unknown streamSettings.sockopt.tproxy mode `{mode}`"),
+            ));
+        }
+        apply_node_mark(&socket, cfg.mark)?;
+        if !cfg.interface.is_empty() {
+            bind_named_interface(&socket, addr, &cfg.interface)?;
+        }
+        if addr.is_ipv6() {
+            socket.set_only_v6(cfg.v6only)?;
+        } else if cfg.v6only {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "streamSettings.sockopt.v6only requires an IPv6 listen address",
+            ));
+        }
+        apply_inbound_tproxy(&socket, addr, cfg.tproxy.as_deref())?;
+        apply_custom_sockopts(&socket, if addr.is_ipv4() { "udp4" } else { "udp6" }, cfg)?;
+    }
+    socket.bind(&addr.into())?;
+    socket.set_nonblocking(true)?;
+    UdpSocket::from_std(socket.into())
+}
+
+fn apply_inbound_socket_config(
+    socket: &Socket,
+    addr: SocketAddr,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    if let Some(mode) = cfg.tproxy.as_deref()
+        && !matches!(
+            mode.trim().to_ascii_lowercase().as_str(),
+            "" | "off" | "tproxy" | "redirect"
+        )
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("unknown streamSettings.sockopt.tproxy mode `{mode}`"),
+        ));
+    }
+    if cfg
+        .tcp_keep_alive_idle
+        .saturating_mul(cfg.tcp_keep_alive_interval)
+        < 0
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "tcpKeepAliveIdle and tcpKeepAliveInterval must not have opposite signs",
+        ));
+    }
+    if cfg.tcp_keep_alive_idle < 0 || cfg.tcp_keep_alive_interval < 0 {
+        socket.set_keepalive(false)?;
+    } else if cfg.tcp_keep_alive_idle > 0 || cfg.tcp_keep_alive_interval > 0 {
+        socket.set_keepalive(true)?;
+        let keepalive = TcpKeepalive::new();
+        let keepalive = if cfg.tcp_keep_alive_idle > 0 {
+            keepalive.with_time(Duration::from_secs(cfg.tcp_keep_alive_idle as u64))
+        } else {
+            keepalive
+        };
+        let keepalive = if cfg.tcp_keep_alive_interval > 0 {
+            keepalive.with_interval(Duration::from_secs(cfg.tcp_keep_alive_interval as u64))
+        } else {
+            keepalive
+        };
+        socket.set_tcp_keepalive(&keepalive)?;
+    }
+
+    apply_node_mark(socket, cfg.mark)?;
+    if !cfg.interface.is_empty() {
+        bind_named_interface(socket, addr, &cfg.interface)?;
+    }
+    if addr.is_ipv6() {
+        socket.set_only_v6(cfg.v6only)?;
+    } else if cfg.v6only {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "streamSettings.sockopt.v6only requires an IPv6 listen address",
+        ));
+    }
+    apply_inbound_tcp_platform_options(socket, cfg)?;
+    apply_inbound_tproxy(socket, addr, cfg.tproxy.as_deref())?;
+    apply_custom_sockopts(socket, if addr.is_ipv4() { "tcp4" } else { "tcp6" }, cfg)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn apply_inbound_tcp_platform_options(
+    socket: &Socket,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    if cfg.tcp_fast_open.is_some() && cfg.tfo_value() != 0 {
+        raw_setsockopt_int(
+            socket,
+            libc::IPPROTO_TCP,
+            libc::TCP_FASTOPEN,
+            cfg.tfo_value().max(0),
+        )?;
+    }
+    if !cfg.tcp_congestion.is_empty() {
+        socket.set_tcp_congestion(cfg.tcp_congestion.as_bytes())?;
+    }
+    if cfg.tcp_window_clamp > 0 {
+        raw_setsockopt_int(
+            socket,
+            libc::IPPROTO_TCP,
+            libc::TCP_WINDOW_CLAMP,
+            cfg.tcp_window_clamp,
+        )?;
+    }
+    if cfg.tcp_user_timeout > 0 {
+        socket.set_tcp_user_timeout(Some(Duration::from_millis(cfg.tcp_user_timeout as u64)))?;
+    }
+    if cfg.tcp_max_seg > 0 {
+        raw_setsockopt_int(socket, libc::IPPROTO_TCP, libc::TCP_MAXSEG, cfg.tcp_max_seg)?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn apply_inbound_tcp_platform_options(
+    socket: &Socket,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    if cfg.tcp_fast_open.is_some() && cfg.tfo_value() != 0 {
+        raw_setsockopt_int(socket, 6, 15, i32::from(cfg.tfo_value() > 0))?;
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn apply_inbound_tcp_platform_options(
+    socket: &Socket,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    if cfg.tcp_fast_open.is_some() && cfg.tfo_value() != 0 {
+        // Darwin TCP_FASTOPEN with the server flag (1).
+        raw_setsockopt_int(
+            socket,
+            libc::IPPROTO_TCP,
+            0x105,
+            i32::from(cfg.tfo_value() > 0),
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "freebsd")]
+fn apply_inbound_tcp_platform_options(
+    socket: &Socket,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    if cfg.tcp_fast_open.is_some() && cfg.tfo_value() != 0 {
+        raw_setsockopt_int(socket, libc::IPPROTO_TCP, 1025, cfg.tfo_value().max(0))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    windows,
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd"
+)))]
+fn apply_inbound_tcp_platform_options(
+    _socket: &Socket,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    if cfg.tcp_fast_open.is_some() && cfg.tfo_value() != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "tcpFastOpen is unsupported on this platform",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn apply_inbound_tproxy(
+    socket: &Socket,
+    _addr: SocketAddr,
+    mode: Option<&str>,
+) -> std::io::Result<()> {
+    if mode.is_some_and(|mode| matches!(mode.to_ascii_lowercase().as_str(), "tproxy" | "redirect"))
+    {
+        raw_setsockopt_int(socket, libc::SOL_IP, libc::IP_TRANSPARENT, 1)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "freebsd")]
+fn apply_inbound_tproxy(
+    socket: &Socket,
+    addr: SocketAddr,
+    mode: Option<&str>,
+) -> std::io::Result<()> {
+    if mode.is_some_and(|mode| matches!(mode.to_ascii_lowercase().as_str(), "tproxy" | "redirect"))
+    {
+        // Xray first tries IPV6_BINDANY, then IP_BINDANY.  Select the option
+        // from the actual socket family to avoid relying on a failed probe.
+        if addr.is_ipv6() {
+            raw_setsockopt_int(socket, libc::IPPROTO_IPV6, libc::IPV6_BINDANY, 1)?;
+        } else {
+            raw_setsockopt_int(socket, libc::IPPROTO_IP, libc::IP_BINDANY, 1)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
+fn apply_inbound_tproxy(
+    _socket: &Socket,
+    _addr: SocketAddr,
+    mode: Option<&str>,
+) -> std::io::Result<()> {
+    if mode.is_some_and(|mode| matches!(mode.to_ascii_lowercase().as_str(), "tproxy" | "redirect"))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "streamSettings.sockopt.tproxy is unsupported on this platform",
+        ));
+    }
+    Ok(())
+}
+
+async fn marked_connect_with_config(
+    addr: SocketAddr,
+    timeout: Duration,
+    cfg: Option<OutboundSocketConfig>,
+) -> std::io::Result<TrackedTcpStream<TcpStream>> {
+    let (stream, guard) = marked_connect_raw_with_config(addr, timeout, cfg).await?;
     Ok(TrackedTcpStream::with_guard(stream, guard))
 }
 
-/// 与 [`marked_connect`] 相同地应用 socket 保护、路由标记和接口绑定，
-/// 但把裸 Tokio TCP 流与自抓回环 guard 分开返回。需要接管真实 TCP 类型的
-/// REALITY TLS 引擎使用此入口，并必须把 guard 保留到最终流被丢弃。
-pub async fn marked_connect_raw(
-    addr: std::net::SocketAddr,
+async fn marked_connect_raw_with_config(
+    addr: SocketAddr,
     timeout: Duration,
+    cfg: Option<OutboundSocketConfig>,
 ) -> std::io::Result<(TcpStream, LoopbackTcpGuard)> {
-    let std_stream =
-        tokio::task::spawn_blocking(move || -> std::io::Result<std::net::TcpStream> {
-            let domain = if addr.is_ipv4() {
-                Domain::IPV4
-            } else {
-                Domain::IPV6
-            };
-            let sock = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-            protect_socket(&sock)?;
-            apply_outbound_mark_for_addr(&sock, addr)?;
-            // 跨平台 OS 级出站接口绑定 —— Linux/Android SO_BINDTODEVICE +
-            // Windows IP_UNICAST_IF + macOS IP_BOUND_IF。让 socket 绕开
-            // TUN 默认路由直走物理出口，杜绝 dial 自循环。
-            crate::adapter::bind_outbound_socket(&sock, addr)?;
-            sock.connect_timeout(&addr.into(), timeout)?;
-            sock.set_nonblocking(true)?;
-            Ok(sock.into())
-        })
-        .await
-        .map_err(|e| {
-            std::io::Error::new(std::io::ErrorKind::Other, format!("spawn_blocking: {e}"))
-        })??;
+    let std_stream = tokio::task::spawn_blocking(move || {
+        let domain = if addr.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let protocol = if cfg.as_ref().is_some_and(|c| c.tcp_mptcp) {
+            Protocol::from(262)
+        } else {
+            Protocol::TCP
+        };
+        let sock = Socket::new(domain, Type::STREAM, Some(protocol))?;
+        protect_socket(&sock)?;
+        apply_outbound_mark_for_addr(&sock, addr)?;
+        crate::adapter::bind_outbound_socket(&sock, addr)?;
+        if let Some(cfg) = cfg.as_ref() {
+            apply_socket_config(&sock, addr, cfg)?;
+        }
+        sock.connect_timeout(&addr.into(), timeout)?;
+        sock.set_nonblocking(true)?;
+        Ok::<std::net::TcpStream, std::io::Error>(sock.into())
+    })
+    .await
+    .map_err(|error| std::io::Error::other(format!("spawn_blocking: {error}")))??;
     let stream = TcpStream::from_std(std_stream)?;
     let local = stream.local_addr()?;
     Ok((stream, register_tcp(local)))
+}
+
+fn apply_socket_config(
+    sock: &Socket,
+    peer: SocketAddr,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    // Chrome defaults used by Xray's net.Dialer.
+    if cfg.tcp_keep_alive_idle < 0 || cfg.tcp_keep_alive_interval < 0 {
+        sock.set_keepalive(false)?;
+    } else {
+        let idle = if cfg.tcp_keep_alive_idle > 0 {
+            cfg.tcp_keep_alive_idle as u64
+        } else {
+            45
+        };
+        let interval = if cfg.tcp_keep_alive_interval > 0 {
+            cfg.tcp_keep_alive_interval as u64
+        } else {
+            45
+        };
+        sock.set_tcp_keepalive(
+            &TcpKeepalive::new()
+                .with_time(Duration::from_secs(idle))
+                .with_interval(Duration::from_secs(interval)),
+        )?;
+    }
+
+    apply_node_mark(sock, cfg.mark)?;
+    if !cfg.interface.is_empty() {
+        bind_named_interface(sock, peer, &cfg.interface)?;
+    }
+    apply_tcp_platform_options(sock, cfg)?;
+    apply_custom_sockopts(sock, if peer.is_ipv4() { "tcp4" } else { "tcp6" }, cfg)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn apply_node_mark(sock: &Socket, mark: i32) -> std::io::Result<()> {
+    if mark != 0 {
+        raw_setsockopt_int(sock, libc::SOL_SOCKET, libc::SO_MARK, mark)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "freebsd")]
+fn apply_node_mark(sock: &Socket, mark: i32) -> std::io::Result<()> {
+    if mark != 0 {
+        raw_setsockopt_int(sock, libc::SOL_SOCKET, libc::SO_USER_COOKIE, mark)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
+fn apply_node_mark(_sock: &Socket, mark: i32) -> std::io::Result<()> {
+    if mark != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "streamSettings.sockopt.mark is unsupported on this platform",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn bind_named_interface(sock: &Socket, _peer: SocketAddr, name: &str) -> std::io::Result<()> {
+    sock.bind_device(Some(name.as_bytes()))
+}
+
+#[cfg(any(windows, target_os = "macos", target_os = "ios"))]
+fn bind_named_interface(sock: &Socket, peer: SocketAddr, name: &str) -> std::io::Result<()> {
+    let index = if_addrs::get_if_addrs()?
+        .into_iter()
+        .find(|interface| interface.name == name && interface.ip().is_ipv4() == peer.is_ipv4())
+        .and_then(|interface| interface.index)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("network interface `{name}` was not found for {peer}"),
+            )
+        })?;
+    bind_interface_index(sock, peer, index)
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    windows,
+    target_os = "macos",
+    target_os = "ios"
+)))]
+fn bind_named_interface(_sock: &Socket, _peer: SocketAddr, name: &str) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        format!("interface binding `{name}` is unsupported on this platform"),
+    ))
+}
+
+#[cfg(windows)]
+fn bind_interface_index(sock: &Socket, peer: SocketAddr, index: u32) -> std::io::Result<()> {
+    use windows_sys::Win32::Networking::WinSock::{
+        IP_UNICAST_IF, IPPROTO_IP, IPPROTO_IPV6, IPV6_UNICAST_IF,
+    };
+    if peer.is_ipv4() {
+        raw_setsockopt_u32(sock, IPPROTO_IP as i32, IP_UNICAST_IF as i32, index.to_be())
+    } else {
+        raw_setsockopt_u32(sock, IPPROTO_IPV6 as i32, IPV6_UNICAST_IF as i32, index)
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn bind_interface_index(sock: &Socket, peer: SocketAddr, index: u32) -> std::io::Result<()> {
+    if peer.is_ipv4() {
+        raw_setsockopt_u32(sock, libc::IPPROTO_IP, 25, index)
+    } else {
+        raw_setsockopt_u32(sock, libc::IPPROTO_IPV6, 125, index)
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn apply_tcp_platform_options(sock: &Socket, cfg: &OutboundSocketConfig) -> std::io::Result<()> {
+    let tfo = cfg.tfo_value();
+    if tfo != 0 {
+        raw_setsockopt_int(
+            sock,
+            libc::IPPROTO_TCP,
+            libc::TCP_FASTOPEN_CONNECT,
+            i32::from(tfo > 0),
+        )?;
+    }
+    if !cfg.tcp_congestion.is_empty() {
+        sock.set_tcp_congestion(cfg.tcp_congestion.as_bytes())?;
+    }
+    if cfg.tcp_window_clamp > 0 {
+        raw_setsockopt_int(
+            sock,
+            libc::IPPROTO_TCP,
+            libc::TCP_WINDOW_CLAMP,
+            cfg.tcp_window_clamp,
+        )?;
+    }
+    if cfg.tcp_user_timeout > 0 {
+        sock.set_tcp_user_timeout(Some(Duration::from_millis(cfg.tcp_user_timeout as u64)))?;
+    }
+    if cfg.tcp_max_seg > 0 {
+        raw_setsockopt_int(sock, libc::IPPROTO_TCP, libc::TCP_MAXSEG, cfg.tcp_max_seg)?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn apply_tcp_platform_options(sock: &Socket, cfg: &OutboundSocketConfig) -> std::io::Result<()> {
+    let tfo = cfg.tfo_value();
+    if tfo != 0 {
+        raw_setsockopt_int(sock, 6, 15, i32::from(tfo > 0))?;
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn apply_tcp_platform_options(sock: &Socket, cfg: &OutboundSocketConfig) -> std::io::Result<()> {
+    // Darwin uses TCP_FASTOPEN_CLIENT=0x02 for outbound sockets.
+    let tfo = cfg.tfo_value();
+    if tfo != 0 {
+        raw_setsockopt_int(
+            sock,
+            libc::IPPROTO_TCP,
+            0x105,
+            if tfo > 0 { 0x02 } else { 0 },
+        )?;
+    }
+    Ok(())
+}
+
+/// Apply the node-scoped options that are meaningful for UDP carrier sockets.
+/// TCP-only fields remain handled by `apply_socket_config`.
+pub(crate) fn apply_current_udp_socket_config(
+    sock: &Socket,
+    peer: Option<SocketAddr>,
+) -> std::io::Result<()> {
+    let Some(cfg) = socket_policy::current().and_then(|policy| policy.socket().cloned()) else {
+        return Ok(());
+    };
+    apply_node_mark(sock, cfg.mark)?;
+    let family_addr = match peer {
+        Some(peer) => peer,
+        None => sock.local_addr()?.as_socket().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "cannot determine UDP socket family for node sockopt",
+            )
+        })?,
+    };
+    if !cfg.interface.is_empty() {
+        bind_named_interface(sock, family_addr, &cfg.interface)?;
+    }
+    apply_custom_sockopts(
+        sock,
+        if family_addr.is_ipv4() {
+            "udp4"
+        } else {
+            "udp6"
+        },
+        &cfg,
+    )
+}
+
+#[cfg(target_os = "freebsd")]
+fn apply_tcp_platform_options(sock: &Socket, cfg: &OutboundSocketConfig) -> std::io::Result<()> {
+    let tfo = cfg.tfo_value();
+    if tfo != 0 {
+        raw_setsockopt_int(sock, libc::IPPROTO_TCP, 1025, i32::from(tfo > 0))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    windows,
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd"
+)))]
+fn apply_tcp_platform_options(_sock: &Socket, cfg: &OutboundSocketConfig) -> std::io::Result<()> {
+    if cfg.tfo_value() != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "tcpFastOpen is unsupported on this platform",
+        ));
+    }
+    Ok(())
+}
+
+fn apply_custom_sockopts(
+    sock: &Socket,
+    network: &str,
+    cfg: &OutboundSocketConfig,
+) -> std::io::Result<()> {
+    for custom in &cfg.custom_sockopt {
+        if !custom.system.is_empty() && custom.system != xray_os_name() {
+            continue;
+        }
+        if !network.starts_with(&custom.network) {
+            continue;
+        }
+        let level = if custom.level.is_empty() {
+            6
+        } else {
+            custom.level.parse().map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "customSockopt.level must be an integer",
+                )
+            })?
+        };
+        let opt = custom.opt.parse().map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "customSockopt.opt must be an integer",
+            )
+        })?;
+        match custom.value_type.as_str() {
+            "int" => {
+                let value = custom.value.parse().map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "customSockopt.value must be an integer for type=int",
+                    )
+                })?;
+                raw_setsockopt_int(sock, level, opt, value)?;
+            }
+            "str" => raw_setsockopt_string(sock, level, opt, &custom.value)?,
+            other => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("unknown customSockopt type `{other}`"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn xray_os_name() -> &'static str {
+    if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
+        "darwin"
+    } else {
+        std::env::consts::OS
+    }
+}
+
+#[cfg(unix)]
+fn raw_setsockopt_int(sock: &Socket, level: i32, opt: i32, value: i32) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            level,
+            opt,
+            (&value as *const i32).cast(),
+            std::mem::size_of_val(&value) as libc::socklen_t,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn raw_setsockopt_int(sock: &Socket, level: i32, opt: i32, value: i32) -> std::io::Result<()> {
+    raw_setsockopt_bytes(sock, level, opt, &value.to_ne_bytes())
+}
+
+#[cfg(any(windows, target_os = "macos", target_os = "ios"))]
+fn raw_setsockopt_u32(sock: &Socket, level: i32, opt: i32, value: u32) -> std::io::Result<()> {
+    raw_setsockopt_bytes(sock, level, opt, &value.to_ne_bytes())
+}
+
+#[cfg(unix)]
+fn raw_setsockopt_string(sock: &Socket, level: i32, opt: i32, value: &str) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let mut value = value.as_bytes().to_vec();
+    value.push(0);
+    let result = unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            level,
+            opt,
+            value.as_ptr().cast(),
+            value.len() as libc::socklen_t,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn raw_setsockopt_string(
+    _sock: &Socket,
+    _level: i32,
+    _opt: i32,
+    _value: &str,
+) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "customSockopt type=str is unsupported on Windows",
+    ))
+}
+
+#[cfg(windows)]
+fn raw_setsockopt_bytes(sock: &Socket, level: i32, opt: i32, value: &[u8]) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    let result = unsafe {
+        windows_sys::Win32::Networking::WinSock::setsockopt(
+            sock.as_raw_socket() as _,
+            level,
+            opt,
+            value.as_ptr(),
+            value.len() as i32,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc8305_interleave_matches_xray_order() {
+        let addresses = vec![
+            "192.0.2.1:1".parse().unwrap(),
+            "192.0.2.2:1".parse().unwrap(),
+            "[2001:db8::1]:1".parse().unwrap(),
+            "[2001:db8::2]:1".parse().unwrap(),
+        ];
+        let got = interleave_addresses(addresses, true, 1);
+        assert_eq!(
+            got.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec![
+                "[2001:db8::1]:1",
+                "192.0.2.1:1",
+                "[2001:db8::2]:1",
+                "192.0.2.2:1",
+            ]
+        );
+    }
+
+    #[test]
+    fn txt_target_accepts_host_and_bracketed_ipv6() {
+        assert_eq!(
+            parse_txt_target("example.com:8443"),
+            Some(("example.com".into(), 8443))
+        );
+        assert_eq!(
+            parse_txt_target("[2001:db8::1]:443"),
+            Some(("2001:db8::1".into(), 443))
+        );
+    }
+
+    #[test]
+    fn zero_interleave_exhausts_the_preferred_family_first() {
+        let addresses = vec![
+            "192.0.2.1:1".parse().unwrap(),
+            "[2001:db8::1]:1".parse().unwrap(),
+            "192.0.2.2:1".parse().unwrap(),
+            "[2001:db8::2]:1".parse().unwrap(),
+        ];
+        let got = interleave_addresses(addresses, true, 0);
+        assert_eq!(
+            got.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec![
+                "[2001:db8::1]:1",
+                "[2001:db8::2]:1",
+                "192.0.2.1:1",
+                "192.0.2.2:1",
+            ]
+        );
+    }
 }

--- a/crates/core-outbound/src/transport/tls.rs
+++ b/crates/core-outbound/src/transport/tls.rs
@@ -25,11 +25,10 @@ use tokio::{net::TcpStream, sync::OnceCell};
 use tokio_rustls::TlsConnector;
 
 use crate::{
-    adapter::{BoxedStream, resolve_host},
-    loopback::TrackedTcpStream,
+    adapter::BoxedStream,
     transport::{
         TlsOptions, Transport,
-        tcp::marked_connect,
+        tcp::connect_boxed,
         utls::{
             fingerprint_is_per_connection_randomized, validate_xray_fingerprint,
             xray_client_hello_settings,
@@ -715,9 +714,15 @@ fn constant_time_eq_32(expected: &[u8; 32], actual: &[u8]) -> bool {
     difference == 0
 }
 
-#[async_trait]
-impl Transport for TlsTransport {
-    async fn connect(&self, host: &str, port: u16) -> std::io::Result<BoxedStream> {
+impl TlsTransport {
+    /// Establish TLS and expose the negotiated ALPN before erasing the stream
+    /// type. Realm uses this to choose HTTP/2 versus HTTP/1.1 with the same
+    /// complete Xray TLS/ECH executor as XHTTP.
+    pub(crate) async fn connect_negotiated(
+        &self,
+        host: &str,
+        port: u16,
+    ) -> std::io::Result<(BoxedStream, Option<Vec<u8>>)> {
         if super::boring_tls::is_required(&self.options) {
             let connector = self
                 .boring_config
@@ -726,7 +731,8 @@ impl Transport for TlsTransport {
                 })
                 .await?
                 .clone();
-            return super::boring_tls::connect(connector, &self.options, host, port).await;
+            return super::boring_tls::connect_negotiated(connector, &self.options, host, port)
+                .await;
         }
         let cached_config = self
             .config
@@ -789,52 +795,9 @@ impl Transport for TlsTransport {
                 )
             })?
         };
-        // 同 TcpTransport：先 resolve 走 WutherCore resolver，避免 TUN 死循环。
-        let addrs = resolve_host(host, port).await?;
-        let mut last_err: Option<std::io::Error> = None;
-        let mut tried = 0usize;
-        let tcp = {
-            let mut chosen: Option<TrackedTcpStream<TcpStream>> = None;
-            let mut chosen_peer: Option<std::net::SocketAddr> = None;
-            for addr in addrs {
-                tried += 1;
-                let t = std::time::Instant::now();
-                match marked_connect(addr, CONNECT_TIMEOUT).await {
-                    Ok(s) => {
-                        tracing::debug!(
-                            target: "dial::tls",
-                            %host, port, peer = %addr,
-                            attempt = tried,
-                            connect_ms = t.elapsed().as_millis() as u64,
-                            "tcp ok, begin TLS handshake",
-                        );
-                        chosen = Some(s);
-                        chosen_peer = Some(addr);
-                        break;
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            target: "dial::tls",
-                            %host, port, peer = %addr,
-                            attempt = tried, error = %e,
-                            "tcp connect failed",
-                        );
-                        last_err = Some(e);
-                    }
-                }
-            }
-            let _ = chosen_peer;
-            chosen.ok_or_else(|| {
-                tracing::warn!(target: "dial::tls", %host, port, tried, "all candidates failed (tcp)");
-                last_err.unwrap_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::AddrNotAvailable,
-                        format!("tls connect: no usable address for {host}:{port}"),
-                    )
-                })
-            })?
-        };
-        let _ = tcp.set_nodelay(true);
+        // Node socket policy and FinalMask wrap the raw carrier before TLS,
+        // matching Xray's tcp.Dial ordering.
+        let tcp = connect_boxed(host, port, false).await?;
         let connector = TlsConnector::from(config);
         let handshake_start = std::time::Instant::now();
         let stream =
@@ -871,7 +834,17 @@ impl Transport for TlsTransport {
             total_ms = started.elapsed().as_millis() as u64,
             "TLS handshake ok",
         );
-        Ok(Box::pin(stream))
+        let negotiated = stream.get_ref().1.alpn_protocol().map(ToOwned::to_owned);
+        Ok((Box::pin(stream), negotiated))
+    }
+}
+
+#[async_trait]
+impl Transport for TlsTransport {
+    async fn connect(&self, host: &str, port: u16) -> std::io::Result<BoxedStream> {
+        self.connect_negotiated(host, port)
+            .await
+            .map(|(stream, _)| stream)
     }
 }
 

--- a/crates/core-reality/src/client.rs
+++ b/crates/core-reality/src/client.rs
@@ -21,7 +21,7 @@ use xray_transport::reality_connector::{
 };
 use xray_transport::{
     BoxedTransportStream, RealityClientConfig as XrayRealityClientConfig,
-    RustlsRealityTlsSessionProvider,
+    RustlsRealityTlsSessionProvider, boxed_transport_stream,
 };
 use zeroize::Zeroize;
 
@@ -310,6 +310,20 @@ impl RealityClient {
         stream: TcpStream,
         lifetime: Option<RealityConnectionLifetime>,
     ) -> Result<RealityClientStream, RealityClientError> {
+        self.connect_io_with_lifetime(stream, lifetime).await
+    }
+
+    /// Complete REALITY over an arbitrary policy-aware byte carrier.  This is
+    /// required for FinalMask, whose TCP wrappers intentionally sit below the
+    /// REALITY ClientHello while preserving the authenticated TLS stream above.
+    pub async fn connect_io_with_lifetime<S>(
+        &self,
+        stream: S,
+        lifetime: Option<RealityConnectionLifetime>,
+    ) -> Result<RealityClientStream, RealityClientError>
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
         let normalized_fingerprint =
             xray_utls::normalize_reality_supported_fingerprint(&self.config.fingerprint)
                 .expect("configuration was validated");
@@ -344,8 +358,11 @@ impl RealityClient {
                 },
             )
             .map_err(|error| RealityClientError::Handshake(error.to_string()))?;
-        let complete =
-            session.complete_with_outcome(stream, prepared, xray_config.mldsa65_verify.clone());
+        let complete = session.complete_with_outcome(
+            boxed_transport_stream(stream),
+            prepared,
+            xray_config.mldsa65_verify.clone(),
+        );
         let completion = tokio::time::timeout(self.config.handshake_timeout, complete)
             .await
             .map_err(|_| RealityClientError::HandshakeTimeout)?;

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -1175,6 +1175,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
             listen: addr,
             auth,
             udp: mixed.udp,
+            stream_settings: mixed.stream_settings.clone(),
         };
         let rt = runtime.clone();
         handles.push(tokio::spawn(async move {

--- a/docs/finalmask-xray-oracle.md
+++ b/docs/finalmask-xray-oracle.md
@@ -1,0 +1,19 @@
+# FinalMask 固定 Xray Oracle
+
+FinalMask 的上游行为固定到 Xray-core `26.7.11` 对应提交
+`50231eaff98ccc31b5cbd247a721c16e97fe5ec1`。验证脚本会拒绝其他提交或带有受跟踪改动的
+Xray 工作区，先运行该提交下的全部官方 FinalMask Go 测试，再运行本项目的配置、实现与入站
+PROXY Protocol 测试。
+
+```powershell
+pwsh -File scripts/verify-xray-finalmask-oracle.ps1
+```
+
+如已有固定提交的 Xray 工作区，可避免重复下载：
+
+```powershell
+$env:XRAY_CORE_ORACLE_DIR = 'D:\src\Xray-core'
+pwsh -File scripts/verify-xray-finalmask-oracle.ps1
+```
+
+仅核验上游 Oracle 时使用 `-SkipRust`。脚本不会修改传入的 Xray 工作区。

--- a/scripts/verify-xray-finalmask-oracle.ps1
+++ b/scripts/verify-xray-finalmask-oracle.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [string]$XrayCore,
+    [switch]$SkipRust
+)
+
+$ErrorActionPreference = 'Stop'
+$PinnedCommit = '50231eaff98ccc31b5cbd247a721c16e97fe5ec1'
+$Repository = 'https://github.com/XTLS/Xray-core.git'
+$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+function Assert-LastExitCode([string]$Operation) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Operation 失败，退出码 $LASTEXITCODE"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($XrayCore)) {
+    if (-not [string]::IsNullOrWhiteSpace($env:XRAY_CORE_ORACLE_DIR)) {
+        $XrayCore = $env:XRAY_CORE_ORACLE_DIR
+    } else {
+        $XrayCore = Join-Path ([System.IO.Path]::GetTempPath()) "rpkernel-xray-$PinnedCommit"
+    }
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $XrayCore '.git'))) {
+    New-Item -ItemType Directory -Force -Path $XrayCore | Out-Null
+    git -C $XrayCore init
+    Assert-LastExitCode '初始化 Xray oracle 仓库'
+    git -C $XrayCore remote add origin $Repository
+    Assert-LastExitCode '配置 Xray oracle 远端'
+    git -C $XrayCore fetch --depth 1 origin $PinnedCommit
+    Assert-LastExitCode '获取固定 Xray 提交'
+    git -C $XrayCore checkout --detach FETCH_HEAD
+    Assert-LastExitCode '检出固定 Xray 提交'
+}
+
+$ActualCommit = (git -C $XrayCore rev-parse HEAD).Trim()
+Assert-LastExitCode '读取 Xray oracle 提交'
+if ($ActualCommit -ne $PinnedCommit) {
+    throw "Xray oracle 提交不匹配：期望 $PinnedCommit，实际 $ActualCommit"
+}
+
+$Dirty = git -C $XrayCore status --porcelain --untracked-files=no
+Assert-LastExitCode '检查 Xray oracle 工作区'
+if ($Dirty) {
+    throw 'Xray oracle 已有受跟踪文件改动；拒绝在非固定源码上验证'
+}
+
+Write-Host "[oracle] Xray-core $PinnedCommit"
+Push-Location $XrayCore
+try {
+    go test -count=1 ./transport/internet/finalmask/...
+    Assert-LastExitCode '运行 Xray FinalMask 官方测试'
+} finally {
+    Pop-Location
+}
+
+if (-not $SkipRust) {
+    Push-Location $ProjectRoot
+    try {
+        cargo test -p core-config stream_settings::tests --lib
+        Assert-LastExitCode '运行 Rust FinalMask 配置测试'
+        cargo test -p core-outbound transport::finalmask --lib
+        Assert-LastExitCode '运行 Rust FinalMask 实现测试'
+        cargo test -p core-inbound --lib proxy_protocol_v
+        Assert-LastExitCode '运行 Rust 入站 PROXY Protocol 测试'
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Host '[oracle] Xray 固定基线与 Rust FinalMask 测试全部通过'

--- a/tests-e2e/tests/e2e_mixed.rs
+++ b/tests-e2e/tests/e2e_mixed.rs
@@ -130,6 +130,7 @@ async fn http_connect_through_mixed() {
         listen: format!("127.0.0.1:{mixed_port}").parse().unwrap(),
         auth: None,
         udp: true,
+        stream_settings: None,
     };
     tokio::spawn(run_mixed(listener, runtime.clone()));
 
@@ -197,6 +198,7 @@ async fn http_absolute_post_preserves_body_and_rewrites_hop_headers() {
         listen: format!("127.0.0.1:{mixed_port}").parse().unwrap(),
         auth: None,
         udp: true,
+        stream_settings: None,
     };
     tokio::spawn(run_mixed(listener, runtime));
     tokio::time::sleep(Duration::from_millis(150)).await;
@@ -245,6 +247,7 @@ async fn http_absolute_chunked_post_stops_at_message_boundary() {
         listen: format!("127.0.0.1:{mixed_port}").parse().unwrap(),
         auth: None,
         udp: true,
+        stream_settings: None,
     };
     tokio::spawn(run_mixed(listener, runtime));
     tokio::time::sleep(Duration::from_millis(150)).await;
@@ -292,6 +295,7 @@ async fn socks5_connect_through_mixed() {
         listen: format!("127.0.0.1:{mixed_port}").parse().unwrap(),
         auth: None,
         udp: true,
+        stream_settings: None,
     };
     tokio::spawn(run_mixed(listener, runtime));
     tokio::time::sleep(Duration::from_millis(150)).await;

--- a/third_party/xray-transport/src/lib.rs
+++ b/third_party/xray-transport/src/lib.rs
@@ -196,6 +196,76 @@ impl TransportStream for tokio_rustls::client::TlsStream<TcpStream> {
 
 pub type BoxedTransportStream = Box<dyn TransportStream>;
 
+struct AsyncTransportStream<S> {
+    inner: S,
+}
+
+impl<S> AsyncRead for AsyncTransportStream<S>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, output)
+    }
+}
+
+impl<S> AsyncWrite for AsyncTransportStream<S>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, input)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+impl<S> TransportStream for AsyncTransportStream<S>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin,
+{
+    fn poll_read_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, output)
+    }
+
+    fn poll_write_direct(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        input: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, input)
+    }
+}
+
+/// Erases an arbitrary asynchronous byte carrier while preserving REALITY's
+/// post-authentication direct-read/direct-write transition.  For carriers
+/// without a second TLS layer (for example FinalMask), "direct" means the
+/// carrier's ordinary byte interface.
+pub fn boxed_transport_stream<S>(stream: S) -> BoxedTransportStream
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    Box::new(AsyncTransportStream { inner: stream })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SocketHandle {
     raw: i64,

--- a/third_party/xray-transport/src/penetrating_tls.rs
+++ b/third_party/xray-transport/src/penetrating_tls.rs
@@ -5,23 +5,25 @@ use std::task::{Context, Poll};
 
 use bytes::BytesMut;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::TcpStream;
 use tokio_rustls::client::TlsStream;
 
-use crate::TransportStream;
+use crate::{BoxedTransportStream, TransportStream};
 
 const TLS_READ_CHUNK_LIMIT: usize = 8 * 1024;
 
 pub(crate) type ServerReadLog = Arc<Mutex<Option<Vec<u8>>>>;
 
 pub(crate) struct CapturedTcpStream {
-    stream: TcpStream,
+    stream: BoxedTransportStream,
     server_read_log: Option<ServerReadLog>,
     tls_read_limiter: TlsRecordReadLimiter,
 }
 
 impl CapturedTcpStream {
-    pub(crate) fn new(stream: TcpStream, server_read_log: Option<ServerReadLog>) -> Self {
+    pub(crate) fn new(
+        stream: BoxedTransportStream,
+        server_read_log: Option<ServerReadLog>,
+    ) -> Self {
         Self {
             stream,
             server_read_log,
@@ -29,7 +31,7 @@ impl CapturedTcpStream {
         }
     }
 
-    fn into_inner(self) -> TcpStream {
+    fn into_inner(self) -> BoxedTransportStream {
         self.stream
     }
 }
@@ -143,7 +145,7 @@ impl AsyncWrite for CapturedTcpStream {
 enum PenetratingTlsState {
     Tls(Option<Box<TlsStream<CapturedTcpStream>>>),
     Direct {
-        stream: TcpStream,
+        stream: BoxedTransportStream,
         pending_plaintext: BytesMut,
     },
 }
@@ -207,7 +209,7 @@ impl PenetratingTlsStream {
             return Poll::Ready(Ok(()));
         }
 
-        Pin::new(stream).poll_read(cx, output)
+        Pin::new(stream.as_mut()).poll_read_direct(cx, output)
     }
 
     fn poll_write_direct_mode(
@@ -223,7 +225,9 @@ impl PenetratingTlsStream {
             PenetratingTlsState::Tls(None) => {
                 Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
             }
-            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_write(cx, input),
+            PenetratingTlsState::Direct { stream, .. } => {
+                Pin::new(stream.as_mut()).poll_write_direct(cx, input)
+            }
         }
     }
 }
@@ -268,7 +272,9 @@ impl AsyncWrite for PenetratingTlsStream {
             PenetratingTlsState::Tls(None) => {
                 Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
             }
-            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_flush(cx),
+            PenetratingTlsState::Direct { stream, .. } => {
+                Pin::new(stream.as_mut()).poll_flush_direct(cx)
+            }
         }
     }
 
@@ -279,7 +285,9 @@ impl AsyncWrite for PenetratingTlsStream {
             PenetratingTlsState::Tls(None) => {
                 Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
             }
-            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_shutdown(cx),
+            PenetratingTlsState::Direct { stream, .. } => {
+                Pin::new(stream.as_mut()).poll_shutdown_direct(cx)
+            }
         }
     }
 }
@@ -311,7 +319,9 @@ impl TransportStream for PenetratingTlsStream {
             PenetratingTlsState::Tls(None) => {
                 Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
             }
-            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_flush(cx),
+            PenetratingTlsState::Direct { stream, .. } => {
+                Pin::new(stream.as_mut()).poll_flush_direct(cx)
+            }
         }
     }
 
@@ -325,7 +335,9 @@ impl TransportStream for PenetratingTlsStream {
             PenetratingTlsState::Tls(None) => {
                 Poll::Ready(Err(io::Error::other("TLS stream was already taken")))
             }
-            PenetratingTlsState::Direct { stream, .. } => Pin::new(stream).poll_shutdown(cx),
+            PenetratingTlsState::Direct { stream, .. } => {
+                Pin::new(stream.as_mut()).poll_shutdown_direct(cx)
+            }
         }
     }
 }
@@ -338,7 +350,7 @@ mod tests {
     use rcgen::{generate_simple_self_signed, CertifiedKey};
     use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpStream};
     use tokio_rustls::{TlsAcceptor, TlsConnector};
 
     use super::*;
@@ -383,7 +395,7 @@ mod tests {
         });
 
         let client = CapturedTcpStream::new(
-            TcpStream::connect(addr).await.expect("connect TLS client"),
+            Box::new(TcpStream::connect(addr).await.expect("connect TLS client")),
             None,
         );
         let server_name = ServerName::try_from("server.test").expect("server name");

--- a/third_party/xray-transport/src/reality_connector.rs
+++ b/third_party/xray-transport/src/reality_connector.rs
@@ -30,7 +30,6 @@ use crate::{
     BoxedTransportStream, RealityClientConfig, TransportError,
 };
 use async_trait::async_trait;
-use tokio::net::TcpStream;
 use zeroize::Zeroize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,7 +76,7 @@ pub trait RealityTlsSession: Send {
 
     async fn complete(
         self: Box<Self>,
-        tcp_stream: TcpStream,
+        tcp_stream: BoxedTransportStream,
         prepared: RealityPreparedHandshake,
         mldsa65_verify: Option<Vec<u8>>,
     ) -> Result<BoxedTransportStream, TransportError> {
@@ -92,7 +91,7 @@ pub trait RealityTlsSession: Send {
 
     async fn complete_with_outcome(
         self: Box<Self>,
-        tcp_stream: TcpStream,
+        tcp_stream: BoxedTransportStream,
         prepared: RealityPreparedHandshake,
         mldsa65_verify: Option<Vec<u8>>,
     ) -> Result<RealityTlsSessionOutcome, TransportError>;

--- a/third_party/xray-transport/src/reality_runtime.rs
+++ b/third_party/xray-transport/src/reality_runtime.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use xray_routing::{Target, TargetAddr};
 
 use crate::{
-    connect_tcp_stream,
+    boxed_transport_stream, connect_tcp_stream,
     reality_connector::{
         RealityClientHelloRequest, RealityConnector, RealityHandshakeContext,
         RealityTlsSessionProvider,
@@ -120,7 +120,11 @@ impl RealityTlsEngine for RealityRuntimeEngine {
         let stream = connect_tcp_stream(addr, self.socket_protector.as_deref()).await?;
 
         session
-            .complete(stream, prepared, config.mldsa65_verify.clone())
+            .complete(
+                boxed_transport_stream(stream),
+                prepared,
+                config.mldsa65_verify.clone(),
+            )
             .await
     }
 }

--- a/third_party/xray-transport/src/reality_rustls.rs
+++ b/third_party/xray-transport/src/reality_rustls.rs
@@ -26,7 +26,6 @@ use rustls::{
     CertificateCompressionAlgorithm, CertificateError, CipherSuite, ClientConfig, ClientConnection,
     DigitallySignedStruct, Error as RustlsError, NamedGroup, ProtocolVersion, SignatureScheme,
 };
-use tokio::net::TcpStream;
 use tokio_rustls::TlsConnector as TokioTlsConnector;
 use zeroize::Zeroize;
 
@@ -1083,7 +1082,7 @@ impl RealityTlsSession for RustlsRealityTlsSession {
 
     async fn complete_with_outcome(
         self: Box<Self>,
-        tcp_stream: TcpStream,
+        tcp_stream: BoxedTransportStream,
         prepared: crate::reality::RealityPreparedHandshake,
         mldsa65_verify: Option<Vec<u8>>,
     ) -> Result<RealityTlsSessionOutcome, TransportError> {


### PR DESCRIPTION
## 背景与目标

本 PR 完整实现 Xray-core 26.7.11 的 FinalMask 传输层，并将配置解析、客户端、服务端、TCP/UDP/QUIC 数据面、套接字策略、入站监听与启动路径一次性接通。实现以 Xray-core v26.7.11 的固定提交 `50231eaff98ccc31b5cbd247a721c16e97fe5ec1` 为行为基线，不使用空壳、透传或“仅解析不执行”的降级方案。

## 完整配置注册

新增强类型、严格未知字段校验的 `streamSettings` 模型，注册并校验：

- `network`；
- `sockopt`：`mark`、`tcpFastOpen`、`tproxy`、`acceptProxyProtocol`、`domainStrategy`、`dialerProxy`、TCP keepalive、拥塞算法、接口、`v6only`、窗口/MSS/user-timeout、`penetrate`、MPTCP、自定义 sockopt、地址端口策略、Happy Eyeballs、可信 X-Forwarded-For 标记头；
- FinalMask TCP：`header-custom`、`fragment`、`sudoku`、`xmc`；
- FinalMask UDP：`header-custom`、`mkcp-legacy`、`noise`、`salamander`、`sudoku`、`xdns`、`xicmp`、`realm`；
- `quicParams`：拥塞模式、调试、BBR profile、Brutal 上下行带宽、UDP Hop、流/连接接收窗口、空闲与保活、PMTU 开关、最大入站流数；
- Header Custom 的客户端/服务端/错误步骤、捕获与复用、字节类型及完整表达式树；
- Sudoku 官方键名及历史兼容键名；
- Realm 完整 TLS 对象，与 XHTTP 的高级 TLS、证书、固定指纹、ECH 等能力共用同一强类型执行路径。

范围、枚举、平台相关 sockopt、XDNS 迁移字段、QUIC 窗口与超时、UDP Hop、FinalMask 层级组合均在配置阶段失败关闭，不把不可执行配置留到运行时。

## TCP FinalMask

- 按 Xray 层级逆序应用 TCP 掩码；
- `header-custom` 实现客户端、服务端与错误响应状态机，支持随机字节、范围、捕获、复用、转换表达式及严格资源上限；
- `fragment` 支持普通分片、`tlshello` 语义、长度/延迟序列与最大拆分；
- `sudoku` 实现官方表生成、Go 随机序列、ASCII/熵布局、提示元组、上下行编解码与分块边界；
- `xmc` 实现 Minecraft 握手、RSA 密钥流程、CFB8 加密与双向代理；
- TCP FinalMask 接入普通 TCP、TLS、Boring TLS、REALITY、XHTTP 和 Mixed/REALITY/XHTTP 入站，掩码位于 TLS/REALITY 握手外层，顺序与 Xray 一致。

## UDP FinalMask

- 实现多层 UDP 掩码的客户端与服务端组合，保持 Xray level 顺序；
- 连续 Header Custom 聚合但不跨越其他变换层；
- `header-custom` 支持 prefix/standalone、逐对端服务端状态隔离、捕获/复用/表达式与边界限制；
- `mkcp-legacy` 实现 original/AES-128-GCM 及 DNS、DTLS、SRTP、uTP、微信、WireGuard 等官方头形状；
- `noise` 实现重置、随机噪声、数据类型与延迟；
- `salamander` 实现 BLAKE2b 派生、简单模式和 Gecko 分片/重组/去重/资源回收；
- `sudoku` 实现逐数据报重新起表的官方 UDP 编解码；
- `xdns` 实现 DNS 查询/响应封装、全部官方记录模式、截断与错误码处理、服务端解码与响应；
- `xicmp` 实现 IPv4/IPv6 ICMP、校验和、序号窗口、防重放及 DGRAM 模式；
- `realm` 实现官方 URL、HTTP API、Bearer 认证、SSE、心跳/恢复、STUN、NAT 候选扩展、打洞与完整 TLS；
- 每层均提供真实客户端和服务端包装器，并包含组合数据报往返测试。

## QUIC、Brutal、UDP Hop

- 使用 `quinn`/`quinn-proto` 构建真实 QUIC 客户端与服务端；
- 使用 `rsteria2` 提供真实 Brutal 拥塞控制器，同时支持 Reno、BBR、force-brutal 与可切换策略；
- 将官方 BBR profile 映射到真实 BBR 控制器启动参数；
- 应用流/连接窗口、空闲超时、保活、PMTU、最大入站流、数据报缓冲等参数；
- 实现 UDP Hop 端口列表、区间、周期与承载切换；
- QUIC PacketConn 桥保持数据报边界、GSO、背压和服务端多对端路由；
- 接入 XHTTP/3 客户端与服务端，以及 Hysteria2 客户端。

## 套接字策略与运行时接线

- 新增强类型出站套接字策略包装器，并在注册表中为所有节点统一应用；
- 实现接口绑定、mark、TFO、MPTCP、TCP keepalive/拥塞/窗口/user-timeout/MSS、Happy Eyeballs、地址与端口策略、自定义 sockopt；
- `dialerProxy` 支持后向引用并在所有节点注册完成后解析，缺失目标会明确报错；
- 入站支持 PROXY Protocol v1/v2，保留首个业务字节并正确覆盖 IPv4/IPv6 端点；
- Mixed 监听保持主程序资源仲裁要求的精确端口绑定，同时应用监听 socket 配置与 TCP FinalMask；
- XHTTP H1/H2/H3、REALITY 与主程序启动路径均传递并执行 `streamSettings`；
- 对当前数据面无法执行的入站 UDP/QUIC 组合明确失败关闭。

## 依赖与安全边界

- 使用 `rsteria2`、`quinn`、`hickory-resolver`、`hickory-proto`、`rsa`、`ggstd` 等真实协议/密码/网络依赖；
- 所有长度、队列、重组、状态表、捕获值、递归表达式、DNS 载荷与连接资源均设置硬上限；
- 非法包、截断、重放、跨对端状态污染、错误层级顺序与配置歧义均有定向测试；
- `Cargo.lock` 已完整更新。

## 上游对齐

新增 `scripts/verify-xray-finalmask-oracle.ps1` 和中文说明文档。脚本固定并校验 Xray-core v26.7.11 提交，拒绝错误提交或有受跟踪改动的 Oracle 工作区，再运行官方 FinalMask Go 测试与本项目定向测试。

已在固定提交上运行全部官方 FinalMask 测试，结果全部通过，包括：

- FinalMask 总体 TCP/UDP 测试；
- Header Custom；
- Sudoku；
- XDNS；
- XICMP；
- XMC；
- 其余无独立测试文件的官方包完成编译。

## 本项目验证

- `core-config`：121/121；
- `core-outbound`：413/413，其中 FinalMask 定向 54/54；
- `core-inbound`：138/138；
- `core-reality`：104/104；
- `xray-transport`：5/5；
- `wuther-core`：16/16；
- `cargo check --workspace --all-targets`：通过；
- `cargo fmt --all -- --check`：通过；
- `git diff --check`：通过。

## 分支与提交关系

本 PR 基于 `codex/protocol-tuic-validation-fix`。该基线是全量回归中发现并独立提交的 TUIC 注册校验修复；本分支相对该基线仅包含 1 个 FinalMask 完整实现提交，从而保持“一个实现一个提交”，不把 TUIC 修复与 FinalMask 混在同一提交中。
