### PR TITLE
修复协议注册时的静默占位与字段校验

### DIFF
--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -157,24 +157,26 @@ pub fn build_outbound(node: &ParsedNode) -> Result<SharedOutbound, String> {
             }
             ob.into_arc()
         }
-        NodeProtocol::Shadowsocks => build_shadowsocks(node),
-        NodeProtocol::ShadowsocksR => build_ssr(node),
+        NodeProtocol::Shadowsocks => build_shadowsocks(node)?,
+        NodeProtocol::ShadowsocksR => build_ssr(node)?,
         NodeProtocol::Vmess => return build_vmess(node),
         NodeProtocol::Vless => return build_vless(node),
         NodeProtocol::Trojan => Arc::new(build_trojan(node)?),
         NodeProtocol::Naive => build_naive(node),
-        NodeProtocol::Snell => build_snell(node),
+        NodeProtocol::Snell => build_snell(node)?,
         NodeProtocol::AnyTls => build_anytls(node),
         NodeProtocol::Ssh => build_ssh(node),
         NodeProtocol::Hysteria => build_hysteria_v1(node),
         NodeProtocol::Hysteria2 => build_hysteria2(node),
         NodeProtocol::Tuic => build_tuic(node)?,
-        NodeProtocol::Wireguard => build_wireguard(node),
+        NodeProtocol::Wireguard => build_wireguard(node)?,
         NodeProtocol::Mieru => build_mieru(node),
-        NodeProtocol::Sudoku => build_sudoku(node),
+        NodeProtocol::Sudoku => build_sudoku(node)?,
         NodeProtocol::TrustTunnel => build_trusttunnel(node),
         NodeProtocol::Young => build_young(node),
-        ref other => StubOutbound::new(node.name.clone(), proto_static_name(other)),
+        NodeProtocol::Other(ref protocol) => {
+            return Err(format!("unsupported outbound protocol `{protocol}`"));
+        }
     };
     Ok(outbound)
 }
@@ -355,33 +357,37 @@ fn decode_config_blob(value: &str) -> Option<Vec<u8>> {
         .or_else(|| URL_SAFE_NO_PAD.decode(encoded.trim_end_matches('=')).ok())
 }
 
