### PR TITLE
feat(ssh): 完整支持 Mihomo 认证与主机密钥配置

### DIFF
--- a/crates/core-feeds/src/parser.rs
+++ b/crates/core-feeds/src/parser.rs
@@ -234,6 +234,24 @@ fn clash_proxy_to_node(m: &serde_yaml::Mapping) -> Option<ParsedNode> {
         }
     }
 
+    // SSH 的主机公钥和算法字段在 mihomo 中是字符串数组。ParsedNode 的
+    // 兼容参数表只存字符串，因此分别用换行和逗号保存，避免通用标量路径
+    // 静默丢弃这些安全关键字段。
+    if matches!(proto, NodeProtocol::Ssh) {
+        for (field, separator) in [("host-key", "\n"), ("host-key-algorithms", ",")] {
+            if let Some(sequence) = g(field).and_then(|value| value.as_sequence().cloned()) {
+                let joined = sequence
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .collect::<Vec<_>>()
+                    .join(separator);
+                if !joined.is_empty() {
+                    node.params.insert(field.into(), joined);
+                }
+            }
+        }
+    }
+
     // 4. transport-opts 平铺
     flatten_transport_opts(m, "ws-opts", &["path", "headers"], &mut node.params, "ws-");
     flatten_transport_opts(m, "grpc-opts", &["grpc-service-name"], &mut node.params, "");
@@ -543,6 +561,40 @@ proxies:
             serde_json::from_str(node.params.get("peers").unwrap()).unwrap();
         assert_eq!(peers.as_array().unwrap().len(), 2);
         assert_eq!(peers[0]["reserved"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn parse_clash_ssh_preserves_username_host_keys_and_algorithms() {
+        let yaml = r#"
+proxies:
+  - name: SSH
+    type: ssh
+    server: ssh.example.com
+    port: 22
+    username: alice
+    password: secret
+    host-key:
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGZha2U"
+      - "rsa-sha2-256 AAAAB3NzaC1yc2EAAAADAQABAAABAQ"
+    host-key-algorithms: [ed25519, rsa]
+"#;
+        let nodes = parse_feed_payload(yaml.as_bytes(), FormatHint::Auto);
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].user.as_deref(), Some("alice"));
+        assert_eq!(
+            nodes[0].params.get("host-key").map(String::as_str),
+            Some(
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGZha2U\n\
+                 rsa-sha2-256 AAAAB3NzaC1yc2EAAAADAQABAAABAQ"
+            )
+        );
+        assert_eq!(
+            nodes[0]
+                .params
+                .get("host-key-algorithms")
+                .map(String::as_str),
+            Some("ed25519,rsa")
+        );
     }
 
     #[test]

--- a/crates/core-outbound/src/proto/ssh.rs
+++ b/crates/core-outbound/src/proto/ssh.rs
@@ -9,8 +9,7 @@
 //!   - 用户 + 密码
 //!   - 用户 + 私钥（OpenSSH 文件路径或字符串内容）
 //!   - 用户 + 私钥 + passphrase
-//!   - 用户 + agent（占位，需外部 agent socket）
-//!   - 用户 + 主机鉴权（host-based，预留接口）
+//!   - 私钥与密码按 mihomo 顺序回退
 //! * **Session 复用**：同一 SshOutbound 实例的多个 dial 共享同一条 SSH 会话；
 //!   会话失效时自动重连
 //! * **Host key 校验**：可选 known_hosts 列表（accept_unknown=false 时严格校验）
@@ -18,7 +17,7 @@
 //! * **Channel 数限制**：通过 `russh::client::Config.maximum_channels`
 //! * **失败重连**：断线时下一个 dial 触发重新握手
 
