### PR TITLE
feat: 完整实现 Young 协议并接入 Firefox Neqo 协议栈

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,14 @@ jobs:
           toolchain: stable
           components: rustfmt
 
-      - name: Install Firefox Neqo build dependencies
+      - name: Install Firefox Neqo source build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
             clang \
             gyp \
-            libnspr4-dev \
-            libnss3-dev \
+            mercurial \
+            ninja-build \
             pkg-config
 
       - name: Cache Cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,16 @@ jobs:
           toolchain: stable
           components: rustfmt
 
+      - name: Install Firefox Neqo build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            clang \
+            gyp \
+            libnspr4-dev \
+            libnss3-dev \
+            pkg-config
+
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2.9.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,7 +603,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -593,6 +611,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfb-mode"
@@ -684,6 +711,17 @@ dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout 0.2.2",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -881,6 +919,7 @@ version = "0.3.1-rc.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "core-young",
  "hex",
  "humantime-serde",
  "ipnet",
@@ -1048,6 +1087,7 @@ dependencies = [
  "chrono",
  "core-config",
  "core-reality",
+ "core-young",
  "crc32fast",
  "ctr",
  "curve25519-dalek",
@@ -1269,6 +1309,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-young"
+version = "0.3.1-rc.5"
+dependencies = [
+ "base64 0.22.1",
+ "hmac",
+ "neqo-common",
+ "neqo-http3",
+ "neqo-transport",
+ "nss-rs",
+ "rand 0.8.7",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1442,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -1586,6 +1713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1758,56 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "enumset"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc5801fd11762e24d1e420d01d2ac518f2a2ca4329d4fbb6639f2412b6204e0"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1928,6 +2111,12 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -2382,6 +2571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,6 +2650,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2560,6 +2764,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "libloading"
@@ -2737,6 +2951,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "mtu"
+version = "0.4.1"
+source = "git+https://github.com/mozilla/neqo?rev=76673b127251c90ad6250de7a0a7400ddd4661f1#76673b127251c90ad6250de7a0a7400ddd4661f1"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "static_assertions",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "neqo-common"
+version = "0.30.1"
+source = "git+https://github.com/mozilla/neqo?rev=76673b127251c90ad6250de7a0a7400ddd4661f1#76673b127251c90ad6250de7a0a7400ddd4661f1"
+dependencies = [
+ "enum-map",
+ "env_logger",
+ "log",
+ "qlog",
+ "static_assertions",
+ "strum",
+ "thiserror 2.0.19",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "neqo-http3"
+version = "0.30.1"
+source = "git+https://github.com/mozilla/neqo?rev=76673b127251c90ad6250de7a0a7400ddd4661f1#76673b127251c90ad6250de7a0a7400ddd4661f1"
+dependencies = [
+ "enumset",
+ "http 1.4.2",
+ "log",
+ "neqo-common",
+ "neqo-qpack",
+ "neqo-transport",
+ "nss-rs",
+ "qlog",
+ "rustc-hash",
+ "sfv",
+ "static_assertions",
+ "strum",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "neqo-qpack"
+version = "0.30.1"
+source = "git+https://github.com/mozilla/neqo?rev=76673b127251c90ad6250de7a0a7400ddd4661f1#76673b127251c90ad6250de7a0a7400ddd4661f1"
+dependencies = [
+ "log",
+ "neqo-common",
+ "neqo-transport",
+ "qlog",
+ "rustc-hash",
+ "static_assertions",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "neqo-transport"
+version = "0.30.1"
+source = "git+https://github.com/mozilla/neqo?rev=76673b127251c90ad6250de7a0a7400ddd4661f1#76673b127251c90ad6250de7a0a7400ddd4661f1"
+dependencies = [
+ "enum-map",
+ "enumset",
+ "indexmap",
+ "log",
+ "mtu",
+ "neqo-common",
+ "nss-rs",
+ "qlog",
+ "rustc-hash",
+ "smallvec",
+ "static_assertions",
+ "strum",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "netconfig-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +3169,26 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nss-rs"
+version = "0.13.4"
+source = "git+https://github.com/mozilla/nss-rs#b7cfa30c8a526167cf6bd653b4a6d4f8549280eb"
+dependencies = [
+ "bindgen",
+ "enum-map",
+ "log",
+ "once_cell",
+ "pkcs11-bindings",
+ "semver",
+ "serde",
+ "serde_derive",
+ "strum",
+ "thiserror 2.0.19",
+ "toml",
+ "windows 0.61.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -3138,6 +3452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs11-bindings"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f2b11de4fec7f1e085891d4a4bf16a8b1beb49978837a80d4e9e705b99295c"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "pkcs5"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3567,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qlog"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16689c500fede96aa7d5e1f8924abe08fafb65146d7e192826bb5fb57a1e1ad0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
 ]
 
 [[package]]
@@ -3448,6 +3783,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3925,6 +4280,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3944,6 +4300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,6 +4318,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3966,6 +4353,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sfv"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "ref-cast",
 ]
 
 [[package]]
@@ -4019,6 +4417,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"
@@ -4229,6 +4633,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "subtle"
@@ -4510,6 +4935,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4660,7 +5116,7 @@ dependencies = [
  "getifaddrs",
  "ipnet",
  "libc",
- "libloading",
+ "libloading 0.9.0",
  "log",
  "netconfig-rs",
  "nix 0.31.3",
@@ -5319,6 +5775,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "winreg"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5361,6 +5829,7 @@ dependencies = [
  "core-runtime",
  "core-smart",
  "core-store",
+ "core-young",
  "rustls 0.23.40",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ core-young    = { path = "crates/core-young", default-features = false }
 neqo-common   = { git = "https://github.com/mozilla/neqo", rev = "76673b127251c90ad6250de7a0a7400ddd4661f1" }
 neqo-http3    = { git = "https://github.com/mozilla/neqo", rev = "76673b127251c90ad6250de7a0a7400ddd4661f1" }
 neqo-transport = { git = "https://github.com/mozilla/neqo", rev = "76673b127251c90ad6250de7a0a7400ddd4661f1" }
-nss           = { package = "nss-rs", git = "https://github.com/mozilla/nss-rs", rev = "b7cfa30c8a526167cf6bd653b4a6d4f8549280eb" }
+nss           = { package = "nss-rs", git = "https://github.com/mozilla/nss-rs" }
 xray-routing  = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584", package = "xray-routing" }
 xray-transport = { path = "third_party/xray-transport" }
 xray-utls     = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584", package = "xray-utls" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/core-observe",
     "crates/core-process",
     "crates/core-reality",
+    "crates/core-young",
     "crates/wuther-core",
     "tests-e2e",
 ]
@@ -155,6 +156,11 @@ core-mesh     = { path = "crates/core-mesh" }
 core-observe  = { path = "crates/core-observe" }
 core-process  = { path = "crates/core-process" }
 core-reality  = { path = "crates/core-reality" }
+core-young    = { path = "crates/core-young", default-features = false }
+neqo-common   = { git = "https://github.com/mozilla/neqo", rev = "76673b127251c90ad6250de7a0a7400ddd4661f1" }
+neqo-http3    = { git = "https://github.com/mozilla/neqo", rev = "76673b127251c90ad6250de7a0a7400ddd4661f1" }
+neqo-transport = { git = "https://github.com/mozilla/neqo", rev = "76673b127251c90ad6250de7a0a7400ddd4661f1" }
+nss           = { package = "nss-rs", git = "https://github.com/mozilla/nss-rs", rev = "b7cfa30c8a526167cf6bd653b4a6d4f8549280eb" }
 xray-routing  = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584", package = "xray-routing" }
 xray-transport = { path = "third_party/xray-transport" }
 xray-utls     = { git = "https://github.com/aimalygin/xray-rust.git", rev = "bb3e00da1abfc5fff70487b0dd2ba16054797584", package = "xray-utls" }

--- a/crates/core-config/Cargo.toml
+++ b/crates/core-config/Cargo.toml
@@ -21,6 +21,7 @@ xray-utls = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }
+core-young = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -211,6 +211,109 @@ pub struct Listen {
     /// `protocol` 指定的内层代理协议。
     #[serde(default, alias = "reality-inbounds", alias = "reality_inbounds")]
     pub reality: Vec<RealityListen>,
+    /// Young 原生入站。传输层是 Firefox 使用的 Mozilla Neqo HTTP/3/WebTransport。
+    #[serde(default, alias = "young-inbounds", alias = "young_inbounds")]
+    pub young: Vec<YoungListen>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct YoungListen {
+    #[serde(default = "default_young_listen_host")]
+    pub host: String,
+    pub port: u16,
+    #[serde(
+        rename = "nssDatabase",
+        alias = "nss_database",
+        alias = "nss-database",
+        alias = "nss-db"
+    )]
+    pub nss_database: String,
+    #[serde(
+        rename = "certificateNickname",
+        alias = "certificate_nickname",
+        alias = "certificate-nickname",
+        alias = "certificate"
+    )]
+    pub certificate_nickname: String,
+    pub authority: String,
+    #[serde(default = "default_young_path")]
+    pub path: String,
+    #[serde(default)]
+    pub users: Vec<String>,
+    #[serde(
+        default = "default_young_clock_skew",
+        with = "humantime_serde",
+        rename = "clockSkew",
+        alias = "clock_skew",
+        alias = "clock-skew"
+    )]
+    pub clock_skew: Duration,
+    #[serde(
+        default = "default_young_idle_timeout",
+        with = "humantime_serde",
+        rename = "idleTimeout",
+        alias = "idle_timeout",
+        alias = "idle-timeout"
+    )]
+    pub idle_timeout: Duration,
+    #[serde(
+        default = "default_young_max_streams",
+        rename = "maxStreams",
+        alias = "max_streams",
+        alias = "max-streams"
+    )]
+    pub max_streams: u64,
+    #[serde(
+        default = "default_young_max_sessions",
+        rename = "maxSessions",
+        alias = "max_sessions",
+        alias = "max-sessions"
+    )]
+    pub max_sessions: usize,
+    #[serde(
+        default = "default_young_max_flows",
+        rename = "maxFlowsPerSession",
+        alias = "max_flows_per_session",
+        alias = "max-flows-per-session"
+    )]
+    pub max_flows_per_session: usize,
+    #[serde(
+        default = "default_young_decoy_status",
+        rename = "decoyStatus",
+        alias = "decoy_status",
+        alias = "decoy-status"
+    )]
+    pub decoy_status: u16,
+    #[serde(
+        default = "default_young_decoy_body",
+        rename = "decoyBody",
+        alias = "decoy_body",
+        alias = "decoy-body"
+    )]
+    pub decoy_body: String,
+}
+
+impl std::fmt::Debug for YoungListen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("YoungListen")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("nss_database", &self.nss_database)
+            .field("certificate_nickname", &self.certificate_nickname)
+            .field("authority", &self.authority)
+            .field("path", &self.path)
+            .field("user_count", &self.users.len())
+            .field("clock_skew", &self.clock_skew)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("max_streams", &self.max_streams)
+            .field("max_sessions", &self.max_sessions)
+            .field("max_flows_per_session", &self.max_flows_per_session)
+            .field("decoy_status", &self.decoy_status)
+            .field("decoy_body_bytes", &self.decoy_body.len())
+            .finish()
+    }
 }
 
 /// Xray REALITY 服务端监听配置。
