### PR TITLE
feat: 完整实现 Shadowsocks 客户端与服务端协议支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm-siv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher 0.4.4",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +572,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bloomfilter"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d7f06817e48ea4e17532fa61bc4e8b9a101437f0623f69d2ea54284f3a817"
+dependencies = [
+ "getrandom 0.2.17",
+ "siphasher",
+]
+
+[[package]]
 name = "blowfish"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byte_string"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11aade7a05aa8c3a351cedc44c3fc45806430543382fcc4743a9b757a2a0b4ed"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +707,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "castaway"
@@ -705,6 +746,18 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex 2.0.1",
+]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher 0.4.4",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -1032,6 +1085,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shadowsocks",
  "thiserror 2.0.19",
  "tracing",
  "url",
@@ -1171,6 +1225,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "serde",
  "sha1",
+ "shadowsocks",
  "subtle",
  "thiserror 2.0.19",
  "tokio",
@@ -1300,6 +1355,7 @@ dependencies = [
  "sha1",
  "sha2",
  "sha3",
+ "shadowsocks",
  "smoltcp 0.11.0",
  "socket2 0.5.10",
  "thiserror 2.0.19",
@@ -1906,6 +1962,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dynosaur"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb33e6854ea615b65faf9c40d4ea9c4de9e9fa5d6772ad6ce57950a6da3957d"
+dependencies = [
+ "dynosaur_derive",
+]
+
+[[package]]
+name = "dynosaur_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac0893f103ae7bf50181323d748d505f27b6255777c28b502030bdaf8749f4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,7 +2220,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3177,7 +3253,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3259,6 +3335,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lru_time_cache"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "managed"
@@ -3526,7 +3608,7 @@ dependencies = [
  "futures",
  "rand 0.8.7",
  "smoltcp 0.12.0",
- "spin",
+ "spin 0.9.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4535,6 +4617,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring-compat"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccce7bae150b815f0811db41b8312fcb74bffa4cab9cee5429ee00f356dd5bd4"
+dependencies = [
+ "aead",
+ "ed25519",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "ring",
+]
+
+[[package]]
 name = "route_manager"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4944,6 +5039,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4985,6 +5091,16 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sendfd"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b183bfd5b1bc64ab0c1ef3ee06b008a9ef1b68a7d3a99ba566fbfe7a7c6d745b"
+dependencies = [
+ "libc",
+ "tokio",
+]
 
 [[package]]
 name = "serde"
@@ -5151,6 +5267,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadowsocks"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482831bf9d55acf3c98e211b6c852c3dfdf1d1b0d23fdf1d887c5a4b2acad4e4"
+dependencies = [
+ "aes",
+ "base64 0.22.1",
+ "blake3",
+ "bloomfilter",
+ "byte_string",
+ "bytes",
+ "cfg-if",
+ "dynosaur",
+ "futures",
+ "libc",
+ "log",
+ "lru_time_cache",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.9.5",
+ "sealed",
+ "sendfd",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "shadowsocks-crypto",
+ "socket2 0.6.5",
+ "spin 0.10.1",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-tfo",
+ "trait-variant",
+ "url",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "shadowsocks-crypto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d038a3d17586f1c1ab3c1c3b9e4d5ef8fba98fb3890ad740c8487038b2e2ca5"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "aes-gcm-siv",
+ "blake3",
+ "bytes",
+ "camellia",
+ "ccm",
+ "cfg-if",
+ "chacha20 0.9.1",
+ "chacha20poly1305",
+ "ctr",
+ "ghash",
+ "hkdf",
+ "md-5",
+ "rand 0.9.5",
+ "ring-compat",
+ "sha1",
+ "sm4",
+ "subtle",
+]
+
+[[package]]
 name = "shake"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,10 +5415,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "sm4"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7abf5135ffd68fb4b438e1fb246923b80d25eda386d8b798bb4ad3ed00f75f"
+dependencies = [
+ "cipher 0.4.4",
+]
 
 [[package]]
 name = "smallvec"
@@ -5324,6 +5520,15 @@ name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]
@@ -5739,6 +5944,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tfo"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ad2c3b3bb958ad992354a7ebc468fc0f7cdc9af4997bf4d3fd3cb28bad36dc"
+dependencies = [
+ "cfg-if",
+ "futures",
+ "libc",
+ "log",
+ "once_cell",
+ "pin-project",
+ "socket2 0.6.5",
+ "tokio",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,6 +6174,17 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6557,6 +6790,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6588,11 +6830,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6626,6 +6885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6636,6 +6901,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6650,10 +6921,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6668,6 +6951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6678,6 +6967,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6692,6 +6987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6702,6 +7003,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 [workspace.package]
 version = "0.3.1-rc.5"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT"
 authors = ["WutherCore Contributors"]
 repository = "https://github.com/MiChongs/WutherCore"
@@ -129,6 +129,7 @@ sha1              = "0.10"
 rc4               = "0.1"
 chacha20          = "0.10"
 cronet            = "0.2.0"
+shadowsocks       = { version = "=1.24.0", default-features = false, features = ["aead-cipher", "aead-cipher-extra", "aead-cipher-2022", "aead-cipher-2022-extra", "stream-cipher", "security-replay-attack-detect"] }
 
 # QUIC + UDP 协议（Hysteria / TUIC）
 quinn             = { version = "0.11", default-features = false, features = ["rustls", "ring", "runtime-tokio"] }

--- a/crates/core-config/Cargo.toml
+++ b/crates/core-config/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_yaml = { workspace = true }
+shadowsocks = { workspace = true }
 serde_json = { workspace = true }
 humantime-serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -212,6 +212,9 @@ pub struct Listen {
         alias = "splithttp"
     )]
     pub xhttp: Option<XhttpListenSet>,
+    /// Shadowsocks SIP003/SIP004/SIP022 服务端监听。
+    #[serde(default, alias = "ss")]
+    pub shadowsocks: Option<ShadowsocksListenSet>,
     #[serde(default)]
     pub share: Option<Share>,
     #[serde(default)]
@@ -231,6 +234,118 @@ pub struct Listen {
     /// 双向流交给 `protocol` 指定的内层代理协议。
     #[serde(default, alias = "grpc-inbounds", alias = "grpc_inbounds")]
     pub grpc: Vec<GrpcListen>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ShadowsocksListenSet {
+    One(ShadowsocksListen),
+    Many(Vec<ShadowsocksListen>),
+}
+
+impl ShadowsocksListenSet {
+    pub fn into_vec(self) -> Vec<ShadowsocksListen> {
+        match self {
+            Self::One(listener) => vec![listener],
+            Self::Many(listeners) => listeners,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShadowsocksListen {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_shadowsocks_listen_address", alias = "host")]
+    pub address: String,
+    pub port: u16,
+    pub method: String,
+    pub password: String,
+    #[serde(default = "default_shadowsocks_mode")]
+    pub mode: String,
+    /// SIP003 服务端插件可执行文件。插件监听公开地址，Shadowsocks
+    /// 服务端本身只监听插件分配的回环地址。
+    #[serde(default)]
+    pub plugin: Option<String>,
+    #[serde(default, rename = "plugin-opts", alias = "plugin_opts")]
+    pub plugin_opts: Option<String>,
+    #[serde(default, rename = "plugin-args", alias = "plugin_args")]
+    pub plugin_args: Vec<String>,
+    #[serde(default, rename = "plugin-mode", alias = "plugin_mode")]
+    pub plugin_mode: Option<String>,
+    #[serde(
+        default = "default_shadowsocks_plugin_startup_timeout",
+        rename = "plugin-startup-timeout",
+        alias = "plugin_startup_timeout",
+        with = "humantime_serde"
+    )]
+    pub plugin_startup_timeout: Duration,
+    #[serde(default)]
+    pub users: Vec<ShadowsocksUser>,
+    #[serde(
+        default = "default_shadowsocks_handshake_timeout",
+        rename = "handshake-timeout",
+        alias = "handshake_timeout",
+        with = "humantime_serde"
+    )]
+    pub handshake_timeout: Duration,
+    #[serde(
+        default = "default_shadowsocks_udp_timeout",
+        rename = "udp-timeout",
+        alias = "udp_timeout",
+        with = "humantime_serde"
+    )]
+    pub udp_timeout: Duration,
+    #[serde(
+        default = "default_shadowsocks_max_connections",
+        rename = "max-connections",
+        alias = "max_connections"
+    )]
+    pub max_connections: usize,
+    #[serde(
+        default = "default_shadowsocks_max_udp_associations",
+        rename = "max-udp-associations",
+        alias = "max_udp_associations"
+    )]
+    pub max_udp_associations: usize,
+    #[serde(default)]
+    pub tag: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShadowsocksUser {
+    pub name: String,
+    pub key: String,
+}
+
+fn default_shadowsocks_listen_address() -> String {
+    "0.0.0.0".into()
+}
+
+fn default_shadowsocks_mode() -> String {
+    "tcp_and_udp".into()
+}
+
+fn default_shadowsocks_handshake_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_shadowsocks_udp_timeout() -> Duration {
+    Duration::from_secs(300)
+}
+
+fn default_shadowsocks_plugin_startup_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_shadowsocks_max_connections() -> usize {
+    1024
+}
+
+fn default_shadowsocks_max_udp_associations() -> usize {
+    4096
 }
 
 /// 完整的 Xray gRPC 服务端监听配置。