-use std::{path::PathBuf, sync::Arc};
+use std::{borrow::Cow, path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::sync::Mutex as AsyncMutex;
@@ -28,15 +27,7 @@ use crate::adapter::{BoxedStream, Capabilities, DialContext, OutboundAdapter};
 #[derive(Debug, Clone)]
 pub enum SshAuth {
     Password(String),
-    PrivateKeyPath {
-        path: PathBuf,
-        passphrase: Option<String>,
-    },
-    PrivateKeyContent {
-        content: String,
-        passphrase: Option<String>,
-    },
-    None,
+    PrivateKey(Arc<russh_keys::key::KeyPair>),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -44,7 +35,7 @@ pub struct SshHostKeyCheck {
     /// 不校验 host key（默认；mihomo 行为）
     pub accept_unknown: bool,
     /// 已知公钥列表（OpenSSH 格式，每行一条；非空时严格校验）
-    pub known_hosts_lines: Vec<String>,
+    pub keys: Vec<russh_keys::key::PublicKey>,
 }
 
 #[derive(Clone)]
@@ -53,7 +44,7 @@ pub struct SshOutbound {
     pub host: String,
     pub port: u16,
     pub user: String,
-    pub auth: SshAuth,
+    pub auth: Vec<SshAuth>,
     pub host_key_check: SshHostKeyCheck,
     pub host_key_alg: Vec<String>,
     pub client_version: String,
@@ -74,20 +65,20 @@ impl SshOutbound {
             host: host.into(),
             port,
             user: user.into(),
-            auth: SshAuth::None,
+            auth: Vec::new(),
             host_key_check: SshHostKeyCheck {
                 accept_unknown: true,
-                known_hosts_lines: vec![],
+                keys: vec![],
             },
             host_key_alg: vec![],
-            client_version: format!("SSH-2.0-WutherCore_{}", env!("CARGO_PKG_VERSION")),
+            client_version: "SSH-2.0-OpenSSH_8.9".into(),
             keepalive_interval_secs: 30,
             session: Arc::new(AsyncMutex::new(None)),
         }
     }
 
     pub fn with_password(mut self, password: impl Into<String>) -> Self {
-        self.auth = SshAuth::Password(password.into());
+        self.auth.push(SshAuth::Password(password.into()));
         self
     }
 
@@ -95,32 +86,54 @@ impl SshOutbound {
         mut self,
         path: impl Into<PathBuf>,
         passphrase: Option<String>,
-    ) -> Self {
-        self.auth = SshAuth::PrivateKeyPath {
-            path: path.into(),
-            passphrase,
-        };
-        self
+    ) -> Result<Self, String> {
+        let path = path.into();
+        let key = russh_keys::load_secret_key(&path, passphrase.as_deref()).map_err(|error| {
+            format!(
+                "failed to load SSH private key `{}`: {error}",
+                path.display()
+            )
+        })?;
+        self.auth.push(SshAuth::PrivateKey(Arc::new(key)));
+        Ok(self)
     }
 
     pub fn with_private_key_content(
         mut self,
         content: impl Into<String>,
         passphrase: Option<String>,
-    ) -> Self {
-        self.auth = SshAuth::PrivateKeyContent {
-            content: content.into(),
-            passphrase,
+    ) -> Result<Self, String> {
+        let content = content.into();
+        let key = russh_keys::decode_secret_key(&content, passphrase.as_deref())
+            .map_err(|error| format!("failed to decode SSH private key: {error}"))?;
+        self.auth.push(SshAuth::PrivateKey(Arc::new(key)));
+        Ok(self)
+    }
+
+    pub fn with_host_keys(mut self, keys: Vec<russh_keys::key::PublicKey>) -> Self {
+        self.host_key_check = SshHostKeyCheck {
+            accept_unknown: false,
+            keys,
         };
         self
     }
 
-    pub fn with_known_hosts(mut self, lines: Vec<String>) -> Self {
-        self.host_key_check = SshHostKeyCheck {
-            accept_unknown: false,
-            known_hosts_lines: lines,
-        };
-        self
+    pub fn with_host_key_algorithms(mut self, algorithms: Vec<String>) -> Result<Self, String> {
+        // Validate here so a misspelt security policy never degrades into the
+        // library default during the first network connection.
+        parse_host_key_algorithms(&algorithms)?;
+        self.host_key_alg = algorithms;
+        Ok(self)
+    }
+
+    pub fn with_client_version(mut self, version: impl Into<String>) -> Result<Self, String> {
+        let version = version.into();
+        if !version.starts_with("SSH-2.0-") || version.contains(['\r', '\n']) || version.len() > 255
+        {
+            return Err("SSH client version must be one RFC 4253 `SSH-2.0-*` line".into());
+        }
+        self.client_version = version;
+        Ok(self)
     }
 
     async fn ensure_session(&self) -> std::io::Result<Arc<russh::client::Handle<NopHandler>>> {
@@ -136,13 +149,20 @@ impl SshOutbound {
     }
 
     async fn connect_session_inner(&self) -> std::io::Result<russh::client::Handle<NopHandler>> {
-        let config = Arc::new(russh::client::Config {
+        let mut config = russh::client::Config {
+            client_id: russh::SshId::Standard(self.client_version.clone()),
             inactivity_timeout: Some(std::time::Duration::from_secs(
                 self.keepalive_interval_secs.max(60),
             )),
-            keepalive_interval: Some(std::time::Duration::from_secs(self.keepalive_interval_secs)),
+            keepalive_interval: (self.keepalive_interval_secs > 0)
+                .then(|| std::time::Duration::from_secs(self.keepalive_interval_secs)),
             ..Default::default()
-        });
+        };
+        if !self.host_key_alg.is_empty() {
+            config.preferred.key =
+                Cow::Owned(parse_host_key_algorithms(&self.host_key_alg).map_err(io_err)?);
+        }
+        let config = Arc::new(config);
         let addr = format!("{}:{}", self.host, self.port);
         let handler = NopHandler {
             check: self.host_key_check.clone(),
@@ -150,35 +170,29 @@ impl SshOutbound {
         let mut session = russh::client::connect(config, addr, handler)
             .await
             .map_err(|e| io_err(format!("ssh connect: {e}")))?;
-        let auth_ok = match &self.auth {
-            SshAuth::Password(pw) => session
-                .authenticate_password(&self.user, pw)
-                .await
-                .map_err(|e| io_err(format!("ssh auth password: {e}")))?,
-            SshAuth::PrivateKeyPath { path, passphrase } => {
-                let key = russh_keys::load_secret_key(path, passphrase.as_deref())
-                    .map_err(|e| io_err(format!("ssh load key path: {e}")))?;
-                session
-                    .authenticate_publickey(&self.user, Arc::new(key))
-                    .await
-                    .map_err(|e| io_err(format!("ssh auth pubkey: {e}")))?
-            }
-            SshAuth::PrivateKeyContent {
-                content,
-                passphrase,
-            } => {
-                let key = russh_keys::decode_secret_key(content, passphrase.as_deref())
-                    .map_err(|e| io_err(format!("ssh decode key: {e}")))?;
-                session
-                    .authenticate_publickey(&self.user, Arc::new(key))
-                    .await
-                    .map_err(|e| io_err(format!("ssh auth pubkey: {e}")))?
-            }
-            SshAuth::None => session
+        let mut auth_ok = false;
+        if self.auth.is_empty() {
+            auth_ok = session
                 .authenticate_none(&self.user)
                 .await
-                .map_err(|e| io_err(format!("ssh auth none: {e}")))?,
-        };
+                .map_err(|e| io_err(format!("ssh auth none: {e}")))?;
+        } else {
+            for auth in &self.auth {
+                auth_ok = match auth {
+                    SshAuth::Password(password) => session
+                        .authenticate_password(&self.user, password)
+                        .await
+                        .map_err(|e| io_err(format!("ssh auth password: {e}")))?,
+                    SshAuth::PrivateKey(key) => session
+                        .authenticate_publickey(&self.user, key.clone())
+                        .await
+                        .map_err(|e| io_err(format!("ssh auth pubkey: {e}")))?,
+                };
+                if auth_ok {
+                    break;
+                }
+            }
+        }
         if !auth_ok {
             return Err(io_err("ssh authentication rejected".to_string()));
         }
@@ -227,7 +241,7 @@ impl OutboundAdapter for SshOutbound {
     }
 }
 
-/// host key 校验 handler。`accept_unknown=true` 时全接受；否则在 known_hosts_lines 中查找。
+/// host key 校验 handler。`accept_unknown=true` 时全接受；否则做公钥字节精确匹配。
 #[derive(Clone)]
 struct NopHandler {
     check: SshHostKeyCheck,
@@ -248,21 +262,62 @@ impl russh::client::Handler for NopHandler {
         Self: 'async_trait,
     {
         let accept = self.check.accept_unknown;
-        let known = self.check.known_hosts_lines.clone();
-        // 取公钥 fingerprint（SHA256 base64）
-        let fp = server_public_key.fingerprint();
+        let known = self.check.keys.clone();
+        let server_public_key = server_public_key.clone();
         Box::pin(async move {
             if accept {
                 return Ok(true);
             }
-            for line in &known {
-                if line.contains(&fp) {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
+            Ok(known.iter().any(|key| key == &server_public_key))
         })
     }
+}
+
+pub fn parse_host_key(value: &str) -> Result<russh_keys::key::PublicKey, String> {
+    let mut fields = value.split_whitespace();
+    let first = fields
+        .next()
+        .ok_or_else(|| "SSH host-key must not be empty".to_string())?;
+    let encoded = if first.starts_with("ssh-") || first.starts_with("ecdsa-") {
+        fields
+            .next()
+            .ok_or_else(|| "SSH host-key is missing base64 key data".to_string())?
+    } else {
+        first
+    };
+    russh_keys::parse_public_key_base64(encoded)
+        .map_err(|error| format!("invalid SSH host-key: {error}"))
+}
+
+fn parse_host_key_algorithms(algorithms: &[String]) -> Result<Vec<russh_keys::key::Name>, String> {
+    let mut parsed = Vec::new();
+    for algorithm in algorithms {
+        let names: &[russh_keys::key::Name] = match algorithm.trim().to_ascii_lowercase().as_str() {
+            "rsa" => &[
+                russh_keys::key::RSA_SHA2_512,
+                russh_keys::key::RSA_SHA2_256,
+                russh_keys::key::SSH_RSA,
+            ],
+            "ed25519" => &[russh_keys::key::ED25519],
+            "ecdsa" => &[
+                russh_keys::key::ECDSA_SHA2_NISTP521,
+                russh_keys::key::ECDSA_SHA2_NISTP384,
+                russh_keys::key::ECDSA_SHA2_NISTP256,
+            ],
+            exact => {
+                let name = russh_keys::key::Name::try_from(exact)
+                    .map_err(|_| format!("unsupported SSH host-key algorithm `{algorithm}`"))?;
+                parsed.push(name);
+                continue;
+            }
+        };
+        for name in names {
+            if !parsed.contains(name) {
+                parsed.push(*name);
+            }
+        }
+    }
+    Ok(parsed)
 }
 
 /// 把 russh::Channel 包成 AsyncRead+AsyncWrite。
@@ -316,14 +371,16 @@ fn io_err<S: Into<String>>(s: S) -> std::io::Error {
 
 #[cfg(test)]
 mod tests {
+    use russh_keys::PublicKeyBase64;
+
     use super::*;
 
     #[test]
     fn ssh_outbound_construct() {
         let ob = SshOutbound::new("ssh1", "1.2.3.4", 22, "alice").with_password("p");
         assert_eq!(ob.protocol(), "ssh");
-        match ob.auth {
-            SshAuth::Password(ref p) => assert_eq!(p, "p"),
+        match &ob.auth[0] {
+            SshAuth::Password(p) => assert_eq!(p, "p"),
             _ => panic!(),
         }
     }
@@ -332,20 +389,64 @@ mod tests {
     fn known_hosts_default_accept() {
         let ob = SshOutbound::new("ssh1", "1.2.3.4", 22, "alice");
         assert!(ob.host_key_check.accept_unknown);
-        assert!(ob.host_key_check.known_hosts_lines.is_empty());
+        assert!(ob.host_key_check.keys.is_empty());
     }
 
     #[test]
     fn known_hosts_strict_mode() {
-        let ob = SshOutbound::new("ssh1", "1.2.3.4", 22, "alice")
-            .with_known_hosts(vec!["ssh-ed25519 AAAAxxx".into()]);
+        let key = russh_keys::key::KeyPair::generate_ed25519()
+            .clone_public_key()
+            .unwrap();
+        let ob = SshOutbound::new("ssh1", "1.2.3.4", 22, "alice").with_host_keys(vec![key]);
         assert!(!ob.host_key_check.accept_unknown);
-        assert_eq!(ob.host_key_check.known_hosts_lines.len(), 1);
+        assert_eq!(ob.host_key_check.keys.len(), 1);
     }
 
     #[test]
     fn capabilities_show_mux() {
         let ob = SshOutbound::new("ssh1", "1.2.3.4", 22, "alice");
         assert!(ob.capabilities().multiplex);
+    }
+
+    #[test]
+    fn host_key_parser_accepts_authorized_key_and_raw_base64() {
+        let key = russh_keys::key::KeyPair::generate_ed25519()
+            .clone_public_key()
+            .unwrap();
+        let encoded = key.public_key_base64();
+        assert_eq!(parse_host_key(&encoded).unwrap(), key);
+        assert_eq!(
+            parse_host_key(&format!("ssh-ed25519 {encoded} test@example")).unwrap(),
+            key
+        );
+    }
+
+    #[test]
+    fn host_key_algorithm_aliases_expand_and_unknown_values_fail() {
+        let parsed = parse_host_key_algorithms(&["rsa".into(), "ed25519".into()]).unwrap();
+        assert_eq!(
+            parsed,
+            vec![
+                russh_keys::key::RSA_SHA2_512,
+                russh_keys::key::RSA_SHA2_256,
+                russh_keys::key::SSH_RSA,
+                russh_keys::key::ED25519,
+            ]
+        );
+        assert!(parse_host_key_algorithms(&["not-an-algorithm".into()]).is_err());
+    }
+
+    #[test]
+    fn client_version_is_strictly_validated() {
+        assert!(
+            SshOutbound::new("ssh1", "1.2.3.4", 22, "alice")
+                .with_client_version("SSH-2.0-OpenSSH_9.9")
+                .is_ok()
+        );
+        assert!(
+            SshOutbound::new("ssh1", "1.2.3.4", 22, "alice")
+                .with_client_version("SSH-2.0-good\r\ninjected")
+                .is_err()
+        );
     }
 }

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -165,7 +165,7 @@ pub fn build_outbound(node: &ParsedNode) -> Result<SharedOutbound, String> {
         NodeProtocol::Naive => build_naive(node),
         NodeProtocol::Snell => build_snell(node)?,
         NodeProtocol::AnyTls => build_anytls(node),
-        NodeProtocol::Ssh => build_ssh(node),
+        NodeProtocol::Ssh => build_ssh(node)?,
         NodeProtocol::Hysteria => build_hysteria_v1(node),
         NodeProtocol::Hysteria2 => build_hysteria2(node),
         NodeProtocol::Tuic => build_tuic(node)?,
@@ -2147,20 +2147,62 @@ fn build_anytls(node: &ParsedNode) -> SharedOutbound {
     Arc::new(ob)
 }
 
-fn build_ssh(node: &ParsedNode) -> SharedOutbound {
+fn build_ssh(node: &ParsedNode) -> Result<SharedOutbound, String> {
     let user = node.user.clone().unwrap_or_default();
+    if user.trim().is_empty() {
+        return Err("SSH username is required".into());
+    }
     let mut ob = SshOutbound::new(&node.name, &node.host, node.port, user);
-    if let Some(pwd) = &node.password {
-        ob = ob.with_password(pwd);
-    } else if let Some(key_path) = node.params.get("private-key") {
-        let pp = node.params.get("private-key-passphrase").cloned();
-        ob = ob.with_private_key_path(key_path, pp);
+    if let Some(private_key) = node.params.get("private-key") {
+        let passphrase = node
+            .params
+            .get("private-key-passphrase")
+            .filter(|value| !value.is_empty())
+            .cloned();
+        ob = if private_key.contains("PRIVATE KEY") {
+            ob.with_private_key_content(private_key, passphrase)?
+        } else {
+            ob.with_private_key_path(private_key, passphrase)?
+        };
     }
-    if let Some(known) = node.params.get("known-hosts") {
-        let lines: Vec<String> = known.lines().map(|s| s.to_string()).collect();
-        ob = ob.with_known_hosts(lines);
+    if let Some(password) = node.password.as_ref().filter(|value| !value.is_empty()) {
+        // Match mihomo: public-key authentication is attempted before password
+        // when both fields are configured.
+        ob = ob.with_password(password);
     }
-    Arc::new(ob)
+    if let Some(host_keys) = node
+        .params
+        .get("host-key")
+        .or_else(|| node.params.get("known-hosts"))
+    {
+        let keys = host_keys
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(crate::proto::ssh::parse_host_key)
+            .collect::<Result<Vec<_>, _>>()?;
+        if !keys.is_empty() {
+            ob = ob.with_host_keys(keys);
+        }
+    }
+    if let Some(algorithms) = node.params.get("host-key-algorithms") {
+        let algorithms = algorithms
+            .split([',', '\n'])
+            .map(str::trim)
+            .filter(|algorithm| !algorithm.is_empty())
+            .map(str::to_string)
+            .collect();
+        ob = ob.with_host_key_algorithms(algorithms)?;
+    }
+    if let Some(version) = node.params.get("client-version") {
+        ob = ob.with_client_version(version)?;
+    }
+    if let Some(value) = node.params.get("keepalive-interval") {
+        ob.keepalive_interval_secs = value
+            .parse()
+            .map_err(|_| format!("invalid SSH keepalive-interval `{value}`"))?;
+    }
+    Ok(Arc::new(ob))
 }
 
 fn build_hysteria_v1(node: &ParsedNode) -> SharedOutbound {
@@ -3267,6 +3309,36 @@ mod tests {
             .params
             .insert("padding-max".into(), "not-a-number".into());
         assert!(build_error(&sudoku).contains("invalid Sudoku padding-max"));
+    }
+
+    #[test]
+    fn ssh_registry_validates_every_security_field_before_network_io() {
+        let missing_user = node(NodeProtocol::Ssh);
+        assert!(build_error(&missing_user).contains("SSH username is required"));
+
+        let mut ssh = node(NodeProtocol::Ssh);
+        ssh.user = Some("alice".into());
+        ssh.password = Some("secret".into());
+        assert!(build_outbound(&ssh).is_ok());
+
+        ssh.params
+            .insert("host-key".into(), "ssh-ed25519 not-base64".into());
+        assert!(build_error(&ssh).contains("invalid SSH host-key"));
+        ssh.params.remove("host-key");
+
+        ssh.params
+            .insert("host-key-algorithms".into(), "not-an-algorithm".into());
+        assert!(build_error(&ssh).contains("unsupported SSH host-key algorithm"));
+        ssh.params.remove("host-key-algorithms");
+
+        ssh.params
+            .insert("client-version".into(), "SSH-2.0-good\r\ninjected".into());
+        assert!(build_error(&ssh).contains("SSH client version"));
+        ssh.params.remove("client-version");
+
+        ssh.params
+            .insert("keepalive-interval".into(), "not-a-number".into());
+        assert!(build_error(&ssh).contains("invalid SSH keepalive-interval"));
     }
 
     #[test]


### PR DESCRIPTION
## 背景

现有 SSH 出站虽然已经通过 `russh` 建立真实的 `direct-tcpip` 通道，但配置层与 Mihomo 的 SSH 节点字段并未完整对齐：订阅解析会丢失用户名和数组形式的主机公钥字段，私钥仅被当作文件路径处理，密码与私钥不能按顺序回退，主机公钥校验错误地用指纹子串匹配原始文本，并且已暴露的主机密钥算法及客户端版本字段没有进入实际 SSH 握手。

本提交在独立分支中补齐 SSH 客户端配置链路，确保安全相关字段在注册阶段完成解析和校验，并由 `russh` 在真实握手及认证过程中执行。

## 实现内容

- 完整保留 Clash/Mihomo SSH 节点的 `username`/`user`、`password`、`private-key`、`private-key-passphrase`、`host-key` 与 `host-key-algorithms` 字段。
- 支持 `private-key` 同时接受 PEM 私钥内容和私钥文件路径；加密私钥通过 `private-key-passphrase` 解密。
- 在节点注册阶段解析私钥，错误配置立即返回明确错误，不再延迟到首次网络连接。
- 对同时配置的私钥与密码采用 Mihomo 一致的认证顺序：先尝试公钥认证，失败后再尝试密码认证。
- 未配置私钥和密码时保留 SSH `none` 认证能力，兼容允许无凭据登录的服务端。
- 将 `host-key` 解析为真实 SSH 公钥对象，支持授权密钥格式和原始 Base64 公钥，并在握手时执行完整公钥精确比较。
- 支持 `host-key-algorithms` 的 `rsa`、`ed25519`、`ecdsa` 别名及 `russh` 支持的精确算法名称，配置结果写入 `russh::client::Config.preferred.key`。
- 将 `client-version` 写入真实 SSH 客户端标识，并拒绝非 `SSH-2.0-*`、换行注入及过长配置。
- 将 `keepalive-interval` 写入真实会话保活策略；值为零时明确禁用保活。
- 要求 SSH 用户名非空，并对主机公钥、算法、客户端版本、保活间隔等安全字段执行注册期严格校验。

## 兼容性

- 保留旧的 `known-hosts` 参数作为 `host-key` 的兼容别名。
- 未配置 `client-version` 时使用与 Mihomo 行为相符的 OpenSSH 客户端标识。
- 原有 SSH 会话复用、断线重连和 `direct-tcpip` 多路通道实现保持不变。

## 测试

- `cargo test -p core-outbound --no-fail-fast`：419 项通过。
- `cargo test -p core-feeds --no-fail-fast`：28 项通过。
- `cargo check --workspace --all-targets`：通过。
- `git diff --check`：通过。
- 新增订阅字段保留、主机公钥解析、算法别名展开、未知算法拒绝、客户端版本注入防护，以及全部安全字段注册期校验测试。