@@ -1744,6 +1847,33 @@ fn default_localhost() -> String {
 }
 fn default_reality_listen_host() -> String {
     "0.0.0.0".into()
+}
+fn default_young_listen_host() -> String {
+    "0.0.0.0".into()
+}
+fn default_young_path() -> String {
+    "/assets".into()
+}
+fn default_young_clock_skew() -> Duration {
+    Duration::from_secs(120)
+}
+fn default_young_idle_timeout() -> Duration {
+    Duration::from_secs(5 * 60)
+}
+fn default_young_max_streams() -> u64 {
+    1024
+}
+fn default_young_max_sessions() -> usize {
+    4096
+}
+fn default_young_max_flows() -> usize {
+    1024
+}
+fn default_young_decoy_status() -> u16 {
+    404
+}
+fn default_young_decoy_body() -> String {
+    "<!doctype html><html><head><title>Not Found</title></head><body><h1>Not Found</h1></body></html>".into()
 }
 fn default_reality_inner_protocol() -> String {
     "vless".into()

--- a/crates/core-config/src/node_uri.rs
+++ b/crates/core-config/src/node_uri.rs
@@ -37,6 +37,7 @@ pub enum NodeProtocol {
     Mieru,
     Sudoku,
     TrustTunnel,
+    Young,
     /// DNS hijack outbound (mihomo `type: dns`)：把 port-53 流量在本地直接
     /// 用 resolver 应答，不连远端。常配合 `RULE-SET / DST-PORT 53 → DNS_Hijack`
     /// 把 LAN 客户端的 DNS 截到本机解析。
@@ -66,6 +67,7 @@ impl NodeProtocol {
             "mieru" => Self::Mieru,
             "sudoku" => Self::Sudoku,
             "trusttunnel" => Self::TrustTunnel,
+            "young" => Self::Young,
             "dns" => Self::Dns,
             other => Self::Other(other.into()),
         }
@@ -92,6 +94,7 @@ impl NodeProtocol {
             Self::Mieru => "mieru",
             Self::Sudoku => "sudoku",
             Self::TrustTunnel => "trusttunnel",
+            Self::Young => "young",
             Self::Dns => "dns",
             Self::Other(s) => s.as_str(),
         }
@@ -165,6 +168,7 @@ pub fn parse_uri(uri: &str) -> ConfigResult<ParsedNode> {
         NodeProtocol::Shadowsocks => parse_ss(uri)?,
         NodeProtocol::Vmess => parse_vmess(uri)?,
         NodeProtocol::Vless
+        | NodeProtocol::Young
         | NodeProtocol::Trojan
         | NodeProtocol::Hysteria2
         | NodeProtocol::Tuic
@@ -234,7 +238,7 @@ fn parse_url_like(uri: &str, proto: NodeProtocol) -> ConfigResult<ParsedNode> {
     node.raw = uri.to_string();
     node.tls = matches!(
         proto,
-        NodeProtocol::Trojan | NodeProtocol::Hysteria2 | NodeProtocol::Tuic
+        NodeProtocol::Trojan | NodeProtocol::Hysteria2 | NodeProtocol::Tuic | NodeProtocol::Young
     ) || params
         .get("security")
         .map(|s| matches!(s.as_str(), "tls" | "reality"))
@@ -275,8 +279,60 @@ fn parse_url_like(uri: &str, proto: NodeProtocol) -> ConfigResult<ParsedNode> {
             }
         }
     }
+    if matches!(proto, NodeProtocol::Young) {
+        let key = node
+            .user
+            .as_deref()
+            .ok_or_else(|| ConfigError::bad_node("Young URI 必须在 userinfo 中携带 256 位密钥"))?;
+        core_young::YoungKey::parse_base64url(key)
+            .map_err(|error| ConfigError::bad_node(format!("Young 密钥无效：{error}")))?;
+        if params
+            .get("security")
+            .is_some_and(|security| !security.eq_ignore_ascii_case("tls"))
+        {
+            return Err(ConfigError::bad_node(
+                "Young 固定使用 Neqo QUIC/TLS；security 只能是 tls",
+            ));
+        }
+        let pin = params
+            .get("pin-sha256")
+            .or_else(|| params.get("pin_sha256"))
+            .or_else(|| params.get("pin"))
+            .ok_or_else(|| ConfigError::bad_node("Young URI 缺少 pin-sha256 证书固定值"))?;
+        validate_young_certificate_pin(pin)?;
+        if params
+            .get("path")
+            .is_some_and(|path| !path.starts_with('/') || path.len() > 512)
+        {
+            return Err(ConfigError::bad_node(
+                "Young path 必须以 / 开头且不超过 512 字节",
+            ));
+        }
+        node.transport = "webtransport".into();
+    }
     node.params = params;
     Ok(node)
+}
+
+fn validate_young_certificate_pin(value: &str) -> ConfigResult<()> {
+    use base64::Engine as _;
+
+    let decoded = if value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        hex::decode(value)
+            .map_err(|error| ConfigError::bad_node(format!("Young pin-sha256 hex 无效：{error}")))?
+    } else {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|error| {
+                ConfigError::bad_node(format!("Young pin-sha256 base64url 无效：{error}"))
+            })?
+    };
+    if decoded.len() != 32 {
+        return Err(ConfigError::bad_node(
+            "Young pin-sha256 解码后必须正好为 32 字节",
+        ));
+    }
+    Ok(())
 }
 
 fn reality_settings_from_params(
@@ -631,6 +687,30 @@ mod tests {
         assert_eq!(n.password.as_deref(), Some("pwd"));
         assert_eq!(n.sni.as_deref(), Some("example.com"));
         assert!(n.tls);
+    }
+
+    #[test]
+    fn parse_young_requires_firefox_neqo_parameters() {
+        let node = parse_uri(
+            "young://WlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlo@203.0.113.8:443?security=tls&sni=cdn.example&authority=cdn.example&path=%2Fassets&pin-sha256=0000000000000000000000000000000000000000000000000000000000000000#YOUNG",
+        )
+        .unwrap();
+        assert_eq!(node.protocol, NodeProtocol::Young);
+        assert_eq!(node.transport, "webtransport");
+        assert!(node.tls);
+        assert!(node.reality.is_none());
+        assert_eq!(node.sni.as_deref(), Some("cdn.example"));
+        assert_eq!(node.params.get("path").map(String::as_str), Some("/assets"));
+    }
+
+    #[test]
+    fn parse_young_rejects_missing_certificate_pin() {
+        let error = parse_uri(
+            "young://WlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlo@example.com:443?security=tls",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("pin-sha256"), "{error}");
     }
 
     #[test]

--- a/crates/core-config/src/profile.rs
+++ b/crates/core-config/src/profile.rs
@@ -15,6 +15,7 @@ pub fn apply_defaults(cfg: &mut UserConfig) {
         share: None,
         auth: vec![],
         reality: vec![],
+        young: vec![],
     });
     if listen.local.is_none() {
         listen.local = match profile {

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -7,7 +7,11 @@
 //! 这里产出的结构是给 `core-runtime` / `core-route` / `core-outbound`
 //! 共同消费的 *已展开* 数据，而非 YAML 原貌。
 
-use std::{collections::BTreeMap, net::SocketAddr, time::Duration};
+use std::{
+    collections::BTreeMap,
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -41,9 +45,25 @@ pub struct ListenPlan {
     pub mixed: Option<MixedListen>,
     #[serde(default)]
     pub reality: Vec<RealityListen>,
+    #[serde(default)]
+    pub young: Vec<YoungListen>,
     pub panel: Option<PanelListen>,
     pub share: Share,
     pub auth: Vec<UserPass>,
+}
+
+impl YoungListen {
+    pub fn socket_addr(&self) -> ConfigResult<SocketAddr> {
+        let host = self.host.trim();
+        let host = host
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+            .unwrap_or(host);
+        let ip = host
+            .parse::<IpAddr>()
+            .map_err(|_| ConfigError::invalid(format!("非法 Young 监听 IP: {}", self.host)))?;
+        Ok(SocketAddr::new(ip, self.port))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,6 +226,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         share: None,
         auth: vec![],
         reality: vec![],
+        young: vec![],
     });
 
     let share = listen.share.unwrap_or(Share::False);
@@ -280,14 +301,104 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         .collect();
 
     let reality = compile_reality_listeners(&listen.reality)?;
+    let young = compile_young_listeners(&listen.young)?;
 
     Ok(ListenPlan {
         mixed,
         reality,
+        young,
         panel,
         share,
         auth,
     })
+}
+
+fn compile_young_listeners(listeners: &[YoungListen]) -> ConfigResult<Vec<YoungListen>> {
+    let mut output = Vec::with_capacity(listeners.len());
+    let mut bound = std::collections::HashSet::new();
+    let mut nss_database: Option<&str> = None;
+    for (index, listener) in listeners.iter().enumerate() {
+        let location = format!("listen.young[{index}]");
+        if listener.port == 0 {
+            return Err(ConfigError::invalid("Young 入站端口不能为 0").at(location));
+        }
+        if listener.host.trim().is_empty() {
+            return Err(ConfigError::invalid("Young 入站 host 不能为空").at(location));
+        }
+        let listen_addr = listener
+            .socket_addr()
+            .map_err(|error| error.at(location.clone()))?;
+        if !bound.insert(listen_addr) {
+            return Err(ConfigError::invalid("重复的 Young 监听地址").at(location));
+        }
+        if listener.nss_database.trim().is_empty()
+            || listener.certificate_nickname.trim().is_empty()
+        {
+            return Err(ConfigError::invalid(
+                "Young 入站必须配置 nssDatabase 与 certificateNickname",
+            )
+            .at(location));
+        }
+        if let Some(existing) = nss_database {
+            if existing != listener.nss_database {
+                return Err(ConfigError::invalid(
+                    "同一进程的全部 Young 入站必须使用同一个 nssDatabase",
+                )
+                .at(format!("{location}.nssDatabase")));
+            }
+        } else {
+            nss_database = Some(&listener.nss_database);
+        }
+        if listener.authority.trim().is_empty() {
+            return Err(ConfigError::invalid("Young authority 不能为空")
+                .at(format!("{location}.authority")));
+        }
+        if !listener.path.starts_with('/') || listener.path.len() > 512 {
+            return Err(
+                ConfigError::invalid("Young path 必须以 / 开头且不超过 512 字节")
+                    .at(format!("{location}.path")),
+            );
+        }
+        if listener.users.is_empty() {
+            return Err(
+                ConfigError::invalid("Young 入站至少需要一个 256 位 users 密钥")
+                    .at(format!("{location}.users")),
+            );
+        }
+        let keys = listener
+            .users
+            .iter()
+            .enumerate()
+            .map(|(user_index, user)| {
+                core_young::YoungKey::parse_base64url(user).map_err(|error| {
+                    ConfigError::invalid(format!("非法 Young 256 位密钥：{error}"))
+                        .at(format!("{location}.users[{user_index}]"))
+                })
+            })
+            .collect::<ConfigResult<Vec<_>>>()?;
+        core_young::KeyRing::new(keys).map_err(|error| {
+            ConfigError::invalid(format!("Young users key ring 无效：{error}"))
+                .at(format!("{location}.users"))
+        })?;
+        if !(Duration::from_secs(10)..=Duration::from_secs(10 * 60)).contains(&listener.clock_skew)
+        {
+            return Err(ConfigError::invalid("Young clockSkew 必须在 10s..=10m")
+                .at(format!("{location}.clockSkew")));
+        }
+        if listener.idle_timeout < Duration::from_secs(10)
+            || listener.max_streams == 0
+            || listener.max_sessions == 0
+            || listener.max_flows_per_session == 0
+        {
+            return Err(ConfigError::invalid("Young idleTimeout/资源上限无效").at(location));
+        }
+        if !(100..=599).contains(&listener.decoy_status) || listener.decoy_body.len() > 1024 * 1024
+        {
+            return Err(ConfigError::invalid("Young decoyStatus/decoyBody 无效").at(location));
+        }
+        output.push(listener.clone());
+    }
+    Ok(output)
 }
 
 fn compile_reality_listeners(listeners: &[RealityListen]) -> ConfigResult<Vec<RealityListen>> {
@@ -2088,6 +2199,76 @@ listen:
             let error = crate::loader::load_from_str(yaml).unwrap_err();
             assert!(error.to_string().contains("端口不能为 0"));
         }
+    }
+
+    #[test]
+    fn young_listener_compiles_with_ipv6_and_key_ring() {
+        let plan = compile_cfg(&format!(
+            r#"
+version: 1
+profile: server
+listen:
+  young:
+    - host: "::1"
+      port: 2443
+      nssDatabase: data/nss
+      certificateNickname: young.example
+      authority: young.example
+      path: /assets
+      users: [{}]
+"#,
+            base64url_bytes(9, 32)
+        ));
+        assert_eq!(plan.listen.young.len(), 1);
+        assert_eq!(
+            plan.listen.young[0].socket_addr().unwrap(),
+            "[::1]:2443".parse::<SocketAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn young_listener_rejects_duplicate_keys_and_mixed_nss_databases() {
+        let key = base64url_bytes(11, 32);
+        let duplicate = crate::loader::load_from_str(&format!(
+            r#"
+version: 1
+profile: server
+listen:
+  young:
+    - port: 2443
+      nssDatabase: data/nss
+      certificateNickname: young.example
+      authority: young.example
+      users: [{key}, {key}]
+"#
+        ))
+        .unwrap_err();
+        assert!(duplicate.to_string().contains("重复 key id"));
+
+        let mixed_databases = crate::loader::load_from_str(&format!(
+            r#"
+version: 1
+profile: server
+listen:
+  young:
+    - port: 2443
+      nssDatabase: data/nss-a
+      certificateNickname: young-a.example
+      authority: young-a.example
+      users: [{key}]
+    - port: 2444
+      nssDatabase: data/nss-b
+      certificateNickname: young-b.example
+      authority: young-b.example
+      users: [{key}]
+"#
+        ))
+        .unwrap_err();
+        assert!(
+            mixed_databases
+                .to_string()
+                .contains("必须使用同一个 nssDatabase")
+        );
     }
 
     #[test]

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 core-config = { workspace = true }
 core-reality = { workspace = true }
+core-young   = { workspace = true, features = ["firefox-stack"] }
 tokio       = { workspace = true }
 async-trait = { workspace = true }
 bytes       = { workspace = true }

--- a/crates/core-outbound/src/proto/mod.rs
+++ b/crates/core-outbound/src/proto/mod.rs
@@ -39,3 +39,4 @@ pub mod vmess_kdf;
 pub mod vmess_legacy;
 pub mod wireguard;
 pub mod xhttp;
+pub mod young;

--- a/crates/core-outbound/src/proto/young.rs
+++ b/crates/core-outbound/src/proto/young.rs
@@ -1,0 +1,121 @@
+//! Young outbound over Mozilla Neqo HTTP/3/WebTransport.
+
+use std::{
+    io,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use core_young::{Target, YoungClient, YoungClientConfig, YoungUdpChannel};
+
+use crate::adapter::{
+    BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, UdpSocketLike,
+};
+
+#[derive(Debug)]
+pub struct YoungOutbound {
+    name: String,
+    config: YoungClientConfig,
+    client: Mutex<Option<YoungClient>>,
+}
+
+impl YoungOutbound {
+    #[must_use]
+    pub fn new(name: impl Into<String>, config: YoungClientConfig) -> Self {
+        Self {
+            name: name.into(),
+            config,
+            client: Mutex::new(None),
+        }
+    }
+
+    fn client(&self) -> io::Result<YoungClient> {
+        let mut client = self
+            .client
+            .lock()
+            .map_err(|_| io::Error::other("Young client lock poisoned"))?;
+        if let Some(client) = client.as_ref() {
+            return Ok(client.clone());
+        }
+        let started = YoungClient::start(self.config.clone())?;
+        *client = Some(started.clone());
+        Ok(started)
+    }
+}
+
+#[async_trait]
+impl OutboundAdapter for YoungOutbound {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn protocol(&self) -> &'static str {
+        "young"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            tcp: true,
+            udp: true,
+            ipv6: true,
+            multiplex: true,
+        }
+    }
+
+    async fn dial_tcp(&self, context: DialContext) -> io::Result<BoxedStream> {
+        let target = Target::new(context.host, context.port)?;
+        Ok(Box::pin(self.client()?.open_tcp(target).await?))
+    }
+
+    async fn dial_udp(&self, context: DialContext) -> io::Result<BoxedUdp> {
+        let target = Target::new(context.host, context.port)?;
+        let channel = self.client()?.open_udp(target).await?;
+        Ok(Box::new(YoungUdpSocket {
+            channel: Arc::new(channel),
+            closed: AtomicBool::new(false),
+        }))
+    }
+}
+
+struct YoungUdpSocket {
+    channel: Arc<YoungUdpChannel>,
+    closed: AtomicBool,
+}
+
+#[async_trait]
+impl UdpSocketLike for YoungUdpSocket {
+    async fn send_to(&self, payload: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "Young UDP socket 已关闭",
+            ));
+        }
+        let configured = self.channel.target();
+        if configured.host != target || configured.port != port {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Young UDP association 固定到 dial_udp 的目标",
+            ));
+        }
+        self.channel.send(payload).await
+    }
+
+    async fn recv_from(&self, output: &mut [u8]) -> io::Result<usize> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "Young UDP socket 已关闭",
+            ));
+        }
+        self.channel.recv(output).await
+    }
+
+    async fn close(&self) -> io::Result<()> {
+        self.closed.store(true, Ordering::Release);
+        self.channel.close()
+    }
+}

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -33,6 +33,7 @@ use crate::{
         vmess_legacy::VmessLegacyOutbound,
         wireguard::WireGuardOutbound,
         xhttp::Config as XhttpConfig,
+        young::YoungOutbound,
     },
     socks5::Socks5Outbound,
     stub::StubOutbound,
@@ -120,6 +121,7 @@ pub fn build_outbound(node: &ParsedNode) -> SharedOutbound {
         NodeProtocol::Mieru => build_mieru(node),
         NodeProtocol::Sudoku => build_sudoku(node),
         NodeProtocol::TrustTunnel => build_trusttunnel(node),
+        NodeProtocol::Young => build_young(node),
         ref other => StubOutbound::new(node.name.clone(), proto_static_name(other)),
     }
 }
@@ -957,6 +959,82 @@ fn build_trusttunnel(node: &ParsedNode) -> SharedOutbound {
     Arc::new(ob)
 }
 
+fn build_young(node: &ParsedNode) -> SharedOutbound {
+    let encoded_key = node
+        .user
+        .as_deref()
+        .or(node.password.as_deref())
+        .unwrap_or_default();
+    let key = match core_young::YoungKey::parse_base64url(encoded_key) {
+        Ok(key) => key,
+        Err(_) => return StubOutbound::new(node.name.clone(), "young(invalid-key)"),
+    };
+    let encoded_pin = node
+        .params
+        .get("pin-sha256")
+        .or_else(|| node.params.get("pin_sha256"))
+        .or_else(|| node.params.get("pin"))
+        .map(String::as_str)
+        .unwrap_or_default();
+    let pin = if encoded_pin.len() == 64 && encoded_pin.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        hex::decode(encoded_pin).ok()
+    } else {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded_pin)
+            .ok()
+    };
+    let Some(certificate_sha256) = pin.and_then(|pin| pin.try_into().ok()) else {
+        return StubOutbound::new(node.name.clone(), "young(invalid-certificate-pin)");
+    };
+    let server_name = node.sni.clone().unwrap_or_else(|| node.host.clone());
+    let authority = node
+        .params
+        .get("authority")
+        .cloned()
+        .unwrap_or_else(|| server_name.clone());
+    let padding_min = node
+        .params
+        .get("padding-min")
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(64);
+    let padding_max = node
+        .params
+        .get("padding-max")
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(512);
+    if padding_min > padding_max || usize::from(padding_max) > core_young::MAX_PADDING_BYTES {
+        return StubOutbound::new(node.name.clone(), "young(invalid-padding)");
+    }
+    let config = core_young::YoungClientConfig {
+        server: node.host.clone(),
+        port: node.port,
+        server_name,
+        authority,
+        path: node
+            .params
+            .get("path")
+            .cloned()
+            .unwrap_or_else(|| "/assets".into()),
+        key,
+        certificate_sha256,
+        idle_timeout: std::time::Duration::from_secs(
+            node.params
+                .get("idle-secs")
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(300),
+        ),
+        max_streams: node
+            .params
+            .get("max-streams")
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(1024),
+        padding_min,
+        padding_max,
+    };
+    Arc::new(YoungOutbound::new(&node.name, config))
+}
+
 fn decode_b64_32(s: &str) -> Option<[u8; 32]> {
     use base64::Engine;
     let v = base64::engine::general_purpose::STANDARD
@@ -988,6 +1066,7 @@ fn proto_static_name(p: &NodeProtocol) -> &'static str {
         NodeProtocol::Mieru => "mieru",
         NodeProtocol::Sudoku => "sudoku",
         NodeProtocol::TrustTunnel => "trusttunnel",
+        NodeProtocol::Young => "young",
         _ => "stub",
     }
 }

--- a/crates/core-young/Cargo.toml
+++ b/crates/core-young/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "core-young"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[features]
+default = ["firefox-stack"]
+firefox-stack = [
+    "dep:neqo-common",
+    "dep:neqo-http3",
+    "dep:neqo-transport",
+    "dep:nss",
+    "dep:tracing",
+]
+
+[dependencies]
+base64 = { workspace = true }
+hmac = { workspace = true }
+neqo-common = { workspace = true, optional = true }
+neqo-http3 = { workspace = true, optional = true }
+neqo-transport = { workspace = true, optional = true }
+nss = { workspace = true, optional = true }
+rand = { workspace = true }
+sha2 = { workspace = true }
+subtle = "2.6"
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true, optional = true }
+zeroize = { workspace = true }