--- a/crates/core-config/src/profile.rs
+++ b/crates/core-config/src/profile.rs
@@ -13,6 +13,7 @@ pub fn apply_defaults(cfg: &mut UserConfig) {
         local: None,
         panel: None,
         xhttp: None,
+        shadowsocks: None,
         share: None,
         auth: vec![],
         reality: vec![],

--- a/crates/core-config/src/runtime_plan.rs
+++ b/crates/core-config/src/runtime_plan.rs
@@ -52,8 +52,57 @@ pub struct ListenPlan {
     pub grpc: Vec<GrpcListen>,
     pub panel: Option<PanelListen>,
     pub xhttp: Vec<XhttpListenPlan>,
+    pub shadowsocks: Vec<ShadowsocksListenPlan>,
     pub share: Share,
     pub auth: Vec<UserPass>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowsocksListenPlan {
+    pub enabled: bool,
+    pub address: String,
+    pub port: u16,
+    pub method: String,
+    pub password: String,
+    pub mode: String,
+    pub plugin: Option<String>,
+    pub plugin_opts: Option<String>,
+    pub plugin_args: Vec<String>,
+    pub plugin_mode: Option<String>,
+    pub plugin_startup_timeout: Duration,
+    pub users: Vec<ShadowsocksUser>,
+    pub handshake_timeout: Duration,
+    pub udp_timeout: Duration,
+    pub max_connections: usize,
+    pub max_udp_associations: usize,
+    pub tag: String,
+}
+
+impl ShadowsocksListenPlan {
+    pub fn socket_addr(&self) -> ConfigResult<SocketAddr> {
+        parse_shadowsocks_socket(&self.address, self.port).ok_or_else(|| {
+            ConfigError::invalid(format!(
+                "非法 Shadowsocks 监听地址: {}:{}",
+                self.address, self.port
+            ))
+        })
+    }
+
+    pub fn enable_tcp(&self) -> bool {
+        matches!(self.mode.as_str(), "tcp_only" | "tcp_and_udp")
+    }
+
+    pub fn enable_udp(&self) -> bool {
+        matches!(self.mode.as_str(), "udp_only" | "tcp_and_udp")
+    }
+}
+
+fn parse_shadowsocks_socket(address: &str, port: u16) -> Option<SocketAddr> {
+    address
+        .parse::<IpAddr>()
+        .map(|ip| SocketAddr::new(ip, port))
+        .or_else(|_| format!("{address}:{port}").parse())
+        .ok()
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -344,6 +393,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         local: None,
         panel: None,
         xhttp: None,
+        shadowsocks: None,
         share: None,
         auth: vec![],
         reality: vec![],
@@ -415,6 +465,7 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
     }
 
     let xhttp = compile_xhttp_listeners(listen.xhttp)?;
+    let shadowsocks = compile_shadowsocks_listeners(listen.shadowsocks)?;
 
     let auth = listen
         .auth
@@ -440,9 +491,176 @@ fn compile_listen(cfg: &UserConfig) -> ConfigResult<ListenPlan> {
         grpc,
         panel,
         xhttp,
+        shadowsocks,
         share,
         auth,
     })
+}
+
+fn compile_shadowsocks_listeners(
+    listeners: Option<ShadowsocksListenSet>,
+) -> ConfigResult<Vec<ShadowsocksListenPlan>> {
+    let listeners = listeners
+        .map(ShadowsocksListenSet::into_vec)
+        .unwrap_or_default();
+    let mut plans = Vec::with_capacity(listeners.len());
+    let mut tags = HashSet::new();
+    let mut tcp_sockets = HashSet::new();
+    let mut udp_sockets = HashSet::new();
+    for (index, listener) in listeners.into_iter().enumerate() {
+        let path = format!("listen.shadowsocks[{index}]");
+        let method = listener.method.to_ascii_lowercase();
+        let cipher = method
+            .parse::<shadowsocks::crypto::CipherKind>()
+            .map_err(|_| {
+                ConfigError::invalid(format!(
+                    "{path}.method 不支持 Shadowsocks 加密方法 `{method}`"
+                ))
+            })?;
+        shadowsocks::config::ServerConfig::new(
+            shadowsocks::config::ServerAddr::DomainName(listener.address.clone(), listener.port),
+            listener.password.clone(),
+            cipher,
+        )
+        .map_err(|error| ConfigError::invalid(format!("{path}.password/ method 无效: {error}")))?;
+        let mode = match listener
+            .mode
+            .to_ascii_lowercase()
+            .replace('-', "_")
+            .as_str()
+        {
+            "tcp" | "tcp_only" => "tcp_only",
+            "udp" | "udp_only" => "udp_only",
+            "tcp_and_udp" | "tcp_udp" => "tcp_and_udp",
+            other => {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.mode `{other}` 必须为 tcp_only、udp_only 或 tcp_and_udp"
+                )));
+            }
+        }
+        .to_owned();
+        let plugin_mode = listener
+            .plugin_mode
+            .as_deref()
+            .map(|value| value.to_ascii_lowercase().replace('-', "_"))
+            .map(|value| match value.as_str() {
+                "tcp" | "tcp_only" => Ok("tcp_only".to_owned()),
+                "udp" | "udp_only" => Ok("udp_only".to_owned()),
+                "tcp_and_udp" | "tcp_udp" => Ok("tcp_and_udp".to_owned()),
+                other => Err(ConfigError::invalid(format!(
+                    "{path}.plugin-mode `{other}` 必须为 tcp_only、udp_only 或 tcp_and_udp"
+                ))),
+            })
+            .transpose()?;
+        if let Some(plugin) = listener.plugin.as_deref() {
+            if plugin.trim().is_empty() {
+                return Err(ConfigError::invalid(format!("{path}.plugin 不能为空")));
+            }
+            if plugin.contains('\0') || listener.plugin_args.iter().any(|arg| arg.contains('\0')) {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.plugin/plugin-args 不能包含 NUL 字符"
+                )));
+            }
+            if listener.plugin_startup_timeout.is_zero() {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.plugin-startup-timeout 不能为 0"
+                )));
+            }
+            if plugin_mode.as_deref().unwrap_or(&mode) != mode {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.plugin-mode 必须与 mode 一致，避免绕过插件暴露未封装载体"
+                )));
+            }
+        } else if listener.plugin_opts.is_some()
+            || !listener.plugin_args.is_empty()
+            || listener.plugin_mode.is_some()
+        {
+            return Err(ConfigError::invalid(format!(
+                "{path} 配置 plugin-opts/plugin-args/plugin-mode 时必须同时配置 plugin"
+            )));
+        }
+        if listener.enabled {
+            if listener.port == 0 {
+                return Err(ConfigError::invalid(format!("{path}.port 不能为 0")));
+            }
+            if listener.handshake_timeout.is_zero() || listener.udp_timeout.is_zero() {
+                return Err(ConfigError::invalid(format!("{path} 超时必须大于 0")));
+            }
+            if listener.max_connections == 0 || listener.max_udp_associations == 0 {
+                return Err(ConfigError::invalid(format!("{path} 并发上限必须大于 0")));
+            }
+        }
+        if !listener.users.is_empty() && !cipher.is_aead_2022() {
+            return Err(ConfigError::invalid(format!(
+                "{path}.users 仅适用于 Shadowsocks 2022 EIH"
+            )));
+        }
+        let mut user_names = HashSet::new();
+        for (user_index, user) in listener.users.iter().enumerate() {
+            if user.name.trim().is_empty() || !user_names.insert(user.name.clone()) {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.users[{user_index}].name 为空或重复"
+                )));
+            }
+            let parsed_user = shadowsocks::config::ServerUser::with_encoded_key(
+                &user.name, &user.key,
+            )
+            .map_err(|error| {
+                ConfigError::invalid(format!("{path}.users[{user_index}].key 无效: {error}"))
+            })?;
+            if parsed_user.key().len() != cipher.key_len() {
+                return Err(ConfigError::invalid(format!(
+                    "{path}.users[{user_index}].key 解码后必须为 {} 字节，实际为 {} 字节",
+                    cipher.key_len(),
+                    parsed_user.key().len()
+                )));
+            }
+        }
+        let tag = listener
+            .tag
+            .unwrap_or_else(|| format!("shadowsocks-{}", index + 1));
+        if !tags.insert(tag.clone()) {
+            return Err(ConfigError::invalid(format!("{path}.tag `{tag}` 重复")));
+        }
+        let socket = parse_shadowsocks_socket(&listener.address, listener.port)
+            .ok_or_else(|| ConfigError::invalid(format!("{path} 监听地址无效")))?;
+        if listener.enabled
+            && matches!(mode.as_str(), "tcp_only" | "tcp_and_udp")
+            && !tcp_sockets.insert(socket)
+        {
+            return Err(ConfigError::invalid(format!(
+                "{path} TCP 监听地址重复: {socket}"
+            )));
+        }
+        if listener.enabled
+            && matches!(mode.as_str(), "udp_only" | "tcp_and_udp")
+            && !udp_sockets.insert(socket)
+        {
+            return Err(ConfigError::invalid(format!(
+                "{path} UDP 监听地址重复: {socket}"
+            )));
+        }
+        plans.push(ShadowsocksListenPlan {
+            enabled: listener.enabled,
+            address: listener.address,
+            port: listener.port,
+            method,
+            password: listener.password,
+            mode,
+            plugin: listener.plugin,
+            plugin_opts: listener.plugin_opts,
+            plugin_args: listener.plugin_args,
+            plugin_mode,
+            plugin_startup_timeout: listener.plugin_startup_timeout,
+            users: listener.users,
+            handshake_timeout: listener.handshake_timeout,
+            udp_timeout: listener.udp_timeout,
+            max_connections: listener.max_connections,
+            max_udp_associations: listener.max_udp_associations,
+            tag,
+        });
+    }
+    Ok(plans)
 }
 
 fn compile_wireguard_listeners(
@@ -5517,5 +5735,97 @@ route: {preset: direct}
             .unwrap_err()
             .to_string();
         assert!(error.contains("循环链"), "error={error}");
+    }
+
+    #[test]
+    fn shadowsocks_listener_registers_all_fields_and_aliases() {
+        let plan = crate::loader::load_from_str(
+            r#"
+version: 1
+profile: server
+listen:
+  panel: false
+  ss:
+    host: 127.0.0.1
+    port: 8388
+    method: aes-256-gcm
+    password: secret
+    mode: tcp-and-udp
+    plugin: v2ray-plugin
+    plugin_opts: server;tls;host=cdn.example
+    plugin_args: [--loglevel, warning]
+    plugin_mode: tcp-and-udp
+    plugin_startup_timeout: 7s
+    handshake_timeout: 3s
+    udp_timeout: 45s
+    max_connections: 23
+    max_udp_associations: 29
+    tag: full-ss
+route: {preset: direct, final: direct}
+"#,
+        )
+        .unwrap();
+        let listener = &plan.listen.shadowsocks[0];
+        assert_eq!(listener.tag, "full-ss");
+        assert_eq!(listener.mode, "tcp_and_udp");
+        assert_eq!(listener.plugin.as_deref(), Some("v2ray-plugin"));
+        assert_eq!(
+            listener.plugin_opts.as_deref(),
+            Some("server;tls;host=cdn.example")
+        );
+        assert_eq!(listener.plugin_args, ["--loglevel", "warning"]);
+        assert_eq!(listener.plugin_mode.as_deref(), Some("tcp_and_udp"));
+        assert_eq!(listener.plugin_startup_timeout, Duration::from_secs(7));
+        assert_eq!(listener.handshake_timeout, Duration::from_secs(3));
+        assert_eq!(listener.udp_timeout, Duration::from_secs(45));
+        assert_eq!(listener.max_connections, 23);
+        assert_eq!(listener.max_udp_associations, 29);
+        assert!(listener.enable_tcp() && listener.enable_udp());
+        assert_eq!(
+            parse_shadowsocks_socket("::1", 8388),
+            Some("[::1]:8388".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn shadowsocks_listener_rejects_bad_cipher_key_users_and_unknown_fields() {
+        for (fragment, expected) in [
+            ("method: missing\n    password: secret", "method"),
+            (
+                "method: 2022-blake3-aes-128-gcm\n    password: bad-base64",
+                "password",
+            ),
+            (
+                "method: aes-128-gcm\n    password: secret\n    users: [{name: alice, key: YWJjZA==}]",
+                "users",
+            ),
+            (
+                "method: 2022-blake3-aes-128-gcm\n    password: YWJjZGVmZ2hpamtsbW5vcA==\n    users: [{name: alice, key: YWJjZA==}]",
+                "16 字节",
+            ),
+            (
+                "method: aes-128-gcm\n    password: secret\n    plugin-opts: server",
+                "必须同时配置 plugin",
+            ),
+            (
+                "method: aes-128-gcm\n    password: secret\n    mode: tcp_and_udp\n    plugin: v2ray-plugin\n    plugin-mode: tcp_only",
+                "必须与 mode 一致",
+            ),
+            (
+                "method: aes-128-gcm\n    password: secret\n    plugin: v2ray-plugin\n    plugin-startup-timeout: 0s",
+                "不能为 0",
+            ),
+            (
+                "method: aes-128-gcm\n    password: secret\n    typo-field: true",
+                "did not match",
+            ),
+        ] {
+            let yaml = format!(
+                "version: 1\nprofile: server\nlisten:\n  panel: false\n  shadowsocks:\n    port: 8388\n    {fragment}\nroute: {{preset: direct, final: direct}}\n"
+            );
+            let result = crate::loader::load_from_str(&yaml);
+            let error = result.unwrap_err().to_string();
+            assert!(error.contains(expected), "error={error}");
+        }
     }
 }

--- a/crates/core-inbound/Cargo.toml
+++ b/crates/core-inbound/Cargo.toml
@@ -30,6 +30,7 @@ uuid          = { workspace = true }
 subtle        = "2.6"
 rand          = { workspace = true }
 url           = { workspace = true }
+shadowsocks   = { workspace = true }
 
 # XHTTP/SplitHTTP inbound: HTTP/1.1 + HTTP/2 over TCP/TLS and HTTP/3 over QUIC.
 http           = "1"

--- a/crates/core-inbound/src/lib.rs
+++ b/crates/core-inbound/src/lib.rs
@@ -11,6 +11,7 @@ pub mod listener;
 pub mod mixed;
 pub mod privilege;
 pub mod reality;
+pub mod shadowsocks;
 pub mod vless;
 pub mod xhttp;
 mod xhttp_body_budget;
@@ -25,6 +26,9 @@ pub use privilege::{
     PrivilegeLevel, PrivilegeReport, ensure_best_effort_privilege, try_request_root_android,
 };
 pub use reality::{RealityListener, run_reality};
+pub use shadowsocks::{
+    ShadowsocksListenerHandle, start_shadowsocks_listener, start_shadowsocks_listeners,
+};
 pub use vless::{VlessConnectionContext, VlessInboundConfig, serve_vless_stream};
 pub use xhttp_listener::{XhttpListenerHandle, start_xhttp_listener, start_xhttp_listeners};
 pub use xhttp_tls::{XrayServerTlsAcceptor, XrayServerTlsCarrier, XrayServerTlsStream};

--- a/crates/core-inbound/src/shadowsocks.rs
+++ b/crates/core-inbound/src/shadowsocks.rs
@@ -1,0 +1,795 @@
+//! Complete Shadowsocks TCP/UDP inbound backed by shadowsocks-rust 1.24.
+
+use std::{collections::HashMap, io, net::SocketAddr, sync::Arc, time::Duration};
+
+use core_config::runtime_plan::ShadowsocksListenPlan;
+use core_outbound::adapter::UdpSocketLike;
+use core_runtime::{InboundMetadata, ListenerHandler, Runtime};
+use shadowsocks::{
+    config::{Mode, ServerAddr, ServerConfig, ServerType, ServerUser, ServerUserManager},
+    context::{Context, SharedContext},
+    net::UdpSocket as ShadowUdpSocket,
+    plugin::{Plugin, PluginConfig, PluginMode},
+    relay::{
+        socks5::Address,
+        tcprelay::proxy_stream::server::ProxyServerStream,
+        udprelay::{
+            options::UdpSocketControlData,
+            proxy_socket::{ProxySocket, UdpSocketType},
+        },
+    },
+};
+use tokio::{
+    io::copy_bidirectional,
+    net::{TcpListener, TcpStream},
+    sync::{Semaphore, mpsc},
+    task::{JoinHandle, JoinSet},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+const UDP_PACKET_SIZE: usize = 65_536;
+const UDP_QUEUE_DEPTH: usize = 64;
+
+pub struct ShadowsocksListenerHandle {
+    tag: String,
+    tcp_addr: Option<SocketAddr>,
+    udp_addr: Option<SocketAddr>,
+    shutdown: CancellationToken,
+    tasks: Vec<JoinHandle<io::Result<()>>>,
+    plugin: Option<Plugin>,
+}
+
+impl ShadowsocksListenerHandle {
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    pub fn tcp_addr(&self) -> Option<SocketAddr> {
+        self.tcp_addr
+    }
+
+    pub fn udp_addr(&self) -> Option<SocketAddr> {
+        self.udp_addr
+    }
+
+    pub async fn shutdown(&mut self) -> io::Result<()> {
+        self.shutdown.cancel();
+        let mut first_error = None;
+        for task in self.tasks.drain(..) {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) if first_error.is_none() => first_error = Some(error),
+                Err(error) if !error.is_cancelled() && first_error.is_none() => {
+                    first_error = Some(io::Error::other(format!(
+                        "Shadowsocks listener task failed: {error}"
+                    )));
+                }
+                _ => {}
+            }
+        }
+        self.plugin.take();
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+impl Drop for ShadowsocksListenerHandle {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+        for task in self.tasks.drain(..) {
+            task.abort();
+        }
+    }
+}
+
+pub async fn start_shadowsocks_listeners(
+    plans: &[ShadowsocksListenPlan],
+    runtime: Arc<Runtime>,
+) -> io::Result<Vec<ShadowsocksListenerHandle>> {
+    let mut handles = Vec::new();
+    for plan in plans.iter().filter(|plan| plan.enabled) {
+        match start_shadowsocks_listener(plan, Arc::clone(&runtime)).await {
+            Ok(handle) => handles.push(handle),
+            Err(error) => {
+                for handle in &mut handles {
+                    let _ = handle.shutdown().await;
+                }
+                return Err(io::Error::new(
+                    error.kind(),
+                    format!(
+                        "Shadowsocks listener `{}` startup failed: {error}",
+                        plan.tag
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(handles)
+}
+
+pub async fn start_shadowsocks_listener(
+    plan: &ShadowsocksListenPlan,
+    runtime: Arc<Runtime>,
+) -> io::Result<ShadowsocksListenerHandle> {
+    let public_address = plan
+        .socket_addr()
+        .map_err(|error| invalid_input(error.to_string()))?;
+    let mut plugin = if let Some(executable) = plan.plugin.as_ref() {
+        let plugin_mode = parse_mode(plan.plugin_mode.as_deref().unwrap_or(&plan.mode))?;
+        Some(Plugin::start(
+            &PluginConfig {
+                plugin: executable.clone(),
+                plugin_opts: plan.plugin_opts.clone(),
+                plugin_args: plan.plugin_args.clone(),
+                plugin_mode,
+            },
+            &ServerAddr::SocketAddr(public_address),
+            PluginMode::Server,
+        )?)
+    } else {
+        None
+    };
+    let listen_address = plugin
+        .as_ref()
+        .map(Plugin::local_addr)
+        .unwrap_or(public_address);
+    let server = Arc::new(build_server_config(plan, listen_address)?);
+    let context = Context::new_shared(ServerType::Server);
+
+    // Bind every requested carrier before spawning either task. This makes a
+    // tcp_and_udp listener transactional and prevents a half-started server.
+    let tcp = if plan.enable_tcp() {
+        Some(TcpListener::bind(listen_address).await?)
+    } else {
+        None
+    };
+    let udp = if plan.enable_udp() {
+        match ShadowUdpSocket::listen(&listen_address).await {
+            Ok(socket) => Some(socket),
+            Err(error) => {
+                drop(tcp);
+                return Err(error);
+            }
+        }
+    } else {
+        None
+    };
+    if let Some(process) = plugin.as_ref()
+        && !process.wait_started(plan.plugin_startup_timeout).await
+    {
+        drop(tcp);
+        drop(udp);
+        plugin.take();
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "Shadowsocks SIP003 plugin `{}` startup timed out",
+                plan.plugin.as_deref().unwrap_or_default()
+            ),
+        ));
+    }
+    let tcp_addr = plan.enable_tcp().then_some(public_address);
+    let udp_addr = plan.enable_udp().then_some(public_address);
+    let shutdown = CancellationToken::new();
+    let mut tasks = Vec::with_capacity(2);
+    if let Some(listener) = tcp {
+        tasks.push(tokio::spawn(run_tcp_listener(
+            listener,
+            Arc::clone(&server),
+            context.clone(),
+            Arc::clone(&runtime),
+            Arc::new(Semaphore::new(plan.max_connections)),
+            plan.handshake_timeout,
+            plan.tag.clone(),
+            public_address,
+            shutdown.child_token(),
+        )));
+    }
+    if let Some(socket) = udp {
+        tasks.push(tokio::spawn(run_udp_listener(
+            socket,
+            Arc::clone(&server),
+            context,
+            runtime,
+            plan.udp_timeout,
+            plan.max_udp_associations,
+            plan.tag.clone(),
+            public_address,
+            shutdown.child_token(),
+        )));
+    }
+    info!(
+        target: "inbound::shadowsocks",
+        tag = %plan.tag,
+        tcp = ?tcp_addr,
+        udp = ?udp_addr,
+        method = %plan.method,
+        users = plan.users.len(),
+        "Shadowsocks listener ready"
+    );
+    Ok(ShadowsocksListenerHandle {
+        tag: plan.tag.clone(),
+        tcp_addr,
+        udp_addr,
+        shutdown,
+        tasks,
+        plugin,
+    })
+}
+
+fn parse_mode(mode: &str) -> io::Result<Mode> {
+    match mode {
+        "tcp_only" => Ok(Mode::TcpOnly),
+        "udp_only" => Ok(Mode::UdpOnly),
+        "tcp_and_udp" => Ok(Mode::TcpAndUdp),
+        mode => Err(invalid_input(format!("invalid Shadowsocks mode `{mode}`"))),
+    }
+}
+
+fn build_server_config(
+    plan: &ShadowsocksListenPlan,
+    address: SocketAddr,
+) -> io::Result<ServerConfig> {
+    let method = plan
+        .method
+        .parse()
+        .map_err(|_| invalid_input(format!("unsupported Shadowsocks cipher `{}`", plan.method)))?;
+    let mut server = ServerConfig::new(
+        ServerAddr::SocketAddr(address),
+        plan.password.clone(),
+        method,
+    )
+    .map_err(|error| invalid_input(error.to_string()))?;
+    server.set_mode(parse_mode(&plan.mode)?);
+    server.set_timeout(plan.udp_timeout);
+    if !plan.users.is_empty() {
+        let mut manager = ServerUserManager::new();
+        for user in &plan.users {
+            let parsed_user = ServerUser::with_encoded_key(&user.name, &user.key)
+                .map_err(|error| invalid_input(error.to_string()))?;
+            if parsed_user.key().len() != method.key_len() {
+                return Err(invalid_input(format!(
+                    "Shadowsocks 2022 EIH user `{}` key must decode to {} bytes, got {} bytes",
+                    user.name,
+                    method.key_len(),
+                    parsed_user.key().len()
+                )));
+            }
+            manager.add_user(parsed_user);
+        }
+        server.set_user_manager(manager);
+    }
+    Ok(server)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_tcp_listener(
+    listener: TcpListener,
+    server: Arc<ServerConfig>,
+    context: SharedContext,
+    runtime: Arc<Runtime>,
+    permits: Arc<Semaphore>,
+    handshake_timeout: Duration,
+    tag: String,
+    reported_local: SocketAddr,
+    shutdown: CancellationToken,
+) -> io::Result<()> {
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            Some(result) = connections.join_next(), if !connections.is_empty() => {
+                if let Ok(Err(error)) = result {
+                    debug!(target: "inbound::shadowsocks", %error, "Shadowsocks TCP connection closed");
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, peer) = accepted?;
+                let permit = match Arc::clone(&permits).try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        debug!(target: "inbound::shadowsocks", %peer, "Shadowsocks TCP connection rejected by limit");
+                        continue;
+                    }
+                };
+                let server = Arc::clone(&server);
+                let context = context.clone();
+                let runtime = Arc::clone(&runtime);
+                let tag = tag.clone();
+                let connection_shutdown = shutdown.child_token();
+                connections.spawn(async move {
+                    let _permit = permit;
+                    tokio::select! {
+                        _ = connection_shutdown.cancelled() => Ok(()),
+                        result = serve_tcp(stream, peer, reported_local, server, context, runtime, handshake_timeout, tag) => result,
+                    }
+                });
+            }
+        }
+    }
+    connections.abort_all();
+    while connections.join_next().await.is_some() {}
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_tcp(
+    stream: TcpStream,
+    peer: SocketAddr,
+    local: SocketAddr,
+    server: Arc<ServerConfig>,
+    context: SharedContext,
+    runtime: Arc<Runtime>,
+    handshake_timeout: Duration,
+    tag: String,
+) -> io::Result<()> {
+    let mut stream = ProxyServerStream::from_stream_with_user_manager(
+        context,
+        stream,
+        server.method(),
+        server.key(),
+        server.clone_user_manager(),
+    );
+    let target = tokio::time::timeout(handshake_timeout, stream.handshake())
+        .await
+        .map_err(|_| {
+            io::Error::new(io::ErrorKind::TimedOut, "Shadowsocks handshake timed out")
+        })??;
+    let (host, port) = address_parts(&target);
+    let handler = ListenerHandler::new(runtime);
+    let mut prepared = handler
+        .prepare_tcp(InboundMetadata::tcp(
+            &tag,
+            "Shadowsocks",
+            peer,
+            local,
+            host,
+            port,
+        ))
+        .await?;
+    handler.runtime().metrics.inc_connection();
+    let guard = &prepared.guard;
+    let result = copy_bidirectional(&mut stream, &mut prepared.result.stream).await;
+    if let Ok((upload, download)) = result {
+        handler.record_upload(guard, upload);
+        handler.record_download(guard, download);
+    }
+    handler.runtime().metrics.dec_connection();
+    result.map(|_| ())
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+struct AssociationKey {
+    client: SocketAddr,
+    session: u64,
+    target: Address,
+}
+
+struct AssociationPacket {
+    payload: Vec<u8>,
+    control: UdpSocketControlData,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_udp_listener(
+    socket: ShadowUdpSocket,
+    server: Arc<ServerConfig>,
+    context: SharedContext,
+    runtime: Arc<Runtime>,
+    timeout: Duration,
+    max_associations: usize,
+    tag: String,
+    reported_local: SocketAddr,
+    shutdown: CancellationToken,
+) -> io::Result<()> {
+    let proxy = Arc::new(ProxySocket::from_socket(
+        UdpSocketType::Server,
+        context,
+        &server,
+        socket,
+    ));
+    let handler = ListenerHandler::new(runtime);
+    let mut associations = HashMap::<AssociationKey, mpsc::Sender<AssociationPacket>>::new();
+    let mut tasks = JoinSet::new();
+    let mut buffer = vec![0u8; UDP_PACKET_SIZE];
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            Some(result) = tasks.join_next(), if !tasks.is_empty() => {
+                if let Ok(Err(error)) = result {
+                    debug!(target: "inbound::shadowsocks", %error, "Shadowsocks UDP association closed");
+                }
+                associations.retain(|_, sender| !sender.is_closed());
+            }
+            received = proxy.recv_from_with_ctrl(&mut buffer) => {
+                let (length, client, target, _, control) = match received {
+                    Ok(packet) => packet,
+                    Err(error) => {
+                        debug!(target: "inbound::shadowsocks", %error, "rejected invalid Shadowsocks UDP packet");
+                        continue;
+                    }
+                };
+                let control = control.unwrap_or_default();
+                let key = AssociationKey {
+                    client,
+                    session: control.client_session_id,
+                    target: target.clone(),
+                };
+                if !associations.contains_key(&key) {
+                    associations.retain(|_, sender| !sender.is_closed());
+                    if associations.len() >= max_associations {
+                        debug!(target: "inbound::shadowsocks", %client, "Shadowsocks UDP association rejected by limit");
+                        continue;
+                    }
+                    let (host, port) = address_parts(&target);
+                    let prepared = match handler.prepare_udp(InboundMetadata::udp(
+                        &tag,
+                        "Shadowsocks",
+                        client,
+                        Some(reported_local),
+                        host.clone(),
+                        port,
+                    )).await {
+                        Ok(prepared) => prepared,
+                        Err(error) => {
+                            debug!(target: "inbound::shadowsocks", %error, "Shadowsocks UDP route rejected");
+                            continue;
+                        }
+                    };
+                    let (sender, receiver) = mpsc::channel(UDP_QUEUE_DEPTH);
+                    associations.insert(key.clone(), sender);
+                    tasks.spawn(run_udp_association(
+                        prepared.socket.into(),
+                        prepared.guard,
+                        host,
+                        port,
+                        client,
+                        target.clone(),
+                        receiver,
+                        Arc::clone(&proxy),
+                        handler.clone(),
+                        timeout,
+                    ));
+                }
+                if let Some(sender) = associations.get(&key)
+                    && sender.send(AssociationPacket {
+                        payload: buffer[..length].to_vec(),
+                        control,
+                    }).await.is_err()
+                {
+                    associations.remove(&key);
+                }
+            }
+        }
+    }
+    drop(associations);
+    tasks.abort_all();
+    while tasks.join_next().await.is_some() {}
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_udp_association(
+    socket: Arc<dyn UdpSocketLike>,
+    guard: core_observe::ConnectionGuard,
+    host: String,
+    port: u16,
+    client: SocketAddr,
+    target: Address,
+    mut packets: mpsc::Receiver<AssociationPacket>,
+    proxy: Arc<ProxySocket<ShadowUdpSocket>>,
+    handler: ListenerHandler,
+    idle_timeout: Duration,
+) -> io::Result<()> {
+    let mut response = vec![0u8; UDP_PACKET_SIZE];
+    let mut response_control = UdpSocketControlData::default();
+    response_control.server_session_id = rand::random();
+    loop {
+        let idle = tokio::time::sleep(idle_timeout);
+        tokio::pin!(idle);
+        tokio::select! {
+            _ = &mut idle => break,
+            packet = packets.recv() => {
+                let Some(packet) = packet else { break };
+                response_control.client_session_id = packet.control.client_session_id;
+                response_control.user = packet.control.user;
+                let sent = socket.send_to(&packet.payload, &host, port).await?;
+                if sent != packet.payload.len() {
+                    return Err(io::Error::new(io::ErrorKind::WriteZero, "Shadowsocks UDP outbound truncated a datagram"));
+                }
+                handler.record_upload(&guard, sent as u64);
+            }
+            received = socket.recv_from_endpoint(&mut response) => {
+                let (length, source) = received?;
+                if length == 0 {
+                    continue;
+                }
+                let source = source.map(Address::SocketAddress).unwrap_or_else(|| target.clone());
+                proxy.send_to_with_ctrl(client, &source, &response_control, &response[..length])
+                    .await
+                    .map_err(io::Error::other)?;
+                response_control.packet_id = response_control.packet_id.wrapping_add(1);
+                handler.record_download(&guard, length as u64);
+            }
+        }
+    }
+    socket.close().await
+}
+
+fn address_parts(address: &Address) -> (String, u16) {
+    match address {
+        Address::SocketAddress(address) => (address.ip().to_string(), address.port()),
+        Address::DomainNameAddress(host, port) => (host.clone(), *port),
+    }
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_config::model::ShadowsocksUser;
+    use shadowsocks::{
+        config::ServerConfig,
+        net::{ConnectOpts, UdpSocket as ShadowUdpSocket},
+        relay::{
+            tcprelay::proxy_stream::client::ProxyClientStream,
+            udprelay::proxy_socket::{ProxySocket, UdpSocketType},
+        },
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream, UdpSocket},
+    };
+
+    async fn runtime() -> Arc<Runtime> {
+        let plan = core_config::loader::load_from_str(
+            r#"
+version: 1
+profile: server
+listen: {panel: false}
+route: {preset: direct, final: direct}
+"#,
+        )
+        .unwrap();
+        Arc::new(Runtime::build(plan).unwrap())
+    }
+
+    async fn tcp_echo() -> (SocketAddr, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let (mut read, mut write) = stream.split();
+                    let _ = tokio::io::copy(&mut read, &mut write).await;
+                });
+            }
+        });
+        (address, task)
+    }
+
+    async fn udp_echo() -> (SocketAddr, JoinHandle<()>) {
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let address = socket.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let mut packet = [0u8; 65_535];
+            while let Ok((length, peer)) = socket.recv_from(&mut packet).await {
+                let _ = socket.send_to(&packet[..length], peer).await;
+            }
+        });
+        (address, task)
+    }
+
+    #[test]
+    fn sip003_server_plugin_helper() {
+        let Ok(remote_host) = std::env::var("SS_REMOTE_HOST") else {
+            return;
+        };
+        let Ok(remote_port) = std::env::var("SS_REMOTE_PORT") else {
+            return;
+        };
+        let local_host = std::env::var("SS_LOCAL_HOST").unwrap();
+        let local_port = std::env::var("SS_LOCAL_PORT").unwrap();
+        assert_eq!(
+            std::env::var("SS_PLUGIN_OPTIONS").as_deref(),
+            Ok("integration=true")
+        );
+        let listener = std::net::TcpListener::bind(format!("{remote_host}:{remote_port}")).unwrap();
+        for inbound in listener.incoming() {
+            let mut inbound = inbound.unwrap();
+            let mut outbound =
+                std::net::TcpStream::connect(format!("{local_host}:{local_port}")).unwrap();
+            let mut inbound_read = inbound.try_clone().unwrap();
+            let mut outbound_write = outbound.try_clone().unwrap();
+            std::thread::spawn(move || {
+                let _ = std::io::copy(&mut inbound_read, &mut outbound_write);
+            });
+            let _ = std::io::copy(&mut outbound, &mut inbound);
+        }
+    }
+
+    fn plan(port: u16, method: &str, password: &str, mode: &str) -> ShadowsocksListenPlan {
+        ShadowsocksListenPlan {
+            enabled: true,
+            address: "127.0.0.1".into(),
+            port,
+            method: method.into(),
+            password: password.into(),
+            mode: mode.into(),
+            plugin: None,
+            plugin_opts: None,
+            plugin_args: Vec::new(),
+            plugin_mode: None,
+            plugin_startup_timeout: Duration::from_secs(2),
+            users: Vec::<ShadowsocksUser>::new(),
+            handshake_timeout: Duration::from_secs(2),
+            udp_timeout: Duration::from_secs(2),
+            max_connections: 16,
+            max_udp_associations: 16,
+            tag: "test-ss".into(),
+        }
+    }
+
+    async fn free_port() -> u16 {
+        loop {
+            let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = tcp.local_addr().unwrap().port();
+            if let Ok(udp) = UdpSocket::bind(("127.0.0.1", port)).await {
+                drop(udp);
+                drop(tcp);
+                return port;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn official_clients_interoperate_with_tcp_cipher_families() {
+        let (target, target_task) = tcp_echo().await;
+        for (method, server_password, client_password, user_key) in [
+            ("aes-256-gcm", "classic-password", "classic-password", None),
+            ("aes-256-cfb", "stream-password", "stream-password", None),
+            (
+                "2022-blake3-aes-128-gcm",
+                "MDEyMzQ1Njc4OWFiY2RlZg==",
+                "MDEyMzQ1Njc4OWFiY2RlZg==",
+                None,
+            ),
+            (
+                "2022-blake3-aes-128-gcm",
+                "MDEyMzQ1Njc4OWFiY2RlZg==",
+                "MDEyMzQ1Njc4OWFiY2RlZg==:YWJjZGVmZ2hpamtsbW5vcA==",
+                Some("YWJjZGVmZ2hpamtsbW5vcA=="),
+            ),
+        ] {
+            let port = free_port().await;
+            let mut listener_plan = plan(port, method, server_password, "tcp_only");
+            if let Some(key) = user_key {
+                listener_plan.users.push(ShadowsocksUser {
+                    name: "alice".into(),
+                    key: key.into(),
+                });
+            }
+            let mut listener = start_shadowsocks_listener(&listener_plan, runtime().await)
+                .await
+                .unwrap();
+            let server_addr = listener.tcp_addr().unwrap();
+            let method = method.parse().unwrap();
+            let config =
+                ServerConfig::new(ServerAddr::SocketAddr(server_addr), client_password, method)
+                    .unwrap();
+            let transport = TcpStream::connect(server_addr).await.unwrap();
+            let mut client = ProxyClientStream::from_stream(
+                Context::new_shared(ServerType::Local),
+                transport,
+                &config,
+                Address::SocketAddress(target),
+            );
+            client.write_all(b"shadowsocks-tcp").await.unwrap();
+            let mut response = [0u8; 15];
+            client.read_exact(&mut response).await.unwrap();
+            assert_eq!(&response, b"shadowsocks-tcp");
+            listener.shutdown().await.unwrap();
+        }
+        target_task.abort();
+    }
+
+    #[tokio::test]
+    async fn sip003_server_plugin_is_managed_and_forwards_official_client_tcp() {
+        let (target, target_task) = tcp_echo().await;
+        let port = free_port().await;
+        let mut listener_plan = plan(port, "aes-256-gcm", "plugin-password", "tcp_only");
+        listener_plan.plugin = Some(
+            std::env::current_exe()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+        );
+        listener_plan.plugin_opts = Some("integration=true".into());
+        listener_plan.plugin_args = vec![
+            "--exact".into(),
+            "shadowsocks::tests::sip003_server_plugin_helper".into(),
+            "--nocapture".into(),
+        ];
+        listener_plan.plugin_mode = Some("tcp_only".into());
+        let mut listener = start_shadowsocks_listener(&listener_plan, runtime().await)
+            .await
+            .unwrap();
+        let server_addr = listener.tcp_addr().unwrap();
+        let mut transport = None;
+        for _ in 0..100 {
+            match TcpStream::connect(server_addr).await {
+                Ok(stream) => {
+                    transport = Some(stream);
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+        let config = ServerConfig::new(
+            ServerAddr::SocketAddr(server_addr),
+            "plugin-password",
+            "aes-256-gcm".parse().unwrap(),
+        )
+        .unwrap();
+        let mut client = ProxyClientStream::from_stream(
+            Context::new_shared(ServerType::Local),
+            transport.expect("SIP003 server plugin did not bind its public TCP address"),
+            &config,
+            Address::SocketAddress(target),
+        );
+        client.write_all(b"sip003-server").await.unwrap();
+        let mut response = [0u8; 13];
+        client.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"sip003-server");
+        listener.shutdown().await.unwrap();
+        target_task.abort();
+    }
+
+    #[tokio::test]
+    async fn official_client_interoperates_with_udp_and_reuses_association() {
+        let (target, target_task) = udp_echo().await;
+        for (method, password) in [
+            ("aes-128-gcm", "udp-password"),
+            ("2022-blake3-aes-128-gcm", "MDEyMzQ1Njc4OWFiY2RlZg=="),
+        ] {
+            let port = free_port().await;
+            let mut listener = start_shadowsocks_listener(
+                &plan(port, method, password, "tcp_and_udp"),
+                runtime().await,
+            )
+            .await
+            .unwrap();
+            let server_addr = listener.udp_addr().unwrap();
+            let config = ServerConfig::new(
+                ServerAddr::SocketAddr(server_addr),
+                password,
+                method.parse().unwrap(),
+            )
+            .unwrap();
+            let socket = ShadowUdpSocket::connect_with_opts(&server_addr, &ConnectOpts::default())
+                .await
+                .unwrap();
+            let proxy = ProxySocket::from_socket(
+                UdpSocketType::Client,
+                Context::new_shared(ServerType::Local),
+                &config,
+                socket,
+            );
+            for payload in [b"udp-one".as_slice(), b"udp-two".as_slice()] {
+                proxy
+                    .send(&Address::SocketAddress(target), payload)
+                    .await
+                    .unwrap();
+                let mut response = [0u8; 128];
+                let (length, source, _) = proxy.recv(&mut response).await.unwrap();
+                assert_eq!(source, Address::SocketAddress(target));
+                assert_eq!(&response[..length], payload);
+            }
+            listener.shutdown().await.unwrap();
+        }
+        target_task.abort();
+    }
+}

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -71,6 +71,7 @@ zeroize           = { workspace = true }
 sha3              = { workspace = true }
 rc4               = { workspace = true }
 chacha20          = { workspace = true }
+shadowsocks       = { workspace = true }
 chrono            = { version = "0.4", default-features = false, features = ["clock"] }
 russh             = { workspace = true }
 russh-keys        = { workspace = true }

--- a/crates/core-outbound/src/proto/shadowsocks.rs
+++ b/crates/core-outbound/src/proto/shadowsocks.rs
@@ -1,95 +1,43 @@
-//! Shadowsocks AEAD 出站 —— 与 mihomo / shadowsocks-rust 互通。
+//! Shadowsocks SIP003/SIP004/SIP022 outbound backed by shadowsocks-rust.
 //!
-//! 协议：[shadowsocks AEAD specification](https://shadowsocks.org/doc/aead.html)
-//!
-//! 1. **Subkey**：HKDF-SHA1(EVP_BytesToKey(password) → master_key, salt, "ss-subkey", key_len)
-//! 2. **Salt**：发送端首次连接随机生成 N 字节（与 key 等长），明文置于流首。
-//! 3. **TCP frame**：`AEAD( length 2B, len_tag 16B ) || AEAD( payload, payload_tag 16B )`。
-//! 4. **Nonce**：每加密一次自增（小端 12B）。
-//! 5. **首段 payload**：`SOCKS5 ATYP+ADDR+PORT || 真正的应用数据`。
-//!
-//! 支持的 cipher：
-//! * `aes-128-gcm`             —— 16B key, 16B salt, 12B nonce
-//! * `aes-256-gcm`             —— 32B key, 32B salt, 12B nonce
-//! * `chacha20-ietf-poly1305`  —— 32B key, 32B salt, 12B nonce
+//! The upstream implementation is deliberately used as the single crypto and
+//! framing implementation so every cipher enabled by the workspace feature set
+//! has identical TCP/UDP behaviour to shadowsocks-rust.
 
-use std::{
-    net::SocketAddr,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::{io, net::SocketAddr, sync::Arc};
 
-use aes_gcm::{
-    Aes128Gcm, Aes256Gcm, Nonce,
-    aead::{Aead, KeyInit},
-};
 use async_trait::async_trait;
-use bytes::{Buf, BytesMut};
-use chacha20poly1305::ChaCha20Poly1305;
-use hkdf::Hkdf;
-use md5::{Digest, Md5};
-use pin_project_lite::pin_project;
-use rand::RngCore;
-use sha1::Sha1;
-#[allow(unused_imports)]
-use sha2 as _;
-use tokio::{
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf},
-    net::UdpSocket,
+use shadowsocks::{
+    config::{ServerAddr, ServerConfig, ServerType},
+    context::Context,
+    crypto::CipherKind,
+    net::UdpSocket as ShadowUdpSocket,
+    plugin::{Plugin, PluginConfig, PluginMode},
+    relay::{
+        socks5::Address,
+        tcprelay::proxy_stream::client::ProxyClientStream,
+        udprelay::proxy_socket::{ProxySocket, UdpSocketType},
+    },
 };
 
 use crate::{
     adapter::{
         BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, UdpSocketLike,
-        prepare_outbound_udp_socket, resolve_host,
+        resolve_host,
     },
-    proto::addr::{decode_socks_addr, encode_socks_addr},
     transport::{Transport, tcp::TcpTransport},
 };
-
-const PAYLOAD_MAX: usize = 0x3fff;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SsCipher {
-    Aes128Gcm,
-    Aes256Gcm,
-    Chacha20Poly1305,
-}
-
-impl SsCipher {
-    pub fn key_len(&self) -> usize {
-        match self {
-            Self::Aes128Gcm => 16,
-            Self::Aes256Gcm => 32,
-            Self::Chacha20Poly1305 => 32,
-        }
-    }
-    pub fn tag_len(&self) -> usize {
-        16
-    }
-    pub fn salt_len(&self) -> usize {
-        self.key_len()
-    }
-
-    pub fn parse(name: &str) -> Option<Self> {
-        match name.to_ascii_lowercase().as_str() {
-            "aes-128-gcm" => Some(Self::Aes128Gcm),
-            "aes-256-gcm" => Some(Self::Aes256Gcm),
-            "chacha20-ietf-poly1305" | "chacha20-poly1305" => Some(Self::Chacha20Poly1305),
-            _ => None,
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct ShadowsocksOutbound {
     pub name: String,
     pub host: String,
     pub port: u16,
-    pub cipher: SsCipher,
-    pub key: Arc<[u8]>,
+    pub method: CipherKind,
+    pub password: String,
     pub udp: bool,
+    pub plugin: Option<PluginConfig>,
+    plugin_process: Arc<tokio::sync::Mutex<Option<Plugin>>>,
 }
 
 impl ShadowsocksOutbound {
@@ -97,18 +45,94 @@ impl ShadowsocksOutbound {
         name: impl Into<String>,
         host: impl Into<String>,
         port: u16,
-        cipher: SsCipher,
-        password: &str,
-    ) -> Self {
-        let key = evp_bytes_to_key(password.as_bytes(), cipher.key_len());
-        Self {
+        method: CipherKind,
+        password: impl Into<String>,
+    ) -> io::Result<Self> {
+        let outbound = Self {
             name: name.into(),
             host: host.into(),
             port,
-            cipher,
-            key: Arc::from(key.into_boxed_slice()),
+            method,
+            password: password.into(),
             udp: true,
+            plugin: None,
+            plugin_process: Arc::new(tokio::sync::Mutex::new(None)),
+        };
+        // Validate password/key material immediately, especially the exact
+        // base64 key length and EIH chain required by AEAD-2022.
+        outbound.server_config()?;
+        Ok(outbound)
+    }
+
+    pub fn parse_method(method: &str) -> io::Result<CipherKind> {
+        method.parse().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported Shadowsocks cipher `{method}`"),
+            )
+        })
+    }
+
+    fn server_config(&self) -> io::Result<ServerConfig> {
+        ServerConfig::new(
+            ServerAddr::DomainName(self.host.clone(), self.port),
+            self.password.clone(),
+            self.method,
+        )
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))
+    }
+
+    pub fn set_plugin(&mut self, plugin: Option<PluginConfig>) {
+        self.plugin = plugin;
+    }
+
+    async fn transport_endpoint(&self, udp: bool) -> io::Result<SocketAddr> {
+        let Some(plugin_config) = &self.plugin else {
+            return resolve_host(&self.host, self.port)
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "no server address resolved")
+                });
+        };
+        if udp && !plugin_config.plugin_mode.enable_udp() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "SIP003 plugin `{}` is not configured for UDP",
+                    plugin_config.plugin
+                ),
+            ));
         }