-fn build_shadowsocks(node: &ParsedNode) -> SharedOutbound {
+fn build_shadowsocks(node: &ParsedNode) -> Result<SharedOutbound, String> {
     let method = node.method.as_deref().unwrap_or("aes-256-gcm");
     let pwd = node.password.as_deref().unwrap_or("");
+    if pwd.is_empty() {
+        return Err("shadowsocks password must not be empty".into());
+    }
     if let Some(c) = Ss22Cipher::parse(method) {
-        if !pwd.is_empty() {
-            return match Ss2022Outbound::new(&node.name, &node.host, node.port, c, pwd) {
-                Ok(mut ob) => {
-                    ob.udp = node.udp;
-                    Arc::new(ob)
-                }
-                Err(_) => StubOutbound::new(node.name.clone(), "ss2022(invalid-psk)"),
-            };
-        }
+        return match Ss2022Outbound::new(&node.name, &node.host, node.port, c, pwd) {
+            Ok(mut ob) => {
+                ob.udp = node.udp;
+                Ok(Arc::new(ob))
+            }
+            Err(error) => Err(format!("invalid Shadowsocks 2022 PSK: {error}")),
+        };
     }
     match SsCipher::parse(method) {
-        Some(c) if !pwd.is_empty() => {
+        Some(c) => {
             let mut ob = ShadowsocksOutbound::new(&node.name, &node.host, node.port, c, pwd);
             ob.udp = node.udp;
-            Arc::new(ob)
+            Ok(Arc::new(ob))
         }
-        _ => StubOutbound::new(node.name.clone(), "shadowsocks(unknown-cipher)"),
+        None => Err(format!("unsupported Shadowsocks cipher `{method}`")),
     }
 }
 
-fn build_ssr(node: &ParsedNode) -> SharedOutbound {
+fn build_ssr(node: &ParsedNode) -> Result<SharedOutbound, String> {
     let method = node.method.as_deref().unwrap_or("aes-256-cfb");
     let pwd = node.password.as_deref().unwrap_or("");
+    if pwd.is_empty() {
+        return Err("ShadowsocksR password must not be empty".into());
+    }
     let obfs_str = node
         .params
         .get("obfs")
@@ -394,14 +400,14 @@ fn build_ssr(node: &ParsedNode) -> SharedOutbound {
         .unwrap_or("origin");
     let obfs = match SsrObfs::parse(obfs_str, &node.host) {
         Some(o) => o,
-        None => return StubOutbound::new(node.name.clone(), "ssr(unsupported-obfs)"),
+        None => return Err(format!("unsupported ShadowsocksR obfs `{obfs_str}`")),
     };
     let proto = match SsrProtocol::parse(proto_str) {
         Some(p) => p,
-        None => return StubOutbound::new(node.name.clone(), "ssr(unsupported-protocol)"),
+        None => return Err(format!("unsupported ShadowsocksR protocol `{proto_str}`")),
     };
     match SsrCipher::parse(method) {
-        Some(c) if !pwd.is_empty() => {
+        Some(c) => {
             let mut ob = SsrOutbound::new(&node.name, &node.host, node.port, c, pwd);
             ob.obfs = obfs;
             ob.protocol = proto;
@@ -411,9 +417,9 @@ fn build_ssr(node: &ParsedNode) -> SharedOutbound {
                 .get("protocol-param")
                 .cloned()
                 .unwrap_or_default();
-            Arc::new(ob)
+            Ok(Arc::new(ob))
         }
-        _ => StubOutbound::new(node.name.clone(), "ssr(unsupported-cipher)"),
+        None => Err(format!("unsupported ShadowsocksR cipher `{method}`")),
     }
 }
 
@@ -2078,29 +2084,26 @@ fn build_trojan(node: &ParsedNode) -> Result<TrojanOutbound, String> {
     Ok(ob)
 }
 
-fn build_snell(node: &ParsedNode) -> SharedOutbound {
-    let cipher = node
-        .params
-        .get("cipher")
-        .or_else(|| node.method.as_ref())
-        .and_then(|s| SnellCipher::parse(s))
-        .unwrap_or(SnellCipher::Aes128Gcm);
+fn build_snell(node: &ParsedNode) -> Result<SharedOutbound, String> {
+    let cipher = match node.params.get("cipher").or_else(|| node.method.as_ref()) {
+        Some(value) => SnellCipher::parse(value)
+            .ok_or_else(|| format!("unsupported Snell cipher `{value}`"))?,
+        None => SnellCipher::Aes128Gcm,
+    };
     let pwd = node
         .password
         .as_deref()
         .or_else(|| node.params.get("psk").map(|s| s.as_str()))
         .unwrap_or("");
     if pwd.is_empty() {
-        return StubOutbound::new(node.name.clone(), "snell(missing-psk)");
+        return Err("Snell PSK must not be empty".into());
     }
     let mut ob = SnellOutbound::new(&node.name, &node.host, node.port, cipher, pwd);
     ob.udp = node.udp;
-    if let Some(v) = node
-        .params
-        .get("version")
-        .and_then(|s| s.parse::<u8>().ok())
-    {
-        ob.version = v;
+    if let Some(value) = node.params.get("version") {
+        ob.version = value
+            .parse::<u8>()
+            .map_err(|_| format!("invalid Snell version `{value}`"))?;
     }
     if let Some(obfs_type) = node.params.get("obfs").map(|s| s.as_str()) {
         let obfs_host = node
@@ -2111,10 +2114,10 @@ fn build_snell(node: &ParsedNode) -> SharedOutbound {
         match obfs_type {
             "http" => ob = ob.with_obfs_http(obfs_host),
             "tls" => ob = ob.with_obfs_tls(obfs_host),
-            _ => {}
+            other => return Err(format!("unsupported Snell obfs `{other}`")),
         }
     }
-    Arc::new(ob)
+    Ok(Arc::new(ob))
 }
 
 fn build_anytls(node: &ParsedNode) -> SharedOutbound {
@@ -2309,55 +2312,8 @@ fn parse_tuic_duration(value: &str) -> Option<std::time::Duration> {
     std::time::Duration::try_from_secs_f64(seconds).ok()
 }
 
-fn build_wireguard(node: &ParsedNode) -> SharedOutbound {
-    match wireguard_from_node(node) {
-        Ok(outbound) => Arc::new(outbound),
-        Err(reason) => Arc::new(InvalidWireGuardOutbound {
-            name: node.name.clone(),
-            reason,
-        }),
-    }
-}
-
-#[derive(Debug)]
-struct InvalidWireGuardOutbound {
-    name: String,
-    reason: String,
-}
-
-#[async_trait::async_trait]
-impl crate::adapter::OutboundAdapter for InvalidWireGuardOutbound {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn protocol(&self) -> &'static str {
-        "wireguard"
-    }
-
-    fn capabilities(&self) -> crate::adapter::Capabilities {
-        crate::adapter::Capabilities::default()
-    }
-
-    async fn dial_tcp(
-        &self,
-        _context: crate::adapter::DialContext,
-    ) -> std::io::Result<crate::adapter::BoxedStream> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("wireguard node `{}` is invalid: {}", self.name, self.reason),
-        ))
-    }
-
-    async fn dial_udp(
-        &self,
-        _context: crate::adapter::DialContext,
-    ) -> std::io::Result<crate::adapter::BoxedUdp> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("wireguard node `{}` is invalid: {}", self.name, self.reason),
-        ))
-    }
+fn build_wireguard(node: &ParsedNode) -> Result<SharedOutbound, String> {
+    wireguard_from_node(node).map(|outbound| Arc::new(outbound) as SharedOutbound)
 }
 
 fn wireguard_from_node(node: &ParsedNode) -> Result<WireGuardOutbound, String> {
@@ -2958,7 +2914,7 @@ fn build_mieru(node: &ParsedNode) -> SharedOutbound {
     Arc::new(ob)
 }
 
-fn build_sudoku(node: &ParsedNode) -> SharedOutbound {
+fn build_sudoku(node: &ParsedNode) -> Result<SharedOutbound, String> {
     let key = node
         .params
         .get("key")
@@ -2966,7 +2922,7 @@ fn build_sudoku(node: &ParsedNode) -> SharedOutbound {
         .or_else(|| node.password.clone())
         .unwrap_or_default();
     if key.is_empty() {
-        return StubOutbound::new(node.name.clone(), "sudoku(missing-key)");
+        return Err("Sudoku key must not be empty".into());
     }
     let mut cfg = crate::proto::sudoku::outbound::SudokuConfig::default();
     cfg.key = key;
@@ -2977,9 +2933,7 @@ fn build_sudoku(node: &ParsedNode) -> SharedOutbound {
     {
         match SudokuAead::parse(method) {
             Ok(m) => cfg.aead_method = m,
-            Err(_) => {
-                return StubOutbound::new(node.name.clone(), "sudoku(invalid-aead)");
-            }
+            Err(error) => return Err(format!("invalid Sudoku AEAD method `{method}`: {error}")),
         }
     }
     if let Some(t) = node.params.get("table-type") {
@@ -2988,19 +2942,15 @@ fn build_sudoku(node: &ParsedNode) -> SharedOutbound {
     if let Some(t) = node.params.get("custom-table") {
         cfg.custom_table = t.clone();
     }
-    if let Some(min) = node
-        .params
-        .get("padding-min")
-        .and_then(|s| s.parse::<i32>().ok())
-    {
-        cfg.padding_min = min;
+    if let Some(value) = node.params.get("padding-min") {
+        cfg.padding_min = value
+            .parse::<i32>()
+            .map_err(|_| format!("invalid Sudoku padding-min `{value}`"))?;
     }
-    if let Some(max) = node
-        .params
-        .get("padding-max")
-        .and_then(|s| s.parse::<i32>().ok())
-    {
-        cfg.padding_max = max;
+    if let Some(value) = node.params.get("padding-max") {
+        cfg.padding_max = value
+            .parse::<i32>()
+            .map_err(|_| format!("invalid Sudoku padding-max `{value}`"))?;
     }
     if let Some(d) = node
         .params
@@ -3012,10 +2962,9 @@ fn build_sudoku(node: &ParsedNode) -> SharedOutbound {
     if let Some(pr) = node.params.get("path-root") {
         cfg.http_mask_path_root = pr.clone();
     }
-    match SudokuOutbound::new(&node.name, &node.host, node.port, cfg) {
-        Ok(ob) => Arc::new(ob),
-        Err(_) => StubOutbound::new(node.name.clone(), "sudoku(table-build-error)"),
-    }
+    SudokuOutbound::new(&node.name, &node.host, node.port, cfg)
+        .map(|ob| Arc::new(ob) as SharedOutbound)
+        .map_err(|error| format!("invalid Sudoku table configuration: {error}"))
 }
 
 fn build_trusttunnel(node: &ParsedNode) -> SharedOutbound {
@@ -3158,30 +3107,6 @@ fn decode_b64_32(s: &str) -> Option<[u8; 32]> {
     Some(out)
 }
 
-fn proto_static_name(p: &NodeProtocol) -> &'static str {
-    match p {
-        NodeProtocol::Dns => "dns",
-        NodeProtocol::Shadowsocks => "shadowsocks",
-        NodeProtocol::ShadowsocksR => "shadowsocksr",
-        NodeProtocol::Vmess => "vmess",
-        NodeProtocol::Vless => "vless",
-        NodeProtocol::Trojan => "trojan",
-        NodeProtocol::Naive => "naive",
-        NodeProtocol::Hysteria => "hysteria",
-        NodeProtocol::Hysteria2 => "hysteria2",
-        NodeProtocol::Tuic => "tuic",
-        NodeProtocol::Wireguard => "wireguard",
-        NodeProtocol::Ssh => "ssh",
-        NodeProtocol::Snell => "snell",
-        NodeProtocol::AnyTls => "anytls",
-        NodeProtocol::Mieru => "mieru",
-        NodeProtocol::Sudoku => "sudoku",
-        NodeProtocol::TrustTunnel => "trusttunnel",
-        NodeProtocol::Young => "young",
-        _ => "stub",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use base64::Engine;
@@ -3231,6 +3156,117 @@ mod tests {
         assert_eq!(decode_config_blob("000102ff"), Some(vec![0, 1, 2, 255]));
         assert_eq!(decode_config_blob("AAEC/w=="), Some(vec![0, 1, 2, 255]));
         assert_eq!(decode_config_blob("%%%"), None);
+    }
+
+    fn node(protocol: NodeProtocol) -> ParsedNode {
+        ParsedNode::new("validation-test", protocol, "127.0.0.1", 443)
+    }
+
+    fn build_error(node: &ParsedNode) -> String {
+        match build_outbound(node) {
+            Err(error) => error,
+            Ok(_) => panic!("invalid test node unexpectedly registered"),
+        }
+    }
+
+    #[test]
+    fn registry_rejects_unknown_protocol_and_missing_required_credentials() {
+        let cases = [
+            (
+                node(NodeProtocol::Other("future-protocol".into())),
+                "unsupported outbound protocol `future-protocol`",
+            ),
+            (
+                node(NodeProtocol::Shadowsocks),
+                "shadowsocks password must not be empty",
+            ),
+            (
+                node(NodeProtocol::ShadowsocksR),
+                "ShadowsocksR password must not be empty",
+            ),
+            (node(NodeProtocol::Snell), "Snell PSK must not be empty"),
+            (node(NodeProtocol::Wireguard), "missing-private-key"),
+            (node(NodeProtocol::Sudoku), "Sudoku key must not be empty"),
+        ];
+
+        for (node, expected) in cases {
+            let error = build_error(&node);
+            assert!(error.contains(expected), "error={error:?}");
+        }
+    }
+
+    #[test]
+    fn registry_rejects_invalid_protocol_options_instead_of_registering_stubs() {
+        let mut ss = node(NodeProtocol::Shadowsocks);
+        ss.password = Some("secret".into());
+        ss.method = Some("not-a-cipher".into());
+        assert!(build_error(&ss).contains("unsupported Shadowsocks cipher"));
+
+        let mut ss2022 = node(NodeProtocol::Shadowsocks);
+        ss2022.password = Some("not-a-valid-2022-key".into());
+        ss2022.method = Some("2022-blake3-aes-128-gcm".into());
+        assert!(build_error(&ss2022).contains("invalid Shadowsocks 2022 PSK"));
+
+        let mut ssr = node(NodeProtocol::ShadowsocksR);
+        ssr.password = Some("secret".into());
+        ssr.params.insert("obfs".into(), "unknown-obfs".into());
+        assert!(build_error(&ssr).contains("unsupported ShadowsocksR obfs"));
+        ssr.params.insert("obfs".into(), "plain".into());
+        ssr.params
+            .insert("protocol".into(), "unknown-protocol".into());
+        assert!(build_error(&ssr).contains("unsupported ShadowsocksR protocol"));
+        ssr.params.insert("protocol".into(), "origin".into());
+        ssr.method = Some("unknown-cipher".into());
+        assert!(build_error(&ssr).contains("unsupported ShadowsocksR cipher"));
+
+        let mut snell = node(NodeProtocol::Snell);
+        snell.password = Some("secret".into());
+        snell.method = Some("unknown-cipher".into());
+        assert!(build_error(&snell).contains("unsupported Snell cipher"));
+        snell.method = None;
+        snell.params.insert("version".into(), "not-a-number".into());
+        assert!(build_error(&snell).contains("invalid Snell version"));
+        snell.params.insert("version".into(), "3".into());
+        snell.params.insert("obfs".into(), "unknown-obfs".into());
+        assert!(build_error(&snell).contains("unsupported Snell obfs"));
+
+        let valid_key = base64::engine::general_purpose::STANDARD.encode([7u8; 32]);
+        let mut wireguard = node(NodeProtocol::Wireguard);
+        wireguard
+            .params
+            .insert("private-key".into(), valid_key.clone());
+        wireguard
+            .params
+            .insert("public-key".into(), valid_key.clone());
+        wireguard
+            .params
+            .insert("address".into(), "10.0.0.2/32".into());
+        wireguard
+            .params
+            .insert("preshared-key".into(), "invalid".into());
+        assert!(build_error(&wireguard).contains("invalid-preshared-key"));
+        wireguard.params.remove("preshared-key");
+        wireguard
+            .params
+            .insert("address".into(), "not-an-address".into());
+        assert!(build_error(&wireguard).contains("invalid-address"));
+
+        let mut sudoku = node(NodeProtocol::Sudoku);
+        sudoku.password = Some("secret".into());
+        sudoku
+            .params
+            .insert("aead-method".into(), "unknown-aead".into());
+        assert!(build_error(&sudoku).contains("invalid Sudoku AEAD"));
+        sudoku.params.remove("aead-method");
+        sudoku
+            .params
+            .insert("padding-min".into(), "not-a-number".into());
+        assert!(build_error(&sudoku).contains("invalid Sudoku padding-min"));
+        sudoku.params.remove("padding-min");
+        sudoku
+            .params
+            .insert("padding-max".into(), "not-a-number".into());
+        assert!(build_error(&sudoku).contains("invalid Sudoku padding-max"));
     }
 
     #[test]
@@ -4182,10 +4218,7 @@ mod tests {
 
         let mut node = wireguard_node();
         node.params.insert("mtu".into(), "70000".into());
-        let outbound = build_outbound(&node).unwrap();
-        assert_eq!(outbound.protocol(), "wireguard");
-        assert!(!outbound.capabilities().tcp);
-        assert!(!outbound.capabilities().udp);
+        assert!(build_outbound(&node).is_err());
 
         let mut node = wireguard_node();
         node.params.insert("workres".into(), "8".into());


### PR DESCRIPTION
## 背景

协议注册表此前会把未知协议以及部分协议的无效配置转换成 `StubOutbound`。这种节点能够通过配置加载和运行时构建，只有真正拨号时才返回“不支持”，导致错误被推迟到数据面，并且可能在订阅热更新后留下一个表面可用、实际不可拨号的节点。

本变更位于完整 FinalMask 实现之上，专门收紧所有仍会生成占位出站的注册路径。该分支只包含一个提交，便于独立审查和回滚。

## 修改内容

- 未知协议不再注册占位出站，直接返回包含原始协议名的配置错误。
- Shadowsocks：
  - 强制要求非空密码；
  - 未知加密算法在注册期报错；
  - Shadowsocks 2022 密钥长度或格式错误会保留底层错误并拒绝注册。
- ShadowsocksR：
  - 强制要求非空密码；
  - 未知加密算法、混淆方式和协议插件均在注册期报错。
- Snell：
  - 强制要求非空 PSK；
  - 显式配置的未知加密算法不再回退到默认算法；
  - 非法版本号和未知混淆类型不再被静默忽略。
- WireGuard：
  - 强制要求私钥和对端公钥；
  - 私钥、公钥、预共享密钥必须严格解码为 32 字节；
  - 地址列表中的每个地址都必须合法，错误项不再被跳过。
- Sudoku：
  - 强制要求非空密钥；
  - 非法 AEAD、填充上下限和自定义表配置均在注册期失败。
- 删除注册表对 `StubOutbound` 的依赖以及已无用途的协议名映射函数。
- 增加覆盖未知协议、缺失凭据、非法算法、密钥、地址、版本、混淆和数值字段的回归测试。

## 行为变化

错误配置现在会使静态配置构建或订阅节点热更新原子失败，不会污染运行中的出站注册表。合法配置的协议行为不变。

## 验证

- `cargo test -p core-outbound --no-fail-fast`：415 项全部通过。
- `cargo test -p core-config --no-fail-fast`：121 项全部通过。
- `cargo check --workspace --all-targets`：通过。
- `cargo fmt --all`：通过。
- `git diff --check`：通过。

## 依赖关系

本 PR 的目标分支为 `codex/transport-finalmask-full`，因为审查和修复是在完整 FinalMask 协议栈基础上完成。合并时应先处理其基线 PR。