--- a/crates/core-young/src/client.rs
+++ b/crates/core-young/src/client.rs
@@ -1,0 +1,1116 @@
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+    io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    rc::Rc,
+    sync::atomic::{AtomicBool, Ordering},
+    thread,
+    time::{Duration, Instant},
+};
+
+use neqo_common::{Datagram, Header, Tos, event::Provider as _, header::HeadersExt as _};
+use neqo_http3::{
+    Http3Client, Http3ClientEvent, Http3Parameters, Http3State, WebTransportEvent,
+    webtransport::ClientSession as _,
+};
+use neqo_transport::{
+    ConnectionParameters, Output, RandomConnectionIdGenerator, StreamId, StreamType,
+};
+use nss::AuthenticationStatus;
+use rand::{Rng, RngCore, rngs::OsRng};
+use sha2::{Digest as _, Sha256};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream},
+    net::UdpSocket,
+    sync::{Mutex, mpsc, oneshot},
+};
+use tracing::{debug, warn};
+
+use crate::codec::{
+    FlowKind, FlowOpen, SessionKey, Status, Target, UdpReassembler, YoungKey, create_authorization,
+    decode_flow_response, decode_udp_fragment, derive_rotating_path, derive_session_key,
+    encode_flow_open, encode_udp_fragments, unix_time_secs, verify_server_accept_proof,
+};
+
+const STREAM_BUFFER_BYTES: usize = 256 * 1024;
+const STREAM_CHUNK_BYTES: usize = 32 * 1024;
+const MAX_FLOW_WRITE_BUFFER_BYTES: usize = 1024 * 1024;
+const EXPORTER_LABEL: &[u8] = b"young-session-v1";
+const EXPORTER_CONTEXT: &[u8] = b"wuther-core";
+const CAP_TCP: u32 = 1;
+const CAP_UDP: u32 = 2;
+
+#[derive(Clone)]
+pub struct YoungClientConfig {
+    pub server: String,
+    pub port: u16,
+    pub server_name: String,
+    pub authority: String,
+    pub path: String,
+    pub key: YoungKey,
+    pub certificate_sha256: [u8; 32],
+    pub idle_timeout: Duration,
+    pub max_streams: u64,
+    pub padding_min: u16,
+    pub padding_max: u16,
+}
+
+impl fmt::Debug for YoungClientConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("YoungClientConfig")
+            .field("server", &self.server)
+            .field("port", &self.port)
+            .field("server_name", &self.server_name)
+            .field("authority", &self.authority)
+            .field("path", &self.path)
+            .field("key", &self.key)
+            .field("certificate_sha256", &"<redacted>")
+            .field("idle_timeout", &self.idle_timeout)
+            .field("max_streams", &self.max_streams)
+            .field("padding_min", &self.padding_min)
+            .field("padding_max", &self.padding_max)
+            .finish()
+    }
+}
+
+use std::fmt;
+
+impl YoungClientConfig {
+    pub fn validate(&self) -> io::Result<()> {
+        if self.server.trim().is_empty()
+            || self.server_name.trim().is_empty()
+            || self.authority.trim().is_empty()
+            || self.port == 0
+        {
+            return Err(invalid_input(
+                "Young client server、server_name、authority 和 port 均不能为空",
+            ));
+        }
+        if self.padding_min > self.padding_max
+            || usize::from(self.padding_max) > crate::codec::MAX_PADDING_BYTES
+        {
+            return Err(invalid_input("Young client padding 范围无效"));
+        }
+        if self.max_streams == 0 {
+            return Err(invalid_input("Young client max_streams 必须大于 0"));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct YoungClient {
+    commands: mpsc::UnboundedSender<ClientCommand>,
+}
+
+impl fmt::Debug for YoungClient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("YoungClient")
+            .field("worker", &"neqo")
+            .finish()
+    }
+}
+
+impl YoungClient {
+    pub fn start(config: YoungClientConfig) -> io::Result<Self> {
+        config.validate()?;
+        let (commands, receiver) = mpsc::unbounded_channel();
+        let worker_commands = commands.clone();
+        thread::Builder::new()
+            .name(format!("young-neqo-client-{}", config.server_name))
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        warn!(%error, "Young Neqo client runtime 创建失败");
+                        return;
+                    }
+                };
+                let local = tokio::task::LocalSet::new();
+                local.block_on(
+                    &runtime,
+                    ClientDriver::new(config, receiver, worker_commands).run(),
+                );
+            })
+            .map_err(|error| io::Error::other(format!("Young client worker 启动失败：{error}")))?;
+        Ok(Self { commands })
+    }
+
+    pub async fn open_tcp(&self, target: Target) -> io::Result<DuplexStream> {
+        let (result, receiver) = oneshot::channel();
+        self.commands
+            .send(ClientCommand::OpenTcp { target, result })
+            .map_err(|_| not_connected("Young client worker 已退出"))?;
+        receiver
+            .await
+            .map_err(|_| not_connected("Young client worker 未返回 TCP 结果"))?
+    }
+
+    pub async fn open_udp(&self, target: Target) -> io::Result<YoungUdpChannel> {
+        let (result, receiver) = oneshot::channel();
+        self.commands
+            .send(ClientCommand::OpenUdp { target, result })
+            .map_err(|_| not_connected("Young client worker 已退出"))?;
+        let opened = receiver
+            .await
+            .map_err(|_| not_connected("Young client worker 未返回 UDP 结果"))??;
+        Ok(YoungUdpChannel {
+            association_id: opened.association_id,
+            target: opened.target,
+            commands: self.commands.clone(),
+            incoming: Mutex::new(opened.incoming),
+            closed: AtomicBool::new(false),
+        })
+    }
+}
+
+pub struct YoungUdpChannel {
+    association_id: u64,
+    target: Target,
+    commands: mpsc::UnboundedSender<ClientCommand>,
+    incoming: Mutex<mpsc::Receiver<Vec<u8>>>,
+    closed: AtomicBool,
+}
+
+impl fmt::Debug for YoungUdpChannel {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("YoungUdpChannel")
+            .field("association_id", &self.association_id)
+            .field("target", &self.target)
+            .field("closed", &self.closed.load(Ordering::Acquire))
+            .finish()
+    }
+}
+
+impl YoungUdpChannel {
+    #[must_use]
+    pub const fn target(&self) -> &Target {
+        &self.target
+    }
+
+    pub async fn send(&self, payload: &[u8]) -> io::Result<usize> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(not_connected("Young UDP association 已关闭"));
+        }
+        self.commands
+            .send(ClientCommand::SendUdp {
+                association_id: self.association_id,
+                payload: payload.to_vec(),
+            })
+            .map_err(|_| not_connected("Young client worker 已退出"))?;
+        Ok(payload.len())
+    }
+
+    pub async fn recv(&self, output: &mut [u8]) -> io::Result<usize> {
+        let payload = self
+            .incoming
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or_else(|| not_connected("Young UDP association 已结束"))?;
+        if payload.len() > output.len() {
+            return Err(invalid_input("Young UDP 接收缓冲区过小"));
+        }
+        output[..payload.len()].copy_from_slice(&payload);
+        Ok(payload.len())
+    }
+
+    pub fn close(&self) -> io::Result<()> {
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            self.commands
+                .send(ClientCommand::CloseUdp {
+                    association_id: self.association_id,
+                })
+                .map_err(|_| not_connected("Young client worker 已退出"))?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for YoungUdpChannel {
+    fn drop(&mut self) {
+        let _ = self.close();
+    }
+}
+
+struct OpenedUdp {
+    association_id: u64,
+    target: Target,
+    incoming: mpsc::Receiver<Vec<u8>>,
+}
+
+enum ClientCommand {
+    OpenTcp {
+        target: Target,
+        result: oneshot::Sender<io::Result<DuplexStream>>,
+    },
+    OpenUdp {
+        target: Target,
+        result: oneshot::Sender<io::Result<OpenedUdp>>,
+    },
+    SendStream {
+        stream_id: StreamId,
+        payload: Vec<u8>,
+    },
+    FinishStream {
+        stream_id: StreamId,
+    },
+    SendUdp {
+        association_id: u64,
+        payload: Vec<u8>,
+    },
+    CloseUdp {
+        association_id: u64,
+    },
+}
+
+struct PendingWrite {
+    bytes: Vec<u8>,
+    offset: usize,
+}
+
+enum OpenResult {
+    Tcp {
+        result: oneshot::Sender<io::Result<DuplexStream>>,
+        application: DuplexStream,
+    },
+    Udp {
+        result: oneshot::Sender<io::Result<OpenedUdp>>,
+        incoming: mpsc::Receiver<Vec<u8>>,
+    },
+}
+
+struct ClientFlow {
+    flow_id: u64,
+    kind: FlowKind,
+    target: Target,
+    response: Vec<u8>,
+    result: Option<OpenResult>,
+    to_application: Option<mpsc::Sender<Vec<u8>>>,
+    bridge_task: Option<tokio::task::JoinHandle<()>>,
+    writes: VecDeque<PendingWrite>,
+    queued_write_bytes: usize,
+    finish_after_writes: bool,
+    send_finished: bool,
+    receive_finished: bool,
+}
+
+struct ClientDriver {
+    config: YoungClientConfig,
+    receiver: mpsc::UnboundedReceiver<ClientCommand>,
+    commands: mpsc::UnboundedSender<ClientCommand>,
+    client: Option<Http3Client>,
+    socket: Option<UdpSocket>,
+    local_addr: Option<SocketAddr>,
+    remote_addr: Option<SocketAddr>,
+    session_id: Option<StreamId>,
+    session_key: Option<SessionKey>,
+    client_nonce: Option<[u8; 16]>,
+    session_started: bool,
+    pending: VecDeque<ClientCommand>,
+    flows: HashMap<StreamId, ClientFlow>,
+    udp_streams: HashMap<u64, StreamId>,
+    udp_reassembler: UdpReassembler,
+    next_packet_id: u32,
+}
+
+impl ClientDriver {
+    fn new(
+        config: YoungClientConfig,
+        receiver: mpsc::UnboundedReceiver<ClientCommand>,
+        commands: mpsc::UnboundedSender<ClientCommand>,
+    ) -> Self {
+        Self {
+            config,
+            receiver,
+            commands,
+            client: None,
+            socket: None,
+            local_addr: None,
+            remote_addr: None,
+            session_id: None,
+            session_key: None,
+            client_nonce: None,
+            session_started: false,
+            pending: VecDeque::new(),
+            flows: HashMap::new(),
+            udp_streams: HashMap::new(),
+            udp_reassembler: UdpReassembler::default(),
+            next_packet_id: OsRng.next_u32(),
+        }
+    }
+
+    async fn run(mut self) {
+        if let Err(error) = self.initialize().await {
+            self.fail_all(format!("Young Neqo client 初始化失败：{error}"));
+            return;
+        }
+        loop {
+            if let Err(error) = self.process_events().await {
+                self.fail_all(error.to_string());
+                return;
+            }
+            let callback = match self.process_output().await {
+                Ok(duration) => duration,
+                Err(error) => {
+                    self.fail_all(error.to_string());
+                    return;
+                }
+            };
+            let Some(socket) = self.socket.as_ref() else {
+                self.fail_all("Young UDP socket 不存在".into());
+                return;
+            };
+            let mut packet = vec![0; 65_535];
+            let sleep_for = if callback.is_zero() {
+                Duration::from_millis(250)
+            } else {
+                callback
+            };
+            tokio::select! {
+                command = self.receiver.recv() => {
+                    let Some(command) = command else {
+                        return;
+                    };
+                    if let Err(error) = self.handle_command(command).await {
+                        debug!(%error, "Young client command 被拒绝");
+                    }
+                }
+                received = socket.recv_from(&mut packet) => {
+                    match received {
+                        Ok((length, source)) => {
+                            if Some(source) == self.remote_addr {
+                                let local = self.local_addr.expect("initialized");
+                                let datagram = Datagram::new(source, local, Tos::default(), packet[..length].to_vec());
+                                self.client.as_mut().expect("initialized").process_input(datagram, Instant::now());
+                            }
+                        }
+                        Err(error) => {
+                            self.fail_all(format!("Young UDP recv 失败：{error}"));
+                            return;
+                        }
+                    }
+                }
+                () = tokio::time::sleep(sleep_for) => {}
+            }
+        }
+    }
+
+    async fn initialize(&mut self) -> io::Result<()> {
+        nss::init().map_err(|error| io::Error::other(format!("NSS 初始化失败：{error}")))?;
+        let remote_addr = tokio::net::lookup_host((self.config.server.as_str(), self.config.port))
+            .await?
+            .next()
+            .ok_or_else(|| not_connected("Young server DNS 没有可用地址"))?;
+        let bind = match remote_addr {
+            SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+            SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+        };
+        let socket = UdpSocket::bind(bind).await?;
+        let local_addr = socket.local_addr()?;
+        let connection_parameters = ConnectionParameters::default()
+            .idle_timeout(self.config.idle_timeout)
+            .max_streams(StreamType::BiDi, self.config.max_streams)
+            .max_streams(StreamType::UniDi, 16);
+        let parameters = Http3Parameters::default()
+            .connection_parameters(connection_parameters)
+            .webtransport(true)
+            .http3_datagram(true);
+        let client = Http3Client::new(
+            self.config.server_name.clone(),
+            Rc::new(RefCell::new(RandomConnectionIdGenerator::new(10))),
+            local_addr,
+            remote_addr,
+            parameters,
+            Instant::now(),
+        )
+        .map_err(neqo_error)?;
+        self.socket = Some(socket);
+        self.local_addr = Some(local_addr);
+        self.remote_addr = Some(remote_addr);
+        self.client = Some(client);
+        Ok(())
+    }
+
+    async fn process_output(&mut self) -> io::Result<Duration> {
+        loop {
+            match self
+                .client
+                .as_mut()
+                .expect("initialized")
+                .process_output(Instant::now())
+            {
+                Output::Datagram(datagram) => {
+                    self.socket
+                        .as_ref()
+                        .expect("initialized")
+                        .send_to(datagram.as_ref(), datagram.destination())
+                        .await?;
+                }
+                Output::Callback(duration) => return Ok(duration),
+                Output::None => return Ok(Duration::from_millis(250)),
+            }
+        }
+    }
+
+    async fn process_events(&mut self) -> io::Result<()> {
+        while let Some(event) = self.client.as_mut().expect("initialized").next_event() {
+            match event {
+                Http3ClientEvent::AuthenticationNeeded => self.authenticate_certificate()?,
+                Http3ClientEvent::StateChange(Http3State::Connected)
+                | Http3ClientEvent::RequestsCreatable
+                | Http3ClientEvent::WebTransport(WebTransportEvent::Negotiated(true)) => {
+                    self.maybe_start_session()?;
+                }
+                Http3ClientEvent::WebTransport(WebTransportEvent::NewSession {
+                    stream_id,
+                    status,
+                    headers,
+                }) => self.finish_session(stream_id, status, &headers)?,
+                Http3ClientEvent::WebTransport(WebTransportEvent::NewStream {
+                    stream_id, ..
+                }) => {
+                    self.client
+                        .as_mut()
+                        .expect("initialized")
+                        .cancel_fetch(stream_id, neqo_http3::Error::HttpRequestRejected.code())
+                        .map_err(neqo_error)?;
+                }
+                Http3ClientEvent::WebTransport(WebTransportEvent::Datagram {
+                    session_id,
+                    datagram,
+                }) if Some(session_id) == self.session_id => {
+                    self.handle_udp_datagram(datagram.as_ref()).await?;
+                }
+                Http3ClientEvent::DataReadable { stream_id } => {
+                    self.read_stream(stream_id).await?;
+                }
+                Http3ClientEvent::DataWritable { stream_id } => {
+                    self.flush_stream(stream_id)?;
+                }
+                Http3ClientEvent::Reset { stream_id, .. }
+                | Http3ClientEvent::StopSending { stream_id, .. } => {
+                    self.fail_flow(stream_id, "Young WebTransport stream 被对端重置");
+                }
+                Http3ClientEvent::WebTransport(WebTransportEvent::SessionClosed {
+                    stream_id,
+                    ..
+                }) if Some(stream_id) == self.session_id => {
+                    return Err(not_connected("Young WebTransport session 已关闭"));
+                }
+                Http3ClientEvent::StateChange(Http3State::Closing(reason))
+                | Http3ClientEvent::StateChange(Http3State::Closed(reason)) => {
+                    return Err(not_connected(format!("Young QUIC 连接关闭：{reason:?}")));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn authenticate_certificate(&mut self) -> io::Result<()> {
+        let certificate = self
+            .client
+            .as_ref()
+            .expect("initialized")
+            .peer_certificate()
+            .and_then(|certificates| certificates.iter().next().map(ToOwned::to_owned));
+        let accepted = certificate.is_some_and(|der| {
+            let digest: [u8; 32] = Sha256::digest(der).into();
+            bool::from(subtle::ConstantTimeEq::ct_eq(
+                digest.as_slice(),
+                self.config.certificate_sha256.as_slice(),
+            ))
+        });
+        self.client.as_mut().expect("initialized").authenticated(
+            if accepted {
+                AuthenticationStatus::Ok
+            } else {
+                AuthenticationStatus::CertUntrusted
+            },
+            Instant::now(),
+        );
+        if accepted {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Young server 证书 SHA-256 pin 不匹配",
+            ))
+        }
+    }
+
+    fn maybe_start_session(&mut self) -> io::Result<()> {
+        if self.session_started
+            || !self
+                .client
+                .as_ref()
+                .expect("initialized")
+                .webtransport_enabled()
+        {
+            return Ok(());
+        }
+        let now = unix_time_secs()?;
+        let path = derive_rotating_path(&self.config.key, &self.config.path, now);
+        let (authorization, nonce) = create_authorization(
+            &self.config.key,
+            &self.config.authority,
+            &path,
+            CAP_TCP | CAP_UDP,
+        )?;
+        let headers = [
+            Header::new("authorization", format!("Bearer {authorization}")),
+            Header::new(
+                "user-agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:141.0) Gecko/20100101 Firefox/141.0",
+            ),
+            Header::new("cache-control", "no-cache"),
+        ];
+        let session_id = self
+            .client
+            .as_mut()
+            .expect("initialized")
+            .webtransport_create_session(
+                Instant::now(),
+                ("https", self.config.authority.as_str(), path.as_str()),
+                &headers,
+            )
+            .map_err(neqo_error)?;
+        self.session_started = true;
+        self.session_id = Some(session_id);
+        self.client_nonce = Some(nonce);
+        Ok(())
+    }
+
+    fn finish_session(
+        &mut self,
+        stream_id: StreamId,
+        status: u16,
+        headers: &[Header],
+    ) -> io::Result<()> {
+        if Some(stream_id) != self.session_id || status != 200 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("Young WebTransport session 被拒绝，HTTP {status}"),
+            ));
+        }
+        let proof = headers
+            .find_header("sec-young-accept")
+            .and_then(|header| header.value_utf8().ok())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "Young server 缺少 accept proof",
+                )
+            })?;
+        let nonce = self.client_nonce.expect("session started");
+        verify_server_accept_proof(&self.config.key, nonce, proof)?;
+        let mut exporter = [0; 32];
+        self.client
+            .as_ref()
+            .expect("initialized")
+            .webtransport_export_keying_material(
+                stream_id,
+                EXPORTER_LABEL,
+                EXPORTER_CONTEXT,
+                &mut exporter,
+            )
+            .map_err(neqo_error)?;
+        self.session_key = Some(derive_session_key(&self.config.key, &exporter, nonce));
+        while let Some(command) = self.pending.pop_front() {
+            self.handle_ready_command(command)?;
+        }
+        Ok(())
+    }
+
+    async fn handle_command(&mut self, command: ClientCommand) -> io::Result<()> {
+        if self.session_key.is_none() {
+            match command {
+                ClientCommand::OpenTcp { .. } | ClientCommand::OpenUdp { .. } => {
+                    self.pending.push_back(command);
+                    return Ok(());
+                }
+                _ => return Err(not_connected("Young session 尚未就绪")),
+            }
+        }
+        self.handle_ready_command(command)
+    }
+
+    fn handle_ready_command(&mut self, command: ClientCommand) -> io::Result<()> {
+        match command {
+            ClientCommand::OpenTcp { target, result } => {
+                self.open_flow(FlowKind::Tcp, target, Some(result), None)
+            }
+            ClientCommand::OpenUdp { target, result } => {
+                self.open_flow(FlowKind::Udp, target, None, Some(result))
+            }
+            ClientCommand::SendStream { stream_id, payload } => {
+                let mut reset = false;
+                if let Some(flow) = self.flows.get_mut(&stream_id) {
+                    if flow.queued_write_bytes.saturating_add(payload.len())
+                        > MAX_FLOW_WRITE_BUFFER_BYTES
+                    {
+                        reset = true;
+                    } else {
+                        flow.queued_write_bytes += payload.len();
+                        flow.writes.push_back(PendingWrite {
+                            bytes: payload,
+                            offset: 0,
+                        });
+                    }
+                }
+                if reset {
+                    let _ = self
+                        .client
+                        .as_mut()
+                        .expect("initialized")
+                        .cancel_fetch(stream_id, neqo_http3::Error::HttpRequestRejected.code());
+                    self.abort_flow(stream_id);
+                } else {
+                    self.flush_stream(stream_id)?;
+                }
+                Ok(())
+            }
+            ClientCommand::FinishStream { stream_id } => {
+                if let Some(flow) = self.flows.get_mut(&stream_id) {
+                    flow.finish_after_writes = true;
+                    self.flush_stream(stream_id)?;
+                }
+                Ok(())
+            }
+            ClientCommand::SendUdp {
+                association_id,
+                payload,
+            } => self.send_udp(association_id, &payload),
+            ClientCommand::CloseUdp { association_id } => {
+                if let Some(stream_id) = self.udp_streams.remove(&association_id) {
+                    self.client
+                        .as_mut()
+                        .expect("initialized")
+                        .stream_close_send(stream_id, Instant::now())
+                        .map_err(neqo_error)?;
+                    self.remove_flow(stream_id);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn open_flow(
+        &mut self,
+        kind: FlowKind,
+        target: Target,
+        tcp_result: Option<oneshot::Sender<io::Result<DuplexStream>>>,
+        udp_result: Option<oneshot::Sender<io::Result<OpenedUdp>>>,
+    ) -> io::Result<()> {
+        let session_id = self
+            .session_id
+            .ok_or_else(|| not_connected("Young session 缺失"))?;
+        let stream_id = self
+            .client
+            .as_mut()
+            .expect("initialized")
+            .webtransport_create_stream(session_id, StreamType::BiDi)
+            .map_err(neqo_error)?;
+        let mut flow_id = OsRng.next_u64();
+        while flow_id == 0 || self.udp_streams.contains_key(&flow_id) {
+            flow_id = OsRng.next_u64();
+        }
+        let padding = if self.config.padding_min == self.config.padding_max {
+            self.config.padding_min
+        } else {
+            OsRng.gen_range(self.config.padding_min..=self.config.padding_max)
+        };
+        let frame = encode_flow_open(
+            self.session_key.as_ref().expect("ready"),
+            &FlowOpen {
+                kind,
+                flow_id,
+                target: target.clone(),
+            },
+            usize::from(padding),
+        )?;
+        let (result, to_application, bridge_task) = match kind {
+            FlowKind::Tcp => {
+                let result = tcp_result.expect("TCP result");
+                let (application, bridge) = tokio::io::duplex(STREAM_BUFFER_BYTES);
+                let (incoming, incoming_rx) = mpsc::channel(64);
+                let bridge_task = tokio::task::spawn_local(stream_bridge(
+                    bridge,
+                    incoming_rx,
+                    stream_id,
+                    self.commands.clone(),
+                ));
+                (
+                    OpenResult::Tcp {
+                        result,
+                        application,
+                    },
+                    Some(incoming),
+                    Some(bridge_task),
+                )
+            }
+            FlowKind::Udp => {
+                let result = udp_result.expect("UDP result");
+                let (incoming, incoming_rx) = mpsc::channel(256);
+                self.udp_streams.insert(flow_id, stream_id);
+                (
+                    OpenResult::Udp {
+                        result,
+                        incoming: incoming_rx,
+                    },
+                    Some(incoming),
+                    None,
+                )
+            }
+        };
+        let queued_write_bytes = frame.len();
+        self.flows.insert(
+            stream_id,
+            ClientFlow {
+                flow_id,
+                kind,
+                target,
+                response: Vec::new(),
+                result: Some(result),
+                to_application,
+                bridge_task,
+                writes: VecDeque::from([PendingWrite {
+                    bytes: frame,
+                    offset: 0,
+                }]),
+                queued_write_bytes,
+                finish_after_writes: false,
+                send_finished: false,
+                receive_finished: false,
+            },
+        );
+        self.flush_stream(stream_id)
+    }
+
+    fn flush_stream(&mut self, stream_id: StreamId) -> io::Result<()> {
+        let mut remove_after_flush = false;
+        {
+            let Some(flow) = self.flows.get_mut(&stream_id) else {
+                return Ok(());
+            };
+            while let Some(front) = flow.writes.front_mut() {
+                let written = self
+                    .client
+                    .as_mut()
+                    .expect("initialized")
+                    .send_data(stream_id, &front.bytes[front.offset..], Instant::now())
+                    .map_err(neqo_error)?;
+                if written == 0 {
+                    break;
+                }
+                flow.queued_write_bytes = flow.queued_write_bytes.saturating_sub(written);
+                front.offset += written;
+                if front.offset == front.bytes.len() {
+                    flow.writes.pop_front();
+                }
+            }
+            if flow.writes.is_empty() && flow.finish_after_writes {
+                flow.finish_after_writes = false;
+                self.client
+                    .as_mut()
+                    .expect("initialized")
+                    .stream_close_send(stream_id, Instant::now())
+                    .map_err(neqo_error)?;
+                flow.send_finished = true;
+                remove_after_flush = flow.receive_finished;
+            }
+        }
+        if remove_after_flush {
+            self.remove_flow(stream_id);
+        }
+        Ok(())
+    }
+
+    async fn read_stream(&mut self, stream_id: StreamId) -> io::Result<()> {
+        loop {
+            let mut buffer = vec![0; STREAM_CHUNK_BYTES];
+            let (length, fin) = self
+                .client
+                .as_mut()
+                .expect("initialized")
+                .read_data(Instant::now(), stream_id, &mut buffer)
+                .map_err(neqo_error)?;
+            if length > 0 {
+                buffer.truncate(length);
+                self.consume_stream_data(stream_id, buffer).await?;
+            }
+            if fin || length == 0 {
+                if fin {
+                    let remove_after_read = self.flows.get_mut(&stream_id).is_some_and(|flow| {
+                        flow.receive_finished = true;
+                        flow.to_application.take();
+                        flow.send_finished
+                    });
+                    if remove_after_read {
+                        self.remove_flow(stream_id);
+                    }
+                }
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    async fn consume_stream_data(
+        &mut self,
+        stream_id: StreamId,
+        payload: Vec<u8>,
+    ) -> io::Result<()> {
+        let Some(flow) = self.flows.get_mut(&stream_id) else {
+            return Ok(());
+        };
+        let mut reset_after_delivery = false;
+        if flow.result.is_some() {
+            flow.response.extend_from_slice(&payload);
+            let Some((response, consumed)) =
+                decode_flow_response(self.session_key.as_ref().expect("ready"), &flow.response)?
+            else {
+                return Ok(());
+            };
+            if response.flow_id != flow.flow_id {
+                return Err(invalid_data("Young flow response id 不匹配"));
+            }
+            let remaining = flow.response.split_off(consumed);
+            flow.response.clear();
+            let result = flow.result.take().expect("checked");
+            if response.status != Status::Ok {
+                let error = status_error(response.status);
+                match result {
+                    OpenResult::Tcp { result, .. } => {
+                        let _ = result.send(Err(error));
+                    }
+                    OpenResult::Udp { result, .. } => {
+                        let _ = result.send(Err(error));
+                    }
+                }
+                self.client
+                    .as_mut()
+                    .expect("initialized")
+                    .stream_close_send(stream_id, Instant::now())
+                    .map_err(neqo_error)?;
+                self.abort_flow(stream_id);
+                return Ok(());
+            }
+            match result {
+                OpenResult::Tcp {
+                    result,
+                    application,
+                } => {
+                    let _ = result.send(Ok(application));
+                }
+                OpenResult::Udp { result, incoming } => {
+                    let _ = result.send(Ok(OpenedUdp {
+                        association_id: flow.flow_id,
+                        target: flow.target.clone(),
+                        incoming,
+                    }));
+                }
+            }
+            if !remaining.is_empty()
+                && flow.kind == FlowKind::Tcp
+                && let Some(sender) = &flow.to_application
+            {
+                reset_after_delivery = sender.try_send(remaining).is_err();
+            }
+        } else if flow.kind == FlowKind::Tcp
+            && let Some(sender) = &flow.to_application
+        {
+            reset_after_delivery = sender.try_send(payload).is_err();
+        }
+        if reset_after_delivery {
+            let _ = self
+                .client
+                .as_mut()
+                .expect("initialized")
+                .cancel_fetch(stream_id, neqo_http3::Error::HttpRequestRejected.code());
+            self.abort_flow(stream_id);
+        }
+        Ok(())
+    }
+
+    fn send_udp(&mut self, association_id: u64, payload: &[u8]) -> io::Result<()> {
+        if !self.udp_streams.contains_key(&association_id) {
+            return Err(not_connected("Young UDP association 不存在"));
+        }
+        let session_id = self.session_id.expect("ready");
+        let max_size = usize::try_from(
+            self.client
+                .as_ref()
+                .expect("initialized")
+                .webtransport_max_datagram_size(session_id)
+                .map_err(neqo_error)?,
+        )
+        .map_err(|_| invalid_input("WebTransport datagram size 超过 usize"))?;
+        self.next_packet_id = self.next_packet_id.wrapping_add(1);
+        for fragment in encode_udp_fragments(
+            self.session_key.as_ref().expect("ready"),
+            association_id,
+            self.next_packet_id,
+            payload,
+            max_size,
+        )? {
+            self.client
+                .as_mut()
+                .expect("initialized")
+                .webtransport_send_datagram(session_id, &fragment, None, Instant::now())
+                .map_err(neqo_error)?;
+        }
+        Ok(())
+    }
+
+    async fn handle_udp_datagram(&mut self, datagram: &[u8]) -> io::Result<()> {
+        let fragment = decode_udp_fragment(self.session_key.as_ref().expect("ready"), datagram)?;
+        let association_id = fragment.association_id;
+        let Some(stream_id) = self.udp_streams.get(&association_id).copied() else {
+            return Ok(());
+        };
+        if let Some(payload) = self.udp_reassembler.push(fragment, Instant::now())?
+            && let Some(sender) = self
+                .flows
+                .get(&stream_id)
+                .and_then(|flow| flow.to_application.as_ref())
+        {
+            let _ = sender.try_send(payload);
+        }
+        Ok(())
+    }
+
+    fn fail_flow(&mut self, stream_id: StreamId, message: &str) {
+        if let Some(mut flow) = self.abort_flow(stream_id)
+            && let Some(result) = flow.result.take()
+        {
+            match result {
+                OpenResult::Tcp { result, .. } => {
+                    let _ = result.send(Err(not_connected(message)));
+                }
+                OpenResult::Udp { result, .. } => {
+                    let _ = result.send(Err(not_connected(message)));
+                }
+            }
+        }
+    }
+
+    fn remove_flow(&mut self, stream_id: StreamId) -> Option<ClientFlow> {
+        let flow = self.flows.remove(&stream_id)?;
+        if flow.kind == FlowKind::Udp {
+            self.udp_streams.remove(&flow.flow_id);
+        }
+        Some(flow)
+    }
+
+    fn abort_flow(&mut self, stream_id: StreamId) -> Option<ClientFlow> {
+        let mut flow = self.remove_flow(stream_id)?;
+        if let Some(task) = flow.bridge_task.take() {
+            task.abort();
+        }
+        Some(flow)
+    }
+
+    fn fail_all(&mut self, message: String) {
+        while let Some(command) = self.pending.pop_front() {
+            match command {
+                ClientCommand::OpenTcp { result, .. } => {
+                    let _ = result.send(Err(not_connected(message.clone())));
+                }
+                ClientCommand::OpenUdp { result, .. } => {
+                    let _ = result.send(Err(not_connected(message.clone())));
+                }
+                _ => {}
+            }
+        }
+        let stream_ids: Vec<_> = self.flows.keys().copied().collect();
+        for stream_id in stream_ids {
+            self.fail_flow(stream_id, &message);
+        }
+    }
+}
+
+async fn stream_bridge(
+    stream: DuplexStream,
+    mut incoming: mpsc::Receiver<Vec<u8>>,
+    stream_id: StreamId,
+    commands: mpsc::UnboundedSender<ClientCommand>,
+) {
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    let mut buffer = vec![0; STREAM_CHUNK_BYTES];
+    let mut local_send_open = true;
+    let mut remote_send_open = true;
+    while local_send_open || remote_send_open {
+        tokio::select! {
+            read = reader.read(&mut buffer), if local_send_open => {
+                match read {
+                    Ok(0) => {
+                        local_send_open = false;
+                        let _ = commands.send(ClientCommand::FinishStream { stream_id });
+                    }
+                    Ok(length) => {
+                        let _ = commands.send(ClientCommand::SendStream {
+                            stream_id,
+                            payload: buffer[..length].to_vec(),
+                        });
+                    }
+                    Err(_) => {
+                        local_send_open = false;
+                        let _ = commands.send(ClientCommand::FinishStream { stream_id });
+                    }
+                }
+            }
+            payload = incoming.recv(), if remote_send_open => {
+                match payload {
+                    Some(payload) if writer.write_all(&payload).await.is_ok() => {}
+                    Some(_) => {
+                        remote_send_open = false;
+                        incoming.close();
+                        let _ = writer.shutdown().await;
+                    }
+                    None => {
+                        remote_send_open = false;
+                        let _ = writer.shutdown().await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn neqo_error(error: impl fmt::Display) -> io::Error {
+    io::Error::other(format!("Neqo：{error}"))
+}
+
+fn status_error(status: Status) -> io::Error {
+    let (kind, message) = match status {
+        Status::Ok => (io::ErrorKind::Other, "unexpected OK"),
+        Status::BadRequest => (io::ErrorKind::InvalidData, "请求格式无效"),
+        Status::Unauthorized => (io::ErrorKind::PermissionDenied, "未授权"),
+        Status::ConnectFailed => (io::ErrorKind::ConnectionRefused, "目标连接失败"),
+        Status::Unsupported => (io::ErrorKind::Unsupported, "命令不受支持"),
+        Status::ResourceLimit => (io::ErrorKind::OutOfMemory, "服务端资源限制"),
+    };
+    io::Error::new(kind, format!("Young server 拒绝 flow：{message}"))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn not_connected(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::NotConnected, message.into())
+}

--- a/crates/core-young/src/codec.rs
+++ b/crates/core-young/src/codec.rs
@@ -1,0 +1,932 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt, io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use base64::Engine as _;
+use hmac::{Hmac, Mac};
+use rand::{RngCore, rngs::OsRng};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+type HmacSha256 = Hmac<Sha256>;
+
+pub const VERSION: u8 = 1;
+pub const DEFAULT_CLOCK_SKEW_SECS: u64 = 120;
+pub const MAX_PADDING_BYTES: usize = 4096;
+pub const MAX_UDP_PAYLOAD_BYTES: usize = 65_507;
+const MAX_UDP_FRAGMENTS: usize = 256;
+const AUTH_TOKEN_BYTES: usize = 1 + 8 + 8 + 16 + 4 + 32;
+const FLOW_TAG_BYTES: usize = 16;
+const FLOW_RESPONSE_BYTES: usize = 2 + 1 + 1 + 8 + FLOW_TAG_BYTES;
+const UDP_HEADER_BYTES: usize = 2 + 1 + 1 + 8 + 4 + 2 + 2 + 2;
+const UDP_TAG_BYTES: usize = 16;
+
+#[derive(Clone)]
+pub struct YoungKey(Arc<Zeroizing<[u8; 32]>>);
+
+impl YoungKey {
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(Arc::new(Zeroizing::new(bytes)))
+    }
+
+    pub fn parse_base64url(value: &str) -> io::Result<Self> {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(value.trim())
+            .map_err(|error| invalid_input(format!("Young 密钥不是合法 base64url：{error}")))?;
+        let bytes: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| invalid_input("Young 密钥解码后必须正好为 32 字节"))?;
+        Ok(Self::from_bytes(bytes))
+    }
+
+    #[must_use]
+    pub fn id(&self) -> [u8; 8] {
+        let digest = Sha256::digest(self.as_bytes());
+        digest[..8]
+            .try_into()
+            .expect("SHA-256 prefix has fixed size")
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
+
+impl fmt::Debug for YoungKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("YoungKey")
+            .field("id", &hex_id(self.id()))
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct SessionKey(Arc<Zeroizing<[u8; 32]>>);
+
+impl SessionKey {
+    fn new(bytes: [u8; 32]) -> Self {
+        Self(Arc::new(Zeroizing::new(bytes)))
+    }
+
+    fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_ref()
+    }
+}
+
+impl fmt::Debug for SessionKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionKey")
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct KeyRing {
+    keys: Vec<YoungKey>,
+}
+
+impl KeyRing {
+    pub fn new(keys: Vec<YoungKey>) -> io::Result<Self> {
+        if keys.is_empty() {
+            return Err(invalid_input("Young key ring 不能为空"));
+        }
+        let mut ids = HashSet::new();
+        for key in &keys {
+            if !ids.insert(key.id()) {
+                return Err(invalid_input("Young key ring 包含重复 key id"));
+            }
+        }
+        Ok(Self { keys })
+    }
+
+    #[must_use]
+    pub fn find(&self, id: [u8; 8]) -> Option<YoungKey> {
+        self.keys.iter().find(|key| key.id() == id).cloned()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+#[derive(Debug)]
+pub struct ReplayCache {
+    entries: Mutex<HashMap<[u8; 24], u64>>,
+    max_entries: usize,
+}
+
+impl Default for ReplayCache {
+    fn default() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            max_entries: 65_536,
+        }
+    }
+}
+
+impl ReplayCache {
+    #[must_use]
+    pub fn with_capacity(max_entries: usize) -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    pub fn check_and_insert(
+        &self,
+        key_id: [u8; 8],
+        nonce: [u8; 16],
+        timestamp: u64,
+        now: u64,
+        window_secs: u64,
+    ) -> io::Result<()> {
+        let mut replay_key = [0; 24];
+        replay_key[..8].copy_from_slice(&key_id);
+        replay_key[8..].copy_from_slice(&nonce);
+        let cutoff = now.saturating_sub(window_secs.saturating_mul(2));
+        let mut entries = self
+            .entries
+            .lock()
+            .map_err(|_| io::Error::other("Young replay cache lock poisoned"))?;
+        entries.retain(|_, seen_at| *seen_at >= cutoff);
+        if entries.contains_key(&replay_key) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Young 会话认证重放被拒绝",
+            ));
+        }
+        if entries.len() >= self.max_entries {
+            if let Some(oldest) = entries
+                .iter()
+                .min_by_key(|(_, seen_at)| **seen_at)
+                .map(|(key, _)| *key)
+            {
+                entries.remove(&oldest);
+            }
+        }
+        entries.insert(replay_key, timestamp);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.lock().map_or(0, |entries| entries.len())
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Target {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Target {
+    pub fn new(host: impl Into<String>, port: u16) -> io::Result<Self> {
+        let host = host.into();
+        if port == 0 {
+            return Err(invalid_input("Young 目标端口不能为 0"));
+        }
+        if host.is_empty() || host.len() > 253 || host.as_bytes().contains(&0) {
+            return Err(invalid_input("Young 目标主机长度必须为 1..=253 字节"));
+        }
+        Ok(Self { host, port })
+    }
+
+    #[must_use]
+    pub fn authority(&self) -> String {
+        if self.host.contains(':') && self.host.parse::<Ipv6Addr>().is_ok() {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FlowKind {
+    Tcp = 1,
+    Udp = 2,
+}
+
+impl TryFrom<u8> for FlowKind {
+    type Error = io::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Tcp),
+            2 => Ok(Self::Udp),
+            _ => Err(unsupported(format!("不支持的 Young flow kind：{value}"))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlowOpen {
+    pub kind: FlowKind,
+    pub flow_id: u64,
+    pub target: Target,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Status {
+    Ok = 0,
+    BadRequest = 1,
+    Unauthorized = 2,
+    ConnectFailed = 3,
+    Unsupported = 4,
+    ResourceLimit = 5,
+}
+
+impl TryFrom<u8> for Status {
+    type Error = io::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Ok),
+            1 => Ok(Self::BadRequest),
+            2 => Ok(Self::Unauthorized),
+            3 => Ok(Self::ConnectFailed),
+            4 => Ok(Self::Unsupported),
+            5 => Ok(Self::ResourceLimit),
+            _ => Err(invalid_data(format!("未知 Young 状态码：{value}"))),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FlowResponse {
+    pub status: Status,
+    pub flow_id: u64,
+}
+
+pub fn unix_time_secs() -> io::Result<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|error| io::Error::other(format!("系统时钟早于 UNIX epoch：{error}")))
+}
+
+#[must_use]
+pub fn derive_rotating_path(key: &YoungKey, base_path: &str, unix_seconds: u64) -> String {
+    let day = unix_seconds / 86_400;
+    let suffix = hmac_tag(key.as_bytes(), &[b"young/path/v1", &day.to_be_bytes()]);
+    let token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&suffix[..9]);
+    let base = if base_path.starts_with('/') {
+        base_path.trim_end_matches('/').to_owned()
+    } else {
+        format!("/{}", base_path.trim_end_matches('/'))
+    };
+    format!("{base}/{token}")
+}
+
+pub fn create_authorization(
+    key: &YoungKey,
+    authority: &str,
+    path: &str,
+    capabilities: u32,
+) -> io::Result<(String, [u8; 16])> {
+    let timestamp = unix_time_secs()?;
+    let mut nonce = [0; 16];
+    OsRng.fill_bytes(&mut nonce);
+    Ok((
+        create_authorization_at(key, authority, path, capabilities, timestamp, nonce),
+        nonce,
+    ))
+}
+
+#[must_use]
+pub fn create_authorization_at(
+    key: &YoungKey,
+    authority: &str,
+    path: &str,
+    capabilities: u32,
+    timestamp: u64,
+    nonce: [u8; 16],
+) -> String {
+    let mut token = Vec::with_capacity(AUTH_TOKEN_BYTES);
+    token.push(VERSION);
+    token.extend_from_slice(&key.id());
+    token.extend_from_slice(&timestamp.to_be_bytes());
+    token.extend_from_slice(&nonce);
+    token.extend_from_slice(&capabilities.to_be_bytes());
+    let tag = hmac_tag(
+        key.as_bytes(),
+        &[
+            b"young/session/v1",
+            authority.as_bytes(),
+            path.as_bytes(),
+            &token,
+        ],
+    );
+    token.extend_from_slice(&tag);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(token)
+}
+
+pub fn verify_authorization(
+    encoded: &str,
+    authority: &str,
+    path: &str,
+    keys: &KeyRing,
+    replay: &ReplayCache,
+    now: u64,
+    clock_skew_secs: u64,
+) -> io::Result<(YoungKey, [u8; 16], u32)> {
+    let token = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| permission_denied("Young authorization 编码无效"))?;
+    if token.len() != AUTH_TOKEN_BYTES || token[0] != VERSION {
+        return Err(permission_denied("Young authorization 版本或长度无效"));
+    }
+    let key_id: [u8; 8] = token[1..9].try_into().expect("checked length");
+    let timestamp = u64::from_be_bytes(token[9..17].try_into().expect("checked length"));
+    let nonce: [u8; 16] = token[17..33].try_into().expect("checked length");
+    let capabilities = u32::from_be_bytes(token[33..37].try_into().expect("checked length"));
+    if now.abs_diff(timestamp) > clock_skew_secs {
+        return Err(permission_denied("Young authorization 超出允许时间窗"));
+    }
+    let key = keys
+        .find(key_id)
+        .ok_or_else(|| permission_denied("Young key id 未授权"))?;
+    verify_hmac(
+        key.as_bytes(),
+        &[
+            b"young/session/v1",
+            authority.as_bytes(),
+            path.as_bytes(),
+            &token[..37],
+        ],
+        &token[37..],
+    )?;
+    replay.check_and_insert(key_id, nonce, timestamp, now, clock_skew_secs)?;
+    Ok((key, nonce, capabilities))
+}
+
+#[must_use]
+pub fn server_accept_proof(key: &YoungKey, client_nonce: [u8; 16]) -> String {
+    let tag = hmac_tag(key.as_bytes(), &[b"young/server-accept/v1", &client_nonce]);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(tag)
+}
+
+pub fn verify_server_accept_proof(
+    key: &YoungKey,
+    client_nonce: [u8; 16],
+    encoded: &str,
+) -> io::Result<()> {
+    let proof = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| permission_denied("Young server proof 编码无效"))?;
+    verify_hmac(
+        key.as_bytes(),
+        &[b"young/server-accept/v1", &client_nonce],
+        &proof,
+    )
+}
+
+#[must_use]
+pub fn derive_session_key(key: &YoungKey, exporter: &[u8], client_nonce: [u8; 16]) -> SessionKey {
+    SessionKey::new(hmac_tag(
+        key.as_bytes(),
+        &[b"young/exporter/v1", exporter, &client_nonce],
+    ))
+}
+
+pub fn encode_flow_open(
+    session_key: &SessionKey,
+    open: &FlowOpen,
+    padding_len: usize,
+) -> io::Result<Vec<u8>> {
+    if padding_len > MAX_PADDING_BYTES {
+        return Err(invalid_input("Young flow padding 超过上限"));
+    }
+    let mut frame = Vec::with_capacity(64 + padding_len);
+    frame.extend_from_slice(b"YF");
+    frame.push(VERSION);
+    frame.push(open.kind as u8);
+    frame.extend_from_slice(&open.flow_id.to_be_bytes());
+    encode_target(&mut frame, &open.target)?;
+    frame.extend_from_slice(
+        &u16::try_from(padding_len)
+            .map_err(|_| invalid_input("Young flow padding 过大"))?
+            .to_be_bytes(),
+    );
+    let padding_start = frame.len();
+    frame.resize(padding_start + padding_len, 0);
+    OsRng.fill_bytes(&mut frame[padding_start..]);
+    let tag = hmac_tag(session_key.as_bytes(), &[b"young/flow-open/v1", &frame]);
+    frame.extend_from_slice(&tag[..FLOW_TAG_BYTES]);
+    Ok(frame)
+}
+
+pub fn decode_flow_open(
+    session_key: &SessionKey,
+    input: &[u8],
+) -> io::Result<Option<(FlowOpen, usize)>> {
+    const FIXED: usize = 2 + 1 + 1 + 8;
+    if input.len() < FIXED {
+        return Ok(None);
+    }
+    if &input[..2] != b"YF" || input[2] != VERSION {
+        return Err(invalid_data("Young flow open magic/version 无效"));
+    }
+    let kind = FlowKind::try_from(input[3])?;
+    let flow_id = u64::from_be_bytes(input[4..12].try_into().expect("checked fixed header"));
+    let Some((target, target_bytes)) = decode_target(&input[12..])? else {
+        return Ok(None);
+    };
+    let padding_offset = 12 + target_bytes;
+    if input.len() < padding_offset + 2 {
+        return Ok(None);
+    }
+    let padding_len = usize::from(u16::from_be_bytes(
+        input[padding_offset..padding_offset + 2]
+            .try_into()
+            .expect("checked"),
+    ));
+    if padding_len > MAX_PADDING_BYTES {
+        return Err(invalid_data("Young flow padding 超过上限"));
+    }
+    let authenticated_len = padding_offset + 2 + padding_len;
+    let total = authenticated_len + FLOW_TAG_BYTES;
+    if input.len() < total {
+        return Ok(None);
+    }
+    verify_hmac_truncated(
+        session_key.as_bytes(),
+        &[b"young/flow-open/v1", &input[..authenticated_len]],
+        &input[authenticated_len..total],
+    )?;
+    Ok(Some((
+        FlowOpen {
+            kind,
+            flow_id,
+            target,
+        },
+        total,
+    )))
+}
+
+#[must_use]
+pub fn encode_flow_response(
+    session_key: &SessionKey,
+    response: FlowResponse,
+) -> [u8; FLOW_RESPONSE_BYTES] {
+    let mut output = [0; FLOW_RESPONSE_BYTES];
+    output[..2].copy_from_slice(b"YR");
+    output[2] = VERSION;
+    output[3] = response.status as u8;
+    output[4..12].copy_from_slice(&response.flow_id.to_be_bytes());
+    let tag = hmac_tag(
+        session_key.as_bytes(),
+        &[b"young/flow-response/v1", &output[..12]],
+    );
+    output[12..].copy_from_slice(&tag[..FLOW_TAG_BYTES]);
+    output
+}
+
+pub fn decode_flow_response(
+    session_key: &SessionKey,
+    input: &[u8],
+) -> io::Result<Option<(FlowResponse, usize)>> {
+    if input.len() < FLOW_RESPONSE_BYTES {
+        return Ok(None);
+    }
+    if &input[..2] != b"YR" || input[2] != VERSION {
+        return Err(invalid_data("Young flow response magic/version 无效"));
+    }
+    verify_hmac_truncated(
+        session_key.as_bytes(),
+        &[b"young/flow-response/v1", &input[..12]],
+        &input[12..FLOW_RESPONSE_BYTES],
+    )?;
+    Ok(Some((
+        FlowResponse {
+            status: Status::try_from(input[3])?,
+            flow_id: u64::from_be_bytes(input[4..12].try_into().expect("checked")),
+        },
+        FLOW_RESPONSE_BYTES,
+    )))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UdpFragment {
+    pub association_id: u64,
+    pub packet_id: u32,
+    pub index: u16,
+    pub count: u16,
+    pub total_len: u16,
+    pub payload: Vec<u8>,
+}
+
+pub fn encode_udp_fragments(
+    session_key: &SessionKey,
+    association_id: u64,
+    packet_id: u32,
+    payload: &[u8],
+    max_datagram_size: usize,
+) -> io::Result<Vec<Vec<u8>>> {
+    if payload.is_empty() || payload.len() > MAX_UDP_PAYLOAD_BYTES {
+        return Err(invalid_input("Young UDP payload 长度必须为 1..=65507"));
+    }
+    let overhead = UDP_HEADER_BYTES + UDP_TAG_BYTES;
+    if max_datagram_size <= overhead {
+        return Err(invalid_input(
+            "WebTransport datagram 上限不足以承载 Young header",
+        ));
+    }
+    let chunk_size = max_datagram_size - overhead;
+    let count = payload.len().div_ceil(chunk_size);
+    if count > MAX_UDP_FRAGMENTS {
+        return Err(invalid_input("Young UDP fragment 数量超过上限"));
+    }
+    let count_u16 =
+        u16::try_from(count).map_err(|_| invalid_input("Young UDP fragment 数量过多"))?;
+    let total_len =
+        u16::try_from(payload.len()).map_err(|_| invalid_input("Young UDP payload 超过 u16"))?;
+    payload
+        .chunks(chunk_size)
+        .enumerate()
+        .map(|(index, chunk)| {
+            let mut frame = Vec::with_capacity(overhead + chunk.len());
+            frame.extend_from_slice(b"YD");
+            frame.push(VERSION);
+            frame.push(0);
+            frame.extend_from_slice(&association_id.to_be_bytes());
+            frame.extend_from_slice(&packet_id.to_be_bytes());
+            frame.extend_from_slice(
+                &u16::try_from(index)
+                    .map_err(|_| invalid_input("Young UDP fragment index 过大"))?
+                    .to_be_bytes(),
+            );
+            frame.extend_from_slice(&count_u16.to_be_bytes());
+            frame.extend_from_slice(&total_len.to_be_bytes());
+            frame.extend_from_slice(chunk);
+            let tag = hmac_tag(session_key.as_bytes(), &[b"young/udp-fragment/v1", &frame]);
+            frame.extend_from_slice(&tag[..UDP_TAG_BYTES]);
+            Ok(frame)
+        })
+        .collect()
+}
+
+pub fn decode_udp_fragment(session_key: &SessionKey, input: &[u8]) -> io::Result<UdpFragment> {
+    if input.len() < UDP_HEADER_BYTES + UDP_TAG_BYTES
+        || &input[..2] != b"YD"
+        || input[2] != VERSION
+        || input[3] != 0
+    {
+        return Err(invalid_data("Young UDP fragment header 无效"));
+    }
+    let authenticated_len = input.len() - UDP_TAG_BYTES;
+    verify_hmac_truncated(
+        session_key.as_bytes(),
+        &[b"young/udp-fragment/v1", &input[..authenticated_len]],
+        &input[authenticated_len..],
+    )?;
+    let association_id = u64::from_be_bytes(input[4..12].try_into().expect("checked"));
+    let packet_id = u32::from_be_bytes(input[12..16].try_into().expect("checked"));
+    let index = u16::from_be_bytes(input[16..18].try_into().expect("checked"));
+    let count = u16::from_be_bytes(input[18..20].try_into().expect("checked"));
+    let total_len = u16::from_be_bytes(input[20..22].try_into().expect("checked"));
+    let payload_len = authenticated_len - UDP_HEADER_BYTES;
+    if count == 0
+        || usize::from(count) > MAX_UDP_FRAGMENTS
+        || count > total_len
+        || index >= count
+        || total_len == 0
+        || usize::from(total_len) > MAX_UDP_PAYLOAD_BYTES
+        || payload_len == 0
+        || payload_len > usize::from(total_len)
+    {
+        return Err(invalid_data("Young UDP fragment metadata 无效"));
+    }
+    Ok(UdpFragment {
+        association_id,
+        packet_id,
+        index,
+        count,
+        total_len,
+        payload: input[UDP_HEADER_BYTES..authenticated_len].to_vec(),
+    })
+}
+
+#[derive(Debug)]
+struct PartialPacket {
+    created: Instant,
+    total_len: usize,
+    fragments: Vec<Option<Vec<u8>>>,
+    received_len: usize,
+}
+
+#[derive(Debug)]
+pub struct UdpReassembler {
+    entries: HashMap<(u64, u32), PartialPacket>,
+    max_packets: usize,
+    timeout: Duration,
+}
+
+impl Default for UdpReassembler {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            max_packets: 256,
+            timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+impl UdpReassembler {
+    pub fn push(&mut self, fragment: UdpFragment, now: Instant) -> io::Result<Option<Vec<u8>>> {
+        self.entries
+            .retain(|_, packet| now.duration_since(packet.created) <= self.timeout);
+        if self.entries.len() >= self.max_packets
+            && !self
+                .entries
+                .contains_key(&(fragment.association_id, fragment.packet_id))
+        {
+            if let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, packet)| packet.created)
+                .map(|(key, _)| *key)
+            {
+                self.entries.remove(&oldest);
+            }
+        }
+        let key = (fragment.association_id, fragment.packet_id);
+        let packet = self.entries.entry(key).or_insert_with(|| PartialPacket {
+            created: now,
+            total_len: usize::from(fragment.total_len),
+            fragments: vec![None; usize::from(fragment.count)],
+            received_len: 0,
+        });
+        if packet.total_len != usize::from(fragment.total_len)
+            || packet.fragments.len() != usize::from(fragment.count)
+        {
+            self.entries.remove(&key);
+            return Err(invalid_data(
+                "Young UDP fragment 元数据在同一 packet 内不一致",
+            ));
+        }
+        let slot = &mut packet.fragments[usize::from(fragment.index)];
+        if slot.is_none() {
+            packet.received_len = packet.received_len.saturating_add(fragment.payload.len());
+            *slot = Some(fragment.payload);
+        }
+        if packet.fragments.iter().any(Option::is_none) {
+            return Ok(None);
+        }
+        let packet = self.entries.remove(&key).expect("entry exists");
+        if packet.received_len != packet.total_len {
+            return Err(invalid_data("Young UDP fragment 重组长度不符"));
+        }
+        let mut output = Vec::with_capacity(packet.total_len);
+        for fragment in packet.fragments {
+            output.extend_from_slice(fragment.as_deref().expect("all present"));
+        }
+        Ok(Some(output))
+    }
+}
+
+fn encode_target(output: &mut Vec<u8>, target: &Target) -> io::Result<()> {
+    output.extend_from_slice(&target.port.to_be_bytes());
+    if let Ok(ip) = target.host.parse::<Ipv4Addr>() {
+        output.push(1);
+        output.extend_from_slice(&ip.octets());
+    } else if let Ok(ip) = target.host.parse::<Ipv6Addr>() {
+        output.push(3);
+        output.extend_from_slice(&ip.octets());
+    } else {
+        let host = target.host.as_bytes();
+        output.push(2);
+        output.push(
+            u8::try_from(host.len()).map_err(|_| invalid_input("Young 目标域名超过 255 字节"))?,
+        );
+        output.extend_from_slice(host);
+    }
+    Ok(())
+}
+
+fn decode_target(input: &[u8]) -> io::Result<Option<(Target, usize)>> {
+    if input.len() < 3 {
+        return Ok(None);
+    }
+    let port = u16::from_be_bytes([input[0], input[1]]);
+    let (host, consumed) = match input[2] {
+        1 => {
+            if input.len() < 7 {
+                return Ok(None);
+            }
+            (
+                IpAddr::V4(Ipv4Addr::from(
+                    <[u8; 4]>::try_from(&input[3..7]).expect("checked"),
+                ))
+                .to_string(),
+                7,
+            )
+        }
+        2 => {
+            if input.len() < 4 {
+                return Ok(None);
+            }
+            let length = usize::from(input[3]);
+            if length == 0 {
+                return Err(invalid_data("Young 目标域名为空"));
+            }
+            if input.len() < 4 + length {
+                return Ok(None);
+            }
+            (
+                String::from_utf8(input[4..4 + length].to_vec())
+                    .map_err(|_| invalid_data("Young 目标域名不是 UTF-8"))?,
+                4 + length,
+            )
+        }
+        3 => {
+            if input.len() < 19 {
+                return Ok(None);
+            }
+            (
+                IpAddr::V6(Ipv6Addr::from(
+                    <[u8; 16]>::try_from(&input[3..19]).expect("checked"),
+                ))
+                .to_string(),
+                19,
+            )
+        }
+        value => return Err(invalid_data(format!("未知 Young 地址类型：{value}"))),
+    };
+    Ok(Some((Target::new(host, port)?, consumed)))
+}
+
+fn hmac_tag(key: &[u8], parts: &[&[u8]]) -> [u8; 32] {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key size");
+    for part in parts {
+        mac.update(part);
+    }
+    mac.finalize().into_bytes().into()
+}
+
+fn verify_hmac(key: &[u8], parts: &[&[u8]], tag: &[u8]) -> io::Result<()> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key size");
+    for part in parts {
+        mac.update(part);
+    }
+    mac.verify_slice(tag)
+        .map_err(|_| permission_denied("Young authentication tag 不匹配"))
+}
+
+fn verify_hmac_truncated(key: &[u8], parts: &[&[u8]], tag: &[u8]) -> io::Result<()> {
+    if tag.len() != FLOW_TAG_BYTES {
+        return Err(permission_denied("Young truncated tag 长度无效"));
+    }
+    let expected = hmac_tag(key, parts);
+    use subtle::ConstantTimeEq as _;
+    if bool::from(expected[..tag.len()].ct_eq(tag)) {
+        Ok(())
+    } else {
+        Err(permission_denied("Young authentication tag 不匹配"))
+    }
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn permission_denied(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, message.into())
+}
+
+fn unsupported(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::Unsupported, message.into())
+}
+
+fn hex_id(id: [u8; 8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(16);
+    for byte in id {
+        output.push(HEX[usize::from(byte >> 4)] as char);
+        output.push(HEX[usize::from(byte & 0x0f)] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> YoungKey {
+        YoungKey::from_bytes([byte; 32])
+    }
+
+    #[test]
+    fn authorization_is_bound_to_path_and_replay_safe() {
+        let key = key(7);
+        let keys = KeyRing::new(vec![key.clone()]).unwrap();
+        let replay = ReplayCache::default();
+        let path = derive_rotating_path(&key, "/assets", 1_700_000_000);
+        let token = create_authorization_at(&key, "example.com", &path, 3, 1_700_000_000, [9; 16]);
+        let verified = verify_authorization(
+            &token,
+            "example.com",
+            &path,
+            &keys,
+            &replay,
+            1_700_000_001,
+            120,
+        )
+        .unwrap();
+        assert_eq!(verified.0.id(), key.id());
+        assert_eq!(verified.2, 3);
+        assert!(
+            verify_authorization(
+                &token,
+                "example.com",
+                &path,
+                &keys,
+                &replay,
+                1_700_000_001,
+                120,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn flow_open_is_incremental_and_authenticated() {
+        let session = SessionKey::new([5; 32]);
+        let open = FlowOpen {
+            kind: FlowKind::Tcp,
+            flow_id: 42,
+            target: Target::new("example.com", 443).unwrap(),
+        };
+        let encoded = encode_flow_open(&session, &open, 127).unwrap();
+        assert!(
+            decode_flow_open(&session, &encoded[..20])
+                .unwrap()
+                .is_none()
+        );
+        let (decoded, consumed) = decode_flow_open(&session, &encoded).unwrap().unwrap();
+        assert_eq!(decoded, open);
+        assert_eq!(consumed, encoded.len());
+        let mut tampered = encoded;
+        tampered[15] ^= 1;
+        assert!(decode_flow_open(&session, &tampered).is_err());
+    }
+
+    #[test]
+    fn udp_fragments_reassemble_out_of_order() {
+        let session = SessionKey::new([3; 32]);
+        let payload = vec![0x5a; 5000];
+        assert!(
+            encode_udp_fragments(
+                &session,
+                99,
+                6,
+                &payload,
+                UDP_HEADER_BYTES + UDP_TAG_BYTES + 1,
+            )
+            .is_err()
+        );
+        let mut fragments = encode_udp_fragments(&session, 99, 7, &payload, 900).unwrap();
+        fragments.reverse();
+        let mut reassembler = UdpReassembler::default();
+        let mut output = None;
+        for encoded in fragments {
+            output = reassembler
+                .push(
+                    decode_udp_fragment(&session, &encoded).unwrap(),
+                    Instant::now(),
+                )
+                .unwrap()
+                .or(output);
+        }
+        assert_eq!(output.unwrap(), payload);
+    }
+}

--- a/crates/core-young/src/lib.rs
+++ b/crates/core-young/src/lib.rs
@@ -1,0 +1,26 @@
+//! Young v1: an authenticated proxy protocol carried by Mozilla Neqo.
+//!
+//! The public API deliberately separates the Young wire format from the
+//! Firefox HTTP/3/WebTransport carrier.  `codec` can be tested without NSS;
+//! `client` and `server` drive Neqo on dedicated current-thread runtimes
+//! because Neqo mirrors Firefox's `Rc<RefCell<_>>` integration model.
+
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "firefox-stack")]
+mod client;
+mod codec;
+#[cfg(feature = "firefox-stack")]
+mod server;
+
+#[cfg(feature = "firefox-stack")]
+pub use client::{YoungClient, YoungClientConfig, YoungUdpChannel};
+pub use codec::{
+    DEFAULT_CLOCK_SKEW_SECS, FlowKind, FlowOpen, FlowResponse, KeyRing, MAX_PADDING_BYTES,
+    ReplayCache, SessionKey, Status, Target, UdpReassembler, VERSION, YoungKey,
+    create_authorization, decode_flow_open, decode_flow_response, decode_udp_fragment,
+    derive_rotating_path, derive_session_key, encode_flow_open, encode_flow_response,
+    encode_udp_fragments, server_accept_proof, verify_authorization, verify_server_accept_proof,
+};
+#[cfg(feature = "firefox-stack")]
+pub use server::{YoungServerConfig, YoungServerHandle};

--- a/crates/core-young/src/server.rs
+++ b/crates/core-young/src/server.rs
@@ -1,0 +1,1120 @@
+use std::{
+    cell::RefCell,
+    collections::{HashMap, VecDeque},
+    fmt, io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    path::PathBuf,
+    rc::Rc,
+    sync::OnceLock,
+    thread,
+    time::{Duration, Instant},
+};
+
+use neqo_common::{Datagram, Header, Tos, header::HeadersExt as _};
+use neqo_http3::{
+    Http3OrWebTransportStream, Http3Parameters, Http3Server, Http3ServerEvent, SessionAcceptAction,
+    webtransport::{ServerEvent, ServerSession},
+};
+use neqo_transport::{
+    ConnectionParameters, Output, RandomConnectionIdGenerator, StreamId, StreamType,
+};
+use nss::AntiReplay;
+use rand::{RngCore, rngs::OsRng};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::{TcpStream, UdpSocket},
+    sync::mpsc,
+};
+use tracing::{debug, warn};
+
+use crate::codec::{
+    FlowKind, FlowResponse, KeyRing, ReplayCache, SessionKey, Status, Target, UdpReassembler,
+    decode_flow_open, decode_udp_fragment, derive_rotating_path, derive_session_key,
+    encode_flow_response, encode_udp_fragments, server_accept_proof, unix_time_secs,
+    verify_authorization,
+};
+
+const STREAM_CHUNK_BYTES: usize = 32 * 1024;
+const MAX_FLOW_WRITE_BUFFER_BYTES: usize = 1024 * 1024;
+const EXPORTER_LABEL: &[u8] = b"young-session-v1";
+const EXPORTER_CONTEXT: &[u8] = b"wuther-core";
+const NSS_ANTI_REPLAY_WINDOW: Duration = Duration::from_secs(10);
+static NSS_DATABASE: OnceLock<PathBuf> = OnceLock::new();
+
+#[derive(Clone)]
+pub struct YoungServerConfig {
+    pub listen: SocketAddr,
+    pub nss_database: PathBuf,
+    pub certificate_nickname: String,
+    pub authority: String,
+    pub path: String,
+    pub keys: KeyRing,
+    pub clock_skew: Duration,
+    pub idle_timeout: Duration,
+    pub max_streams: u64,
+    pub max_sessions: usize,
+    pub max_flows_per_session: usize,
+    pub decoy_status: u16,
+    pub decoy_body: Vec<u8>,
+}
+
+impl fmt::Debug for YoungServerConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("YoungServerConfig")
+            .field("listen", &self.listen)
+            .field("nss_database", &self.nss_database)
+            .field("certificate_nickname", &self.certificate_nickname)
+            .field("authority", &self.authority)
+            .field("path", &self.path)
+            .field("key_count", &self.keys.len())
+            .field("clock_skew", &self.clock_skew)
+            .field("idle_timeout", &self.idle_timeout)
+            .field("max_streams", &self.max_streams)
+            .field("max_sessions", &self.max_sessions)
+            .field("max_flows_per_session", &self.max_flows_per_session)
+            .field("decoy_status", &self.decoy_status)
+            .field("decoy_body_bytes", &self.decoy_body.len())
+            .finish()
+    }
+}
+
+impl YoungServerConfig {
+    pub fn validate(&self) -> io::Result<()> {
+        if !self.nss_database.is_dir() {
+            return Err(invalid_input(format!(
+                "Young server NSS database 目录不存在：{}",
+                self.nss_database.display()
+            )));
+        }
+        if self.certificate_nickname.trim().is_empty()
+            || self.authority.trim().is_empty()
+            || self.path.trim().is_empty()
+        {
+            return Err(invalid_input(
+                "Young server certificate_nickname、authority、path 不能为空",
+            ));
+        }
+        if self.max_streams == 0 || self.max_sessions == 0 || self.max_flows_per_session == 0 {
+            return Err(invalid_input("Young server 资源上限必须大于 0"));
+        }
+        if !(100..=599).contains(&self.decoy_status) {
+            return Err(invalid_input(
+                "Young server decoy_status 必须是 HTTP 状态码",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub struct YoungServerHandle {
+    local_addr: SocketAddr,
+    commands: mpsc::UnboundedSender<ServerCommand>,
+}
+
+impl fmt::Debug for YoungServerHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("YoungServerHandle")
+            .field("local_addr", &self.local_addr)
+            .finish()
+    }
+}
+
+impl YoungServerHandle {
+    pub fn start(config: YoungServerConfig) -> io::Result<Self> {
+        config.validate()?;
+        if let Some(existing) = NSS_DATABASE.get() {
+            if existing != &config.nss_database {
+                return Err(invalid_input(format!(
+                    "同一进程只能使用一个 NSS database；已使用 {}，收到 {}",
+                    existing.display(),
+                    config.nss_database.display()
+                )));
+            }
+        } else {
+            let _ = NSS_DATABASE.set(config.nss_database.clone());
+        }
+
+        let (commands, receiver) = mpsc::unbounded_channel();
+        let worker_commands = commands.clone();
+        let (ready, ready_receiver) = std::sync::mpsc::sync_channel(1);
+        thread::Builder::new()
+            .name(format!("young-neqo-server-{}", config.listen.port()))
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = ready.send(Err(format!("Tokio runtime 创建失败：{error}")));
+                        return;
+                    }
+                };
+                let local = tokio::task::LocalSet::new();
+                local.block_on(&runtime, async move {
+                    match ServerDriver::initialize(config, receiver, worker_commands).await {
+                        Ok(mut driver) => {
+                            let _ = ready.send(Ok(driver.local_addr));
+                            if let Err(error) = driver.run().await {
+                                warn!(%error, "Young Neqo server 退出");
+                            }
+                        }
+                        Err(error) => {
+                            let _ = ready.send(Err(error.to_string()));
+                        }
+                    }
+                });
+            })
+            .map_err(|error| io::Error::other(format!("Young server worker 启动失败：{error}")))?;
+        let local_addr = ready_receiver
+            .recv_timeout(Duration::from_secs(30))
+            .map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "Young server 启动超时"))?
+            .map_err(io::Error::other)?;
+        Ok(Self {
+            local_addr,
+            commands,
+        })
+    }
+
+    #[must_use]
+    pub const fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn shutdown(&self) -> io::Result<()> {
+        self.commands
+            .send(ServerCommand::Shutdown)
+            .map_err(|_| not_connected("Young server 已退出"))
+    }
+}
+
+impl Drop for YoungServerHandle {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+struct PendingWrite {
+    bytes: Vec<u8>,
+    offset: usize,
+}
+
+struct ServerStream {
+    stream: Http3OrWebTransportStream,
+    session_id: StreamId,
+    open_buffer: Vec<u8>,
+    opened: bool,
+    kind: Option<FlowKind>,
+    flow_id: Option<u64>,
+    target_input: Option<mpsc::Sender<Vec<u8>>>,
+    target_task: Option<tokio::task::JoinHandle<()>>,
+    writes: VecDeque<PendingWrite>,
+    queued_write_bytes: usize,
+    finish_after_writes: bool,
+    send_finished: bool,
+    receive_finished: bool,
+}
+
+struct DecoyStream {
+    stream: Http3OrWebTransportStream,
+    writes: VecDeque<PendingWrite>,
+    finish_after_writes: bool,
+    send_finished: bool,
+    receive_finished: bool,
+}
+
+struct SessionState {
+    session: ServerSession,
+    session_key: SessionKey,
+    reassembler: UdpReassembler,
+    flow_count: usize,
+}
+
+enum ServerCommand {
+    TcpOpened {
+        stream_id: StreamId,
+    },
+    TcpFailed {
+        stream_id: StreamId,
+        message: String,
+    },
+    StreamOutput {
+        stream_id: StreamId,
+        payload: Vec<u8>,
+    },
+    StreamFinished {
+        stream_id: StreamId,
+    },
+    UdpOpened {
+        stream_id: StreamId,
+        association_id: u64,
+    },
+    UdpFailed {
+        stream_id: StreamId,
+        message: String,
+    },
+    UdpOutput {
+        session_id: StreamId,
+        association_id: u64,
+        packet_id: u32,
+        payload: Vec<u8>,
+    },
+    UdpClosed {
+        session_id: StreamId,
+        association_id: u64,
+    },
+    Shutdown,
+}
+
+struct ServerDriver {
+    config: YoungServerConfig,
+    socket: UdpSocket,
+    local_addr: SocketAddr,
+    server: Http3Server,
+    replay: ReplayCache,
+    receiver: mpsc::UnboundedReceiver<ServerCommand>,
+    commands: mpsc::UnboundedSender<ServerCommand>,
+    sessions: HashMap<StreamId, SessionState>,
+    streams: HashMap<StreamId, ServerStream>,
+    decoys: HashMap<StreamId, DecoyStream>,
+    udp_inputs: HashMap<(StreamId, u64), mpsc::Sender<Vec<u8>>>,
+}
+
+impl ServerDriver {
+    async fn initialize(
+        config: YoungServerConfig,
+        receiver: mpsc::UnboundedReceiver<ServerCommand>,
+        commands: mpsc::UnboundedSender<ServerCommand>,
+    ) -> io::Result<Self> {
+        nss::init_db(config.nss_database.clone())
+            .map_err(|error| io::Error::other(format!("NSS database 初始化失败：{error}")))?;
+        let socket = UdpSocket::bind(config.listen).await?;
+        let local_addr = socket.local_addr()?;
+        let connection_parameters = ConnectionParameters::default()
+            .idle_timeout(config.idle_timeout)
+            .max_streams(StreamType::BiDi, config.max_streams)
+            .max_streams(StreamType::UniDi, 16);
+        let parameters = Http3Parameters::default()
+            .connection_parameters(connection_parameters)
+            .webtransport(true)
+            .http3_datagram(true);
+        let server = Http3Server::new(
+            Instant::now(),
+            &[config.certificate_nickname.as_str()],
+            &["h3"],
+            AntiReplay::new(Instant::now(), NSS_ANTI_REPLAY_WINDOW, 7, 14)
+                .map_err(|error| io::Error::other(format!("NSS anti-replay 创建失败：{error}")))?,
+            Rc::new(RefCell::new(RandomConnectionIdGenerator::new(10))),
+            parameters,
+            None,
+        )
+        .map_err(neqo_error)?;
+        Ok(Self {
+            config,
+            socket,
+            local_addr,
+            server,
+            replay: ReplayCache::default(),
+            receiver,
+            commands,
+            sessions: HashMap::new(),
+            streams: HashMap::new(),
+            decoys: HashMap::new(),
+            udp_inputs: HashMap::new(),
+        })
+    }
+
+    async fn run(&mut self) -> io::Result<()> {
+        let mut callback = Duration::ZERO;
+        loop {
+            self.process_events().await?;
+            callback = self.process_output(callback).await?;
+            let mut packet = vec![0; 65_535];
+            let sleep_for = if callback.is_zero() {
+                Duration::from_millis(250)
+            } else {
+                callback
+            };
+            tokio::select! {
+                command = self.receiver.recv() => {
+                    match command {
+                        Some(ServerCommand::Shutdown) | None => return Ok(()),
+                        Some(command) => self.handle_command(command).await?,
+                    }
+                }
+                received = self.socket.recv_from(&mut packet) => {
+                    let (length, source) = received?;
+                    let datagram = Datagram::new(
+                        source,
+                        self.local_addr,
+                        Tos::default(),
+                        packet[..length].to_vec(),
+                    );
+                    let output = self.server.process(Some(datagram), Instant::now());
+                    self.send_output(output).await?;
+                }
+                () = tokio::time::sleep(sleep_for) => {}
+            }
+        }
+    }
+
+    async fn process_output(&mut self, previous: Duration) -> io::Result<Duration> {
+        loop {
+            match self.server.process_output(Instant::now()) {
+                Output::Datagram(datagram) => self.send_output(Output::Datagram(datagram)).await?,
+                Output::Callback(duration) => return Ok(duration),
+                Output::None => {
+                    return Ok(if previous.is_zero() {
+                        Duration::from_millis(250)
+                    } else {
+                        previous
+                    });
+                }
+            }
+        }
+    }
+
+    async fn send_output(&self, output: Output) -> io::Result<()> {
+        if let Output::Datagram(datagram) = output {
+            self.socket
+                .send_to(datagram.as_ref(), datagram.destination())
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn process_events(&mut self) -> io::Result<()> {
+        while let Some(event) = self.server.next_event() {
+            match event {
+                Http3ServerEvent::WebTransport(ServerEvent::NewSession { session, headers }) => {
+                    self.handle_new_session(session, &headers)?
+                }
+                Http3ServerEvent::WebTransport(ServerEvent::NewStream(stream)) => {
+                    self.handle_new_stream(stream)?;
+                }
+                Http3ServerEvent::WebTransport(ServerEvent::Datagram { session, datagram }) => {
+                    self.handle_datagram(session.stream_id(), datagram.as_ref())
+                        .await?
+                }
+                Http3ServerEvent::WebTransport(ServerEvent::SessionClosed { session, .. }) => {
+                    self.close_session(session.stream_id());
+                }
+                Http3ServerEvent::Data { stream, data, fin } => {
+                    let stream_id = stream.stream_id();
+                    if self.streams.contains_key(&stream_id) {
+                        self.handle_stream_data(stream, data, fin).await?;
+                    } else if self.decoys.contains_key(&stream_id) {
+                        self.handle_decoy_data(stream_id, fin);
+                    }
+                }
+                Http3ServerEvent::DataWritable { stream } => {
+                    let stream_id = stream.stream_id();
+                    if self.streams.contains_key(&stream_id) {
+                        self.flush_stream(stream_id)?;
+                    } else if self.decoys.contains_key(&stream_id) {
+                        self.flush_decoy(stream_id)?;
+                    }
+                }
+                Http3ServerEvent::Headers {
+                    stream,
+                    headers,
+                    fin,
+                } => self.handle_decoy(stream, &headers, fin)?,
+                Http3ServerEvent::StreamReset { stream, .. }
+                | Http3ServerEvent::StreamStopSending { stream, .. } => {
+                    self.remove_stream(stream.stream_id());
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn handle_new_session(&mut self, session: ServerSession, headers: &[Header]) -> io::Result<()> {
+        if self.sessions.len() >= self.config.max_sessions {
+            return self.reject_session(&session);
+        }
+        let authority = header_text(headers, ":authority").unwrap_or_default();
+        let path = header_text(headers, ":path").unwrap_or_default();
+        let authorization = header_text(headers, "authorization")
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .unwrap_or_default();
+        let now = unix_time_secs()?;
+        let verified = verify_authorization(
+            authorization,
+            authority,
+            path,
+            &self.config.keys,
+            &self.replay,
+            now,
+            self.config.clock_skew.as_secs(),
+        );
+        let Ok((key, nonce, _capabilities)) = verified else {
+            return self.reject_session(&session);
+        };
+        let path_valid = [now.saturating_sub(86_400), now, now.saturating_add(86_400)]
+            .iter()
+            .any(|time| derive_rotating_path(&key, &self.config.path, *time) == path);
+        if authority != self.config.authority || !path_valid {
+            return self.reject_session(&session);
+        }
+        let proof = server_accept_proof(&key, nonce);
+        session
+            .response(
+                &SessionAcceptAction::AcceptWith(vec![Header::new("sec-young-accept", proof)]),
+                Instant::now(),
+            )
+            .map_err(neqo_error)?;
+        let mut exporter = [0; 32];
+        session
+            .export_keying_material(EXPORTER_LABEL, EXPORTER_CONTEXT, &mut exporter)
+            .map_err(neqo_error)?;
+        self.sessions.insert(
+            session.stream_id(),
+            SessionState {
+                session,
+                session_key: derive_session_key(&key, &exporter, nonce),
+                reassembler: UdpReassembler::default(),
+                flow_count: 0,
+            },
+        );
+        Ok(())
+    }
+
+    fn reject_session(&self, session: &ServerSession) -> io::Result<()> {
+        session
+            .response(
+                &SessionAcceptAction::Reject(vec![
+                    Header::new(":status", self.config.decoy_status.to_string()),
+                    Header::new("content-type", "text/html; charset=utf-8"),
+                    Header::new("cache-control", "public, max-age=300"),
+                ]),
+                Instant::now(),
+            )
+            .map_err(neqo_error)
+    }
+
+    fn handle_new_stream(&mut self, stream: Http3OrWebTransportStream) -> io::Result<()> {
+        let session_id = stream
+            .stream_info
+            .session_id()
+            .ok_or_else(|| invalid_data("收到不属于 WebTransport session 的 Young stream"))?;
+        let Some(session) = self.sessions.get_mut(&session_id) else {
+            stream
+                .stream_reset_send(neqo_http3::Error::HttpRequestRejected.code())
+                .map_err(neqo_error)?;
+            return Ok(());
+        };
+        if session.flow_count >= self.config.max_flows_per_session {
+            let response = encode_flow_response(
+                &session.session_key,
+                FlowResponse {
+                    status: Status::ResourceLimit,
+                    flow_id: 0,
+                },
+            );
+            let _ = stream.send_data(&response, Instant::now());
+            let _ = stream.stream_close_send(Instant::now());
+            return Ok(());
+        }
+        session.flow_count += 1;
+        self.streams.insert(
+            stream.stream_id(),
+            ServerStream {
+                stream,
+                session_id,
+                open_buffer: Vec::new(),
+                opened: false,
+                kind: None,
+                flow_id: None,
+                target_input: None,
+                target_task: None,
+                writes: VecDeque::new(),
+                queued_write_bytes: 0,
+                finish_after_writes: false,
+                send_finished: false,
+                receive_finished: false,
+            },
+        );
+        Ok(())
+    }
+
+    async fn handle_stream_data(
+        &mut self,
+        stream: Http3OrWebTransportStream,
+        data: Vec<u8>,
+        fin: bool,
+    ) -> io::Result<()> {
+        let stream_id = stream.stream_id();
+        let Some(flow) = self.streams.get_mut(&stream_id) else {
+            return Ok(());
+        };
+        let mut reset_after_read = false;
+        if !flow.opened {
+            flow.open_buffer.extend_from_slice(&data);
+            let session_key = &self
+                .sessions
+                .get(&flow.session_id)
+                .ok_or_else(|| not_connected("Young session 已关闭"))?
+                .session_key;
+            let decoded = match decode_flow_open(session_key, &flow.open_buffer) {
+                Ok(decoded) => decoded,
+                Err(error) => {
+                    debug!(%error, "丢弃无效 Young flow open");
+                    if fin {
+                        flow.receive_finished = true;
+                        flow.target_input.take();
+                    }
+                    self.fail_stream(stream_id, Status::BadRequest)?;
+                    return Ok(());
+                }
+            };
+            let Some((open, consumed)) = decoded else {
+                if fin {
+                    flow.receive_finished = true;
+                    flow.target_input.take();
+                    self.fail_stream(stream_id, Status::BadRequest)?;
+                }
+                return Ok(());
+            };
+            let remaining = flow.open_buffer.split_off(consumed);
+            flow.open_buffer.clear();
+            flow.opened = true;
+            flow.kind = Some(open.kind);
+            flow.flow_id = Some(open.flow_id);
+            if open.kind == FlowKind::Udp && !remaining.is_empty() {
+                if fin {
+                    flow.receive_finished = true;
+                }
+                self.fail_stream(stream_id, Status::BadRequest)?;
+                return Ok(());
+            }
+            let (target_input, target_receiver) = mpsc::channel(128);
+            flow.target_input = Some(target_input.clone());
+            flow.target_task = Some(match open.kind {
+                FlowKind::Tcp => tokio::task::spawn_local(tcp_target(
+                    stream_id,
+                    open.target,
+                    target_receiver,
+                    self.commands.clone(),
+                )),
+                FlowKind::Udp => tokio::task::spawn_local(udp_target(
+                    flow.session_id,
+                    stream_id,
+                    open.flow_id,
+                    open.target,
+                    target_receiver,
+                    self.commands.clone(),
+                )),
+            });
+            if !remaining.is_empty() && target_input.try_send(remaining).is_err() {
+                reset_after_read = true;
+            }
+        } else if flow.kind == Some(FlowKind::Udp) && !data.is_empty() {
+            reset_after_read = true;
+        } else if !data.is_empty()
+            && let Some(target) = &flow.target_input
+            && target.try_send(data).is_err()
+        {
+            reset_after_read = true;
+        }
+        if reset_after_read {
+            flow.target_input.take();
+            self.reset_stream(stream_id);
+            return Ok(());
+        }
+        let remove_after_read = if fin {
+            flow.target_input.take();
+            flow.receive_finished = true;
+            flow.send_finished
+        } else {
+            false
+        };
+        if remove_after_read {
+            self.remove_stream(stream_id);
+        }
+        Ok(())
+    }
+
+    fn handle_decoy(
+        &mut self,
+        stream: Http3OrWebTransportStream,
+        headers: &[Header],
+        receive_finished: bool,
+    ) -> io::Result<()> {
+        let method = header_text(headers, ":method").unwrap_or("GET");
+        let status = if matches!(method, "GET" | "HEAD") {
+            self.config.decoy_status
+        } else {
+            405
+        };
+        let body = if method == "HEAD" {
+            Vec::new()
+        } else {
+            self.config.decoy_body.clone()
+        };
+        stream
+            .send_headers(&[
+                Header::new(":status", status.to_string()),
+                Header::new("content-type", "text/html; charset=utf-8"),
+                Header::new("content-length", body.len().to_string()),
+                Header::new("cache-control", "public, max-age=300"),
+                Header::new("server", "nginx"),
+            ])
+            .map_err(neqo_error)?;
+        let stream_id = stream.stream_id();
+        self.decoys.insert(
+            stream_id,
+            DecoyStream {
+                stream,
+                writes: if body.is_empty() {
+                    VecDeque::new()
+                } else {
+                    VecDeque::from([PendingWrite {
+                        bytes: body,
+                        offset: 0,
+                    }])
+                },
+                finish_after_writes: true,
+                send_finished: false,
+                receive_finished,
+            },
+        );
+        self.flush_decoy(stream_id)
+    }
+
+    fn handle_decoy_data(&mut self, stream_id: StreamId, fin: bool) {
+        let remove = self.decoys.get_mut(&stream_id).is_some_and(|decoy| {
+            decoy.receive_finished |= fin;
+            decoy.receive_finished && decoy.send_finished
+        });
+        if remove {
+            self.decoys.remove(&stream_id);
+        }
+    }
+
+    async fn handle_datagram(&mut self, session_id: StreamId, data: &[u8]) -> io::Result<()> {
+        let Some(session_key) = self
+            .sessions
+            .get(&session_id)
+            .map(|session| session.session_key.clone())
+        else {
+            return Ok(());
+        };
+        let Ok(fragment) = decode_udp_fragment(&session_key, data) else {
+            return Ok(());
+        };
+        let association_id = fragment.association_id;
+        let Some(target) = self.udp_inputs.get(&(session_id, association_id)).cloned() else {
+            return Ok(());
+        };
+        let Some(session) = self.sessions.get_mut(&session_id) else {
+            return Ok(());
+        };
+        let Ok(payload) = session.reassembler.push(fragment, Instant::now()) else {
+            return Ok(());
+        };
+        if let Some(payload) = payload {
+            let _ = target.try_send(payload);
+        }
+        Ok(())
+    }
+
+    async fn handle_command(&mut self, command: ServerCommand) -> io::Result<()> {
+        match command {
+            ServerCommand::TcpOpened { stream_id } => self.respond_flow(stream_id, Status::Ok),
+            ServerCommand::TcpFailed { stream_id, message } => {
+                debug!(%message, "Young TCP 目标连接失败");
+                self.fail_stream(stream_id, Status::ConnectFailed)
+            }
+            ServerCommand::StreamOutput { stream_id, payload } => {
+                let mut reset = false;
+                if let Some(flow) = self.streams.get_mut(&stream_id) {
+                    if flow.queued_write_bytes.saturating_add(payload.len())
+                        > MAX_FLOW_WRITE_BUFFER_BYTES
+                    {
+                        reset = true;
+                    } else {
+                        flow.queued_write_bytes += payload.len();
+                        flow.writes.push_back(PendingWrite {
+                            bytes: payload,
+                            offset: 0,
+                        });
+                    }
+                }
+                if reset {
+                    self.reset_stream(stream_id);
+                } else {
+                    self.flush_stream(stream_id)?;
+                }
+                Ok(())
+            }
+            ServerCommand::StreamFinished { stream_id } => {
+                if let Some(flow) = self.streams.get_mut(&stream_id) {
+                    flow.finish_after_writes = true;
+                    self.flush_stream(stream_id)?;
+                }
+                Ok(())
+            }
+            ServerCommand::UdpOpened {
+                stream_id,
+                association_id,
+            } => {
+                let Some(flow) = self.streams.get(&stream_id) else {
+                    return Ok(());
+                };
+                if let Some(input) = &flow.target_input {
+                    self.udp_inputs
+                        .insert((flow.session_id, association_id), input.clone());
+                }
+                self.respond_flow(stream_id, Status::Ok)
+            }
+            ServerCommand::UdpFailed { stream_id, message } => {
+                debug!(%message, "Young UDP 目标创建失败");
+                self.fail_stream(stream_id, Status::ConnectFailed)
+            }
+            ServerCommand::UdpOutput {
+                session_id,
+                association_id,
+                packet_id,
+                payload,
+            } => self.send_udp(session_id, association_id, packet_id, &payload),
+            ServerCommand::UdpClosed {
+                session_id,
+                association_id,
+            } => {
+                self.udp_inputs.remove(&(session_id, association_id));
+                Ok(())
+            }
+            ServerCommand::Shutdown => Ok(()),
+        }
+    }
+
+    fn respond_flow(&mut self, stream_id: StreamId, status: Status) -> io::Result<()> {
+        let flow = self
+            .streams
+            .get_mut(&stream_id)
+            .ok_or_else(|| not_connected("Young stream 不存在"))?;
+        let session = self
+            .sessions
+            .get(&flow.session_id)
+            .ok_or_else(|| not_connected("Young session 不存在"))?;
+        let response = encode_flow_response(
+            &session.session_key,
+            FlowResponse {
+                status,
+                flow_id: flow.flow_id.unwrap_or(0),
+            },
+        );
+        flow.queued_write_bytes += response.len();
+        flow.writes.push_front(PendingWrite {
+            bytes: response.to_vec(),
+            offset: 0,
+        });
+        self.flush_stream(stream_id)
+    }
+
+    fn fail_stream(&mut self, stream_id: StreamId, status: Status) -> io::Result<()> {
+        self.respond_flow(stream_id, status)?;
+        if let Some(flow) = self.streams.get_mut(&stream_id) {
+            flow.finish_after_writes = true;
+            self.flush_stream(stream_id)?;
+        }
+        Ok(())
+    }
+
+    fn flush_stream(&mut self, stream_id: StreamId) -> io::Result<()> {
+        let mut remove_after_flush = false;
+        {
+            let Some(flow) = self.streams.get_mut(&stream_id) else {
+                return Ok(());
+            };
+            while let Some(front) = flow.writes.front_mut() {
+                let written = flow
+                    .stream
+                    .send_data(&front.bytes[front.offset..], Instant::now())
+                    .map_err(neqo_error)?;
+                if written == 0 {
+                    break;
+                }
+                flow.queued_write_bytes = flow.queued_write_bytes.saturating_sub(written);
+                front.offset += written;
+                if front.offset == front.bytes.len() {
+                    flow.writes.pop_front();
+                }
+            }
+            if flow.writes.is_empty() && flow.finish_after_writes {
+                flow.finish_after_writes = false;
+                flow.stream
+                    .stream_close_send(Instant::now())
+                    .map_err(neqo_error)?;
+                flow.send_finished = true;
+                remove_after_flush = flow.receive_finished;
+            }
+        }
+        if remove_after_flush {
+            self.remove_stream(stream_id);
+        }
+        Ok(())
+    }
+
+    fn flush_decoy(&mut self, stream_id: StreamId) -> io::Result<()> {
+        let mut remove_after_flush = false;
+        {
+            let Some(decoy) = self.decoys.get_mut(&stream_id) else {
+                return Ok(());
+            };
+            while let Some(front) = decoy.writes.front_mut() {
+                let written = decoy
+                    .stream
+                    .send_data(&front.bytes[front.offset..], Instant::now())
+                    .map_err(neqo_error)?;
+                if written == 0 {
+                    break;
+                }
+                front.offset += written;
+                if front.offset == front.bytes.len() {
+                    decoy.writes.pop_front();
+                }
+            }
+            if decoy.writes.is_empty() && decoy.finish_after_writes {
+                decoy.finish_after_writes = false;
+                decoy
+                    .stream
+                    .stream_close_send(Instant::now())
+                    .map_err(neqo_error)?;
+                decoy.send_finished = true;
+                remove_after_flush = decoy.receive_finished;
+            }
+        }
+        if remove_after_flush {
+            self.decoys.remove(&stream_id);
+        }
+        Ok(())
+    }
+
+    fn send_udp(
+        &mut self,
+        session_id: StreamId,
+        association_id: u64,
+        packet_id: u32,
+        payload: &[u8],
+    ) -> io::Result<()> {
+        let session = self
+            .sessions
+            .get(&session_id)
+            .ok_or_else(|| not_connected("Young session 不存在"))?;
+        let max_size = usize::try_from(session.session.max_datagram_size().map_err(neqo_error)?)
+            .map_err(|_| invalid_input("WebTransport datagram size 超过 usize"))?;
+        for fragment in encode_udp_fragments(
+            &session.session_key,
+            association_id,
+            packet_id,
+            payload,
+            max_size,
+        )? {
+            session
+                .session
+                .send_datagram(&fragment, None, Instant::now())
+                .map_err(neqo_error)?;
+        }
+        Ok(())
+    }
+
+    fn close_session(&mut self, session_id: StreamId) {
+        self.sessions.remove(&session_id);
+        let streams: Vec<_> = self
+            .streams
+            .iter()
+            .filter_map(|(id, stream)| (stream.session_id == session_id).then_some(*id))
+            .collect();
+        for stream_id in streams {
+            self.remove_stream(stream_id);
+        }
+        self.udp_inputs
+            .retain(|(candidate, _), _| *candidate != session_id);
+    }
+
+    fn remove_stream(&mut self, stream_id: StreamId) {
+        if let Some(mut flow) = self.streams.remove(&stream_id) {
+            if let Some(session) = self.sessions.get_mut(&flow.session_id) {
+                session.flow_count = session.flow_count.saturating_sub(1);
+            }
+            if let Some(flow_id) = flow.flow_id {
+                self.udp_inputs.remove(&(flow.session_id, flow_id));
+            }
+            if let Some(task) = flow.target_task.take() {
+                task.abort();
+            }
+        }
+        self.decoys.remove(&stream_id);
+    }
+
+    fn reset_stream(&mut self, stream_id: StreamId) {
+        if let Some(flow) = self.streams.get_mut(&stream_id) {
+            let _ = flow
+                .stream
+                .stream_reset_send(neqo_http3::Error::HttpRequestRejected.code());
+        }
+        self.remove_stream(stream_id);
+    }
+}
+
+async fn tcp_target(
+    stream_id: StreamId,
+    target: Target,
+    mut incoming: mpsc::Receiver<Vec<u8>>,
+    commands: mpsc::UnboundedSender<ServerCommand>,
+) {
+    let socket = match TcpStream::connect(target.authority()).await {
+        Ok(socket) => socket,
+        Err(error) => {
+            let _ = commands.send(ServerCommand::TcpFailed {
+                stream_id,
+                message: error.to_string(),
+            });
+            return;
+        }
+    };
+    let _ = socket.set_nodelay(true);
+    let _ = commands.send(ServerCommand::TcpOpened { stream_id });
+    let (mut target_reader, mut target_writer) = socket.into_split();
+    let mut buffer = vec![0; STREAM_CHUNK_BYTES];
+    let mut target_send_open = true;
+    let mut client_send_open = true;
+    while target_send_open || client_send_open {
+        tokio::select! {
+            read = target_reader.read(&mut buffer), if target_send_open => {
+                match read {
+                    Ok(0) | Err(_) => {
+                        target_send_open = false;
+                        let _ = commands.send(ServerCommand::StreamFinished { stream_id });
+                    }
+                    Ok(length) => {
+                        let _ = commands.send(ServerCommand::StreamOutput {
+                            stream_id,
+                            payload: buffer[..length].to_vec(),
+                        });
+                    }
+                }
+            }
+            payload = incoming.recv(), if client_send_open => {
+                match payload {
+                    Some(payload) => {
+                        if target_writer.write_all(&payload).await.is_err() {
+                            client_send_open = false;
+                            incoming.close();
+                            let _ = target_writer.shutdown().await;
+                        }
+                    }
+                    None => {
+                        client_send_open = false;
+                        let _ = target_writer.shutdown().await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn udp_target(
+    session_id: StreamId,
+    stream_id: StreamId,
+    association_id: u64,
+    target: Target,
+    mut incoming: mpsc::Receiver<Vec<u8>>,
+    commands: mpsc::UnboundedSender<ServerCommand>,
+) {
+    let remote = match tokio::net::lookup_host((target.host.as_str(), target.port))
+        .await
+        .ok()
+        .and_then(|mut addresses| addresses.next())
+    {
+        Some(remote) => remote,
+        None => {
+            let _ = commands.send(ServerCommand::UdpFailed {
+                stream_id,
+                message: "目标 DNS 解析失败".into(),
+            });
+            return;
+        }
+    };
+    let bind = match remote {
+        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+    };
+    let socket = match UdpSocket::bind(bind).await {
+        Ok(socket) => socket,
+        Err(error) => {
+            let _ = commands.send(ServerCommand::UdpFailed {
+                stream_id,
+                message: error.to_string(),
+            });
+            return;
+        }
+    };
+    if let Err(error) = socket.connect(remote).await {
+        let _ = commands.send(ServerCommand::UdpFailed {
+            stream_id,
+            message: error.to_string(),
+        });
+        return;
+    }
+    let _ = commands.send(ServerCommand::UdpOpened {
+        stream_id,
+        association_id,
+    });
+    let mut packet_id = OsRng.next_u32();
+    let mut buffer = vec![0; 65_535];
+    loop {
+        tokio::select! {
+            read = socket.recv(&mut buffer) => {
+                match read {
+                    Ok(length) if length > 0 => {
+                        packet_id = packet_id.wrapping_add(1);
+                        let _ = commands.send(ServerCommand::UdpOutput {
+                            session_id,
+                            association_id,
+                            packet_id,
+                            payload: buffer[..length].to_vec(),
+                        });
+                    }
+                    _ => break,
+                }
+            }
+            payload = incoming.recv() => {
+                match payload {
+                    Some(payload) if socket.send(&payload).await.is_ok() => {}
+                    _ => break,
+                }
+            }
+        }
+    }
+    let _ = commands.send(ServerCommand::UdpClosed {
+        session_id,
+        association_id,
+    });
+    let _ = commands.send(ServerCommand::StreamFinished { stream_id });
+}
+
+fn header_text<'a>(headers: &'a [Header], name: &'a str) -> Option<&'a str> {
+    headers.find_header(name)?.value_utf8().ok()
+}
+
+fn neqo_error(error: impl fmt::Display) -> io::Error {
+    io::Error::other(format!("Neqo：{error}"))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn not_connected(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::NotConnected, message.into())
+}

--- a/crates/core-young/tests/neqo_roundtrip.rs
+++ b/crates/core-young/tests/neqo_roundtrip.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "firefox-stack")]
+
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
+
+use core_young::{
+    KeyRing, Target, YoungClient, YoungClientConfig, YoungKey, YoungServerConfig, YoungServerHandle,
+};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    net::{TcpListener, UdpSocket},
+};
+
+const TEST_CERTIFICATE_SHA256: [u8; 32] = [
+    0xbf, 0xdb, 0xfc, 0x5a, 0xf1, 0x68, 0x7a, 0xc9, 0x08, 0x48, 0x53, 0x01, 0x44, 0xb9, 0xee, 0x94,
+    0x28, 0x50, 0x2e, 0x4b, 0xa6, 0xb0, 0x67, 0x75, 0x21, 0xb7, 0x61, 0xd9, 0xfc, 0x1a, 0xa3, 0x91,
+];
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn neqo_webtransport_tcp_and_udp_round_trip() {
+    let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let tcp_addr = tcp.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = tcp.accept().await.unwrap();
+        let mut request = Vec::new();
+        stream.read_to_end(&mut request).await.unwrap();
+        stream.write_all(&request).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let udp_addr = udp.local_addr().unwrap();
+    tokio::spawn(async move {
+        let mut buffer = [0; 65_535];
+        loop {
+            let (length, peer) = udp.recv_from(&mut buffer).await.unwrap();
+            udp.send_to(&buffer[..length], peer).await.unwrap();
+        }
+    });
+
+    let key = YoungKey::from_bytes([0x5a; 32]);
+    let server = YoungServerHandle::start(YoungServerConfig {
+        listen: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        nss_database: PathBuf::from(nss::TEST_FIXTURE_DB),
+        certificate_nickname: "key".into(),
+        authority: "example.com".into(),
+        path: "/assets".into(),
+        keys: KeyRing::new(vec![key.clone()]).unwrap(),
+        clock_skew: Duration::from_secs(120),
+        idle_timeout: Duration::from_secs(30),
+        max_streams: 32,
+        max_sessions: 8,
+        max_flows_per_session: 16,
+        decoy_status: 404,
+        decoy_body: b"<html>not found</html>".to_vec(),
+    })
+    .unwrap();
+    let client_config = YoungClientConfig {
+        server: "127.0.0.1".into(),
+        port: server.local_addr().port(),
+        server_name: "example.com".into(),
+        authority: "example.com".into(),
+        path: "/assets".into(),
+        key,
+        certificate_sha256: TEST_CERTIFICATE_SHA256,
+        idle_timeout: Duration::from_secs(30),
+        max_streams: 32,
+        padding_min: 17,
+        padding_max: 79,
+    };
+    let mut rejected_config = client_config.clone();
+    rejected_config.key = YoungKey::from_bytes([0x33; 32]);
+    let rejected_client = YoungClient::start(rejected_config).unwrap();
+    let rejected = tokio::time::timeout(
+        Duration::from_secs(10),
+        rejected_client.open_tcp(Target::new("127.0.0.1", 9).unwrap()),
+    )
+    .await
+    .unwrap();
+    assert!(rejected.is_err());
+
+    let client = YoungClient::start(client_config).unwrap();
+
+    let mut stream = tokio::time::timeout(
+        Duration::from_secs(10),
+        client.open_tcp(Target::new(tcp_addr.ip().to_string(), tcp_addr.port()).unwrap()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    stream.write_all(b"young-over-neqo").await.unwrap();
+    stream.shutdown().await.unwrap();
+    let mut tcp_reply = [0; 15];
+    tokio::time::timeout(Duration::from_secs(10), stream.read_exact(&mut tcp_reply))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&tcp_reply, b"young-over-neqo");
+
+    let udp = tokio::time::timeout(
+        Duration::from_secs(10),
+        client.open_udp(Target::new(udp_addr.ip().to_string(), udp_addr.port()).unwrap()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let datagram = vec![0xa5; 5000];
+    udp.send(&datagram).await.unwrap();
+    let mut udp_reply = vec![0; 6000];
+    let received = tokio::time::timeout(Duration::from_secs(10), udp.recv(&mut udp_reply))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(&udp_reply[..received], &datagram);
+
+    server.shutdown().unwrap();
+}

--- a/crates/wuther-core/Cargo.toml
+++ b/crates/wuther-core/Cargo.toml
@@ -30,6 +30,7 @@ core-api      = { workspace = true }
 core-capture  = { workspace = true }
 core-mesh     = { workspace = true }
 core-observe  = { workspace = true }
+core-young    = { workspace = true, features = ["firefox-stack"] }
 clap          = { workspace = true }
 tokio         = { workspace = true }
 anyhow        = { workspace = true }

--- a/crates/wuther-core/src/host_resources.rs
+++ b/crates/wuther-core/src/host_resources.rs
@@ -42,6 +42,21 @@ pub(crate) fn listener_resource_claims(plan: &RuntimePlan) -> Result<Vec<HostRes
         ));
     }
 
+    for young in &plan.listen.young {
+        let address = young
+            .socket_addr()
+            .map_err(|error| anyhow::anyhow!("Young listener declaration failed: {error}"))?;
+        ensure!(
+            address.port() != 0,
+            "Young listener port 0 cannot be reserved"
+        );
+        claims.insert(socket_claim(
+            host_owner("wuther.young"),
+            SocketTransport::Udp,
+            address,
+        ));
+    }
+
     if plan.ui.on {
         if let Some(panel) = &plan.listen.panel {
             let address = panel

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -936,6 +936,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
 
     let mut handles = Vec::new();
+    let mut young_server_handles = Vec::new();
 
     // Standalone DNS server —— mihomo `dns.listen` 等价。
     // 与 mihomo `dns/server.go::ReCreateServer` 行为一致：空地址 / port=0 → disabled。
@@ -970,6 +971,41 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
     // 防止编译器优化掉 handle —— drop 时取消两个后台 task。
     let _dns_listener_keepalive = dns_listener_handle;
+
+    // Young 原生入站：每个监听器由独立 current-thread runtime 驱动 Mozilla Neqo。
+    // handle 持有关闭通道，必须存活到全局 shutdown。
+    for listener in &plan.listen.young {
+        let listen = listener
+            .socket_addr()
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        let keys = listener
+            .users
+            .iter()
+            .map(|key| core_young::YoungKey::parse_base64url(key))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        let server = core_young::YoungServerHandle::start(core_young::YoungServerConfig {
+            listen,
+            nss_database: PathBuf::from(&listener.nss_database),
+            certificate_nickname: listener.certificate_nickname.clone(),
+            authority: listener.authority.clone(),
+            path: listener.path.clone(),
+            keys: core_young::KeyRing::new(keys)?,
+            clock_skew: listener.clock_skew,
+            idle_timeout: listener.idle_timeout,
+            max_streams: listener.max_streams,
+            max_sessions: listener.max_sessions,
+            max_flows_per_session: listener.max_flows_per_session,
+            decoy_status: listener.decoy_status,
+            decoy_body: listener.decoy_body.as_bytes().to_vec(),
+        })?;
+        info!(
+            addr = %server.local_addr(),
+            authority = %listener.authority,
+            carrier = "mozilla-neqo-h3-webtransport",
+            "Young inbound ready"
+        );
+        young_server_handles.push(server);
+    }
 
     // Mixed 入站
     if let Some(mixed) = &plan.listen.mixed {
@@ -1054,6 +1090,11 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
     feed_mgr_handle.stop();
     runtime.shutdown().await;
+    for server in &young_server_handles {
+        if let Err(error) = server.shutdown() {
+            warn!(target: "young", %error, "Young server shutdown failed");
+        }
+    }
     for h in handles {
         h.abort();
     }

--- a/docs/YOUNG_PROTOCOL.md
+++ b/docs/YOUNG_PROTOCOL.md
@@ -270,9 +270,14 @@ young://<base64url-key>@<server-ip-or-host>:443\
 Linux（Debian/Ubuntu）：
 
 ```bash
-sudo apt-get install clang gyp pkg-config libnss3-dev libnspr4-dev libssl-dev
+# Debian/Ubuntu 稳定版的 NSS 若低于 3.121，不要安装 libnss3-dev：
+# nss-rs 会拉取并构建满足版本要求的 NSS/NSPR。
+sudo apt-get install clang gyp mercurial ninja-build pkg-config
 cargo build --release -p wuther-core
 ```
+
+若 `pkg-config --modversion nss` 已报告 `3.121` 或更高版本，可改用发行版提供的
+`libnss3-dev` 与 `libnspr4-dev`，避免源码构建。
 
 Windows 需要可供 `nss-rs` 使用的 NSS/NSPR、Clang/libclang 和相应构建环境；
 MozillaBuild 是推荐的准备方式。若依赖不在默认搜索路径，需要配置

--- a/docs/YOUNG_PROTOCOL.md
+++ b/docs/YOUNG_PROTOCOL.md
@@ -1,0 +1,305 @@
+# Young v1 协议规范与部署指南
+
+Young 是 WutherCore 自主实现的新代理协议。它不是 VLESS、REALITY、Hysteria
+或其他现有协议的改名，也不复用这些协议的握手。Young v1 的网络栈为：
+
+```text
+UDP
+└── Mozilla Neqo QUIC v1 + NSS/TLS 1.3
+    └── HTTP/3（ALPN: h3）
+        └── WebTransport
+            ├── 双向流：Young TCP
+            └── Datagram：Young UDP
+```
+
+客户端与服务端都直接调用 Mozilla 的 Rust Neqo API。当前依赖固定到 Neqo
+`main` 的提交 `76673b127251c90ad6250de7a0a7400ddd4661f1`，确保可复现构建。
+Neqo 的 TLS 实现通过 `nss-rs` 使用 Mozilla NSS；WutherCore 不包含手写 FFI，
+但运行和构建仍需要 NSS 原生库。`nss-rs` 同样固定到
+`b7cfa30c8a526167cf6bd653b4a6d4f8549280eb`。
+
+## 1. 设计目标
+
+- 外层是可互操作的 HTTP/3 + WebTransport，不伪造“类似 QUIC”的私有报文。
+- 一个已认证的 QUIC 连接承载多个并发 TCP、UDP 流。
+- 预共享密钥不直接作为流量密钥；会话密钥同时绑定 TLS exporter 和随机 nonce。
+- 抵抗无凭据主动探测、认证重放、路径枚举和内层报文篡改。
+- 未认证请求表现为普通 HTTP/3 响应，不暴露 Young 错误、版本或认证状态。
+- TCP 支持双向传输和半关闭；UDP 支持最大 65507 字节报文、分片和乱序重组。
+- 配置限制会话数、每会话流数、QUIC 流数、重放缓存和重组缓存。
+
+## 2. 密钥和证书
+
+### 2.1 Young 用户密钥
+
+每个用户密钥必须是 32 个 CSPRNG 随机字节，以无填充 base64url 表示：
+
+```bash
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '=\n'
+```
+
+`key_id = SHA-256(key)[0..8]`，只用于服务端从 key ring 选择密钥。日志和
+`Debug` 输出只显示 key id，不显示密钥。服务端 `users` 可以同时保留新旧密钥，
+用于无中断轮换。
+
+### 2.2 TLS 证书固定
+
+Young 客户端必须提供服务端叶证书 DER 的 SHA-256 摘要，支持 64 位十六进制或
+无填充 base64url。客户端严格校验该摘要，不提供跳过校验的开关。
+
+```bash
+openssl x509 -in cert.pem -outform DER |
+  openssl dgst -sha256
+```
+
+证书固定值变化时，必须先更新客户端，再替换服务端证书。
+
+## 3. WebTransport 会话认证
+
+客户端向每日轮换的路径发送标准 WebTransport CONNECT。客户端使用 Firefox
+User-Agent，并携带以下 HTTP/3 请求信息；这些头部位于 QUIC 加密层内：
+
+```text
+:method = CONNECT
+:protocol = webtransport
+:scheme = https
+:authority = <configured authority>
+:path = <base path>/<daily token>
+authorization = Bearer <Young authorization>
+```
+
+每日路径为：
+
+```text
+day = floor(unix_seconds / 86400)
+daily_token = base64url(HMAC-SHA256(key, "young/path/v1" || day)[0..9])
+path = trim_end_slash(base_path) || "/" || daily_token
+```
+
+服务端接受当前日期及前后各一天的轮换路径，以容忍日期边界。
+
+Authorization 解码后的固定布局如下，所有整数使用网络字节序：
+
+| 字段 | 长度 | 说明 |
+| --- | ---: | --- |
+| Version | 1 | `0x01` |
+| Key ID | 8 | `SHA-256(key)[0..8]` |
+| Timestamp | 8 | UNIX 秒 |
+| Client nonce | 16 | CSPRNG 随机数 |
+| Capabilities | 4 | 客户端能力位 |
+| Tag | 32 | HMAC-SHA-256 |
+
+Tag 覆盖：
+
+```text
+"young/session/v1" || authority || path || fields_before_tag
+```
+
+服务端按固定时间窗校验时间戳，并把 `(key_id, nonce)` 原子写入有界重放缓存。
+同一个认证值只能成功一次。认证成功后服务端在
+`sec-young-accept` 响应头中返回：
+
+```text
+base64url(HMAC-SHA256(key, "young/server-accept/v1" || client_nonce))
+```
+
+客户端必须验证服务端证明。随后双方从 WebTransport 会话导出的 TLS exporter
+生成内层会话密钥：
+
+```text
+session_key = HMAC-SHA256(
+  key,
+  "young/exporter/v1" || tls_exporter || client_nonce
+)
+```
+
+因此，截获的 Young Authorization 不能脱离原 TLS 会话复用为内层流量密钥。
+
+## 4. TCP 流
+
+每个 TCP 代理流使用一条 WebTransport 双向流。第一个帧为 FlowOpen：
+
+| 字段 | 长度 | 说明 |
+| --- | ---: | --- |
+| Magic | 2 | `YF` |
+| Version | 1 | `0x01` |
+| Kind | 1 | `1=TCP`，`2=UDP association` |
+| Flow ID | 8 | 随机会话内标识 |
+| Target | 可变 | IPv4、IPv6 或域名及端口 |
+| Padding length | 2 | `0..=4096` |
+| Random padding | 可变 | CSPRNG 字节 |
+| Tag | 16 | 截断 HMAC-SHA-256 |
+
+Tag 覆盖：
+
+```text
+"young/flow-open/v1" || all_fields_before_tag
+```
+
+服务端响应固定长度 FlowResponse：
+
+| 字段 | 长度 | 说明 |
+| --- | ---: | --- |
+| Magic | 2 | `YR` |
+| Version | 1 | `0x01` |
+| Status | 1 | 状态码 |
+| Flow ID | 8 | 对应请求 |
+| Tag | 16 | 截断 HMAC-SHA-256 |
+
+状态码为 `0=成功`、`1=请求错误`、`2=未授权`、`3=连接失败`、
+`4=不支持`、`5=资源上限`。成功响应后是目标 TCP 字节流。WebTransport
+两个发送方向分别映射 TCP 两个发送方向，FIN 独立传播，支持“发送完成后继续接收”
+的半关闭语义。
+
+## 5. UDP association
+
+UDP association 先用双向流执行与 TCP 相同的 FlowOpen/FlowResponse，随后每个
+UDP 报文通过 WebTransport Datagram 传输。报文长度范围为 `1..=65507`。
+
+当一份 UDP 报文超过当前 QUIC datagram 上限时，编码为多个 Young 分片：
+
+| 字段 | 长度 | 说明 |
+| --- | ---: | --- |
+| Magic | 2 | `YD` |
+| Version | 1 | `0x01` |
+| Flags | 1 | v1 必须为 0 |
+| Association ID | 8 | 对应 UDP association |
+| Packet ID | 4 | 每份原始 UDP 报文递增 |
+| Fragment index | 2 | 从 0 开始 |
+| Fragment count | 2 | 总分片数 |
+| Total length | 2 | 原始 UDP 报文长度 |
+| Payload | 可变 | 当前分片 |
+| Tag | 16 | 截断 HMAC-SHA-256 |
+
+Tag 覆盖：
+
+```text
+"young/udp-fragment/v1" || all_fields_before_tag
+```
+
+接收端先验证 Tag，再进行有界、带超时的乱序重组。Association ID、Packet ID、
+分片数量、总长度或 Tag 不一致时丢弃整份报文，避免把不同 UDP 报文拼接在一起。
+每份原始报文最多 256 个分片，未知 association 不进入重组缓存。
+
+## 6. 主动探测和封锁对抗
+
+Young v1 实现以下防护：
+
+- 使用真实 Neqo QUIC、HTTP/3 和 WebTransport 状态机，不发送自制伪 QUIC 握手。
+- Young 认证头、轮换路径、目标地址和内层帧均位于 QUIC 加密层内。
+- 每日路径、随机 nonce、时间窗和有界重放缓存消除可长期重放的固定入口。
+- 双向认证：证书 SHA-256 固定与 `sec-young-accept` 同时验证服务端。
+- 内层 FlowOpen、FlowResponse 和每个 UDP 分片都用 TLS-exporter 派生密钥认证。
+- 无效认证、错误路径和普通 HTTP/3 请求返回可配置的普通网页，不返回 Young
+  专用错误；并在验证认证前不连接任意目标。
+- 随机 FlowOpen padding 降低固定长度特征；一个连接复用多个流，减少逐流握手。
+- 会话、流、缓存和报文尺寸均有限制；每流待发送队列上限为 1 MiB，流结束或
+  重置时会取消对应 relay task，降低慢连接和探测造成的资源消耗。
+- 已认证会话中的非法流帧只重置该流，非法 UDP 分片只丢弃该报文，不会终止
+  整个 Neqo server worker。
+
+这里的“抗封锁”不是“不可封锁”。能够整体阻断 UDP、QUIC 或目标 IP 的网络仍可
+中断 Young；流量分析者也可能基于长期统计特征分类 HTTP/3。Young v1 不宣称具备
+尚未实现的 ECH、域前置或 TCP fallback。需要运营侧配合轮换 IP、证书、密钥和
+伪装内容，并监控 QUIC 可达性。
+
+## 7. 服务端配置
+
+NSS 数据库中必须存在可用于 `authority` 的证书及私钥。一个进程只能初始化一份
+NSS 数据库，因此同一配置中的所有 Young listener 必须使用相同的
+`nssDatabase`。
+
+```bash
+mkdir -p data/nss
+certutil -N -d sql:data/nss
+pk12util -i server.p12 -d sql:data/nss
+certutil -L -d sql:data/nss
+```
+
+```yaml
+version: 1
+profile: server
+
+listen:
+  young:
+    - host: 0.0.0.0
+      port: 443
+      nssDatabase: data/nss
+      certificateNickname: young.example.com
+      authority: young.example.com
+      path: /assets
+      users:
+        - REPLACE_WITH_32_BYTE_BASE64URL_KEY
+      clockSkew: 2m
+      idleTimeout: 5m
+      maxStreams: 1024
+      maxSessions: 4096
+      maxFlowsPerSession: 256
+      decoyStatus: 404
+      decoyBody: "<!doctype html><title>Not Found</title>"
+
+route:
+  preset: direct
+```
+
+`wuther-core check` 会验证端口冲突、密钥长度和 key id 重复、NSS 数据库一致性、
+路径、状态码及所有资源上限。`run` 会先启动 Young UDP listener，再启动本地
+Mixed listener；出站客户端延迟初始化，从而避免 NSS 全局初始化顺序冲突。
+
+## 8. 客户端 URI
+
+```text
+young://<base64url-key>@<server-ip-or-host>:443\
+?security=tls\
+&sni=young.example.com\
+&authority=young.example.com\
+&path=%2Fassets\
+&pin-sha256=<leaf-certificate-sha256-hex>\
+&padding-min=64\
+&padding-max=512\
+&idle-secs=300\
+&max-streams=1024\
+#Young
+```
+
+必填项是 32 字节 base64url key、服务器地址、端口、`security=tls`、SNI 和
+`pin-sha256`。`authority` 默认等于 SNI，`path` 默认 `/assets`。
+
+## 9. 构建依赖
+
+Linux（Debian/Ubuntu）：
+
+```bash
+sudo apt-get install clang pkg-config libnss3-dev libnspr4-dev libssl-dev
+cargo build --release -p wuther-core
+```
+
+Windows 需要可供 `nss-rs` 使用的 NSS/NSPR、Clang/libclang 和相应构建环境；
+MozillaBuild 是推荐的准备方式。若依赖不在默认搜索路径，需要配置
+`NSS_DIR`、`NSPR_DIR` 和 `LIBCLANG_PATH`。纯协议编解码测试可以关闭 Neqo：
+
+```bash
+cargo test -p core-young --no-default-features --lib
+```
+
+真实网络互操作测试需要 NSS：
+
+```bash
+cargo test -p core-young --features firefox-stack --test neqo_roundtrip
+```
+
+该测试覆盖错误用户密钥拒绝后服务端继续可用、真实 WebTransport 会话、TCP
+半关闭后回包，以及 5000 字节 UDP 报文的分片和乱序安全重组路径。
+
+## 10. 实现状态与上游边界
+
+Young v1 已接入配置解析、运行计划、内核 listener、出站注册、TCP、UDP、
+半关闭、证书固定、重放防护、伪装响应和真实 Neqo 互操作测试。Mozilla 当前仍将
+Neqo 服务端能力标记为实验性；部署前应进行容量、升级和异常网络回归，不应把
+上游实验性服务端当作无风险的长期兼容承诺。
+
+参考：
+
+- [Mozilla Neqo](https://github.com/mozilla/neqo)
+- [Firefox HTTP/3 文档](https://firefox-source-docs.mozilla.org/networking/http/http3.html)
+- [Firefox Networking / Necko 术语](https://firefox-source-docs.mozilla.org/networking/necko_lingo.html)

--- a/docs/YOUNG_PROTOCOL.md
+++ b/docs/YOUNG_PROTOCOL.md
@@ -270,7 +270,7 @@ young://<base64url-key>@<server-ip-or-host>:443\
 Linux（Debian/Ubuntu）：
 
 ```bash
-sudo apt-get install clang pkg-config libnss3-dev libnspr4-dev libssl-dev
+sudo apt-get install clang gyp pkg-config libnss3-dev libnspr4-dev libssl-dev
 cargo build --release -p wuther-core
 ```
 


### PR DESCRIPTION
## 概要

本 PR 在独立 worktree 中完整实现全新的 Young v1 代理协议，并将 Mozilla Firefox 使用的 Rust Neqo HTTP/3/QUIC 协议栈接入 WutherCore。实现不复用 VLESS/REALITY 握手，也没有自制伪 QUIC 外层。

网络分层为：UDP → Neqo QUIC v1/NSS TLS 1.3 → HTTP/3 (`h3`) → WebTransport → Young TCP/UDP。

## 主要实现

- 新增 `core-young` crate，客户端与服务端均直接使用 Neqo API；Neqo 固定到当前 `main` 提交 `76673b127251c90ad6250de7a0a7400ddd4661f1`，`nss-rs` 由锁文件固定到当前 `main` 提交 `b7cfa30c8a526167cf6bd653b4a6d4f8549280eb`。
- 实现标准 WebTransport CONNECT、共享 QUIC 会话和多流复用。
- 实现 TCP 双向 relay 与独立 FIN 传播，支持发送半关闭后继续接收。
- 实现 UDP association、WebTransport Datagram、最多 65507 字节报文、最多 256 分片、乱序重组、超时和缓存上限。
- 实现 256 位用户密钥、key ring、每日轮换路径、时间窗、随机 nonce、有界重放缓存。
- 会话密钥绑定 TLS exporter；FlowOpen、FlowResponse、UDP 分片均有 HMAC 认证。
- 实现叶证书 SHA-256 固定和服务端 `sec-young-accept` 证明。
- 无效认证和普通 HTTP/3 请求返回可配置网页；认证前不连接目标。
- 非法流帧只重置对应流，非法 UDP 分片只丢弃报文；未知 association 不进入重组缓存。
- 每流待发送队列限制为 1 MiB；流结束或重置时取消 relay task；会话、流和监听资源均有上限。
- 新增 `young://` URI、`listen.young` YAML、配置校验、IPv4/IPv6 监听、资源声明、内核启动与关闭流程。
- 新增完整中文协议规范、NSS 证书库部署步骤、URI 示例和抗封锁边界说明。

## 抗封锁边界

Young 使用真实 Neqo HTTP/3/WebTransport 状态机，认证、轮换路径、目标和内层帧都位于 QUIC 加密层内，并抵抗无凭据主动探测与握手重放。它不宣称“永不可封锁”：整体阻断 UDP/QUIC/IP 的网络仍可中断连接；ECH、域前置和 TCP fallback 不在 v1 的虚假承诺范围内。

## 验证

- GitHub Required CI（Ubuntu）通过：格式、`cargo check --workspace --all-targets --locked`、CLI 品牌、`cargo test --workspace --locked`、`RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`。
- Ubuntu runner 在发行版 NSS 低于 `nss-rs` 要求时，从 Mozilla 源码构建满足 `>=3.121` 的 NSS/NSPR；依赖链与锁文件已在干净环境验证。
- `cargo clippy -p core-young --features firefox-stack --all-targets -- -D warnings`：通过。
- Young 真实互操作测试覆盖：错误用户密钥拒绝后 listener 继续可用、真实 WebTransport 会话、TCP 半关闭后回包、5000 字节 UDP 分片回显。
- `cargo test -p core-config`：74 项通过。
- `cargo test -p core-young --no-default-features --lib`（Windows 纯 Rust 编解码）：3 项通过。

## 构建说明

Neqo 本身是 Rust，但其 TLS 后端通过 `nss-rs` 使用 Mozilla NSS。本 PR 没有手写 FFI；完整网络栈构建仍需要 NSS/NSPR 与 Clang。若发行版 NSS 低于 `3.121`，文档与 CI 会走 Mozilla NSS/NSPR 源码构建。Mozilla 当前把 Neqo 服务端能力标记为实验性，文档中已明确这一上游边界。