+        if !udp && !plugin_config.plugin_mode.enable_tcp() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "SIP003 plugin `{}` is not configured for TCP",
+                    plugin_config.plugin
+                ),
+            ));
+        }
+        let mut process = self.plugin_process.lock().await;
+        if process.is_none() {
+            let remote = ServerAddr::DomainName(self.host.clone(), self.port);
+            let started = Plugin::start(plugin_config, &remote, PluginMode::Client)?;
+            if !started
+                .wait_started(std::time::Duration::from_secs(10))
+                .await
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("SIP003 plugin `{}` startup timed out", plugin_config.plugin),
+                ));
+            }
+            *process = Some(started);
+        }
+        Ok(process
+            .as_ref()
+            .expect("plugin was initialized")
+            .local_addr())
     }
 }
 
@@ -117,9 +141,15 @@ impl OutboundAdapter for ShadowsocksOutbound {
     fn name(&self) -> &str {
         &self.name
     }
+
     fn protocol(&self) -> &'static str {
-        "shadowsocks"
+        if self.method.is_aead_2022() {
+            "ss2022"
+        } else {
+            "shadowsocks"
+        }
     }
+
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             tcp: true,
@@ -129,481 +159,271 @@ impl OutboundAdapter for ShadowsocksOutbound {
         }
     }
 
-    async fn dial_tcp(&self, ctx: DialContext) -> std::io::Result<BoxedStream> {
-        let mut stream = TcpTransport::default()
-            .connect(&self.host, self.port)
+    async fn dial_tcp(&self, ctx: DialContext) -> io::Result<BoxedStream> {
+        let endpoint = self.transport_endpoint(false).await?;
+        let stream = TcpTransport::default()
+            .connect(&endpoint.ip().to_string(), endpoint.port())
             .await?;
-
-        // 1) 发送 salt
-        let salt_len = self.cipher.salt_len();
-        let mut salt = vec![0u8; salt_len];
-        rand::rngs::OsRng.fill_bytes(&mut salt);
-        stream.write_all(&salt).await?;
-
-        // 2) 用 subkey 初始化 writer，把 SOCKS5 目标地址作为首段 payload
-        let send_key = hkdf_subkey(&self.key, &salt, salt_len);
-        let mut writer = SsCryptor::new(self.cipher, &send_key);
-        let target = encode_socks_addr(&ctx.host, ctx.port);
-        let head_packet = encrypt_chunk(&mut writer, &target)?;
-        stream.write_all(&head_packet).await?;
+        let server = self.server_config()?;
+        let target = Address::from((ctx.host.clone(), ctx.port));
+        let stream = ProxyClientStream::from_stream(
+            Context::new_shared(ServerType::Local),
+            stream,
+            &server,
+            target,
+        );
         tracing::info!(
             target: "dial::shadowsocks",
             id = ctx.dial_id,
             proxy = %self.name,
             server = %format!("{}:{}", self.host, self.port),
             target = %format!("{}:{}", ctx.host, ctx.port),
-            "tcp request header sent",
+            method = %self.method,
+            "Shadowsocks TCP stream established",
         );
-
-        // 3) 包装成 SS 流（reader 在第一次读取时才拿到对端 salt）
-        Ok(Box::pin(SsStream {
-            inner: stream,
-            send: writer,
-            recv_state: RecvState::WaitSalt,
-            master: self.key.clone(),
-            cipher: self.cipher,
-            cipher_buf: BytesMut::with_capacity(16 * 1024),
-            plain_buf: BytesMut::with_capacity(16 * 1024),
-        }))
+        Ok(Box::pin(stream))
     }
 
-    async fn dial_udp(&self, ctx: DialContext) -> std::io::Result<BoxedUdp> {
+    async fn dial_udp(&self, ctx: DialContext) -> io::Result<BoxedUdp> {
         if !self.udp {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
                 format!(
                     "outbound `{}`/shadowsocks udp disabled by config",
                     self.name
                 ),
             ));
         }
-        let server = resolve_first(&self.host, self.port).await?;
-        let (std_sock, loopback_guard) = crate::create_outbound_udp_socket(server)?;
-        let sock = UdpSocket::from_std(std_sock)?;
+        let server_addr = self.transport_endpoint(true).await?;
+        let (reservation, loopback_guard) = crate::create_outbound_udp_socket(server_addr)?;
+        // Preserve the exact socket prepared by the runtime. Recreating it in
+        // shadowsocks-rust would lose Android VPN protection, interface/mark
+        // binding and the loopback guard's observed local endpoint.
+        let socket = ShadowUdpSocket::from(tokio::net::UdpSocket::from_std(reservation)?);
+        let server = self.server_config()?;
+        let socket = ProxySocket::from_socket(
+            UdpSocketType::Client,
+            Context::new_shared(ServerType::Local),
+            &server,
+            socket,
+        );
         tracing::info!(
             target: "dial::shadowsocks",
             id = ctx.dial_id,
             proxy = %self.name,
-            server = %server,
-            "udp associate ok",
+            server = %server_addr,
+            method = %self.method,
+            "Shadowsocks UDP association established",
         );
         Ok(Box::new(ShadowsocksUdp {
-            sock: Arc::new(sock),
-            cipher: self.cipher,
-            key: self.key.clone(),
+            socket,
+            recv_buf: tokio::sync::Mutex::new(vec![0u8; 65_536]),
             loopback_guard,
         }))
     }
 }
 
 struct ShadowsocksUdp {
-    sock: Arc<UdpSocket>,
-    cipher: SsCipher,
-    key: Arc<[u8]>,
+    socket: ProxySocket<ShadowUdpSocket>,
+    recv_buf: tokio::sync::Mutex<Vec<u8>>,
     loopback_guard: crate::loopback::LoopbackUdpGuard,
 }
 
 #[async_trait]
 impl UdpSocketLike for ShadowsocksUdp {
-    async fn send_to(&self, buf: &[u8], target: &str, port: u16) -> std::io::Result<usize> {
-        let salt_len = self.cipher.salt_len();
-        let mut salt = vec![0u8; salt_len];
-        rand::rngs::OsRng.fill_bytes(&mut salt);
-        let subkey = hkdf_subkey(&self.key, &salt, salt_len);
-        let cryptor = SsCryptor::new(self.cipher, &subkey);
-        let addr = encode_socks_addr(target, port);
-        let mut plaintext = Vec::with_capacity(addr.len() + buf.len());
-        plaintext.extend_from_slice(&addr);
-        plaintext.extend_from_slice(buf);
-        let ct = cryptor.aead.encrypt(&[0u8; 12], &plaintext)?;
-        let mut packet = Vec::with_capacity(salt.len() + ct.len());
-        packet.extend_from_slice(&salt);
-        packet.extend_from_slice(&ct);
-        self.sock.send(&packet).await?;
-        Ok(buf.len())
+    async fn send_to(&self, buf: &[u8], target: &str, port: u16) -> io::Result<usize> {
+        self.socket
+            .send(&Address::from((target.to_owned(), port)), buf)
+            .await
+            .map_err(io::Error::other)
     }
 
-    async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut packet = vec![0u8; buf.len().saturating_add(512).max(1500)];
-        let n = self.sock.recv(&mut packet).await?;
-        let salt_len = self.cipher.salt_len();
-        if n <= salt_len + self.cipher.tag_len() {
-            return Err(io_err("ss udp packet too short"));
-        }
-        let subkey = hkdf_subkey(&self.key, &packet[..salt_len], salt_len);
-        let cryptor = SsCryptor::new(self.cipher, &subkey);
-        let plaintext = cryptor.aead.decrypt(&[0u8; 12], &packet[salt_len..n])?;
-        let (_, _, used) = decode_socks_addr(&plaintext)?;
-        let payload = &plaintext[used..];
-        let copy_len = payload.len().min(buf.len());
-        buf[..copy_len].copy_from_slice(&payload[..copy_len]);
-        Ok(copy_len)
+    async fn recv_from(&self, buf: &mut [u8]) -> io::Result<usize> {
+        // The encrypted datagram is larger than the caller's plaintext
+        // buffer. Always receive into a full UDP packet buffer first, then
+        // apply ordinary datagram truncation semantics to the destination.
+        let mut packet = self.recv_buf.lock().await;
+        let (payload_len, _, _) = self
+            .socket
+            .recv(&mut packet)
+            .await
+            .map_err(io::Error::other)?;
+        let copied = payload_len.min(buf.len());
+        buf[..copied].copy_from_slice(&packet[..copied]);
+        Ok(copied)
     }
 
-    async fn close(&self) -> std::io::Result<()> {
+    fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
+        self.socket.local_addr().map(Some)
+    }
+
+    async fn close(&self) -> io::Result<()> {
         let _ = &self.loopback_guard;
         Ok(())
     }
 }
 
-/* ---------------- AEAD 抽象 ---------------- */
-
-enum Aead12 {
-    Aes128(Aes128Gcm),
-    Aes256(Aes256Gcm),
-    Chacha(ChaCha20Poly1305),
-}
-
-impl Aead12 {
-    fn new(cipher: SsCipher, key: &[u8]) -> Self {
-        match cipher {
-            SsCipher::Aes128Gcm => Self::Aes128(Aes128Gcm::new_from_slice(key).expect("len")),
-            SsCipher::Aes256Gcm => Self::Aes256(Aes256Gcm::new_from_slice(key).expect("len")),
-            SsCipher::Chacha20Poly1305 => {
-                Self::Chacha(ChaCha20Poly1305::new_from_slice(key).expect("len"))
-            }
-        }
-    }
-    fn encrypt(&self, nonce: &[u8; 12], data: &[u8]) -> std::io::Result<Vec<u8>> {
-        let n = Nonce::from_slice(nonce);
-        let res = match self {
-            Self::Aes128(c) => c.encrypt(n, data),
-            Self::Aes256(c) => c.encrypt(n, data),
-            Self::Chacha(c) => c.encrypt(chacha20poly1305::Nonce::from_slice(nonce), data),
-        };
-        res.map_err(|_| io_err("ss encrypt failed"))
-    }
-    fn decrypt(&self, nonce: &[u8; 12], data: &[u8]) -> std::io::Result<Vec<u8>> {
-        let n = Nonce::from_slice(nonce);
-        let res = match self {
-            Self::Aes128(c) => c.decrypt(n, data),
-            Self::Aes256(c) => c.decrypt(n, data),
-            Self::Chacha(c) => c.decrypt(chacha20poly1305::Nonce::from_slice(nonce), data),
-        };
-        res.map_err(|_| io_err("ss decrypt failed"))
-    }
-}
-
-struct SsCryptor {
-    aead: Aead12,
-    nonce: [u8; 12],
-}
-
-impl SsCryptor {
-    fn new(cipher: SsCipher, key: &[u8]) -> Self {
-        Self {
-            aead: Aead12::new(cipher, key),
-            nonce: [0u8; 12],
-        }
-    }
-    fn next_nonce(&mut self) -> [u8; 12] {
-        let n = self.nonce;
-        // little-endian +1
-        for b in self.nonce.iter_mut() {
-            let (v, c) = b.overflowing_add(1);
-            *b = v;
-            if !c {
-                break;
-            }
-        }
-        n
-    }
-}
-
-fn encrypt_chunk(c: &mut SsCryptor, data: &[u8]) -> std::io::Result<Vec<u8>> {
-    let chunk = &data[..data.len().min(PAYLOAD_MAX)];
-    let len_buf = (chunk.len() as u16).to_be_bytes();
-    let n1 = c.next_nonce();
-    let n2 = c.next_nonce();
-    let mut out = Vec::with_capacity(2 + 16 + chunk.len() + 16);
-    out.extend(c.aead.encrypt(&n1, &len_buf)?);
-    out.extend(c.aead.encrypt(&n2, chunk)?);
-    Ok(out)
-}
-
-/* ---------------- 双向流 ---------------- */
-
-enum RecvState {
-    WaitSalt,
-    Ready {
-        recv: SsCryptor,
-        expecting_len: Option<usize>,
-    },
-}
-
-pin_project! {
-    struct SsStream {
-        #[pin]
-        inner: BoxedStream,
-        send: SsCryptor,
-        recv_state: RecvState,
-        master: Arc<[u8]>,
-        cipher: SsCipher,
-        cipher_buf: BytesMut, // 来自远端的密文
-        plain_buf: BytesMut,  // 已解密但尚未交给上层的明文
-    }
-}
-
-impl AsyncRead for SsStream {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let mut this = self.project();
-        loop {
-            // 1) 优先把已解密的明文给上层
-            if !this.plain_buf.is_empty() {
-                let n = std::cmp::min(buf.remaining(), this.plain_buf.len());
-                buf.put_slice(&this.plain_buf[..n]);
-                this.plain_buf.advance(n);
-                return Poll::Ready(Ok(()));
-            }
-
-            // 2) 尝试从 cipher_buf 解密下一段
-            match try_decrypt_step(
-                &mut *this.recv_state,
-                this.master,
-                *this.cipher,
-                this.cipher_buf,
-                this.plain_buf,
-            )? {
-                StepResult::Produced => continue,
-                StepResult::NeedMore => {}
-            }
-
-            // 3) 读更多密文
-            let mut tmp = [0u8; 16 * 1024];
-            let mut rb = ReadBuf::new(&mut tmp);
-            match this.inner.as_mut().poll_read(cx, &mut rb) {
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Ready(Ok(())) => {
-                    let filled = rb.filled().len();
-                    if filled == 0 {
-                        return Poll::Ready(Ok(())); // EOF
-                    }
-                    this.cipher_buf.extend_from_slice(rb.filled());
-                }
-            }
-        }
-    }
-}
-
-enum StepResult {
-    Produced,
-    NeedMore,
-}
-
-fn try_decrypt_step(
-    state: &mut RecvState,
-    master: &Arc<[u8]>,
-    cipher: SsCipher,
-    cipher_buf: &mut BytesMut,
-    plain_buf: &mut BytesMut,
-) -> std::io::Result<StepResult> {
-    match state {
-        RecvState::WaitSalt => {
-            let salt_len = cipher.salt_len();
-            if cipher_buf.len() < salt_len {
-                return Ok(StepResult::NeedMore);
-            }
-            let salt = cipher_buf.split_to(salt_len);
-            let subkey = hkdf_subkey(master, &salt, salt_len);
-            *state = RecvState::Ready {
-                recv: SsCryptor::new(cipher, &subkey),
-                expecting_len: None,
-            };
-            Ok(StepResult::Produced) // 让 outer loop 再走一次
-        }
-        RecvState::Ready {
-            recv,
-            expecting_len,
-        } => {
-            let tag = cipher.tag_len();
-            // 阶段 A：未知 length
-            if expecting_len.is_none() {
-                if cipher_buf.len() < 2 + tag {
-                    return Ok(StepResult::NeedMore);
-                }
-                let n1 = recv.next_nonce();
-                let dec = recv.aead.decrypt(&n1, &cipher_buf[..2 + tag])?;
-                let length = u16::from_be_bytes([dec[0], dec[1]]) as usize;
-                cipher_buf.advance(2 + tag);
-                *expecting_len = Some(length);
-            }
-            // 阶段 B：已知 length，等 payload + tag
-            let length = expecting_len.expect("just set");
-            if cipher_buf.len() < length + tag {
-                return Ok(StepResult::NeedMore);
-            }
-            let n2 = recv.next_nonce();
-            let payload = recv.aead.decrypt(&n2, &cipher_buf[..length + tag])?;
-            cipher_buf.advance(length + tag);
-            plain_buf.extend_from_slice(&payload);
-            *expecting_len = None;
-            Ok(StepResult::Produced)
-        }
-    }
-}
-
-impl AsyncWrite for SsStream {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        data: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let mut this = self.project();
-        // 单次最多写一个 PAYLOAD_MAX；上层若给更多，由它 loop。
-        let chunk = &data[..data.len().min(PAYLOAD_MAX)];
-        let packet = encrypt_chunk(this.send, chunk)?;
-        let mut written = 0;
-        while written < packet.len() {
-            match this.inner.as_mut().poll_write(cx, &packet[written..]) {
-                Poll::Ready(Ok(0)) => {
-                    return Poll::Ready(Err(std::io::ErrorKind::WriteZero.into()));
-                }
-                Poll::Ready(Ok(n)) => written += n,
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-        Poll::Ready(Ok(chunk.len()))
-    }
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        self.project().inner.poll_flush(cx)
-    }
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        self.project().inner.poll_shutdown(cx)
-    }
-}
-
-fn io_err(s: &'static str) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::Other, s)
-}
-
-async fn resolve_first(host: &str, port: u16) -> std::io::Result<SocketAddr> {
-    resolve_host(host, port)
-        .await?
-        .into_iter()
-        .next()
-        .ok_or_else(|| io_err("no addr resolved"))
-}
-
-/* ---------------- 密钥派生 ---------------- */
-
-fn evp_bytes_to_key(password: &[u8], key_len: usize) -> Vec<u8> {
-    // OpenSSL EVP_BytesToKey with MD5, no salt, count=1
-    let mut key = Vec::with_capacity(key_len);
-    let mut prev: Vec<u8> = Vec::new();
-    while key.len() < key_len {
-        let mut h = Md5::new();
-        h.update(&prev);
-        h.update(password);
-        let digest = h.finalize();
-        prev = digest.to_vec();
-        key.extend_from_slice(&prev);
-    }
-    key.truncate(key_len);
-    key
-}
-
-fn hkdf_subkey(master: &[u8], salt: &[u8], len: usize) -> Vec<u8> {
-    let hk = Hkdf::<Sha1>::new(Some(salt), master);
-    let mut okm = vec![0u8; len];
-    hk.expand(b"ss-subkey", &mut okm).expect("hkdf");
-    okm
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use shadowsocks::relay::{
+        tcprelay::proxy_stream::server::ProxyServerStream, udprelay::options::UdpSocketControlData,
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, UdpSocket},
+    };
 
-    #[test]
-    fn evp_kdf_aes_256_deterministic() {
-        let k = evp_bytes_to_key(b"hello", 32);
-        let k2 = evp_bytes_to_key(b"hello", 32);
-        assert_eq!(k, k2);
-        assert_eq!(k.len(), 32);
+    fn context(host: &str, port: u16, network: &'static str) -> DialContext {
+        DialContext {
+            host: host.into(),
+            port,
+            network,
+            dial_id: 1,
+        }
     }
 
     #[test]
-    fn cipher_parse_works() {
-        assert_eq!(SsCipher::parse("AES-256-GCM"), Some(SsCipher::Aes256Gcm));
-        assert_eq!(
-            SsCipher::parse("chacha20-ietf-poly1305"),
-            Some(SsCipher::Chacha20Poly1305)
-        );
-        assert_eq!(SsCipher::parse("rc4"), None);
+    fn accepts_every_enabled_cipher_family() {
+        for method in [
+            "aes-128-gcm",
+            "aes-256-gcm",
+            "chacha20-ietf-poly1305",
+            "aes-128-ccm",
+            "aes-256-ccm",
+            "aes-128-gcm-siv",
+            "aes-256-gcm-siv",
+            "xchacha20-ietf-poly1305",
+            "sm4-gcm",
+            "sm4-ccm",
+            "aes-128-ctr",
+            "aes-192-ctr",
+            "aes-256-ctr",
+            "aes-128-cfb",
+            "aes-192-cfb",
+            "aes-256-cfb",
+            "camellia-128-cfb",
+            "camellia-192-cfb",
+            "camellia-256-cfb",
+            "rc4-md5",
+            "chacha20-ietf",
+            "2022-blake3-aes-128-gcm",
+            "2022-blake3-aes-256-gcm",
+            "2022-blake3-chacha20-poly1305",
+            "2022-blake3-chacha8-poly1305",
+        ] {
+            assert!(
+                ShadowsocksOutbound::parse_method(method).is_ok(),
+                "method {method} must be registered"
+            );
+        }
     }
 
     #[test]
-    fn aead_chunk_round_trip() {
-        let key = evp_bytes_to_key(b"pwd", 32);
-        let salt = [7u8; 32];
-        let subkey = hkdf_subkey(&key, &salt, 32);
-        let mut send = SsCryptor::new(SsCipher::Aes256Gcm, &subkey);
-        let mut recv = SsCryptor::new(SsCipher::Aes256Gcm, &subkey);
-        // 写一段
-        let pkt = encrypt_chunk(&mut send, b"hello world").unwrap();
-        // 解 length
-        let n1 = recv.next_nonce();
-        let dec_len = recv.aead.decrypt(&n1, &pkt[..2 + 16]).unwrap();
-        let length = u16::from_be_bytes([dec_len[0], dec_len[1]]) as usize;
-        assert_eq!(length, 11);
-        let n2 = recv.next_nonce();
-        let dec = recv.aead.decrypt(&n2, &pkt[2 + 16..]).unwrap();
-        assert_eq!(dec, b"hello world");
-    }
-
-    #[test]
-    fn udp_capability_is_declared_when_enabled() {
-        let ob = ShadowsocksOutbound::new("ss", "127.0.0.1", 8388, SsCipher::Aes128Gcm, "password");
-        assert!(ob.capabilities().udp);
+    fn rejects_bad_2022_key_at_construction() {
+        let method = ShadowsocksOutbound::parse_method("2022-blake3-aes-128-gcm").unwrap();
+        let error =
+            ShadowsocksOutbound::new("ss", "127.0.0.1", 8388, method, "not-base64").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[tokio::test]
-    async fn udp_send_encrypts_socks_address_and_payload() {
-        tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            shadowsocks_udp_send_and_decrypt(),
+    async fn official_server_interoperates_with_outbound_tcp() {
+        let method = ShadowsocksOutbound::parse_method("aes-256-gcm").unwrap();
+        let server_config = ServerConfig::new(
+            ServerAddr::DomainName("127.0.0.1".into(), 0),
+            "tcp-password",
+            method,
         )
-        .await
-        .expect("Shadowsocks UDP network test timed out");
-    }
-
-    async fn shadowsocks_udp_send_and_decrypt() {
-        use crate::adapter::OutboundAdapter;
-
-        let server = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        let server_addr = server.local_addr().unwrap();
-        let ob = ShadowsocksOutbound::new(
+        .unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
+        let key = server_config.key().to_vec();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut stream = ProxyServerStream::from_stream(
+                Context::new_shared(ServerType::Server),
+                stream,
+                method,
+                &key,
+            );
+            let target = stream.handshake().await.unwrap();
+            assert_eq!(target, Address::from(("echo.example".to_owned(), 443)));
+            let mut request = [0u8; 12];
+            stream.read_exact(&mut request).await.unwrap();
+            assert_eq!(&request, b"outbound-tcp");
+            stream.write_all(&request).await.unwrap();
+        });
+        let outbound = ShadowsocksOutbound::new(
             "ss",
             server_addr.ip().to_string(),
             server_addr.port(),
-            SsCipher::Aes128Gcm,
-            "password",
-        );
-        let udp = ob
-            .dial_udp(DialContext::udp("example.com", 53))
+            method,
+            "tcp-password",
+        )
+        .unwrap();
+        let mut stream = outbound
+            .dial_tcp(context("echo.example", 443, "tcp"))
             .await
             .unwrap();
-        udp.send_to(b"ping", "example.com", 53).await.unwrap();
+        stream.write_all(b"outbound-tcp").await.unwrap();
+        let mut response = [0u8; 12];
+        stream.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"outbound-tcp");
+        server.await.unwrap();
+    }
 
-        let mut packet = [0u8; 1500];
-        let (n, _) = server.recv_from(&mut packet).await.unwrap();
-        let salt_len = ob.cipher.salt_len();
-        assert!(n > salt_len + ob.cipher.tag_len());
-        let subkey = hkdf_subkey(&ob.key, &packet[..salt_len], salt_len);
-        let cryptor = SsCryptor::new(ob.cipher, &subkey);
-        let plaintext = cryptor
-            .aead
-            .decrypt(&[0u8; 12], &packet[salt_len..n])
+    #[tokio::test]
+    async fn official_server_interoperates_with_prepared_outbound_udp_socket() {
+        let method = ShadowsocksOutbound::parse_method("2022-blake3-aes-128-gcm").unwrap();
+        let password = "MDEyMzQ1Njc4OWFiY2RlZg==";
+        let raw = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = raw.local_addr().unwrap();
+        let server_config =
+            ServerConfig::new(ServerAddr::SocketAddr(server_addr), password, method).unwrap();
+        let proxy = ProxySocket::from_socket(
+            UdpSocketType::Server,
+            Context::new_shared(ServerType::Server),
+            &server_config,
+            ShadowUdpSocket::from(raw),
+        );
+        let server = tokio::spawn(async move {
+            let mut packet = [0u8; 256];
+            let (length, client, target, _, control) =
+                proxy.recv_from_with_ctrl(&mut packet).await.unwrap();
+            assert_eq!(target, Address::from(("dns.example".to_owned(), 53)));
+            assert_eq!(&packet[..length], b"outbound-udp");
+            let request_control = control.unwrap_or_default();
+            let mut response_control = UdpSocketControlData::default();
+            response_control.client_session_id = request_control.client_session_id;
+            response_control.server_session_id = 7;
+            response_control.packet_id = 0;
+            response_control.user = request_control.user;
+            proxy
+                .send_to_with_ctrl(client, &target, &response_control, &packet[..length])
+                .await
+                .unwrap();
+        });
+        let outbound = ShadowsocksOutbound::new(
+            "ss2022",
+            server_addr.ip().to_string(),
+            server_addr.port(),
+            method,
+            password,
+        )
+        .unwrap();
+        let socket = outbound
+            .dial_udp(context("dns.example", 53, "udp"))
+            .await
             .unwrap();
-        assert_eq!(plaintext[0], 0x03);
-        assert_eq!(plaintext[1] as usize, "example.com".len());
-        assert_eq!(&plaintext[2..13], b"example.com");
-        assert_eq!(&plaintext[13..15], &53u16.to_be_bytes());
-        assert_eq!(&plaintext[15..], b"ping");
+        socket
+            .send_to(b"outbound-udp", "dns.example", 53)
+            .await
+            .unwrap();
+        let mut response = [0u8; 64];
+        let length = socket.recv_from(&mut response).await.unwrap();
+        assert_eq!(&response[..length], b"outbound-udp");
+        assert!(socket.local_addr().unwrap().is_some());
+        server.await.unwrap();
     }
 }

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -30,9 +30,8 @@ use crate::{
         hysteria::HysteriaOutbound,
         hysteria2::Hysteria2Outbound,
         mieru::{MieruCipher, MieruOutbound},
-        shadowsocks::{ShadowsocksOutbound, SsCipher},
+        shadowsocks::ShadowsocksOutbound,
         snell::{SnellCipher, SnellOutbound},
-        ss2022::{Ss22Cipher, Ss2022Outbound},
         ssh::SshOutbound,
         ssr::{SsrCipher, SsrObfs, SsrOutbound, SsrProtocol},
         sudoku::{AeadMethod as SudokuAead, SudokuOutbound},
@@ -363,23 +362,81 @@ fn build_shadowsocks(node: &ParsedNode) -> Result<SharedOutbound, String> {
     if pwd.is_empty() {
         return Err("shadowsocks password must not be empty".into());
     }
-    if let Some(c) = Ss22Cipher::parse(method) {
-        return match Ss2022Outbound::new(&node.name, &node.host, node.port, c, pwd) {
-            Ok(mut ob) => {
-                ob.udp = node.udp;
-                Ok(Arc::new(ob))
+    let method = ShadowsocksOutbound::parse_method(method).map_err(|error| error.to_string())?;
+    let is_2022 = method.is_aead_2022();
+    let mut outbound = ShadowsocksOutbound::new(&node.name, &node.host, node.port, method, pwd)
+        .map_err(|error| {
+            if is_2022 {
+                format!("invalid Shadowsocks 2022 PSK: {error}")
+            } else {
+                format!("invalid Shadowsocks configuration: {error}")
             }
-            Err(error) => Err(format!("invalid Shadowsocks 2022 PSK: {error}")),
-        };
-    }
-    match SsCipher::parse(method) {
-        Some(c) => {
-            let mut ob = ShadowsocksOutbound::new(&node.name, &node.host, node.port, c, pwd);
-            ob.udp = node.udp;
-            Ok(Arc::new(ob))
+        })?;
+    outbound.udp = node.udp;
+    if let Some(spec) = node.params.get("plugin") {
+        let (plugin, inline_opts) = spec
+            .split_once(';')
+            .map_or((spec.as_str(), None), |(name, opts)| (name, Some(opts)));
+        if plugin.trim().is_empty() {
+            return Err("Shadowsocks SIP003 plugin name must not be empty".into());
         }
-        None => Err(format!("unsupported Shadowsocks cipher `{method}`")),
+        let plugin_opts = node
+            .params
+            .get("plugin-opts")
+            .or_else(|| node.params.get("plugin_opts"))
+            .map(String::as_str)
+            .or(inline_opts)
+            .map(ToOwned::to_owned);
+        let plugin_mode = match node
+            .params
+            .get("plugin-mode")
+            .or_else(|| node.params.get("plugin_mode"))
+            .map(|value| value.to_ascii_lowercase().replace('-', "_"))
+            .as_deref()
+            .unwrap_or("tcp_only")
+        {
+            "tcp" | "tcp_only" => shadowsocks::config::Mode::TcpOnly,
+            "udp" | "udp_only" => shadowsocks::config::Mode::UdpOnly,
+            "tcp_and_udp" | "tcp_udp" => shadowsocks::config::Mode::TcpAndUdp,
+            mode => return Err(format!("invalid Shadowsocks SIP003 plugin mode `{mode}`")),
+        };
+        let plugin_args = node
+            .params
+            .get("plugin-args")
+            .or_else(|| node.params.get("plugin_args"))
+            .map(|value| {
+                if value.trim().is_empty() {
+                    Ok(Vec::new())
+                } else if value.trim_start().starts_with('[') {
+                    serde_json::from_str::<Vec<String>>(value).map_err(|error| {
+                        format!("invalid Shadowsocks SIP003 plugin-args JSON array: {error}")
+                    })
+                } else {
+                    Ok(vec![value.clone()])
+                }
+            })
+            .transpose()?
+            .unwrap_or_default();
+        outbound.set_plugin(Some(shadowsocks::plugin::PluginConfig {
+            plugin: plugin.to_owned(),
+            plugin_opts,
+            plugin_args,
+            plugin_mode,
+        }));
+    } else if [
+        "plugin-opts",
+        "plugin_opts",
+        "plugin-args",
+        "plugin_args",
+        "plugin-mode",
+        "plugin_mode",
+    ]
+    .iter()
+    .any(|key| node.params.contains_key(*key))
+    {
+        return Err("Shadowsocks SIP003 plugin options require the `plugin` parameter".to_owned());
     }
+    Ok(Arc::new(outbound))
 }
 
 fn build_ssr(node: &ParsedNode) -> Result<SharedOutbound, String> {
@@ -3248,6 +3305,22 @@ mod tests {
         ss2022.password = Some("not-a-valid-2022-key".into());
         ss2022.method = Some("2022-blake3-aes-128-gcm".into());
         assert!(build_error(&ss2022).contains("invalid Shadowsocks 2022 PSK"));
+
+        let mut ss_plugin = node(NodeProtocol::Shadowsocks);
+        ss_plugin.password = Some("secret".into());
+        ss_plugin.params.insert("plugin-opts".into(), "tls".into());
+        assert!(build_error(&ss_plugin).contains("require the `plugin`"));
+        ss_plugin
+            .params
+            .insert("plugin".into(), "v2ray-plugin".into());
+        ss_plugin
+            .params
+            .insert("plugin-args".into(), "[not-json".into());
+        assert!(build_error(&ss_plugin).contains("plugin-args JSON array"));
+        ss_plugin
+            .params
+            .insert("plugin-args".into(), r#"["--loglevel","warning"]"#.into());
+        assert!(build_outbound(&ss_plugin).is_ok());
 
         let mut ssr = node(NodeProtocol::ShadowsocksR);
         ssr.password = Some("secret".into());

--- a/crates/wuther-core/src/host_resources.rs
+++ b/crates/wuther-core/src/host_resources.rs
@@ -65,6 +65,28 @@ pub(crate) fn listener_resource_claims(plan: &RuntimePlan) -> Result<Vec<HostRes
         ));
     }
 
+    for shadowsocks in plan
+        .listen
+        .shadowsocks
+        .iter()
+        .filter(|listener| listener.enabled)
+    {
+        let address = shadowsocks
+            .socket_addr()
+            .map_err(|error| anyhow::anyhow!("{error}"))?;
+        ensure!(
+            address.port() != 0,
+            "Shadowsocks listener port 0 cannot be reserved"
+        );
+        let owner = host_owner("wuther.shadowsocks");
+        if shadowsocks.enable_tcp() {
+            claims.insert(socket_claim(owner.clone(), SocketTransport::Tcp, address));
+        }
+        if shadowsocks.enable_udp() {
+            claims.insert(socket_claim(owner, SocketTransport::Udp, address));
+        }
+    }
+
     if plan.ui.on {
         if let Some(panel) = &plan.listen.panel {
             let address = panel
@@ -281,6 +303,50 @@ ui:
         );
 
         assert!(listener_resource_claims(&plan).unwrap().is_empty());
+    }
+
+    #[test]
+    fn shadowsocks_listener_modes_reserve_their_tcp_and_udp_resources() {
+        let plan = plan(
+            r#"
+version: 1
+profile: server
+listen:
+  panel: false
+  shadowsocks:
+    - {address: 127.0.0.1, port: 8388, method: aes-128-gcm, password: one, mode: tcp_only, tag: tcp}
+    - {address: 127.0.0.1, port: 8389, method: aes-128-gcm, password: two, mode: udp_only, tag: udp}
+    - {address: 127.0.0.1, port: 8390, method: aes-128-gcm, password: three, mode: tcp_and_udp, tag: both}
+    - {enabled: false, address: 127.0.0.1, port: 8391, method: aes-128-gcm, password: four, mode: tcp_and_udp, tag: disabled}
+route:
+  preset: direct
+"#,
+        );
+        assert_eq!(
+            sockets(&listener_resource_claims(&plan).unwrap()),
+            BTreeSet::from([
+                (
+                    "wuther.shadowsocks".to_owned(),
+                    SocketTransport::Tcp,
+                    "127.0.0.1:8388".parse().unwrap(),
+                ),
+                (
+                    "wuther.shadowsocks".to_owned(),
+                    SocketTransport::Udp,
+                    "127.0.0.1:8389".parse().unwrap(),
+                ),
+                (
+                    "wuther.shadowsocks".to_owned(),
+                    SocketTransport::Tcp,
+                    "127.0.0.1:8390".parse().unwrap(),
+                ),
+                (
+                    "wuther.shadowsocks".to_owned(),
+                    SocketTransport::Udp,
+                    "127.0.0.1:8390".parse().unwrap(),
+                ),
+            ])
+        );
     }
 
     #[test]

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -17,8 +17,9 @@ use core_api::ApiServer;
 use core_config::loader::load_from_path;
 use core_feeds::{FeedDiskCache, FeedManager, FeedSink, FeedUpdate};
 use core_inbound::{
-    GrpcListener, MixedListener, XhttpListenerHandle, ensure_best_effort_privilege, run_grpc,
-    run_mixed, start_xhttp_listeners,
+    GrpcListener, MixedListener, ShadowsocksListenerHandle, XhttpListenerHandle,
+    ensure_best_effort_privilege, run_grpc, run_mixed, start_shadowsocks_listeners,
+    start_xhttp_listeners,
 };
 use core_outbound::proto::wireguard::{
     WireGuardServer, WireGuardServerConfig, WireGuardServerPeerConfig,
@@ -865,6 +866,8 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     // 任何一项失败都会关闭已启动的同类监听并直接返回 cmd_run。
     let mut xhttp_listener_handles =
         start_configured_xhttp_inbounds(&plan, runtime.clone()).await?;
+    let mut shadowsocks_listener_handles =
+        start_configured_shadowsocks_inbounds(&plan, runtime.clone()).await?;
 
     // 把运行期 LogBus 挂到 tracing 桥上 —— 让 /v1/logs 与 Clash 兼容 /logs WS
     // 流式输出。tracing 可能已被早期初始化占用，所以 observe 层使用可后挂载的
@@ -1266,6 +1269,16 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         warn!(target: "mesh", error = %error, "mesh supervisor stop failed");
     }
     feed_mgr_handle.stop();
+    for listener in &mut shadowsocks_listener_handles {
+        if let Err(error) = listener.shutdown().await {
+            warn!(
+                target: "inbound::shadowsocks",
+                tag = listener.tag(),
+                %error,
+                "Shadowsocks listener shutdown failed"
+            );
+        }
+    }
     for listener in &mut xhttp_listener_handles {
         if let Err(error) = listener.shutdown().await {
             warn!(
@@ -1326,6 +1339,15 @@ async fn start_configured_xhttp_inbounds(
     start_xhttp_listeners(&plan.listen.xhttp, runtime)
         .await
         .context("XHTTP 入站启动失败")
+}
+
+async fn start_configured_shadowsocks_inbounds(
+    plan: &core_config::runtime_plan::RuntimePlan,
+    runtime: Arc<Runtime>,
+) -> anyhow::Result<Vec<ShadowsocksListenerHandle>> {
+    start_shadowsocks_listeners(&plan.listen.shadowsocks, runtime)
+        .await
+        .context("Shadowsocks 入站启动失败")
 }
 
 /// 把 [`core_ruleset::RulesetIndex`] 适配为 [`core_capture::IpSetProvider`]。

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -37,7 +37,7 @@
 | --- | --- | --- |
 | 内置动作 | Direct、Block、DNS Hijack | 直连、拒绝和 DNS 劫持 |
 | 通用代理 | HTTP、SOCKS5 | 支持认证；UDP 能力由具体实现决定 |
-| Shadowsocks | Shadowsocks、Shadowsocks 2022、SSR | 包含多种 AEAD/流加密与 SSR 组件 |
+| Shadowsocks | Shadowsocks、Shadowsocks 2022、SSR | 全加密族 TCP/UDP 客户端与服务端、SIP003 插件、SIP022 EIH 多用户；SSR 保持独立实现 |
 | 经典 TLS | Trojan、VLESS、VMess | 支持对应 TLS、UUID 与安全参数 |
 | 现代隧道 | AnyTLS、Hysteria、Hysteria 2、TUIC、Naive | Naive 为可选 feature，包含 H2/H3、ECH、填充与 UoT v2，见 [Naive 指南](NAIVE.md) |
 | 专用协议 | Snell、Mieru、Sudoku、TrustTunnel | 按各自握手、加密和复用模型实现 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@
 | --- | --- |
 | [功能矩阵](FEATURES.md) | 当前有哪些能力，哪些行为依赖平台或服务端 |
 | [配置指南](CONFIGURATION.md) | 如何选择 Profile、组织配置、校验与迁移 |
+| [Shadowsocks 配置](SHADOWSOCKS.md) | 全加密族客户端、TCP/UDP 服务端、SIP003 插件与 SIP022 EIH 多用户 |
 | [Linux TUN auto_redirect](LINUX-TUN-AUTO-REDIRECT.md) | 本机 TCP REDIRECT + UDP TUN 的前置条件、安全边界和回滚 |
 | [管理 API](API.md) | 如何鉴权、查询状态和控制运行时 |
 | [排错手册](TROUBLESHOOTING.md) | TUN、DNS、订阅、权限和连接失败如何定位 |

--- a/docs/SHADOWSOCKS.md
+++ b/docs/SHADOWSOCKS.md
@@ -1,0 +1,101 @@
+# Shadowsocks 完整协议支持
+
+WutherCore 的 Shadowsocks 客户端与服务端统一使用 `shadowsocks-rust 1.24.0`。TCP、UDP、经典流加密、AEAD、扩展 AEAD、Shadowsocks 2022（SIP022）以及 EIH 多用户验证共享同一套上游协议实现和重放保护。
+
+## 客户端
+
+节点可以来自 `ss://` SIP002 URI、订阅或手工节点。URI 查询参数支持 SIP003：
+
+```text
+ss://BASE64(method:password)@server.example:8388/?plugin=v2ray-plugin%3Btls%3Bhost%3Dcdn.example&plugin-mode=tcp_only#example
+```
+
+- `plugin`：插件可执行文件；分号后的内容作为插件选项。
+- `plugin-opts` / `plugin_opts`：独立插件选项，优先于内联选项。
+- `plugin-args` / `plugin_args`：JSON 字符串数组（或单个参数），作为独立命令行参数传给插件。
+- `plugin-mode` / `plugin_mode`：`tcp_only`、`udp_only` 或 `tcp_and_udp`。
+
+插件按 SIP003 环境变量规范作为受管子进程启动，首次连接会等待插件就绪。插件模式未覆盖请求的 TCP/UDP 载体时会明确报错，不会绕过插件直连。
+
+启用的加密族包括经典 AES/Camellia/RC4/ChaCha20 流加密，AES-GCM 与 ChaCha20-IETF-Poly1305，AES-CCM、AES-GCM-SIV、XChaCha20、SM4 扩展 AEAD，以及全部 BLAKE3 Shadowsocks 2022 方法。具体名称以 `shadowsocks-rust 1.24.0` 接受的标准名称为准。2022 密码必须是长度匹配的 Base64；EIH 客户端身份链使用 SIP022 的冒号分隔格式。
+
+## 服务端
+
+`listen.shadowsocks` 接受单个对象或数组：
+
+```yaml
+version: 1
+profile: server
+
+listen:
+  panel: false
+  shadowsocks:
+    - tag: ss-classic
+      address: 0.0.0.0
+      port: 8388
+      method: aes-256-gcm
+      password: replace-with-a-strong-password
+      mode: tcp_and_udp
+      handshake-timeout: 10s
+      udp-timeout: 5m
+      max-connections: 4096
+      max-udp-associations: 4096
+
+    - tag: ss-sip003
+      address: 0.0.0.0
+      port: 8443
+      method: aes-256-gcm
+      password: replace-with-a-strong-password
+      mode: tcp_only
+      plugin: v2ray-plugin
+      plugin-opts: server;tls;host=cdn.example
+      plugin-args: [--loglevel, warning]
+      plugin-mode: tcp_only
+      plugin-startup-timeout: 10s
+
+    - tag: ss-2022-eih
+      address: 0.0.0.0
+      port: 8390
+      method: 2022-blake3-aes-128-gcm
+      password: MDEyMzQ1Njc4OWFiY2RlZg==
+      mode: tcp_and_udp
+      users:
+        - name: alice
+          key: YWJjZGVmZ2hpamtsbW5vcA==
+```
+
+| 字段 | 默认值 | 含义 |
+| --- | --- | --- |
+| `enabled` | `true` | 是否启动 |
+| `address` / `host` | `127.0.0.1` | 监听 IP |
+| `port` | 必填 | TCP/UDP 端口，不能为 0 |
+| `method` | 必填 | 标准 Shadowsocks 方法名 |
+| `password` | 必填 | 密码或 2022 Base64 PSK/EIH 密钥链 |
+| `mode` | `tcp_and_udp` | `tcp_only`、`udp_only` 或 `tcp_and_udp` |
+| `plugin` | 未启用 | SIP003 服务端插件可执行文件 |
+| `plugin-opts` / `plugin_opts` | 未设置 | 传入 `SS_PLUGIN_OPTIONS` 的插件选项 |
+| `plugin-args` / `plugin_args` | `[]` | 直接传给插件进程的独立命令行参数 |
+| `plugin-mode` / `plugin_mode` | 继承 `mode` | 插件载体模式；必须与监听模式一致 |
+| `plugin-startup-timeout` / `plugin_startup_timeout` | `10s` | 受管插件和内部回环监听的启动上限 |
+| `users` | `[]` | 仅 SIP022 EIH 使用的用户名称与 Base64 密钥 |
+| `handshake-timeout` | `10s` | TCP 认证及目标头读取上限 |
+| `udp-timeout` | `5m` | UDP 关联空闲回收时间 |
+| `max-connections` | `4096` | 单监听 TCP 并发上限 |
+| `max-udp-associations` | `4096` | 单监听 UDP 关联上限 |
+| `tag` | 自动生成 | 路由与观测标签，必须唯一 |
+
+未知字段会被拒绝。启动前会验证方法、密码/PSK、EIH 用户 Base64 与精确密钥长度、空或重复用户名、模式、插件字段依赖关系、插件/监听载体一致性、标签及按传输层区分的端口冲突。启用 SIP003 时，插件按服务端模式监听公开地址，Shadowsocks 解密服务只绑定插件分配的回环地址；插件进程由监听句柄托管并随关闭一并终止。`tcp_and_udp` 会先完成两个内部 socket 的预绑定再启动任务，任一绑定失败都会整体回滚。
+
+## 运行与安全语义
+
+- TCP 在解密并认证目标头后才进入统一入站路由。
+- UDP 按客户端地址、SIP022 会话 ID 和目标地址隔离关联，并保留真实响应源地址。
+- 监听级共享上下文让重放检测跨 TCP 连接和 UDP 数据包生效。
+- 无效密文、错误密码、未知 EIH 用户及重放包会在进入路由前拒绝。
+- TCP 连接、UDP 关联、单关联队列和空闲时间都有界；关闭会取消全部子任务。
+- 客户端 UDP 复用运行时已施加 VPN protect、接口/mark 绑定和回环登记的原始 socket；独立密文缓冲保证较小的调用方明文缓冲不会被加密开销挤爆。
+- mesh 预检会按模式分别声明 TCP/UDP 独占监听资源。
+
+## Rust 版本
+
+`shadowsocks-rust 1.24.0` 的 MSRV 为 Rust 1.88，本项目工作区的 `rust-version` 因此同步提升为 1.88；CI 与发布流程使用满足该下限的 stable 工具链。


### PR DESCRIPTION
## 背景与目标

现有 Shadowsocks 出站仅维护少量自实现加密路径，缺少完整算法覆盖、标准 Shadowsocks 2022 行为、服务端入口、严格配置注册和双向互操作保证。本次变更以官方 `shadowsocks-rust` 为唯一协议与密码学实现来源，完整补齐客户端、服务端、TCP、UDP、SIP003 插件和 SIP022 EIH 多用户能力，避免继续维护不完整的自定义帧与加密实现。

## 依赖与工具链

- 精确引入当前最新的 `shadowsocks 1.24.0`。
- 启用流加密、标准 AEAD、扩展 AEAD、Shadowsocks 2022、2022 扩展算法和重放攻击检测全部相关特性。
- 依照该依赖声明的最低 Rust 版本，将工作区 `rust-version` 从 1.85 提升到 1.88；现有持续集成和发布流程继续使用满足要求的稳定工具链。
- 锁文件已同步更新，保证依赖解析可复现。

## 客户端实现

- 用官方实现替换原有仅覆盖三种算法的自定义 Shadowsocks 客户端。
- 完整支持经典 AES、Camellia、RC4、ChaCha20 流加密，AES-GCM、ChaCha20-IETF-Poly1305，以及 AES-CCM、AES-GCM-SIV、XChaCha20、SM4 等扩展 AEAD。
- 完整支持 BLAKE3 系列 Shadowsocks 2022 方法及 EIH 身份链，并保留 `ss2022` 协议标识和既有注册错误契约。
- TCP 与 UDP 均通过官方代理流和代理数据报实现。
- UDP 直接复用运行时已完成 VPN 保护、接口绑定、套接字标记和回环登记的原始套接字，不会因依赖库重新建套接字而绕过系统网络策略。
- UDP 增加独立密文接收缓冲，正确处理加密开销大于调用方明文缓冲的场景。
- SIP003 客户端插件支持内联选项、独立选项、命令行参数和 TCP、UDP、双栈载体模式；插件作为受管子进程惰性启动，并在模式不覆盖请求载体时明确拒绝。

## 服务端实现

- 新增完整 Shadowsocks TCP 与 UDP 入站，并注册到核心启动和关闭生命周期。
- TCP 在官方协议层完成认证、解密和目标头解析后才进入统一入站路由，支持握手超时和有界连接并发。
- UDP 按客户端地址、SIP022 会话编号和目标地址隔离关联，保留真实响应源地址，提供有界关联数、有界队列和空闲回收。
- Shadowsocks 2022 UDP 响应维护独立服务端会话编号与递增数据包编号，避免响应重放或编号重复。
- 监听级共享官方上下文，使 TCP 连接与 UDP 数据包共享重放检测状态。
- 支持 SIP022 EIH 多用户管理，严格校验用户名称、Base64 编码及解码后的精确密钥长度。
- 支持 SIP003 服务端插件：插件监听公开地址，解密服务仅监听插件分配的回环地址；插件参数、载体模式和启动超时均可配置，插件随监听句柄关闭。
- TCP 与 UDP 双载体采用事务式预绑定；任一载体失败时整体回滚，不留下半启动服务。
- 支持 IPv4、原始 IPv6 与带方括号 IPv6 监听地址。

## 配置与注册

`listen.shadowsocks` 和别名 `listen.ss` 均支持单对象或数组，并严格注册以下字段：

- `enabled`
- `address` 与 `host`
- `port`
- `method`
- `password`
- `mode`
- `plugin`
- `plugin-opts` 与 `plugin_opts`
- `plugin-args` 与 `plugin_args`
- `plugin-mode` 与 `plugin_mode`
- `plugin-startup-timeout` 与 `plugin_startup_timeout`
- `users`
- `handshake-timeout` 与 `handshake_timeout`
- `udp-timeout` 与 `udp_timeout`
- `max-connections` 与 `max_connections`
- `max-udp-associations` 与 `max_udp_associations`
- `tag`

配置编译阶段会拒绝未知字段、不支持的算法、无效或长度错误的 2022 密钥、非 2022 算法上的 EIH 用户、空或重复用户名、非法模式、零超时或零上限、缺失插件主体的插件选项、插件与监听载体不一致、重复标签，以及按传输层区分的监听地址冲突。

## 运行时与资源管理

- 服务端入口已接入主进程启动、失败回滚和优雅关闭路径。
- 主机资源预检按监听模式分别声明 TCP 与 UDP 独占资源，禁用的监听不会占用资源。
- 连接、关联、子任务和插件进程均由取消令牌及监听句柄统一管理。
- 上传、下载和连接指标继续进入现有观测体系。

## 文档

- 新增完整中文 Shadowsocks 配置与安全语义文档。
- 更新文档索引和功能矩阵，明确客户端、服务端、SIP003 与 SIP022 的支持范围。

## 验证结果

已执行并通过：

- `cargo search shadowsocks --limit 1`，确认当前最新版本为 1.24.0。
- `cargo info shadowsocks@1.24.0`，确认依赖最低 Rust 版本为 1.88。
- `cargo check --workspace --all-targets --locked`。
- `cargo test --workspace --all-targets --locked`；全部可运行测试通过，依赖外部官方 Xray 二进制的既有测试按原条件忽略。
- `cargo doc --workspace --no-deps --locked`。
- 官方客户端到本服务端的经典 AEAD、流加密、Shadowsocks 2022、EIH、经典 UDP 与 2022 UDP 互操作测试。
- 本客户端到官方服务端的 TCP 与 Shadowsocks 2022 UDP 互操作测试。
- SIP003 服务端受管子进程端到端转发与关闭测试。
- 完整配置字段、别名、非法组合、资源声明和端口冲突测试。

## 兼容性与审阅说明

- 本分支只包含一个 Shadowsocks 协议提交，符合单协议单提交要求。
- 拉取请求基于 `codex/protocol-snell-full`，用于保持协议实现按独立分支顺序叠加；审阅时可直接查看该基线之后的唯一提交。
- 工作区最低 Rust 版本提升到 1.88 是采用最新官方依赖的必要条件。
- 构建中仍可见的未使用项警告来自既有模块，本次变更未新增协议实现警告或文档错误。
