### PR TITLE
feat(capture): harden traffic interception and implement endpoint-independent UDP NAT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,11 +1064,13 @@ dependencies = [
  "ipnet",
  "jni 0.21.1",
  "libc",
+ "netlink-packet-route 0.30.0",
  "netstack-smoltcp",
  "nix 0.29.0",
  "once_cell",
  "parking_lot",
  "route_manager",
+ "rtnetlink",
  "serde",
  "serde_json",
  "smoltcp 0.11.0",
@@ -3599,14 +3601,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "netlink-sys"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
 dependencies = [
  "bytes",
+ "futures-util",
  "libc",
  "log",
+ "tokio",
 ]
 
 [[package]]
@@ -4697,6 +4728,24 @@ dependencies = [
  "tokio",
  "tracing",
  "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route 0.30.0",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.30.1",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1050,7 @@ dependencies = [
  "blake3",
  "boringtun",
  "bytes",
+ "caps",
  "compact_str",
  "core-config",
  "core-mesh",
@@ -1058,6 +1068,7 @@ dependencies = [
  "nix 0.29.0",
  "once_cell",
  "parking_lot",
+ "route_manager",
  "serde",
  "serde_json",
  "smoltcp 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,7 @@ dependencies = [
  "cronet",
  "ctr",
  "curve25519-dalek",
+ "dashmap",
  "data-encoding",
  "flate2",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,8 @@ rand = "0.8"
 hex = "0.4"
 tempfile = "3"
 libc = "0.2"
+caps = "0.5.6"
+route_manager = "0.2.12"
 
 # 内部 crate
 core-config   = { path = "crates/core-config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,8 @@ tempfile = "3"
 libc = "0.2"
 caps = "0.5.6"
 route_manager = "0.2.12"
+rtnetlink = "0.21.0"
+netlink-packet-route = "0.30.0"
 
 # 内部 crate
 core-config   = { path = "crates/core-config" }

--- a/crates/core-capture/Cargo.toml
+++ b/crates/core-capture/Cargo.toml
@@ -46,6 +46,7 @@ tun-rs = { version = "2", features = ["async"] }
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 nix      = { version = "0.29", features = ["net", "socket", "ioctl", "fs", "user"] }
 libc     = "0.2"
+caps     = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # blake3 用于 wintun adapter 稳定 GUID
@@ -59,6 +60,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
     "Win32_System_LibraryLoader",
 ] }
+route_manager = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 libc = "0.2"

--- a/crates/core-capture/Cargo.toml
+++ b/crates/core-capture/Cargo.toml
@@ -47,6 +47,8 @@ tun-rs = { version = "2", features = ["async"] }
 nix      = { version = "0.29", features = ["net", "socket", "ioctl", "fs", "user"] }
 libc     = "0.2"
 caps     = { workspace = true }
+rtnetlink = { workspace = true }
+netlink-packet-route = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # blake3 用于 wintun adapter 稳定 GUID

--- a/crates/core-capture/src/doctor.rs
+++ b/crates/core-capture/src/doctor.rs
@@ -66,9 +66,9 @@ pub fn diagnose(c: &Capture, mesh: &Mesh) -> Result<DoctorReport, CaptureError> 
     }
 
     // sing-box 字段一致性检查
-    if plan.auto_redirect && !cfg!(any(target_os = "linux", target_os = "android")) {
+    if plan.auto_redirect && !cfg!(target_os = "linux") {
         warnings.push(format!(
-            "auto_redirect 仅在 Linux/Android 生效（当前 {}）",
+            "auto_redirect 当前仅在 root-managed Linux TUN 生效（当前 {}）",
             std::env::consts::OS
         ));
     }
@@ -103,16 +103,37 @@ pub fn diagnose(c: &Capture, mesh: &Mesh) -> Result<DoctorReport, CaptureError> 
 
     // 平台特定 doctor
     match plan.kind {
-        EngineKind::Tproxy | EngineKind::Redirect => {
+        EngineKind::Tproxy => {
             if !cfg!(target_os = "linux") && !cfg!(target_os = "android") {
-                blockers.push(format!("{:?} 仅 Linux/Android", plan.kind));
-            } else {
-                if !has_tool("nft") && !has_tool("iptables") {
-                    blockers.push(
-                        "缺少 nft 或 iptables —— OpenWrt 请安装 kmod-nft-tproxy 或 iptables-mod-tproxy"
-                            .into(),
-                    );
-                }
+                blockers.push("Tproxy 仅 Linux/Android".into());
+            } else if !has_tool("iptables") {
+                blockers.push(
+                    "TPROXY 需要 iptables mangle/TPROXY（OpenWrt 请安装 iptables-mod-tproxy）"
+                        .into(),
+                );
+            } else if plan.ipv6_enabled && !has_tool("ip6tables") {
+                blockers.push("IPv6 TPROXY 已启用但缺少 ip6tables".into());
+            }
+            #[cfg(target_os = "android")]
+            if !nix::unistd::Uid::effective().is_root() {
+                blockers.push(
+                    "Android 显式 tproxy 必须以 root 启动 native daemon；普通 App 请使用 method=auto/virtual_nic + VpnService"
+                        .into(),
+                );
+            }
+        }
+        EngineKind::Redirect => {
+            if !cfg!(target_os = "linux") && !cfg!(target_os = "android") {
+                blockers.push("Redirect 仅 Linux/Android".into());
+            } else if !has_tool("nft") {
+                blockers.push("Redirect 需要 nftables，以保证规则原子安装和精确回滚".into());
+            }
+            #[cfg(target_os = "android")]
+            if !nix::unistd::Uid::effective().is_root() {
+                blockers.push(
+                    "Android 显式 redirect 必须以 root 启动 native daemon；普通 App 请使用 method=auto/virtual_nic + VpnService"
+                        .into(),
+                );
             }
         }
         EngineKind::Tun => {

--- a/crates/core-capture/src/doctor.rs
+++ b/crates/core-capture/src/doctor.rs
@@ -114,12 +114,9 @@ pub fn diagnose(c: &Capture, mesh: &Mesh) -> Result<DoctorReport, CaptureError> 
             } else if plan.ipv6_enabled && !has_tool("ip6tables") {
                 blockers.push("IPv6 TPROXY 已启用但缺少 ip6tables".into());
             }
-            #[cfg(target_os = "android")]
-            if !nix::unistd::Uid::effective().is_root() {
-                blockers.push(
-                    "Android 显式 tproxy 必须以 root 启动 native daemon；普通 App 请使用 method=auto/virtual_nic + VpnService"
-                        .into(),
-                );
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if let Err(error) = crate::platform::linux_caps::require_net_admin("TPROXY capture") {
+                blockers.push(error);
             }
         }
         EngineKind::Redirect => {
@@ -128,12 +125,9 @@ pub fn diagnose(c: &Capture, mesh: &Mesh) -> Result<DoctorReport, CaptureError> 
             } else if !has_tool("nft") {
                 blockers.push("Redirect 需要 nftables，以保证规则原子安装和精确回滚".into());
             }
-            #[cfg(target_os = "android")]
-            if !nix::unistd::Uid::effective().is_root() {
-                blockers.push(
-                    "Android 显式 redirect 必须以 root 启动 native daemon；普通 App 请使用 method=auto/virtual_nic + VpnService"
-                        .into(),
-                );
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if let Err(error) = crate::platform::linux_caps::require_net_admin("REDIRECT capture") {
+                blockers.push(error);
             }
         }
         EngineKind::Tun => {
@@ -146,7 +140,10 @@ pub fn diagnose(c: &Capture, mesh: &Mesh) -> Result<DoctorReport, CaptureError> 
             #[cfg(target_os = "windows")]
             {
                 if !has_tool("netsh") {
-                    warnings.push("未找到 netsh；可能无法自动写路由表".into());
+                    warnings.push(
+                        "未找到 netsh；路由已使用 IP Helper API，但 DNS 快照/恢复仍可能不可用"
+                            .into(),
+                    );
                 }
             }
             #[cfg(target_os = "macos")]

--- a/crates/core-capture/src/eim_nat.rs
+++ b/crates/core-capture/src/eim_nat.rs
@@ -18,7 +18,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use tokio::net::UdpSocket;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -65,17 +65,20 @@ impl EimNatTable {
     where
         F: FnOnce() -> std::io::Result<Arc<UdpSocket>>,
     {
-        if let Some(mut e) = self.map.get_mut(&key) {
-            e.last_seen = Instant::now();
-            return Ok(e.outbound.clone());
+        match self.map.entry(key) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().last_seen = Instant::now();
+                Ok(entry.get().outbound.clone())
+            }
+            Entry::Vacant(entry) => {
+                let outbound = build()?;
+                entry.insert(EimEntry {
+                    outbound: outbound.clone(),
+                    last_seen: Instant::now(),
+                });
+                Ok(outbound)
+            }
         }
-        let sock = build()?;
-        let entry = EimEntry {
-            outbound: sock.clone(),
-            last_seen: Instant::now(),
-        };
-        self.map.insert(key, entry);
-        Ok(sock)
     }
 
     pub fn touch(&self, key: &EimKey) {

--- a/crates/core-capture/src/engine.rs
+++ b/crates/core-capture/src/engine.rs
@@ -435,13 +435,20 @@ fn default_iface_name() -> String {
 }
 
 fn decide_kind(c: &Capture) -> Result<EngineKind, CaptureError> {
+    decide_kind_for_os(c, std::env::consts::OS)
+}
+
+fn decide_kind_for_os(c: &Capture, os: &str) -> Result<EngineKind, CaptureError> {
     if !c.on {
         return Ok(EngineKind::None);
     }
-    let os = std::env::consts::OS;
     let kind = match c.method {
         CaptureMethod::Auto => match os {
-            "linux" | "android" => EngineKind::Tproxy,
+            "linux" => EngineKind::Tproxy,
+            // Android applications normally do not run with CAP_NET_ADMIN.
+            // VpnService is the platform-native, non-root interception path;
+            // explicit tproxy/redirect remain available to root-run daemons.
+            "android" => EngineKind::Tun,
             "windows" | "macos" | "ios" => EngineKind::Tun,
             other => return Err(CaptureError::Unsupported(other.into())),
         },
@@ -556,6 +563,25 @@ mod tests {
                 ..TunInboundOptions::default()
             },
         }
+    }
+
+    #[test]
+    fn auto_uses_vpn_tun_on_android_and_native_backends_elsewhere() {
+        let mut capture = base();
+        capture.method = CaptureMethod::Auto;
+
+        assert_eq!(
+            decide_kind_for_os(&capture, "android").unwrap(),
+            EngineKind::Tun
+        );
+        assert_eq!(
+            decide_kind_for_os(&capture, "linux").unwrap(),
+            EngineKind::Tproxy
+        );
+        assert_eq!(
+            decide_kind_for_os(&capture, "windows").unwrap(),
+            EngineKind::Tun
+        );
     }
 
     #[test]

--- a/crates/core-capture/src/engine.rs
+++ b/crates/core-capture/src/engine.rs
@@ -450,6 +450,7 @@ pub struct CaptureCapabilities {
     pub dns_hijack: bool,
     pub transparent_tcp: bool,
     pub transparent_udp: bool,
+    pub endpoint_independent_nat: bool,
     pub native_route_api: bool,
     pub crash_recovery: bool,
     pub network_rebind: bool,
@@ -482,6 +483,7 @@ impl CaptureCapabilities {
             dns_hijack: plan.kind != EngineKind::None && plan.hijack_dns,
             transparent_tcp: transparent,
             transparent_udp: plan.kind == EngineKind::Tproxy,
+            endpoint_independent_nat: plan.kind == EngineKind::Tun && plan.endpoint_independent_nat,
             native_route_api: cfg!(any(
                 target_os = "linux",
                 target_os = "android",
@@ -671,7 +673,7 @@ mod tests {
         c.tun.auto_redirect_nfqueue = Some(100);
         c.tun.auto_redirect_iproute2_fallback_rule_index = Some(32768);
         c.tun.strict_route = true;
-        c.tun.endpoint_independent_nat = false;
+        c.tun.endpoint_independent_nat = true;
         c.tun.udp_timeout = Duration::from_secs(300);
         c.tun.route_address = vec!["0.0.0.0/1".into(), "128.0.0.0/1".into()];
         c.tun.route_exclude_address = vec!["192.168.0.0/16".into(), "fc00::/7".into()];
@@ -707,6 +709,8 @@ mod tests {
         assert_eq!(plan.auto_redirect_marks.reset, Some(0x2025));
         assert_eq!(plan.auto_redirect_marks.nfqueue, Some(100));
         assert!(plan.strict_route);
+        assert!(plan.endpoint_independent_nat);
+        assert!(CaptureCapabilities::for_plan(&plan).endpoint_independent_nat);
         assert_eq!(plan.udp_timeout, Duration::from_secs(300));
         assert_eq!(plan.route_addresses.len(), 2);
         assert_eq!(plan.route_exclude_addresses.len(), 2);

--- a/crates/core-capture/src/engine.rs
+++ b/crates/core-capture/src/engine.rs
@@ -438,6 +438,66 @@ fn decide_kind(c: &Capture) -> Result<EngineKind, CaptureError> {
     decide_kind_for_os(c, std::env::consts::OS)
 }
 
+/// Machine-readable platform/data-plane contract exposed by every engine.
+///
+/// Callers should use this instead of inferring support from an engine name.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct CaptureCapabilities {
+    pub ipv4: bool,
+    pub ipv6: bool,
+    pub tcp: bool,
+    pub udp: bool,
+    pub dns_hijack: bool,
+    pub transparent_tcp: bool,
+    pub transparent_udp: bool,
+    pub native_route_api: bool,
+    pub crash_recovery: bool,
+    pub network_rebind: bool,
+    pub outbound_loop_guard: bool,
+    pub interface_filter: bool,
+    pub uid_filter: bool,
+    pub application_filter: bool,
+    pub limitations: Vec<&'static str>,
+}
+
+impl CaptureCapabilities {
+    pub fn for_plan(plan: &CapturePlan) -> Self {
+        let linux_family = cfg!(any(target_os = "linux", target_os = "android"));
+        let transparent = matches!(plan.kind, EngineKind::Tproxy | EngineKind::Redirect);
+        let mut limitations = Vec::new();
+        if plan.kind == EngineKind::Redirect {
+            limitations.push("redirect_is_tcp_only");
+        }
+        if cfg!(target_os = "windows") && transparent {
+            limitations.push("windows_requires_tun");
+        }
+        if !cfg!(target_os = "android") && !plan.filters.include_package.is_empty() {
+            limitations.push("package_filter_requires_android");
+        }
+        Self {
+            ipv4: plan.kind != EngineKind::None,
+            ipv6: plan.kind != EngineKind::None && plan.ipv6_enabled,
+            tcp: plan.kind != EngineKind::None,
+            udp: !matches!(plan.kind, EngineKind::None | EngineKind::Redirect),
+            dns_hijack: plan.kind != EngineKind::None && plan.hijack_dns,
+            transparent_tcp: transparent,
+            transparent_udp: plan.kind == EngineKind::Tproxy,
+            native_route_api: cfg!(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "windows"
+            )),
+            crash_recovery: linux_family,
+            network_rebind: plan.kind != EngineKind::None,
+            outbound_loop_guard: plan.kind != EngineKind::None,
+            interface_filter: linux_family,
+            uid_filter: linux_family,
+            application_filter: cfg!(target_os = "android"),
+            limitations,
+        }
+    }
+}
+
 fn decide_kind_for_os(c: &Capture, os: &str) -> Result<EngineKind, CaptureError> {
     if !c.on {
         return Ok(EngineKind::None);
@@ -530,6 +590,7 @@ pub trait CaptureEngine: Send + Sync {
             "traffic": format!("{:?}", self.plan().traffic).to_lowercase(),
             "mtu": self.plan().mtu,
             "interface": self.plan().interface_name,
+            "capabilities": CaptureCapabilities::for_plan(self.plan()),
         })
     }
 }
@@ -582,6 +643,18 @@ mod tests {
             decide_kind_for_os(&capture, "windows").unwrap(),
             EngineKind::Tun
         );
+    }
+
+    #[test]
+    fn capability_contract_does_not_claim_udp_for_redirect() {
+        let mut plan = CapturePlan::from_config(&base()).unwrap();
+        plan.kind = EngineKind::Redirect;
+        let capabilities = CaptureCapabilities::for_plan(&plan);
+        assert!(capabilities.tcp);
+        assert!(!capabilities.udp);
+        assert!(capabilities.transparent_tcp);
+        assert!(!capabilities.transparent_udp);
+        assert!(capabilities.limitations.contains(&"redirect_is_tcp_only"));
     }
 
     #[test]

--- a/crates/core-capture/src/gc.rs
+++ b/crates/core-capture/src/gc.rs
@@ -29,6 +29,7 @@ pub fn spawn_system_gc(
     let (stop_tx, mut stop_rx) = oneshot::channel();
     let period = purge_period(udp_timeout);
     let handle = tokio::spawn(async move {
+        let mut network_changes = crate::net_monitor::subscribe();
         let mut ticker = tokio::time::interval(period);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         // 跳过首个立即 tick，避免启动瞬间空转。
@@ -36,6 +37,19 @@ pub fn spawn_system_gc(
         loop {
             tokio::select! {
                 _ = &mut stop_rx => break,
+                event = network_changes.recv() => {
+                    if matches!(event, Err(tokio::sync::broadcast::error::RecvError::Closed)) {
+                        break;
+                    }
+                    let udp_removed = udp_sessions.clear();
+                    if udp_removed > 0 {
+                        debug!(
+                            target: "capture::system",
+                            udp_removed,
+                            "network changed; invalidated bound UDP associations"
+                        );
+                    }
+                }
                 _ = ticker.tick() => {
                     let tcp_removed = tcp_nat.purge_expired();
                     let udp_removed = udp_sessions.purge();
@@ -64,12 +78,26 @@ pub fn spawn_tun_gc(
     let (stop_tx, mut stop_rx) = oneshot::channel();
     let period = purge_period(udp_timeout);
     let handle = tokio::spawn(async move {
+        let mut network_changes = crate::net_monitor::subscribe();
         let mut ticker = tokio::time::interval(period);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         ticker.tick().await;
         loop {
             tokio::select! {
                 _ = &mut stop_rx => break,
+                event = network_changes.recv() => {
+                    if matches!(event, Err(tokio::sync::broadcast::error::RecvError::Closed)) {
+                        break;
+                    }
+                    let removed = udp_sessions.clear();
+                    if removed > 0 {
+                        debug!(
+                            target: "capture::tun",
+                            udp_removed = removed,
+                            "network changed; invalidated bound UDP associations"
+                        );
+                    }
+                }
                 _ = ticker.tick() => {
                     let removed = udp_sessions.purge();
                     if removed > 0 {

--- a/crates/core-capture/src/lib.rs
+++ b/crates/core-capture/src/lib.rs
@@ -31,6 +31,8 @@ pub mod fakeip_dns;
 pub mod frame_cache;
 pub mod gc;
 pub mod ipset;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) mod linux_netlink;
 pub mod nat;
 pub mod net_monitor;
 pub mod net_monitor_event;
@@ -67,8 +69,8 @@ pub use dial_meta::{DialTarget, DnsMode, build_dial_target};
 pub use doctor::{DoctorReport, diagnose};
 pub use eim_nat::{EimEntry, EimKey, EimNatTable};
 pub use engine::{
-    AutoRedirectMarks, CaptureEngine, CaptureError, CaptureEvent, CaptureFilters, CapturePlan,
-    EngineKind,
+    AutoRedirectMarks, CaptureCapabilities, CaptureEngine, CaptureError, CaptureEvent,
+    CaptureFilters, CapturePlan, EngineKind,
 };
 pub use ipset::{
     IpSetPrefixSemantics, IpSetPrefixSet, IpSetPrefixSnapshot, IpSetPrefixStatus, IpSetProvider,

--- a/crates/core-capture/src/lib.rs
+++ b/crates/core-capture/src/lib.rs
@@ -95,5 +95,5 @@ pub use tun_dispatch::{TunDispatcher, TunDispatcherHandles};
 pub use tun_inbound::{TunDropReason, TunInbound, TunOutboundMeta, TunPacket, TunSession};
 pub use tun_io::{TunIo, TunIoError, open_tun_device};
 pub use udp_forwarder::{UdpForwarderConfig, run_return_loop, send_one as udp_send_one};
-pub use udp_session::{UdpFlowKey, UdpSession, UdpSessionTable};
+pub use udp_session::{UdpFlowKey, UdpNatKey, UdpSession, UdpSessionTable};
 pub use wireguard_tun::WireGuardTunIo;

--- a/crates/core-capture/src/linux_netlink.rs
+++ b/crates/core-capture/src/linux_netlink.rs
@@ -1,0 +1,223 @@
+//! Native Linux/Android route and policy-rule control.
+//!
+//! Host network mutations are intentionally performed through rtnetlink
+//! instead of parsing or spawning `ip`.  The public surface is synchronous
+//! because RouteTable is also used from rollback/drop paths; each transaction
+//! owns a short-lived netlink connection on a dedicated thread so it remains
+//! safe when called from inside an arbitrary Tokio runtime.
+
+use std::{future::Future, net::IpAddr, thread};
+
+use futures::TryStreamExt;
+use netlink_packet_route::{
+    route::{RouteMessage, RouteScope, RouteType},
+    rule::RuleAction,
+};
+use rtnetlink::{Handle, RouteMessageBuilder};
+
+use crate::route_table::ManagedRoute;
+
+fn transact<F, Fut>(operation: F) -> Result<(), String>
+where
+    F: FnOnce(Handle) -> Fut + Send + 'static,
+    Fut: Future<Output = Result<(), String>> + 'static,
+{
+    thread::Builder::new()
+        .name("capture-netlink".into())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .build()
+                .map_err(|error| format!("create netlink runtime: {error}"))?;
+            runtime.block_on(async move {
+                let (connection, handle, _) =
+                    rtnetlink::new_connection().map_err(|error| error.to_string())?;
+                tokio::spawn(connection);
+                operation(handle).await
+            })
+        })
+        .map_err(|error| format!("spawn netlink transaction: {error}"))?
+        .join()
+        .map_err(|_| "netlink transaction thread panicked".to_owned())?
+}
+
+async fn interface_index(handle: &Handle, name: &str) -> Result<u32, String> {
+    handle
+        .link()
+        .get()
+        .match_name(name.to_owned())
+        .execute()
+        .try_next()
+        .await
+        .map_err(|error| error.to_string())?
+        .map(|link| link.header.index)
+        .ok_or_else(|| format!("network interface `{name}` does not exist"))
+}
+
+async fn route_message(handle: &Handle, route: &ManagedRoute) -> Result<RouteMessage, String> {
+    let index = interface_index(handle, &route.interface).await?;
+    let table = route.table.unwrap_or(254);
+    let message = match (route.dest, route.gateway) {
+        (ipnet::IpNet::V4(dest), gateway) => {
+            let mut builder = RouteMessageBuilder::<std::net::Ipv4Addr>::new()
+                .destination_prefix(dest.network(), dest.prefix_len())
+                .output_interface(index)
+                .priority(route.metric)
+                .table_id(table);
+            if let Some(IpAddr::V4(gateway)) = gateway {
+                builder = builder.gateway(gateway);
+            } else if gateway.is_some() {
+                return Err("IPv6 gateway cannot be used by an IPv4 route".into());
+            }
+            builder.build()
+        }
+        (ipnet::IpNet::V6(dest), gateway) => {
+            let mut builder = RouteMessageBuilder::<std::net::Ipv6Addr>::new()
+                .destination_prefix(dest.network(), dest.prefix_len())
+                .output_interface(index)
+                .priority(route.metric)
+                .table_id(table);
+            if let Some(IpAddr::V6(gateway)) = gateway {
+                builder = builder.gateway(gateway);
+            } else if gateway.is_some() {
+                return Err("IPv4 gateway cannot be used by an IPv6 route".into());
+            }
+            builder.build()
+        }
+    };
+    Ok(message)
+}
+
+pub(crate) fn add_route(route: &ManagedRoute) -> Result<(), String> {
+    let route = route.clone();
+    transact(move |handle| async move {
+        let message = route_message(&handle, &route).await?;
+        handle
+            .route()
+            .add(message)
+            .execute()
+            .await
+            .map_err(|error| error.to_string())
+    })
+}
+
+pub(crate) fn delete_route(route: &ManagedRoute) -> Result<(), String> {
+    let route = route.clone();
+    transact(move |handle| async move {
+        let message = route_message(&handle, &route).await?;
+        handle
+            .route()
+            .del(message)
+            .execute()
+            .await
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn tproxy_route(index: u32, ipv6: bool, table: u32) -> RouteMessage {
+    if ipv6 {
+        RouteMessageBuilder::<std::net::Ipv6Addr>::new()
+            .output_interface(index)
+            .table_id(table)
+            .scope(RouteScope::Host)
+            .kind(RouteType::Local)
+            .build()
+    } else {
+        RouteMessageBuilder::<std::net::Ipv4Addr>::new()
+            .output_interface(index)
+            .table_id(table)
+            .scope(RouteScope::Host)
+            .kind(RouteType::Local)
+            .build()
+    }
+}
+
+pub(crate) fn install_tproxy_policy(
+    ipv6_enabled: bool,
+    mark: u32,
+    table: u32,
+) -> Result<(), String> {
+    transact(move |handle| async move {
+        let lo = interface_index(&handle, "lo").await?;
+        for ipv6 in [false, true]
+            .into_iter()
+            .take(if ipv6_enabled { 2 } else { 1 })
+        {
+            if ipv6 {
+                handle
+                    .rule()
+                    .add()
+                    .v6()
+                    .fw_mark(mark)
+                    .table_id(table)
+                    .action(RuleAction::ToTable)
+                    .execute()
+                    .await
+                    .map_err(|error| error.to_string())?;
+            } else {
+                handle
+                    .rule()
+                    .add()
+                    .v4()
+                    .fw_mark(mark)
+                    .table_id(table)
+                    .action(RuleAction::ToTable)
+                    .execute()
+                    .await
+                    .map_err(|error| error.to_string())?;
+            }
+            if let Err(error) = handle
+                .route()
+                .add(tproxy_route(lo, ipv6, table))
+                .execute()
+                .await
+            {
+                return Err(error.to_string());
+            }
+        }
+        Ok(())
+    })
+}
+
+pub(crate) fn remove_tproxy_policy(ipv6_enabled: bool, mark: u32, table: u32) {
+    let _ = transact(move |handle| async move {
+        let lo = interface_index(&handle, "lo").await?;
+        for ipv6 in [false, true]
+            .into_iter()
+            .take(if ipv6_enabled { 2 } else { 1 })
+        {
+            if ipv6 {
+                let mut request = handle
+                    .rule()
+                    .add()
+                    .v6()
+                    .fw_mark(mark)
+                    .table_id(table)
+                    .action(RuleAction::ToTable);
+                let message = request.message_mut().clone();
+                let _ = handle.rule().del(message).execute().await;
+                let _ = handle
+                    .route()
+                    .del(tproxy_route(lo, true, table))
+                    .execute()
+                    .await;
+            } else {
+                let mut request = handle
+                    .rule()
+                    .add()
+                    .v4()
+                    .fw_mark(mark)
+                    .table_id(table)
+                    .action(RuleAction::ToTable);
+                let message = request.message_mut().clone();
+                let _ = handle.rule().del(message).execute().await;
+                let _ = handle
+                    .route()
+                    .del(tproxy_route(lo, false, table))
+                    .execute()
+                    .await;
+            }
+        }
+        Ok(())
+    });
+}

--- a/crates/core-capture/src/netstack_dispatch.rs
+++ b/crates/core-capture/src/netstack_dispatch.rs
@@ -293,6 +293,7 @@ impl NetstackDispatcher {
             inbound: self.inbound.clone(),
             dns_service: self.dns_service.clone(),
             frame_formats: self.frame_formats.clone(),
+            endpoint_independent_nat: self.plan.endpoint_independent_nat,
         };
         crate::udp_handle::handle_udp_packet(&ctx, device, handler, inner_src, outer_dst, payload)
             .await;

--- a/crates/core-capture/src/platform/android.rs
+++ b/crates/core-capture/src/platform/android.rs
@@ -6,6 +6,8 @@
 //!   transactional policy/firewall rule ledger.
 //! - explicit `Redirect`: TCP `SO_ORIGINAL_DST` listeners plus an atomic nft
 //!   ruleset.
+//! Transparent modes require effective `CAP_NET_ADMIN`; the process does not
+//! need UID 0 when the capability is delegated explicitly.
 //!
 //! The legacy tier implementation remains available only as a cross-platform
 //! capability-reporting stub; [`build_engine`] never selects it on Android.
@@ -39,8 +41,8 @@ pub fn build_engine(plan: CapturePlan) -> Result<Arc<dyn CaptureEngine>, Capture
     match plan.kind {
         // Android shares the packet/socket implementation with Linux:
         // - TUN opens root /dev/net/tun first, then the injected VpnService fd.
-        // - Explicit TPROXY/REDIRECT is intended for a daemon launched as root;
-        //   it must own real listeners as well as firewall rules.
+        // - Explicit TPROXY/REDIRECT is intended for a daemon with
+        //   CAP_NET_ADMIN; it must own real listeners as well as firewall rules.
         #[cfg(target_os = "android")]
         EngineKind::Tun | EngineKind::Tproxy | EngineKind::Redirect => {
             crate::platform::linux::build_engine(plan)

--- a/crates/core-capture/src/platform/android.rs
+++ b/crates/core-capture/src/platform/android.rs
@@ -1,17 +1,14 @@
-//! Android 后端：root 模式完整透明代理能力。
+//! Android capture platform selection.
 //!
-//! 行为：
-//! 1. [`detect_capability`] 通过 `su -c` 执行多个探测命令收集 [`AndroidCapability`]；
-//! 2. [`AndroidCapability::select_tier`] 选最高可用 root Tier；
-//! 3. [`AndroidCapture::start`] 调用对应 Tier 的 install_rules：
-//!    - **NftablesFull**：`nft add table inet wuthercore` + 双栈 TPROXY chain
-//!    - **IptablesV4V6Tproxy**：`iptables` + `ip6tables` 双栈 TPROXY
-//!    - **IptablesV4V6Redirect**：`iptables -t nat REDIRECT` + `ip6tables -t nat REDIRECT`
-//!    - **IptablesV4Only**：仅 v4 NAT REDIRECT
-//! 4. [`AndroidCapture::stop`] 严格按 Tier 卸载规则，恢复路由表。
+//! Production Android uses the shared Linux data plane:
+//! - `Tun`: root `/dev/net/tun`, with an injected `VpnService` fd fallback.
+//! - explicit `Tproxy`: dual-stack TCP+UDP transparent listeners plus the
+//!   transactional policy/firewall rule ledger.
+//! - explicit `Redirect`: TCP `SO_ORIGINAL_DST` listeners plus an atomic nft
+//!   ruleset.
 //!
-//! 跨平台编译：本文件在所有平台都参与构建，但 `su -c` 命令调用使用 `cfg(target_os = "android")` 守护；
-//! 其它平台下 `detect_capability()` 返回空能力，`install_rules` 仅写日志。
+//! The legacy tier implementation remains available only as a cross-platform
+//! capability-reporting stub; [`build_engine`] never selects it on Android.
 
 use std::sync::Arc;
 
@@ -40,13 +37,19 @@ pub fn list_interfaces() -> Vec<String> {
 
 pub fn build_engine(plan: CapturePlan) -> Result<Arc<dyn CaptureEngine>, CaptureError> {
     match plan.kind {
-        // Tun → 走 Linux engine 拿真实 TunIo（root /dev/net/tun 优先；VpnService fd fallback）。
+        // Android shares the packet/socket implementation with Linux:
+        // - TUN opens root /dev/net/tun first, then the injected VpnService fd.
+        // - Explicit TPROXY/REDIRECT is intended for a daemon launched as root;
+        //   it must own real listeners as well as firewall rules.
         #[cfg(target_os = "android")]
-        EngineKind::Tun => crate::platform::linux::build_engine(plan),
-        // 非 Android 主机调试编译时，Tun 走 stub AndroidCapture（不会真正生效）。
+        EngineKind::Tun | EngineKind::Tproxy | EngineKind::Redirect => {
+            crate::platform::linux::build_engine(plan)
+        }
+        // 非 Android 主机调试编译时走 stub（不会真正生效）。
         #[cfg(not(target_os = "android"))]
-        EngineKind::Tun => Ok(Arc::new(AndroidCapture::new(plan))),
-        EngineKind::Tproxy | EngineKind::Redirect => Ok(Arc::new(AndroidCapture::new(plan))),
+        EngineKind::Tun | EngineKind::Tproxy | EngineKind::Redirect => {
+            Ok(Arc::new(AndroidCapture::new(plan)))
+        }
         EngineKind::None => Err(CaptureError::Unsupported("kind=None".into())),
     }
 }

--- a/crates/core-capture/src/platform/android_jni.rs
+++ b/crates/core-capture/src/platform/android_jni.rs
@@ -206,6 +206,9 @@ pub extern "system" fn Java_org_wuthercore_VpnBridge_nativeStop(
     _class: *mut core::ffi::c_void,
 ) {
     STARTED.store(false, Ordering::SeqCst);
+    // If establish() succeeded but native startup did not consume the fd,
+    // stopping/restarting the service must not leak the detached descriptor.
+    crate::platform::android_tun_io::clear_vpn_fd();
 }
 
 /// `void notifyNetworkChanged(String interfaceName)` —— 物理网卡/连接变更通知。

--- a/crates/core-capture/src/platform/android_tun_io.rs
+++ b/crates/core-capture/src/platform/android_tun_io.rs
@@ -8,7 +8,7 @@
 //! 3. 都不可用：返回 `Unsupported`。
 
 #[cfg(target_os = "android")]
-use std::os::fd::RawFd;
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::sync::Arc;
 
 #[cfg(target_os = "android")]
@@ -22,7 +22,7 @@ use crate::{
 };
 
 #[cfg(target_os = "android")]
-static INJECTED_FD: Mutex<Option<RawFd>> = Mutex::new(None);
+static INJECTED_FD: Mutex<Option<OwnedFd>> = Mutex::new(None);
 
 /// 由 JNI 调用：注入 VpnService 创建的 fd（dup 后所有权交本进程）。
 /// 多次调用以最后一次为准；尚未消费的旧 fd 会立即关闭，避免 VPN 重建泄漏。
@@ -31,33 +31,23 @@ pub fn set_vpn_fd(fd: RawFd) {
     if fd < 0 {
         return;
     }
-    let old = INJECTED_FD.lock().replace(fd);
-    if let Some(old) = old
-        && old != fd
+    let mut pending = INJECTED_FD.lock();
+    if pending
+        .as_ref()
+        .is_some_and(|current| current.as_raw_fd() == fd)
     {
-        // SAFETY: set_vpn_fd's API contract transfers ownership to this
-        // module. The fd is still pending and has not been wrapped elsewhere.
-        unsafe {
-            libc::close(old);
-        }
+        return;
     }
-}
-
-/// 取出 VpnService fd（take 语义，只能取一次）。
-#[cfg(target_os = "android")]
-pub fn take_injected_fd() -> Option<RawFd> {
-    INJECTED_FD.lock().take()
+    // SAFETY: the JNI contract transfers ownership of detachFd() to native.
+    // OwnedFd closes the replaced descriptor automatically.
+    *pending = Some(unsafe { OwnedFd::from_raw_fd(fd) });
 }
 
 /// 丢弃尚未被 native TUN 消费的 VpnService fd。
 #[cfg(target_os = "android")]
 pub fn clear_vpn_fd() {
-    if let Some(fd) = INJECTED_FD.lock().take() {
-        // SAFETY: pending injected descriptors are exclusively owned here.
-        unsafe {
-            libc::close(fd);
-        }
-    }
+    // Dropping OwnedFd closes a descriptor that startup has not consumed.
+    drop(INJECTED_FD.lock().take());
 }
 
 #[cfg(target_os = "android")]
@@ -90,11 +80,12 @@ pub fn open(plan: &CapturePlan) -> Result<Arc<dyn TunIo>, TunIoError> {
 
     // 2. 非 root / root TUN 不可用时，才使用 VpnService fd。
     if let Some(fd) = INJECTED_FD.lock().take() {
+        let raw_fd = fd.as_raw_fd();
         info!(
             target: "capture::android",
             iface = %plan.interface_name,
             mtu = plan.mtu,
-            fd,
+            fd = raw_fd,
             "opening TUN from VpnService fd"
         );
         if !core_outbound::has_socket_protector() {
@@ -104,7 +95,7 @@ pub fn open(plan: &CapturePlan) -> Result<Arc<dyn TunIo>, TunIoError> {
             );
         }
         let dev = crate::platform::vpnservice_tun_io::VpnServiceTunIo::from_raw_fd(
-            fd,
+            fd.into_raw_fd(),
             plan.interface_name.clone(),
             plan.mtu,
         )?;

--- a/crates/core-capture/src/platform/android_tun_io.rs
+++ b/crates/core-capture/src/platform/android_tun_io.rs
@@ -25,16 +25,39 @@ use crate::{
 static INJECTED_FD: Mutex<Option<RawFd>> = Mutex::new(None);
 
 /// 由 JNI 调用：注入 VpnService 创建的 fd（dup 后所有权交本进程）。
-/// 多次调用以最后一次为准。
+/// 多次调用以最后一次为准；尚未消费的旧 fd 会立即关闭，避免 VPN 重建泄漏。
 #[cfg(target_os = "android")]
 pub fn set_vpn_fd(fd: RawFd) {
-    *INJECTED_FD.lock() = Some(fd);
+    if fd < 0 {
+        return;
+    }
+    let old = INJECTED_FD.lock().replace(fd);
+    if let Some(old) = old
+        && old != fd
+    {
+        // SAFETY: set_vpn_fd's API contract transfers ownership to this
+        // module. The fd is still pending and has not been wrapped elsewhere.
+        unsafe {
+            libc::close(old);
+        }
+    }
 }
 
 /// 取出 VpnService fd（take 语义，只能取一次）。
 #[cfg(target_os = "android")]
 pub fn take_injected_fd() -> Option<RawFd> {
     INJECTED_FD.lock().take()
+}
+
+/// 丢弃尚未被 native TUN 消费的 VpnService fd。
+#[cfg(target_os = "android")]
+pub fn clear_vpn_fd() {
+    if let Some(fd) = INJECTED_FD.lock().take() {
+        // SAFETY: pending injected descriptors are exclusively owned here.
+        unsafe {
+            libc::close(fd);
+        }
+    }
 }
 
 #[cfg(target_os = "android")]

--- a/crates/core-capture/src/platform/linux.rs
+++ b/crates/core-capture/src/platform/linux.rs
@@ -2685,14 +2685,22 @@ impl CaptureEngine for LinuxTproxy {
 
 pub struct LinuxRedirect {
     plan: CapturePlan,
-    state: Mutex<bool>,
+    state: Mutex<RedirectState>,
+}
+
+#[derive(Default)]
+struct RedirectState {
+    on: bool,
+    backend: Option<AutoRedirectBackend>,
+    listener_tasks: Option<JoinSet<()>>,
+    listener_stops: Vec<oneshot::Sender<()>>,
 }
 
 impl LinuxRedirect {
     pub fn new(plan: CapturePlan) -> Self {
         Self {
             plan,
-            state: Mutex::new(false),
+            state: Mutex::new(RedirectState::default()),
         }
     }
 }
@@ -2707,37 +2715,79 @@ impl CaptureEngine for LinuxRedirect {
     }
     async fn start(
         self: Arc<Self>,
-        _events: mpsc::Sender<CaptureEvent>,
-        _runtime: Arc<core_runtime::Runtime>,
+        events: mpsc::Sender<CaptureEvent>,
+        runtime: Arc<core_runtime::Runtime>,
     ) -> Result<(), CaptureError> {
         let mut g = self.state.lock().await;
-        if *g {
+        if g.on {
             return Ok(());
         }
-        let st = std::process::Command::new("iptables")
-            .args(["-t", "nat", "-N", "WUTHERCORE_REDIR"])
-            .status()
-            .map_err(|e| CaptureError::Doctor(format!("iptables: {e}")))?;
-        if !st.success() {
-            warn!(target: "capture", "iptables -N 失败（可能已存在）");
+        if g.backend.is_some() || g.listener_tasks.is_some() {
+            return Err(CaptureError::Nat(
+                "redirect has a partial activation ledger; stop must clean it before retry".into(),
+            ));
         }
-        *g = true;
-        info!(target: "capture", "linux redirect (TCP-only) started");
+
+        // Bind before publishing firewall rules. This proves both enabled
+        // address families are serviceable and gives nftables exact ports.
+        let listeners = bind_tcp_redirect_listener_set(self.plan.ipv6_enabled)?;
+        let ports =
+            redirect_ports_from_addrs(listeners.iter().map(RedirectTcpListener::local_addr))?;
+
+        // A checked, atomic nft batch is the publication boundary. If this
+        // fails, dropping the pre-bound listeners leaves no host mutation.
+        let backend = linux_auto_redirect::install(&self.plan, ports)?;
+
+        let mut listener_tasks = JoinSet::new();
+        let mut listener_stops = Vec::with_capacity(listeners.len());
+        let mut bound_addrs = Vec::with_capacity(listeners.len());
+        for listener in listeners {
+            let (listener, local_addr) = listener.into_parts();
+            bound_addrs.push(local_addr);
+            let (stop_tx, stop_rx) = oneshot::channel();
+            listener_stops.push(stop_tx);
+            let events = events.clone();
+            let runtime = runtime.clone();
+            listener_tasks.spawn(async move {
+                if let Err(error) = run_tcp_redirect(listener, events, runtime, stop_rx).await {
+                    warn!(
+                        target: "capture::redirect",
+                        %local_addr,
+                        %error,
+                        "TCP REDIRECT listener stopped with error"
+                    );
+                }
+            });
+        }
+
+        g.backend = Some(backend);
+        g.listener_tasks = Some(listener_tasks);
+        g.listener_stops = listener_stops;
+        g.on = true;
+        info!(
+            target: "capture::redirect",
+            addresses = ?bound_addrs,
+            ?backend,
+            "linux/android TCP REDIRECT started"
+        );
         Ok(())
     }
     async fn stop(self: Arc<Self>) -> Result<(), CaptureError> {
         let mut g = self.state.lock().await;
-        if !*g {
+        if !g.on && g.backend.is_none() && g.listener_tasks.is_none() {
             return Ok(());
         }
-        let _ = std::process::Command::new("iptables")
-            .args(["-t", "nat", "-F", "WUTHERCORE_REDIR"])
-            .status();
-        let _ = std::process::Command::new("iptables")
-            .args(["-t", "nat", "-X", "WUTHERCORE_REDIR"])
-            .status();
-        *g = false;
-        info!(target: "capture", "linux redirect stopped");
+        if let Some(backend) = g.backend {
+            // Keep the ledger intact on failure so a supervisor retry can
+            // finish cleanup instead of forgetting live host rules.
+            linux_auto_redirect::uninstall(backend)?;
+            g.backend = None;
+        }
+        let mut listener_tasks = g.listener_tasks.take().unwrap_or_else(JoinSet::new);
+        let mut listener_stops = std::mem::take(&mut g.listener_stops);
+        g.on = false;
+        stop_listener_tasks(&mut listener_stops, &mut listener_tasks).await;
+        info!(target: "capture::redirect", "linux/android TCP REDIRECT stopped");
         Ok(())
     }
 }

--- a/crates/core-capture/src/platform/linux.rs
+++ b/crates/core-capture/src/platform/linux.rs
@@ -2579,6 +2579,8 @@ impl CaptureEngine for LinuxTproxy {
         if g.on {
             return Ok(());
         }
+        crate::platform::linux_caps::require_net_admin("TPROXY capture")
+            .map_err(CaptureError::Doctor)?;
         let outbound_mark = self
             .plan
             .auto_redirect_marks
@@ -2722,6 +2724,8 @@ impl CaptureEngine for LinuxRedirect {
         if g.on {
             return Ok(());
         }
+        crate::platform::linux_caps::require_net_admin("REDIRECT capture")
+            .map_err(CaptureError::Doctor)?;
         if g.backend.is_some() || g.listener_tasks.is_some() {
             return Err(CaptureError::Nat(
                 "redirect has a partial activation ledger; stop must clean it before retry".into(),

--- a/crates/core-capture/src/platform/linux.rs
+++ b/crates/core-capture/src/platform/linux.rs
@@ -654,6 +654,7 @@ impl CaptureEngine for LinuxTun {
             // route, rule, firewall, or interface mutation.
             g.crash_recovery = Some(crate::platform::linux_recovery::LinuxCaptureGuard::acquire(
                 &effective_plan,
+                crate::platform::linux_recovery::RecoveryMode::Tun,
             )?);
             Self::configure_iface(&effective_plan, device.as_ref())?;
 
@@ -2478,14 +2479,27 @@ impl LinuxTproxy {
                 "IPv6 TPROXY 需要 ip6tables mangle/TPROXY 支持；当前找不到 ip6tables".into(),
             ));
         }
-        if !ip_rule_supported() {
-            return Err(CaptureError::Doctor(
-                "TPROXY 需要 ip rule 支持，用于 fwmark local route".into(),
-            ));
-        }
+        crate::linux_netlink::install_tproxy_policy(
+            plan.ipv6_enabled,
+            tproxy_rules::TPROXY_FWMARK,
+            tproxy_rules::TPROXY_ROUTE_TABLE,
+        )
+        .map_err(|reason| {
+            CaptureError::Doctor(format!(
+                "TPROXY native netlink policy-route setup failed: {reason}"
+            ))
+        })?;
 
-        for cmd in tproxy_rules::setup_commands(plan, outbound_mark) {
+        for cmd in tproxy_rules::setup_commands(plan, outbound_mark)
+            .into_iter()
+            .filter(|cmd| cmd.program != "ip")
+        {
             run_tproxy_command(&cmd).map_err(|reason| {
+                crate::linux_netlink::remove_tproxy_policy(
+                    plan.ipv6_enabled,
+                    tproxy_rules::TPROXY_FWMARK,
+                    tproxy_rules::TPROXY_ROUTE_TABLE,
+                );
                 CaptureError::Doctor(format!(
                     "TPROXY rule command failed: `{}`: {reason}",
                     cmd.render()
@@ -2503,7 +2517,10 @@ impl LinuxTproxy {
     }
 
     fn revert_rules(plan: &CapturePlan) {
-        for cmd in tproxy_rules::cleanup_commands(plan) {
+        for cmd in tproxy_rules::cleanup_commands(plan)
+            .into_iter()
+            .filter(|cmd| cmd.program != "ip")
+        {
             if let Err(reason) = run_tproxy_command(&cmd) {
                 debug!(
                     target: "capture::tproxy::rules",
@@ -2513,6 +2530,11 @@ impl LinuxTproxy {
                 );
             }
         }
+        crate::linux_netlink::remove_tproxy_policy(
+            plan.ipv6_enabled,
+            tproxy_rules::TPROXY_FWMARK,
+            tproxy_rules::TPROXY_ROUTE_TABLE,
+        );
     }
 }
 

--- a/crates/core-capture/src/platform/linux_auto_redirect.rs
+++ b/crates/core-capture/src/platform/linux_auto_redirect.rs
@@ -349,9 +349,12 @@ fn validate_plan(plan: &CapturePlan, ports: RedirectPorts) -> Result<(), Capture
     if ports.ipv4 == 0 || ports.ipv6 == Some(0) {
         return Err(nat_error("REDIRECT 监听端口必须是已绑定的非零端口"));
     }
-    if ports.ipv6.is_some() && (!plan.ipv6_enabled || plan.tun_v6_cidr.is_none()) {
+    if ports.ipv6.is_some()
+        && (!plan.ipv6_enabled
+            || (plan.kind == crate::engine::EngineKind::Tun && plan.tun_v6_cidr.is_none()))
+    {
         return Err(nat_error(
-            "提供了 IPv6 REDIRECT 端口，但当前 TUN 计划没有启用 IPv6",
+            "提供了 IPv6 REDIRECT 端口，但当前 capture 计划没有可用的 IPv6 数据面",
         ));
     }
     if !plan.route_address_set.is_empty() || !plan.route_exclude_address_set.is_empty() {
@@ -2054,6 +2057,15 @@ mod tests {
         v4_only.ipv6_enabled = false;
         v4_only.tun_v6_cidr = None;
         assert!(build_nft_script(&v4_only, RedirectPorts::new(12_345, Some(23_456))).is_err());
+    }
+
+    #[test]
+    fn explicit_redirect_ipv6_does_not_require_a_tun_prefix() {
+        let mut plan = base_plan(CaptureTraffic::System);
+        plan.kind = crate::engine::EngineKind::Redirect;
+        plan.tun_v6_cidr = None;
+
+        assert!(build_nft_script(&plan, dual_ports()).is_ok());
     }
 
     #[test]

--- a/crates/core-capture/src/platform/linux_caps.rs
+++ b/crates/core-capture/src/platform/linux_caps.rs
@@ -1,0 +1,38 @@
+//! Linux capability checks shared by Linux and Android transparent capture.
+//!
+//! Checking the effective capability set is more accurate than checking UID 0:
+//! a service may receive `CAP_NET_ADMIN` through systemd, a container runtime,
+//! or file capabilities, while a namespaced root process may not have it.
+
+use caps::{CapSet, Capability};
+
+pub(crate) fn has_effective(capability: Capability) -> Result<bool, String> {
+    caps::has_cap(None, CapSet::Effective, capability)
+        .map_err(|error| format!("read effective Linux capabilities: {error}"))
+}
+
+pub(crate) fn require_net_admin(operation: &str) -> Result<(), String> {
+    match has_effective(Capability::CAP_NET_ADMIN)? {
+        true => Ok(()),
+        false => Err(missing_net_admin_message(operation)),
+    }
+}
+
+fn missing_net_admin_message(operation: &str) -> String {
+    format!(
+        "{operation} requires effective CAP_NET_ADMIN; grant it with systemd AmbientCapabilities/CapabilityBoundingSet, a container NET_ADMIN capability, or run an appropriately privileged daemon"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_capability_message_names_the_operation_and_capability() {
+        let operation = "transparent capture";
+        let error = missing_net_admin_message(operation);
+        assert!(error.contains(operation));
+        assert!(error.contains("CAP_NET_ADMIN"));
+    }
+}

--- a/crates/core-capture/src/platform/linux_recovery.rs
+++ b/crates/core-capture/src/platform/linux_recovery.rs
@@ -30,8 +30,16 @@ const IPTABLES_CHAINS: [(&str, &str, &str); 5] = [
     ("mangle", "PREROUTING", "WUTHERCORE_PREROUTING"),
     ("mangle", "OUTPUT", "WUTHERCORE_OUTPUT"),
 ];
-const TPROXY_TABLE: &str = "0x2d0";
-const TPROXY_MARK: &str = "0x2d0";
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecoveryMode {
+    #[default]
+    /// Version-1 journals did not record the engine kind and owned the union.
+    Legacy,
+    Tun,
+    Tproxy,
+    Redirect,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct RecoveryRecord {
@@ -44,10 +52,12 @@ struct RecoveryRecord {
     auto_redirect: bool,
     strict_route: bool,
     bypass_tables: Vec<String>,
+    #[serde(default)]
+    mode: RecoveryMode,
 }
 
 impl RecoveryRecord {
-    fn from_plan(plan: &CapturePlan) -> Self {
+    fn from_plan(plan: &CapturePlan, mode: RecoveryMode) -> Self {
         Self {
             version: JOURNAL_VERSION,
             pid: std::process::id(),
@@ -62,6 +72,7 @@ impl RecoveryRecord {
             } else {
                 Vec::new()
             },
+            mode,
         }
     }
 
@@ -93,7 +104,7 @@ pub(crate) struct LinuxCaptureGuard {
 }
 
 impl LinuxCaptureGuard {
-    pub(crate) fn acquire(plan: &CapturePlan) -> Result<Self, CaptureError> {
+    pub(crate) fn acquire(plan: &CapturePlan, mode: RecoveryMode) -> Result<Self, CaptureError> {
         let path = journal_path()?;
         let mut file = OpenOptions::new()
             .create(true)
@@ -121,7 +132,7 @@ impl LinuxCaptureGuard {
             );
         }
 
-        let record = RecoveryRecord::from_plan(plan);
+        let record = RecoveryRecord::from_plan(plan, mode);
         write_record(&mut file, &record, &path)?;
         Ok(Self {
             file,
@@ -257,13 +268,16 @@ fn recover(record: &RecoveryRecord) -> Result<(), CaptureError> {
         flush_table(record.table);
     }
 
-    // Standalone TPROXY has fixed ownership selectors, independent of tun
-    // table configuration.
-    for family in ["inet", "inet6"] {
-        delete_exact_ip_rule(family, TPROXY_MARK, TPROXY_TABLE);
-        flush_named_table(family, TPROXY_TABLE);
+    if matches!(record.mode, RecoveryMode::Legacy | RecoveryMode::Tproxy) {
+        crate::linux_netlink::remove_tproxy_policy(
+            true,
+            crate::tproxy_rules::TPROXY_FWMARK,
+            crate::tproxy_rules::TPROXY_ROUTE_TABLE,
+        );
     }
-    delete_tun(&record.interface_name);
+    if matches!(record.mode, RecoveryMode::Legacy | RecoveryMode::Tun) {
+        delete_tun(&record.interface_name);
+    }
     Ok(())
 }
 
@@ -335,24 +349,6 @@ fn flush_table(table: u32) {
     for family in ["-4", "-6"] {
         let _ = command_output("ip", &[family, "route", "flush", "table", &table]);
     }
-}
-
-fn delete_exact_ip_rule(family: &str, mark: &str, table: &str) {
-    loop {
-        let Ok(output) = command_output(
-            "ip",
-            &["-f", family, "rule", "del", "fwmark", mark, "lookup", table],
-        ) else {
-            break;
-        };
-        if !output.status.success() {
-            break;
-        }
-    }
-}
-
-fn flush_named_table(family: &str, table: &str) {
-    let _ = command_output("ip", &["-f", family, "route", "flush", "table", table]);
 }
 
 fn delete_nft_table(table: &str) {
@@ -445,6 +441,7 @@ mod tests {
             auto_redirect: false,
             strict_route: true,
             bypass_tables: vec!["main".into()],
+            mode: RecoveryMode::Tun,
         };
         assert_eq!(record.priorities(), [8997, 8998, 8999, 9000, 9001]);
     }
@@ -461,11 +458,23 @@ mod tests {
             auto_redirect: true,
             strict_route: false,
             bypass_tables: vec!["main".into(), "97".into()],
+            mode: RecoveryMode::Tproxy,
         };
         let bytes = serde_json::to_vec(&record).unwrap();
         assert_eq!(
             serde_json::from_slice::<RecoveryRecord>(&bytes).unwrap(),
             record
         );
+    }
+
+    #[test]
+    fn version_one_journal_without_mode_uses_legacy_union_cleanup() {
+        let json = r#"{
+            "version":1,"pid":42,"interface_name":"wuther0",
+            "table":2022,"rule_priority":9000,"auto_route":false,
+            "auto_redirect":false,"strict_route":false,"bypass_tables":[]
+        }"#;
+        let record: RecoveryRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(record.mode, RecoveryMode::Legacy);
     }
 }

--- a/crates/core-capture/src/platform/mod.rs
+++ b/crates/core-capture/src/platform/mod.rs
@@ -95,7 +95,8 @@ pub fn build_engine(plan: CapturePlan) -> Result<Arc<dyn CaptureEngine>, Capture
     }
     #[cfg(target_os = "android")]
     {
-        // Tun → Linux engine（带真实 TunIo）；Tproxy/Redirect → AndroidCapture（4-tier nft）
+        // Android shares the complete TUN/TPROXY/REDIRECT data plane with
+        // Linux; the TUN opener additionally supports an injected VpnService fd.
         return android::build_engine(plan);
     }
     #[cfg(not(any(

--- a/crates/core-capture/src/platform/mod.rs
+++ b/crates/core-capture/src/platform/mod.rs
@@ -13,6 +13,8 @@ use crate::engine::{CaptureEngine, CaptureError, CapturePlan};
 // Linux 与 Android 共享 /dev/net/tun + nftables 路径。
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) mod linux_caps;
 // Linux TUN auto_redirect 的规则生成器在测试构建中也参与编译，便于在
 // 非 Linux 主机验证命令账本；真实安装入口仅由 Linux/Android 后端调用。
 #[cfg(any(test, target_os = "linux", target_os = "android"))]

--- a/crates/core-capture/src/platform/windows.rs
+++ b/crates/core-capture/src/platform/windows.rs
@@ -8,7 +8,11 @@ use std::{collections::HashSet, net::IpAddr, process::Command, sync::Arc};
 
 use async_trait::async_trait;
 use serde::Deserialize;
-use tokio::sync::{Mutex, mpsc};
+use tokio::{
+    sync::{Mutex, mpsc, oneshot},
+    task::JoinHandle,
+    time::{Duration, sleep},
+};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -56,6 +60,8 @@ struct TunState {
     device: Option<Arc<dyn TunIo>>,
     /// Original per-interface DNS source and ordered server list.
     saved_dns: Vec<DnsInterfaceState>,
+    network_watch_stop: Option<oneshot::Sender<()>>,
+    network_watch_task: Option<JoinHandle<()>>,
 }
 
 impl WindowsTun {
@@ -64,6 +70,53 @@ impl WindowsTun {
             plan,
             state: Mutex::new(TunState::default()),
             routes: RouteTable::new(),
+        }
+    }
+
+    async fn reconcile_after_network_change(&self) {
+        if let Err(error) = self.routes.reconcile_all() {
+            warn!(target: "capture::windows", %error, "failed to reconcile TUN routes");
+        }
+        if !self.plan.hijack_dns {
+            return;
+        }
+
+        let snapshot = match snapshot_system_dns() {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                warn!(target: "capture::windows", %error, "failed to snapshot DNS after network change");
+                return;
+            }
+        };
+        let mut g = self.state.lock().await;
+        if !g.started {
+            return;
+        }
+        let known = g
+            .saved_dns
+            .iter()
+            .map(|state| (state.interface_index, state.address_family))
+            .collect::<HashSet<_>>();
+        let added = snapshot
+            .into_iter()
+            .filter(|state| {
+                !known.contains(&(state.interface_index, state.address_family))
+                    && state.interface_alias != self.plan.interface_name
+            })
+            .collect::<Vec<_>>();
+        let mut targets = g.saved_dns.clone();
+        targets.extend(added.iter().cloned());
+        if let Err(error) = apply_dns_to_all_interfaces(&targets) {
+            warn!(target: "capture::windows", %error, "failed to re-assert DNS hijack after network change");
+            return;
+        }
+        if !added.is_empty() {
+            info!(
+                target: "capture::windows",
+                count = added.len(),
+                "DNS hijack extended to newly available interfaces"
+            );
+            g.saved_dns.extend(added);
         }
     }
 }
@@ -190,6 +243,26 @@ impl CaptureEngine for WindowsTun {
         g.device = Some(device);
         g.saved_dns = saved_dns;
         g.started = true;
+        let (watch_stop_tx, mut watch_stop_rx) = oneshot::channel();
+        let mut changes = crate::net_monitor::subscribe();
+        let watcher = self.clone();
+        g.network_watch_stop = Some(watch_stop_tx);
+        g.network_watch_task = Some(tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut watch_stop_rx => break,
+                    event = changes.recv() => {
+                        if event.is_err() {
+                            break;
+                        }
+                        // Coalesce DHCP/VPN bursts before reading route/DNS state.
+                        sleep(Duration::from_millis(250)).await;
+                        while changes.try_recv().is_ok() {}
+                        watcher.reconcile_after_network_change().await;
+                    }
+                }
+            }
+        }));
         info!(
             target: "capture",
             iface = %self.plan.interface_name,
@@ -198,6 +271,15 @@ impl CaptureEngine for WindowsTun {
         Ok(())
     }
     async fn stop(self: Arc<Self>) -> Result<(), CaptureError> {
+        let mut g = self.state.lock().await;
+        if let Some(stop) = g.network_watch_stop.take() {
+            let _ = stop.send(());
+        }
+        let watch_task = g.network_watch_task.take();
+        drop(g);
+        if let Some(task) = watch_task {
+            let _ = task.await;
+        }
         let mut g = self.state.lock().await;
         let mut cleanup_errors = Vec::new();
         if let Err(error) = self.routes.revert_all_checked() {

--- a/crates/core-capture/src/platform/windows.rs
+++ b/crates/core-capture/src/platform/windows.rs
@@ -1,8 +1,8 @@
 //! Windows 后端：Wintun + 系统路由表。
 //!
-//! Startup is transactional: a real tun-rs device must exist, every netsh
-//! mutation must succeed, and partial DNS/route state is rolled back before an
-//! error reaches the supervisor.
+//! Startup is transactional: a real tun-rs device must exist, native IP Helper
+//! route mutations and DNS changes are recorded, and partial state is rolled
+//! back before an error reaches the supervisor.
 
 use std::{collections::HashSet, net::IpAddr, process::Command, sync::Arc};
 

--- a/crates/core-capture/src/platform/windows.rs
+++ b/crates/core-capture/src/platform/windows.rs
@@ -149,7 +149,7 @@ impl CaptureEngine for WindowsTun {
                         dest,
                         gateway: None,
                         interface: self.plan.interface_name.clone(),
-                        metric: 0,
+                        metric: 1,
                         table: None,
                     })
                     .map_err(CaptureError::Route)?;
@@ -612,8 +612,10 @@ mod tests {
         assert_eq!(
             crate::resource_claims::windows_tun_route_nets(&route_plan(true, true)),
             [
-                "0.0.0.0/0".parse::<ipnet::IpNet>().unwrap(),
-                "::/0".parse::<ipnet::IpNet>().unwrap(),
+                "0.0.0.0/1".parse::<ipnet::IpNet>().unwrap(),
+                "128.0.0.0/1".parse::<ipnet::IpNet>().unwrap(),
+                "::/1".parse::<ipnet::IpNet>().unwrap(),
+                "8000::/1".parse::<ipnet::IpNet>().unwrap(),
             ]
         );
 
@@ -621,7 +623,10 @@ mod tests {
         ipv4_only.ipv6_enabled = false;
         assert_eq!(
             crate::resource_claims::windows_tun_route_nets(&ipv4_only),
-            ["0.0.0.0/0".parse::<ipnet::IpNet>().unwrap()]
+            [
+                "0.0.0.0/1".parse::<ipnet::IpNet>().unwrap(),
+                "128.0.0.0/1".parse::<ipnet::IpNet>().unwrap(),
+            ]
         );
 
         let mut explicit = route_plan(true, true);

--- a/crates/core-capture/src/resource_claims.rs
+++ b/crates/core-capture/src/resource_claims.rs
@@ -424,10 +424,10 @@ pub(crate) fn windows_tun_route_nets(plan: &CapturePlan) -> Vec<ipnet::IpNet> {
         if plan.ipv6_enabled && plan.tun_v6_cidr.is_some() {
             defaults.extend([
                 SPLIT_DEFAULT_ROUTE_V6_LOW
-                    .parse()
+                    .parse::<ipnet::IpNet>()
                     .expect("constant IPv6 split-default route"),
                 SPLIT_DEFAULT_ROUTE_V6_HIGH
-                    .parse()
+                    .parse::<ipnet::IpNet>()
                     .expect("constant IPv6 split-default route"),
             ]);
         }

--- a/crates/core-capture/src/resource_claims.rs
+++ b/crates/core-capture/src/resource_claims.rs
@@ -16,6 +16,10 @@ use crate::engine::{CaptureFilters, CapturePlan, EngineKind};
 
 pub(crate) const DEFAULT_ROUTE_V4: &str = "0.0.0.0/0";
 pub(crate) const DEFAULT_ROUTE_V6: &str = "::/0";
+pub(crate) const SPLIT_DEFAULT_ROUTE_V4_LOW: &str = "0.0.0.0/1";
+pub(crate) const SPLIT_DEFAULT_ROUTE_V4_HIGH: &str = "128.0.0.0/1";
+pub(crate) const SPLIT_DEFAULT_ROUTE_V6_LOW: &str = "::/1";
+pub(crate) const SPLIT_DEFAULT_ROUTE_V6_HIGH: &str = "8000::/1";
 pub(crate) const LINUX_TUN_SPLIT_DEFAULT_V4: [&str; 2] = ["0.0.0.0/1", "128.0.0.0/1"];
 pub(crate) const LINUX_TUN_SPLIT_DEFAULT_V6: [&str; 2] = ["::/1", "8000::/1"];
 
@@ -32,9 +36,9 @@ pub(crate) const LINUX_TUN_SPLIT_DEFAULT_V6: [&str; 2] = ["::/1", "8000::/1"];
 /// All claims are exclusive, sorted, and deduplicated. Android declarations
 /// never execute capability probes: TUN declares the conservative union of the
 /// root Linux path and the framework-preconfigured VpnService fallback, while
-/// transparent capture declares the fail-closed union of every runtime tier.
-/// Linux auto-redirect is likewise a fail-closed union because its
-/// nftables/TPROXY/NAT fallback is selected only while installing rules.
+/// explicit root transparent modes declare the same resources as their shared
+/// Linux implementations. Linux auto-redirect is likewise fail-closed because
+/// its backend is selected only while installing rules.
 pub fn host_resource_claims(plan: &CapturePlan) -> Vec<ResourceClaim> {
     // Keep this guard ahead of even compile-time platform selection. More
     // importantly, Android capability detection is intentionally absent from
@@ -111,8 +115,12 @@ fn claims_for_platform(plan: &CapturePlan, platform: HostPlatform) -> Vec<Resour
             claim(&mut claims, SystemResource::FirewallManager);
             true
         }
-        (HostPlatform::Android, EngineKind::Tproxy | EngineKind::Redirect) => {
-            android_transparent_claims(&mut claims);
+        (HostPlatform::Android, EngineKind::Tproxy) => {
+            linux_tproxy_claims(plan, &mut claims);
+            true
+        }
+        (HostPlatform::Android, EngineKind::Redirect) => {
+            claim(&mut claims, SystemResource::FirewallManager);
             true
         }
         (HostPlatform::Windows, EngineKind::Tun) => {
@@ -156,15 +164,13 @@ fn windows_tun_claims(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) 
     }
     for prefix in routes {
         route_prefix_net(claims, None, prefix);
-        if prefix.prefix_len() == 0 {
-            claim(
-                claims,
-                if prefix.addr().is_ipv4() {
-                    SystemResource::DefaultRouteV4
-                } else {
-                    SystemResource::DefaultRouteV6
-                },
-            );
+    }
+    if plan.auto_route && (plan.route_addresses.is_empty() || !plan.route_address_set.is_empty()) {
+        // Split /1 routes still own the effective catch-all namespace even
+        // though neither concrete kernel object is a /0.
+        claim(claims, SystemResource::DefaultRouteV4);
+        if plan.ipv6_enabled && plan.tun_v6_cidr.is_some() {
+            claim(claims, SystemResource::DefaultRouteV6);
         }
     }
 }
@@ -311,27 +317,6 @@ fn linux_tproxy_claims(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>)
     }
 }
 
-fn android_transparent_claims(claims: &mut BTreeSet<ResourceClaim>) {
-    // Runtime capability selection happens only after mesh preflight and may
-    // load nf_tproxy modules. A read-only snapshot cannot prove that currently
-    // absent modules are not loadable, so reserve the union of all tiers:
-    // REDIRECT owns only the firewall, while either TPROXY tier additionally
-    // owns both policy-route families, table 100, and mark 1.
-    claim(claims, SystemResource::FirewallManager);
-    android_tproxy_route_claims(claims);
-    claim(claims, SystemResource::DefaultRouteV4);
-    claim(claims, SystemResource::DefaultRouteV6);
-}
-
-fn android_tproxy_route_claims(claims: &mut BTreeSet<ResourceClaim>) {
-    let table = crate::platform::android::TRANSPARENT_ROUTE_TABLE;
-    claim(claims, SystemResource::RouteManager);
-    claim(claims, SystemResource::RouteTable { table });
-    route_prefix(claims, Some(table), DEFAULT_ROUTE_V4);
-    route_prefix(claims, Some(table), DEFAULT_ROUTE_V6);
-    fwmark(claims, crate::platform::android::TRANSPARENT_FWMARK);
-}
-
 fn interface_and_addresses(plan: &CapturePlan, claims: &mut BTreeSet<ResourceClaim>) {
     claim(
         claims,
@@ -425,17 +410,26 @@ pub(crate) fn windows_tun_route_nets(plan: &CapturePlan) -> Vec<ipnet::IpNet> {
     }
 
     let mut routes = if plan.route_addresses.is_empty() || !plan.route_address_set.is_empty() {
+        // Split defaults are more robust on Windows than replacing 0/0:
+        // they win by prefix length while preserving the physical default
+        // route used by protected/bound outbound sockets.
         let mut defaults = vec![
-            DEFAULT_ROUTE_V4
+            SPLIT_DEFAULT_ROUTE_V4_LOW
                 .parse()
-                .expect("constant IPv4 default route"),
+                .expect("constant IPv4 split-default route"),
+            SPLIT_DEFAULT_ROUTE_V4_HIGH
+                .parse()
+                .expect("constant IPv4 split-default route"),
         ];
         if plan.ipv6_enabled && plan.tun_v6_cidr.is_some() {
-            defaults.push(
-                DEFAULT_ROUTE_V6
+            defaults.extend([
+                SPLIT_DEFAULT_ROUTE_V6_LOW
                     .parse()
-                    .expect("constant IPv6 default route"),
-            );
+                    .expect("constant IPv6 split-default route"),
+                SPLIT_DEFAULT_ROUTE_V6_HIGH
+                    .parse()
+                    .expect("constant IPv6 split-default route"),
+            ]);
         }
         defaults
     } else {
@@ -745,57 +739,23 @@ mod tests {
     }
 
     #[test]
-    fn android_transparent_preflight_is_pure_fail_closed_union() {
-        for kind in [EngineKind::Tproxy, EngineKind::Redirect] {
-            // HostPlatform::Android carries no detected capability. This pure
-            // boundary therefore cannot run su/modprobe, and the result still
-            // covers a TPROXY tier that runtime activation may unlock later.
-            let mut plan = plan(kind);
-            plan.iproute2_table_index = 9999;
-            let resources = resources(&plan, HostPlatform::Android);
-            let table = crate::platform::android::TRANSPARENT_ROUTE_TABLE;
-
-            assert!(resources.contains(&SystemResource::FirewallManager));
-            assert!(resources.contains(&SystemResource::RouteTable { table }));
-            assert!(!resources.contains(&SystemResource::RouteTable { table: 9999 }));
-            assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V4));
-            assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V6));
-            assert!(resources.contains(&SystemResource::DefaultRouteV4));
-            assert!(resources.contains(&SystemResource::DefaultRouteV6));
-            assert!(
-                resources.contains(&SystemResource::FwmarkRange {
-                    range: FwmarkRange::new(
-                        crate::platform::android::TRANSPARENT_FWMARK,
-                        crate::platform::android::TRANSPARENT_FWMARK,
-                    )
-                    .unwrap()
-                })
-            );
-        }
+    fn android_root_tproxy_claims_match_shared_linux_engine() {
+        let plan = plan(EngineKind::Tproxy);
+        assert_eq!(
+            resources(&plan, HostPlatform::Android),
+            resources(&plan, HostPlatform::Linux)
+        );
     }
 
     #[test]
-    fn android_transparent_uses_shared_runtime_table_and_mark_constants() {
-        let mut plan = plan(EngineKind::Redirect);
-        plan.iproute2_table_index = 9999;
+    fn android_root_redirect_claims_only_its_atomic_firewall_table() {
+        let plan = plan(EngineKind::Redirect);
         let resources = resources(&plan, HostPlatform::Android);
-        let table = crate::platform::android::TRANSPARENT_ROUTE_TABLE;
 
-        assert!(resources.contains(&SystemResource::RouteTable { table }));
-        assert!(!resources.contains(&SystemResource::RouteTable { table: 9999 }));
-        assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V4));
-        assert!(contains_prefix(&resources, Some(table), DEFAULT_ROUTE_V6));
-        assert!(resources.contains(&SystemResource::DefaultRouteV4));
-        assert!(resources.contains(&SystemResource::DefaultRouteV6));
-        assert!(
-            resources.contains(&SystemResource::FwmarkRange {
-                range: FwmarkRange::new(
-                    crate::platform::android::TRANSPARENT_FWMARK,
-                    crate::platform::android::TRANSPARENT_FWMARK,
-                )
-                .unwrap()
-            })
-        );
+        assert!(resources.contains(&SystemResource::FirewallManager));
+        assert!(!resources.contains(&SystemResource::RouteManager));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV4));
+        assert!(!resources.contains(&SystemResource::DefaultRouteV6));
     }
 
     #[test]
@@ -816,20 +776,46 @@ mod tests {
     }
 
     #[test]
-    fn windows_tun_claims_the_shared_default_route_set_with_ipv6_gates() {
+    fn windows_tun_claims_split_defaults_with_ipv6_gates() {
         let mut dual_stack = plan(EngineKind::Tun);
         dual_stack.auto_route = true;
         dual_stack.ipv6_enabled = true;
         let dual_resources = resources(&dual_stack, HostPlatform::Windows);
-        assert!(contains_prefix(&dual_resources, None, DEFAULT_ROUTE_V4));
-        assert!(contains_prefix(&dual_resources, None, DEFAULT_ROUTE_V6));
+        assert!(contains_prefix(
+            &dual_resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V4_LOW
+        ));
+        assert!(contains_prefix(
+            &dual_resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V4_HIGH
+        ));
+        assert!(contains_prefix(
+            &dual_resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V6_LOW
+        ));
+        assert!(contains_prefix(
+            &dual_resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V6_HIGH
+        ));
         assert!(dual_resources.contains(&SystemResource::DefaultRouteV4));
         assert!(dual_resources.contains(&SystemResource::DefaultRouteV6));
 
         dual_stack.ipv6_enabled = false;
         let ipv4_resources = resources(&dual_stack, HostPlatform::Windows);
-        assert!(contains_prefix(&ipv4_resources, None, DEFAULT_ROUTE_V4));
-        assert!(!contains_prefix(&ipv4_resources, None, DEFAULT_ROUTE_V6));
+        assert!(contains_prefix(
+            &ipv4_resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V4_LOW
+        ));
+        assert!(!contains_prefix(
+            &ipv4_resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V6_LOW
+        ));
         assert!(!ipv4_resources.contains(&SystemResource::DefaultRouteV6));
 
         dual_stack.ipv6_enabled = true;
@@ -838,7 +824,7 @@ mod tests {
         assert!(!contains_prefix(
             &no_tun_v6_resources,
             None,
-            DEFAULT_ROUTE_V6
+            SPLIT_DEFAULT_ROUTE_V6_LOW
         ));
         assert!(!no_tun_v6_resources.contains(&SystemResource::DefaultRouteV6));
     }
@@ -871,8 +857,26 @@ mod tests {
         plan.route_address_set = vec!["geoip-cn".into()];
         let resources = resources(&plan, HostPlatform::Windows);
 
-        assert!(contains_prefix(&resources, None, DEFAULT_ROUTE_V4));
-        assert!(contains_prefix(&resources, None, DEFAULT_ROUTE_V6));
+        assert!(contains_prefix(
+            &resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V4_LOW
+        ));
+        assert!(contains_prefix(
+            &resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V4_HIGH
+        ));
+        assert!(contains_prefix(
+            &resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V6_LOW
+        ));
+        assert!(contains_prefix(
+            &resources,
+            None,
+            SPLIT_DEFAULT_ROUTE_V6_HIGH
+        ));
         assert!(!contains_prefix(&resources, None, "203.0.113.0/24"));
         assert!(resources.contains(&SystemResource::DefaultRouteV4));
         assert!(resources.contains(&SystemResource::DefaultRouteV6));

--- a/crates/core-capture/src/route_table.rs
+++ b/crates/core-capture/src/route_table.rs
@@ -9,12 +9,15 @@
 //! |---------|-------------------------------------------------------|-----------------------------------------|
 //! | Linux   | `ip route add <dest> dev <iface> [via <gw>] metric N` | `ip route del <dest> ...`               |
 //! | macOS   | `route -n add -net <dest> -interface <iface>`         | `route -n delete -net <dest>`           |
-//! | Windows | `route ADD <dest> MASK <mask> <gw> METRIC N IF <idx>` | `route DELETE <dest>`                   |
+//! | Windows | IP Helper `CreateIpForwardEntry2`                    | `DeleteIpForwardEntry2`                 |
 //!
 //! 添加失败会返回给调用方，且不会写入回滚账本；调用方可自行决定是否降级。
 //! 撤销已成功添加的路由时尽力回滚（best-effort）。
 
-use std::{net::IpAddr, process::Command, sync::Arc};
+use std::{net::IpAddr, sync::Arc};
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+use std::process::Command;
 
 use ipnet::IpNet;
 use parking_lot::Mutex;
@@ -257,82 +260,44 @@ fn platform_del(r: &ManagedRoute) -> Result<(), String> {
 
 #[cfg(target_os = "windows")]
 fn platform_add(r: &ManagedRoute) -> Result<(), String> {
-    // Windows 的 route 命令接受 IPv4 dotted mask；IPv6 用 netsh。
-    if r.dest.addr().is_ipv6() {
-        if r.gateway.is_some_and(|gateway| gateway.is_ipv4()) {
-            return Err("IPv6 route cannot use an IPv4 next hop".into());
-        }
-        let args = windows_ipv6_route_args(r, true);
-        let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-        run_cmd("netsh", &refs)
-    } else {
-        let interface_index = if_index_from_name(&r.interface)?;
-        let args = windows_ipv4_route_args(r, interface_index, true);
-        let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-        run_cmd("route", &refs)
-    }
+    let route = windows_native_route(r)?;
+    let mut manager = route_manager::RouteManager::new()
+        .map_err(|error| format!("open Windows IP Helper route manager: {error}"))?;
+    manager
+        .add(&route)
+        .map_err(|error| format!("CreateIpForwardEntry2 for {}: {error}", r.dest))
 }
 
 #[cfg(target_os = "windows")]
 fn platform_del(r: &ManagedRoute) -> Result<(), String> {
-    if r.dest.addr().is_ipv6() {
-        if r.gateway.is_some_and(|gateway| gateway.is_ipv4()) {
-            return Err("IPv6 route cannot use an IPv4 next hop".into());
-        }
-        let args = windows_ipv6_route_args(r, false);
-        let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-        run_cmd("netsh", &refs)
-    } else {
-        let interface_index = if_index_from_name(&r.interface)?;
-        let args = windows_ipv4_route_args(r, interface_index, false);
-        let refs = args.iter().map(String::as_str).collect::<Vec<_>>();
-        run_cmd("route", &refs)
-    }
+    let route = windows_native_route(r)?;
+    let mut manager = route_manager::RouteManager::new()
+        .map_err(|error| format!("open Windows IP Helper route manager: {error}"))?;
+    manager
+        .delete(&route)
+        .map_err(|error| format!("DeleteIpForwardEntry2 for {}: {error}", r.dest))
 }
 
 #[cfg(target_os = "windows")]
-fn windows_ipv4_route_args(route: &ManagedRoute, interface_index: u32, add: bool) -> Vec<String> {
-    let mut args = vec![
-        if add { "ADD" } else { "DELETE" }.into(),
-        route.dest.network().to_string(),
-        "MASK".into(),
-        ipv4_mask(route.dest.prefix_len()),
-        route
-            .gateway
-            .map(|gateway| gateway.to_string())
-            .unwrap_or_else(|| "0.0.0.0".into()),
-    ];
-    if add {
-        args.extend(["METRIC".into(), route.metric.to_string()]);
+fn windows_native_route(r: &ManagedRoute) -> Result<route_manager::Route, String> {
+    if r.table.is_some() {
+        return Err("Windows routes do not support Linux policy table IDs".into());
     }
-    args.extend(["IF".into(), interface_index.to_string()]);
-    args
-}
-
-#[cfg(target_os = "windows")]
-fn windows_ipv6_route_args(route: &ManagedRoute, add: bool) -> Vec<String> {
-    let mut args = vec![
-        "interface".into(),
-        "ipv6".into(),
-        if add { "add" } else { "delete" }.into(),
-        "route".into(),
-        format!("prefix={}", route.dest),
-        format!("interface={}", route.interface),
-        format!(
-            "nexthop={}",
-            route
-                .gateway
-                .map(|gateway| gateway.to_string())
-                .unwrap_or_else(|| "::".into())
-        ),
-    ];
-    if add {
-        args.push(format!("metric={}", route.metric));
+    if let Some(gateway) = r.gateway
+        && gateway.is_ipv4() != r.dest.addr().is_ipv4()
+    {
+        return Err(format!(
+            "route {} cannot use next hop {gateway} from another address family",
+            r.dest
+        ));
     }
-    // netsh defaults route mutations to PersistentStore. Capture routes must
-    // never survive a crash or reboot.
-    args.push("store=active".into());
-    args
+    let mut route = route_manager::Route::new(r.dest.network(), r.dest.prefix_len())
+        .with_if_name(r.interface.clone())
+        .with_metric(r.metric);
+    if let Some(gateway) = r.gateway {
+        route = route.with_gateway(gateway);
+    }
+    Ok(route)
 }
 
 #[cfg(not(any(
@@ -355,59 +320,7 @@ fn platform_del(_r: &ManagedRoute) -> Result<(), String> {
     Err("unsupported platform".into())
 }
 
-#[cfg(target_os = "windows")]
-fn ipv4_mask(prefix: u8) -> String {
-    let mask: u32 = if prefix == 0 {
-        0
-    } else {
-        (!0u32) << (32 - prefix.min(32))
-    };
-    std::net::Ipv4Addr::from(mask).to_string()
-}
-
-#[cfg(target_os = "windows")]
-fn if_index_from_name(name: &str) -> Result<u32, String> {
-    // `netsh interface show interface` 的输出第 4 列是接口名；用 `netsh
-    // interface ipv4 show interfaces` 拿索引（idx 在第 1 列）。
-    let output = std::process::Command::new("netsh")
-        .args(["interface", "ipv4", "show", "interfaces"])
-        .output()
-        .map_err(|error| format!("spawn netsh while resolving interface {name:?}: {error}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let detail = if stderr.trim().is_empty() {
-            stdout.trim()
-        } else {
-            stderr.trim()
-        };
-        return Err(format!(
-            "netsh interface lookup failed (status={:?}): {detail}",
-            output.status.code()
-        ));
-    }
-    let txt = String::from_utf8_lossy(&output.stdout);
-    for line in txt.lines().skip(3) {
-        // 行格式：Idx     Met         MTU          State                Name
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 5 {
-            continue;
-        }
-        let if_name = parts[4..].join(" ");
-        if if_name.eq_ignore_ascii_case(name) {
-            return parts[0].parse::<u32>().map_err(|error| {
-                format!(
-                    "invalid interface index {:?} for {name:?}: {error}",
-                    parts[0]
-                )
-            });
-        }
-    }
-    Err(format!(
-        "Windows interface {name:?} was not present in netsh interface list"
-    ))
-}
-
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 fn run_cmd(prog: &str, args: &[&str]) -> Result<(), String> {
     debug!(target: "capture::route", cmd = %prog, ?args, "exec");
     // 用 output() 捕获 stderr 不外泄到终端 —— 错误内容只走 tracing。
@@ -444,6 +357,7 @@ fn is_expected_route_delete_absence(error: &str) -> bool {
         "no such process",
         "not in table",
         "element not found",
+        "(os error 1168)",
     ]
     .iter()
     .any(|needle| lower.contains(needle))
@@ -654,67 +568,68 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn windows_ipv4_delete_targets_only_the_managed_interface() {
+    fn windows_native_route_preserves_interface_metric_and_prefix() {
         let route = ManagedRoute {
-            dest: "0.0.0.0/0".parse().unwrap(),
+            dest: "128.0.0.0/1".parse().unwrap(),
             gateway: None,
             interface: "WutherCoreTun".into(),
-            metric: 0,
+            metric: 1,
             table: None,
         };
+        let native = windows_native_route(&route).unwrap();
 
-        assert_eq!(
-            windows_ipv4_route_args(&route, 42, false),
-            [
-                "DELETE", "0.0.0.0", "MASK", "0.0.0.0", "0.0.0.0", "IF", "42",
-            ]
-        );
+        assert_eq!(native.destination(), "128.0.0.0".parse::<IpAddr>().unwrap());
+        assert_eq!(native.prefix(), 1);
+        assert_eq!(native.if_name().map(String::as_str), Some("WutherCoreTun"));
+        assert_eq!(native.metric(), Some(1));
     }
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn windows_ipv6_routes_are_exact_and_active_only() {
+    fn windows_native_route_preserves_ipv6_gateway() {
         let route = ManagedRoute {
-            dest: "::/0".parse().unwrap(),
+            dest: "8000::/1".parse().unwrap(),
             gateway: Some("fe80::1".parse().unwrap()),
             interface: "WutherCoreTun".into(),
             metric: 7,
             table: None,
         };
+        let native = windows_native_route(&route).unwrap();
 
-        assert_eq!(
-            windows_ipv6_route_args(&route, true),
-            [
-                "interface",
-                "ipv6",
-                "add",
-                "route",
-                "prefix=::/0",
-                "interface=WutherCoreTun",
-                "nexthop=fe80::1",
-                "metric=7",
-                "store=active",
-            ]
-        );
-        assert_eq!(
-            windows_ipv6_route_args(&route, false),
-            [
-                "interface",
-                "ipv6",
-                "delete",
-                "route",
-                "prefix=::/0",
-                "interface=WutherCoreTun",
-                "nexthop=fe80::1",
-                "store=active",
-            ]
-        );
+        assert_eq!(native.destination(), "8000::".parse::<IpAddr>().unwrap());
+        assert_eq!(native.prefix(), 1);
+        assert_eq!(native.gateway(), Some("fe80::1".parse().unwrap()));
+        assert_eq!(native.metric(), Some(7));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_native_route_rejects_policy_tables_and_mixed_families() {
+        let mut route = ManagedRoute {
+            dest: "0.0.0.0/1".parse().unwrap(),
+            gateway: None,
+            interface: "WutherCoreTun".into(),
+            metric: 1,
+            table: Some(2022),
+        };
+        assert!(windows_native_route(&route).is_err());
+
+        route.table = None;
+        route.gateway = Some("fe80::1".parse().unwrap());
+        assert!(windows_native_route(&route).is_err());
     }
 
     #[test]
     fn linux_route_delete_no_such_process_is_expected_absence() {
         assert!(is_expected_route_delete_absence(
             "ip failed (status=Some(2)): RTNETLINK answers: No such process",
+        ));
+    }
+
+    #[test]
+    fn windows_ip_helper_element_not_found_is_expected_absence() {
+        assert!(is_expected_route_delete_absence(
+            "DeleteIpForwardEntry2 for 0.0.0.0/1: Element not found. (os error 1168)",
         ));
     }
 

--- a/crates/core-capture/src/route_table.rs
+++ b/crates/core-capture/src/route_table.rs
@@ -16,7 +16,7 @@
 
 use std::{net::IpAddr, sync::Arc};
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+#[cfg(target_os = "macos")]
 use std::process::Command;
 
 use ipnet::IpNet;
@@ -37,6 +37,10 @@ pub struct ManagedRoute {
 pub trait RouteBackend: Send + Sync + std::fmt::Debug {
     fn add(&self, r: &ManagedRoute) -> Result<(), String>;
     fn del(&self, r: &ManagedRoute) -> Result<(), String>;
+    /// Ensure an owned route still exists without adding another ledger item.
+    fn ensure(&self, r: &ManagedRoute) -> Result<(), String> {
+        self.add(r)
+    }
 }
 
 #[derive(Debug)]
@@ -79,6 +83,23 @@ impl RouteTable {
 
     pub fn list(&self) -> Vec<ManagedRoute> {
         self.inner.lock().clone()
+    }
+
+    /// Re-assert routes already present in the ownership ledger.
+    ///
+    /// This is used after Windows network profile/interface changes, where
+    /// the OS may discard routes while the Wintun adapter remains alive.
+    pub fn reconcile_all(&self) -> Result<(), String> {
+        let routes = self.inner.lock().clone();
+        let errors = routes
+            .iter()
+            .filter_map(|route| self.backend.ensure(route).err())
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
     }
 
     /// 退出时回滚所有由本管理器创建的路由（best-effort）。
@@ -152,79 +173,45 @@ impl RouteBackend for SystemBackend {
     fn del(&self, r: &ManagedRoute) -> Result<(), String> {
         platform_del(r)
     }
+    #[cfg(target_os = "windows")]
+    fn ensure(&self, r: &ManagedRoute) -> Result<(), String> {
+        windows_ensure_route(r)
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn platform_add(r: &ManagedRoute) -> Result<(), String> {
-    let dest = r.dest.to_string();
-    let metric = r.metric.to_string();
-    let mut args: Vec<&str> = if r.dest.addr().is_ipv6() {
-        vec![
-            "-6",
-            "route",
-            "add",
-            &dest,
-            "dev",
-            &r.interface,
-            "metric",
-            &metric,
-        ]
-    } else {
-        vec![
-            "route",
-            "add",
-            &dest,
-            "dev",
-            &r.interface,
-            "metric",
-            &metric,
-        ]
-    };
-    let gw_str;
-    if let Some(gw) = r.gateway {
-        gw_str = gw.to_string();
-        args.extend_from_slice(&["via", &gw_str]);
-    }
-    let table_str;
-    if let Some(table) = r.table {
-        table_str = table.to_string();
-        args.extend_from_slice(&["table", &table_str]);
-    }
-    run_cmd("ip", &args)
+    crate::linux_netlink::add_route(r)
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn platform_del(r: &ManagedRoute) -> Result<(), String> {
-    let dest = r.dest.to_string();
-    let metric = r.metric.to_string();
-    let mut args: Vec<&str> = if r.dest.addr().is_ipv6() {
-        vec![
-            "-6",
-            "route",
-            "del",
-            &dest,
-            "dev",
-            &r.interface,
-            "metric",
-            &metric,
-        ]
+    crate::linux_netlink::delete_route(r)
+}
+
+#[cfg(target_os = "windows")]
+fn windows_ensure_route(r: &ManagedRoute) -> Result<(), String> {
+    let route = windows_native_route(r)?;
+    let mut manager = route_manager::RouteManager::new()
+        .map_err(|error| format!("open Windows IP Helper route manager: {error}"))?;
+    let exists = manager
+        .list()
+        .map_err(|error| format!("GetIpForwardTable2: {error}"))?
+        .into_iter()
+        .any(|current| {
+            current.destination() == route.destination()
+                && current.prefix() == route.prefix()
+                && current.if_name() == route.if_name()
+                && windows_gateway_matches(current.gateway(), route.gateway())
+                && current.metric() == route.metric()
+        });
+    if exists {
+        Ok(())
     } else {
-        vec![
-            "route",
-            "del",
-            &dest,
-            "dev",
-            &r.interface,
-            "metric",
-            &metric,
-        ]
-    };
-    let table_str;
-    if let Some(table) = r.table {
-        table_str = table.to_string();
-        args.extend_from_slice(&["table", &table_str]);
+        manager
+            .add(&route)
+            .map_err(|error| format!("recreate IP Helper route {}: {error}", r.dest))
     }
-    run_cmd("ip", &args)
 }
 
 #[cfg(target_os = "macos")]
@@ -266,6 +253,16 @@ fn platform_add(r: &ManagedRoute) -> Result<(), String> {
     manager
         .add(&route)
         .map_err(|error| format!("CreateIpForwardEntry2 for {}: {error}", r.dest))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_gateway_matches(current: Option<IpAddr>, expected: Option<IpAddr>) -> bool {
+    current == expected
+        || (expected.is_none()
+            && current.is_some_and(|gateway| match gateway {
+                IpAddr::V4(address) => address.is_unspecified(),
+                IpAddr::V6(address) => address.is_unspecified(),
+            }))
 }
 
 #[cfg(target_os = "windows")]
@@ -373,6 +370,7 @@ mod tests {
     struct FakeBackend {
         added: AtomicUsize,
         deleted: AtomicUsize,
+        ensured: AtomicUsize,
         fail_add: bool,
     }
 
@@ -387,6 +385,10 @@ mod tests {
         }
         fn del(&self, _r: &ManagedRoute) -> Result<(), String> {
             self.deleted.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+        fn ensure(&self, _r: &ManagedRoute) -> Result<(), String> {
+            self.ensured.fetch_add(1, Ordering::Relaxed);
             Ok(())
         }
     }
@@ -582,6 +584,38 @@ mod tests {
         assert_eq!(native.prefix(), 1);
         assert_eq!(native.if_name().map(String::as_str), Some("WutherCoreTun"));
         assert_eq!(native.metric(), Some(1));
+    }
+
+    #[test]
+    fn reconcile_reasserts_ledger_without_duplicating_it() {
+        let backend = Arc::new(FakeBackend::default());
+        let table = RouteTable::with_backend(backend.clone());
+        table
+            .add(ManagedRoute {
+                dest: "0.0.0.0/1".parse().unwrap(),
+                gateway: None,
+                interface: "wuther0".into(),
+                metric: 1,
+                table: None,
+            })
+            .unwrap();
+        table.reconcile_all().unwrap();
+        assert_eq!(backend.ensured.load(Ordering::Relaxed), 1);
+        assert_eq!(table.len(), 1);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_unspecified_next_hop_matches_on_link_route() {
+        assert!(windows_gateway_matches(
+            Some("0.0.0.0".parse().unwrap()),
+            None
+        ));
+        assert!(windows_gateway_matches(Some("::".parse().unwrap()), None));
+        assert!(!windows_gateway_matches(
+            Some("192.0.2.1".parse().unwrap()),
+            None
+        ));
     }
 
     #[cfg(target_os = "windows")]

--- a/crates/core-capture/src/route_table.rs
+++ b/crates/core-capture/src/route_table.rs
@@ -16,7 +16,7 @@
 
 use std::{net::IpAddr, sync::Arc};
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 use std::process::Command;
 
 use ipnet::IpNet;

--- a/crates/core-capture/src/supervisor.rs
+++ b/crates/core-capture/src/supervisor.rs
@@ -656,8 +656,13 @@ impl CaptureSupervisor {
             OutboundFwmarkLease::install(runtime.capture_outbound_fwmark())?;
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if self.plan.kind != EngineKind::Tun {
+            let mode = match self.plan.kind {
+                EngineKind::Tproxy => crate::platform::linux_recovery::RecoveryMode::Tproxy,
+                EngineKind::Redirect => crate::platform::linux_recovery::RecoveryMode::Redirect,
+                EngineKind::Tun | EngineKind::None => unreachable!(),
+            };
             transaction.resources_mut().crash_recovery = Some(
-                crate::platform::linux_recovery::LinuxCaptureGuard::acquire(&self.plan)?,
+                crate::platform::linux_recovery::LinuxCaptureGuard::acquire(&self.plan, mode)?,
             );
         }
         transaction.mark_engine_started();

--- a/crates/core-capture/src/system_dispatch.rs
+++ b/crates/core-capture/src/system_dispatch.rs
@@ -398,6 +398,7 @@ impl SystemDispatcher {
             inbound: self.inbound.clone(),
             dns_service: self.dns_service.clone(),
             frame_formats: self.frame_formats.clone(),
+            endpoint_independent_nat: self.plan.endpoint_independent_nat,
         };
         crate::udp_handle::handle_udp_packet(&ctx, device, handler, inner_src, outer_dst, payload)
             .await;

--- a/crates/core-capture/src/tun_dispatch.rs
+++ b/crates/core-capture/src/tun_dispatch.rs
@@ -53,8 +53,8 @@ pub struct TunDispatcher {
     /// DNS hijack 的统一处理链。它内部对接 resolver policy/cache/fake-ip。
     pub dns_service: Arc<core_resolver::DnsService>,
     pub inbound: Arc<TunInbound>,
-    /// 5-tuple → outbound socket 复用表 —— 同一 QUIC/STUN session 的所有包
-    /// 走同一个 outbound socket，与 mihomo `endpoint_independent_nat` 行为对齐。
+    /// UDP NAT association table. Symmetric mode uses `(src,dst)`; EIM mode
+    /// uses only the internal source endpoint.
     pub udp_sessions: Arc<crate::udp_session::UdpSessionTable>,
     frame_formats: Arc<TunFrameFormatCache>,
 }
@@ -422,6 +422,7 @@ impl TunDispatcher {
             inbound: self.inbound.clone(),
             dns_service: self.dns_service.clone(),
             frame_formats: self.frame_formats.clone(),
+            endpoint_independent_nat: self.plan.endpoint_independent_nat,
         };
         crate::udp_handle::handle_udp_packet(&ctx, device, handler, inner_src, outer_dst, payload)
             .await;

--- a/crates/core-capture/src/udp_forwarder.rs
+++ b/crates/core-capture/src/udp_forwarder.rs
@@ -123,8 +123,12 @@ pub async fn run_return_loop(
 /// 把 (src, dst, payload) 编成完整 IP+UDP 包字节 —— 公开给 dns_hijack 等同源模块复用。
 pub fn build_udp_ip_packet(src: SocketAddr, dst: SocketAddr, payload: &[u8]) -> Option<Vec<u8>> {
     match (src.ip(), dst.ip()) {
-        (IpAddr::V4(s), IpAddr::V4(d)) => Some(build_v4(s, src.port(), d, dst.port(), payload)),
-        (IpAddr::V6(s), IpAddr::V6(d)) => Some(build_v6(s, src.port(), d, dst.port(), payload)),
+        (IpAddr::V4(s), IpAddr::V4(d)) if payload.len() <= 65_507 => {
+            Some(build_v4(s, src.port(), d, dst.port(), payload))
+        }
+        (IpAddr::V6(s), IpAddr::V6(d)) if payload.len() <= 65_527 => {
+            Some(build_v6(s, src.port(), d, dst.port(), payload))
+        }
         _ => None,
     }
 }
@@ -242,5 +246,25 @@ mod tests {
             }
             _ => panic!("expected udp"),
         }
+    }
+
+    #[test]
+    fn oversized_udp_datagrams_fail_without_length_wraparound() {
+        assert!(
+            build_udp_ip_packet(
+                "192.0.2.1:53".parse().unwrap(),
+                "198.51.100.1:5000".parse().unwrap(),
+                &vec![0u8; 65_508],
+            )
+            .is_none()
+        );
+        assert!(
+            build_udp_ip_packet(
+                "[2001:db8::1]:53".parse().unwrap(),
+                "[2001:db8::2]:5000".parse().unwrap(),
+                &vec![0u8; 65_528],
+            )
+            .is_none()
+        );
     }
 }

--- a/crates/core-capture/src/udp_handle.rs
+++ b/crates/core-capture/src/udp_handle.rs
@@ -4,7 +4,7 @@
 //! ## 流水
 //! 1. NAT 表登记（仅记账，不参与决策）；
 //! 2. **DNS hijack**：53 + `hijack_dns=true` → 用 `fakeip_dns::synthesize` 内联应答；
-//! 3. **5-tuple 命中既有 session** → 复用 outbound socket，仅 send + 续 last_seen；
+//! 3. 按对称 NAT 或 EIM key 命中 association → 复用 outbound socket；
 //! 4. **首包**：fake-IP 反查 / 路由策略 → `ListenerHandler.new_packet` 拨号 →
 //!    注册 session → 发首包 → spawn reverse loop（外网回包改写成 IP UDP 写回 TUN）。
 //!
@@ -26,7 +26,10 @@ use crate::{
     nat::{NatEntry, NatTable},
     tun_inbound::{TunDropReason, TunInbound, build_inbound_metadata},
     tun_io::TunIo,
-    udp_session::{PendingUdpSession, UDP_PENDING_QUEUE_CAPACITY},
+    udp_session::{
+        PendingUdpSession, UDP_PENDING_QUEUE_CAPACITY, UDP_SESSION_QUEUE_CAPACITY, UdpDatagram,
+        UdpNatKey, UdpSessionReservation,
+    },
 };
 
 /// 跨 dispatcher 的 UDP 派发上下文（克隆开销 = 几个 `Arc::clone`）。
@@ -37,6 +40,7 @@ pub struct UdpDispatchCtx {
     pub inbound: Arc<TunInbound>,
     pub dns_service: Arc<DnsService>,
     pub frame_formats: Arc<TunFrameFormatCache>,
+    pub endpoint_independent_nat: bool,
 }
 
 /// 处理一帧 TUN UDP 包：DNS hijack / session 复用 / 首包拨号 + reverse loop。
@@ -85,160 +89,232 @@ pub async fn handle_udp_packet(
         return;
     }
 
-    // [2] 5-tuple 命中既有 session → 复用
-    let key = crate::udp_session::UdpFlowKey {
-        src: inner_src,
-        dst: outer_dst,
-    };
-    if let Some(session) = ctx.udp_sessions.lookup(&key) {
-        let n = payload.len();
-        match session
-            .socket
-            .send_to(&payload, &session.target_host, session.target_port)
-            .await
-        {
-            Ok(_) => {
-                handler.record_upload(&session.guard, n as u64);
-                session.touch();
-                trace!(
-                    target: "capture::traffic",
-                    conn_id = session.guard.id,
-                    network = "udp",
-                    src = %inner_src,
-                    dst = %outer_dst,
-                    target_host = %session.target_host,
-                    target_port = session.target_port,
-                    upload = n,
-                    "udp session upload"
-                );
-            }
-            Err(e) => {
-                debug!(target: "capture::udp", error = %e, "reuse send failed; remove session");
-                ctx.udp_sessions.remove(&key);
-            }
+    let key = UdpNatKey::new(inner_src, outer_dst, ctx.endpoint_independent_nat);
+    let reservation = ctx.udp_sessions.reserve(key, UDP_PENDING_QUEUE_CAPACITY);
+    match reservation {
+        UdpSessionReservation::Established(session) => {
+            queue_established(ctx, key, session, inner_src, outer_dst, payload);
+            return;
         }
-        return;
-    }
-
-    // [2.5] flow 已在拨号中：只入队，不阻塞 TUN pump。
-    if let Some(pending) = ctx.udp_sessions.lookup_pending(&key) {
-        match pending.try_send(payload) {
-            Ok(()) => {
-                trace!(
-                    target: "capture::traffic",
-                    network = "udp",
-                    src = %inner_src,
-                    dst = %outer_dst,
-                    "udp pending packet queued"
-                );
+        UdpSessionReservation::Pending(pending) => {
+            match pending.try_send(UdpDatagram { outer_dst, payload }) {
+                Ok(()) => {
+                    trace!(
+                        target: "capture::traffic",
+                        network = "udp",
+                        src = %inner_src,
+                        dst = %outer_dst,
+                        "udp pending packet queued"
+                    );
+                }
+                Err(TrySendError::Full(_)) => {
+                    warn!(
+                        target: "capture::udp",
+                        network = "udp",
+                        src = %inner_src,
+                        dst = %outer_dst,
+                        capacity = UDP_PENDING_QUEUE_CAPACITY,
+                        "udp pending queue full; drop packet"
+                    );
+                }
+                Err(TrySendError::Closed(_)) => {
+                    debug!(
+                        target: "capture::udp",
+                        network = "udp",
+                        src = %inner_src,
+                        dst = %outer_dst,
+                        "udp pending queue closed"
+                    );
+                    ctx.udp_sessions.remove_pending_if(key, &pending);
+                }
             }
-            Err(TrySendError::Full(_)) => {
+            return;
+        }
+        UdpSessionReservation::Created { pending, receiver } => {
+            if let Err(error) = pending.try_send(UdpDatagram { outer_dst, payload }) {
                 warn!(
                     target: "capture::udp",
-                    network = "udp",
+                    %error,
                     src = %inner_src,
                     dst = %outer_dst,
-                    capacity = UDP_PENDING_QUEUE_CAPACITY,
-                    "udp pending queue full; drop packet"
+                    "udp pending first packet enqueue failed"
                 );
+                ctx.udp_sessions.remove_pending_if(key, &pending);
+                return;
             }
-            Err(TrySendError::Closed(_)) => {
-                debug!(
-                    target: "capture::udp",
-                    network = "udp",
-                    src = %inner_src,
-                    dst = %outer_dst,
-                    "udp pending queue closed; remove pending flow"
-                );
-                ctx.udp_sessions.remove_pending(&key);
-            }
+            let session_meta = match resolve_udp_session(ctx, inner_src, outer_dst) {
+                Some(session) => session,
+                None => {
+                    ctx.udp_sessions.remove_pending_if(key, &pending);
+                    return;
+                }
+            };
+            debug!(
+                target: "capture::traffic",
+                network = "udp",
+                src = %inner_src,
+                dst = %outer_dst,
+                host = %session_meta.target.host,
+                port = session_meta.target.original_dst_port,
+                dns_mode = session_meta.target.dns_mode.as_str(),
+                bypass = ?session_meta.bypass,
+                eim = ctx.endpoint_independent_nat,
+                "udp new NAT association -> ListenerHandler.NewPacket"
+            );
+            let worker_ctx = ctx.clone();
+            let dev = device.clone();
+            let worker_handler = (*handler).clone();
+            tokio::spawn(async move {
+                run_udp_dial_worker(
+                    worker_ctx,
+                    dev,
+                    worker_handler,
+                    key,
+                    pending,
+                    session_meta,
+                    receiver,
+                    inner_src,
+                    outer_dst,
+                )
+                .await;
+            });
         }
-        return;
     }
+}
 
-    // [3] 首包：先 fake-IP 反查 / 路由策略，payload 入 pending queue 后异步 dial。
-    let session_meta = match ctx
+fn resolve_udp_session(
+    ctx: &UdpDispatchCtx,
+    inner_src: SocketAddr,
+    outer_dst: SocketAddr,
+) -> Option<crate::tun_inbound::TunSession> {
+    match ctx
         .inbound
         .resolve_session("udp", inner_src, outer_dst, None)
     {
-        Ok(s) => s,
+        Ok(session) => Some(session),
         Err(TunDropReason::FakeDnsMissing) => {
             warn!(
                 target: "capture::udp",
                 ip = %outer_dst.ip(),
                 port = outer_dst.port(),
-                "udp fake DNS record missing; drop (与 mihomo 一致)"
+                "udp fake DNS record missing; drop"
             );
-            return;
+            None
         }
         Err(reason) => {
-            debug!(
-                target: "capture::udp",
-                ?reason,
-                %outer_dst,
-                "udp session rejected"
-            );
-            return;
+            debug!(target: "capture::udp", ?reason, %outer_dst, "udp session rejected");
+            None
         }
-    };
-    debug!(
-        target: "capture::traffic",
-        network = "udp",
-        src = %inner_src,
-        dst = %outer_dst,
-        host = %session_meta.target.host,
-        port = session_meta.target.original_dst_port,
-        dns_mode = session_meta.target.dns_mode.as_str(),
-        bypass = ?session_meta.bypass,
-        payload_len = payload.len(),
-        "udp new packet -> ListenerHandler.NewPacket"
-    );
-    let (pending, rx) = PendingUdpSession::new(UDP_PENDING_QUEUE_CAPACITY);
-    if let Err(e) = pending.try_send(payload) {
-        warn!(
+    }
+}
+
+fn queue_established(
+    ctx: &UdpDispatchCtx,
+    key: UdpNatKey,
+    session: Arc<crate::udp_session::UdpSession>,
+    inner_src: SocketAddr,
+    outer_dst: SocketAddr,
+    payload: Vec<u8>,
+) {
+    match session.try_send(UdpDatagram { outer_dst, payload }) {
+        Ok(()) => {}
+        Err(TrySendError::Full(_)) => {
+            warn!(
+                target: "capture::udp",
+                src = %inner_src,
+                dst = %outer_dst,
+                capacity = UDP_SESSION_QUEUE_CAPACITY,
+                "UDP association send queue full; drop datagram"
+            );
+        }
+        Err(TrySendError::Closed(_)) => {
+            ctx.udp_sessions.remove_session_if(key, &session);
+        }
+    }
+}
+
+async fn transmit_datagram(
+    ctx: &UdpDispatchCtx,
+    handler: &ListenerHandler,
+    key: UdpNatKey,
+    session: &Arc<crate::udp_session::UdpSession>,
+    inner_src: SocketAddr,
+    outer_dst: SocketAddr,
+    payload: Vec<u8>,
+) -> bool {
+    let (target_host, target_port, is_new_destination) =
+        if let Some((host, port)) = session.destination(outer_dst) {
+            (host, port, false)
+        } else {
+            let Some(meta) = resolve_udp_session(ctx, inner_src, outer_dst) else {
+                return false;
+            };
+            (
+                meta.target.host.to_string(),
+                meta.target.original_dst_port,
+                true,
+            )
+        };
+    let length = payload.len();
+    if is_new_destination && !session.socket.supports_multi_target() {
+        debug!(
             target: "capture::udp",
-            error = %e,
             src = %inner_src,
             dst = %outer_dst,
-            "udp pending first packet enqueue failed"
+            "outbound UDP carrier is target-bound; rotate EIM association"
         );
-        return;
+        ctx.udp_sessions.remove_session_if(key, session);
+        return false;
     }
-    ctx.udp_sessions.insert_pending(key, pending);
-    trace!(
-        target: "capture::traffic",
-        network = "udp",
-        src = %inner_src,
-        dst = %outer_dst,
-        capacity = UDP_PENDING_QUEUE_CAPACITY,
-        "udp pending session created"
-    );
-
-    let worker_ctx = ctx.clone();
-    let dev = device.clone();
-    let worker_handler = (*handler).clone();
-    tokio::spawn(async move {
-        run_udp_dial_worker(
-            worker_ctx,
-            dev,
-            worker_handler,
-            key,
-            session_meta,
-            rx,
-            inner_src,
-            outer_dst,
-        )
-        .await;
-    });
+    if is_new_destination
+        && !session.register_destination(outer_dst, target_host.clone(), target_port)
+    {
+        warn!(
+            target: "capture::udp",
+            src = %inner_src,
+            limit = crate::udp_session::UDP_EIM_DESTINATION_LIMIT,
+            "EIM destination limit reached; drop datagram"
+        );
+        return true;
+    }
+    match session
+        .socket
+        .send_to(&payload, &target_host, target_port)
+        .await
+    {
+        Ok(_) => {
+            handler.record_upload(&session.guard, length as u64);
+            session.touch();
+            trace!(
+                target: "capture::traffic",
+                conn_id = session.guard.id,
+                network = "udp",
+                src = %inner_src,
+                dst = %outer_dst,
+                %target_host,
+                target_port,
+                eim_destinations = session.destination_count(),
+                upload = length,
+                "udp NAT association upload"
+            );
+        }
+        Err(error) => {
+            debug!(target: "capture::udp", %error, "UDP association send failed; remove session");
+            ctx.udp_sessions.remove_session_if(key, session);
+            return false;
+        }
+    }
+    true
 }
 
 async fn run_udp_dial_worker(
     ctx: UdpDispatchCtx,
     device: Arc<dyn TunIo>,
     handler: ListenerHandler,
-    key: crate::udp_session::UdpFlowKey,
+    key: UdpNatKey,
+    pending: Arc<PendingUdpSession>,
     session_meta: crate::tun_inbound::TunSession,
-    mut rx: mpsc::Receiver<Vec<u8>>,
+    mut rx: mpsc::Receiver<UdpDatagram>,
     inner_src: SocketAddr,
     outer_dst: SocketAddr,
 ) {
@@ -260,24 +336,33 @@ async fn run_udp_dial_worker(
             let host = session_meta.target.host.clone();
             let port = session_meta.target.original_dst_port;
             debug!(target: "capture::udp", "[UDP] dial {host}:{port} failed: {e}");
-            ctx.udp_sessions.remove_pending(&key);
+            ctx.udp_sessions.remove_pending_if(key, &pending);
             return;
         }
     };
-    let session = Arc::new(crate::udp_session::UdpSession {
-        socket: prepared.socket,
-        guard: prepared.guard,
-        target_host: prepared.target_host,
-        target_port: prepared.target_port,
-        last_seen: parking_lot::Mutex::new(Instant::now()),
-    });
-    ctx.udp_sessions.insert(key, session.clone());
-    ctx.udp_sessions.remove_pending(&key);
+    let (session, mut send_rx) = crate::udp_session::UdpSession::new(
+        prepared.socket,
+        prepared.guard,
+        outer_dst,
+        prepared.target_host,
+        prepared.target_port,
+        key.is_endpoint_independent(),
+        UDP_SESSION_QUEUE_CAPACITY,
+    );
+    let session = Arc::new(session);
+    if !ctx.udp_sessions.promote(key, &pending, session.clone()) {
+        session.cancel();
+        return;
+    }
+    // Promotion removed the pending sender from the table. Drop the worker's
+    // last sender so the receiver closes after draining the queued burst.
+    drop(pending);
     {
         let id = session.guard.id;
         let src = inner_src.to_string();
-        let host = &session.target_host;
-        let port = session.target_port;
+        let (host, port) = session
+            .destination(outer_dst)
+            .expect("initial UDP destination must be registered");
         if let Some(b) = session_meta.bypass {
             info!(target: "capture::traffic", "[UDP] #{id} {src} --> {host}:{port} (bypass: {b:?})");
         } else {
@@ -292,38 +377,49 @@ async fn run_udp_dial_worker(
         session.clone(),
         key,
         inner_src,
-        outer_dst,
         handler.runtime().metrics.clone(),
     );
 
-    while let Some(payload) = rx.recv().await {
-        let n = payload.len();
-        match session
-            .socket
-            .send_to(&payload, &session.target_host, session.target_port)
-            .await
+    while let Some(datagram) = rx.recv().await {
+        let destination = datagram.outer_dst;
+        if !transmit_datagram(
+            &ctx,
+            &handler,
+            key,
+            &session,
+            inner_src,
+            destination,
+            datagram.payload,
+        )
+        .await
         {
-            Ok(_) => {
-                handler.record_upload(&session.guard, n as u64);
-                session.touch();
-                trace!(
-                    target: "capture::traffic",
-                    conn_id = session.guard.id,
-                    network = "udp",
-                    upload = n,
-                    "udp pending payload sent"
-                );
-            }
-            Err(e) => {
-                debug!(
-                    target: "capture::udp",
-                    host = %session.target_host,
-                    port = session.target_port,
-                    error = %e,
-                    "udp pending payload send failed"
-                );
-                ctx.udp_sessions.remove(&key);
-                break;
+            return;
+        }
+    }
+    let mut cancel = session.cancel_receiver();
+    loop {
+        if *cancel.borrow() {
+            break;
+        }
+        tokio::select! {
+            changed = cancel.changed() => {
+                if changed.is_err() || *cancel.borrow() {
+                    break;
+                }
+            },
+            datagram = send_rx.recv() => {
+                let Some(datagram) = datagram else { break };
+                if !transmit_datagram(
+                    &ctx,
+                    &handler,
+                    key,
+                    &session,
+                    inner_src,
+                    datagram.outer_dst,
+                    datagram.payload,
+                ).await {
+                    break;
+                }
             }
         }
     }
@@ -334,23 +430,40 @@ fn spawn_udp_reverse_loop(
     frame_formats: Arc<TunFrameFormatCache>,
     sessions: Arc<crate::udp_session::UdpSessionTable>,
     session_for_loop: Arc<crate::udp_session::UdpSession>,
-    key: crate::udp_session::UdpFlowKey,
+    key: UdpNatKey,
     inner_src: SocketAddr,
-    outer_dst: SocketAddr,
     metrics: Arc<core_observe::Metrics>,
 ) {
     tokio::spawn(async move {
         metrics.inc_connection();
-        let cancel = session_for_loop.guard.cancel.clone();
+        let mut cancel = session_for_loop.cancel_receiver();
         let mut buf = vec![0u8; 65535];
         loop {
+            if *cancel.borrow() {
+                break;
+            }
             tokio::select! {
-                _ = cancel.notified() => break,
-                r = session_for_loop.socket.recv_from(&mut buf) => {
-                    let n = match r { Ok(n) => n, Err(_) => break };
+                changed = cancel.changed() => {
+                    if changed.is_err() || *cancel.borrow() {
+                        break;
+                    }
+                },
+                r = session_for_loop.socket.recv_from_endpoint(&mut buf) => {
+                    let (n, transport_source) = match r { Ok(value) => value, Err(_) => break };
                     if n == 0 { break }
+                    let Some(logical_source) =
+                        session_for_loop.logical_response_source(transport_source)
+                    else {
+                        debug!(
+                            target: "capture::udp",
+                            ?transport_source,
+                            destinations = session_for_loop.destination_count(),
+                            "drop ambiguous endpoint-independent UDP response"
+                        );
+                        continue;
+                    };
                     let pkt = match crate::udp_forwarder::build_udp_ip_packet(
-                        outer_dst, inner_src, &buf[..n],
+                        logical_source, inner_src, &buf[..n],
                     ) {
                         Some(b) => b,
                         None => continue,
@@ -377,7 +490,7 @@ fn spawn_udp_reverse_loop(
         let up = session_for_loop.guard.up.load(Ordering::Relaxed);
         let down = session_for_loop.guard.down.load(Ordering::Relaxed);
         let id = session_for_loop.guard.id;
-        sessions.remove(&key);
+        sessions.remove_session_if(key, &session_for_loop);
         metrics.dec_connection();
         let up_s = crate::tun_pump::format_bytes(up);
         let down_s = crate::tun_pump::format_bytes(down);

--- a/crates/core-capture/src/udp_session.rs
+++ b/crates/core-capture/src/udp_session.rs
@@ -1,35 +1,35 @@
-//! TUN UDP 5-tuple ⇄ outbound socket 复用表 —— 与 mihomo `sing-tun` 的
-//! `endpoint_independent_nat` / 5-tuple session 行为对齐。
+//! TUN UDP NAT association table.
 //!
-//! ## 核心问题
-//! 旧实现（已废弃）每收到一个 UDP 包就 `runtime.dial_udp` + 新建 outbound
-//! socket + spawn reverse loop。一个 QUIC stream 1s 内 50-200 包 → 同 5-tuple
-//! 几十次 dial、dashboard `/connections` 被同来源条目淹没、STUN 5-tuple 不稳定。
-//!
-//! 本表把"同 5-tuple"的所有后续包路由到 *第一个* 包建立的 outbound socket：
-//! 1. 第 1 包 → 查表未命中 → `dial_udp` + 注册 [`UdpSession`] + spawn 1 条
-//!    reverse loop 长期持有这个 session。
-//! 2. 第 N 包 → 查表命中 → `socket.send_to(...)` + 续 `last_seen`。
-//! 3. 周期 `purge(idle)`（supervisor 调用）→ 移除超过 `udp_timeout` 没活动的
-//!    session；`Arc<UdpSession>` 引用为 0 时 reverse loop 通过 `cancel.notify`
-//!    或 `recv_from` EOF 自然退出，`ConnectionGuard` drop 时自动从
-//!    `ConnectionTable` 移除（dashboard `/connections` 同步消失）。
+//! The table is the production implementation of `endpoint_independent_nat`:
+//! symmetric mode keys associations by `(source, destination)`, while EIM keys
+//! them only by the internal source endpoint. Pending dial and established
+//! state share one DashMap entry, making first-packet reservation atomic.
 
 use std::{
-    net::SocketAddr,
-    sync::Arc,
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
 use core_observe::ConnectionGuard;
 use core_outbound::adapter::BoxedUdp;
-use dashmap::DashMap;
-use parking_lot::Mutex;
-use tokio::sync::mpsc;
+use dashmap::{DashMap, mapref::entry::Entry};
+use parking_lot::RwLock;
+use tokio::sync::{mpsc, watch};
 
-/// 新 UDP flow 在 outbound dial 完成前最多缓存的 payload 数。
-/// 与 mihomo NAT 首包入队语义对齐：TUN pump 只负责投递，不等待拨号。
 pub const UDP_PENDING_QUEUE_CAPACITY: usize = 64;
+pub const UDP_SESSION_QUEUE_CAPACITY: usize = 256;
+pub const UDP_EIM_DESTINATION_LIMIT: usize = 1024;
+
+#[derive(Debug)]
+pub struct UdpDatagram {
+    pub outer_dst: SocketAddr,
+    pub payload: Vec<u8>,
+}
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UdpFlowKey {
@@ -37,68 +37,261 @@ pub struct UdpFlowKey {
     pub dst: SocketAddr,
 }
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum UdpNatKey {
+    Symmetric(UdpFlowKey),
+    EndpointIndependent { src: SocketAddr },
+}
+
+impl UdpNatKey {
+    pub fn new(src: SocketAddr, dst: SocketAddr, endpoint_independent: bool) -> Self {
+        if endpoint_independent {
+            Self::EndpointIndependent { src }
+        } else {
+            Self::Symmetric(UdpFlowKey { src, dst })
+        }
+    }
+
+    pub fn source(self) -> SocketAddr {
+        match self {
+            Self::Symmetric(flow) => flow.src,
+            Self::EndpointIndependent { src } => src,
+        }
+    }
+
+    pub fn is_endpoint_independent(self) -> bool {
+        matches!(self, Self::EndpointIndependent { .. })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UdpDestination {
+    target_host: String,
+    target_port: u16,
+}
+
 pub struct UdpSession {
-    /// 持有 outbound 出站 socket —— 与 mihomo NAT entry 的"已分配 socket"等价。
     pub socket: BoxedUdp,
-    /// 持有 ConnectionTable guard：dashboard 看到一条 long session（network=udp）。
     pub guard: ConnectionGuard,
-    /// 解析后的目标 host 字符串（DirectUdp.send_to 时用；后续可缓存解析结果）。
-    pub target_host: String,
-    pub target_port: u16,
-    /// 最近活动时间 —— purge 判定依据。
-    pub last_seen: Mutex<Instant>,
+    destinations: RwLock<HashMap<SocketAddr, UdpDestination>>,
+    endpoint_independent: bool,
+    sender: mpsc::Sender<UdpDatagram>,
+    cancel: watch::Sender<bool>,
+    last_seen: AtomicU64,
 }
 
 impl UdpSession {
-    pub fn touch(&self) {
-        *self.last_seen.lock() = Instant::now();
-    }
-}
-
-pub struct PendingUdpSession {
-    sender: mpsc::Sender<Vec<u8>>,
-    last_seen: Mutex<Instant>,
-}
-
-impl PendingUdpSession {
-    pub fn new(capacity: usize) -> (Arc<Self>, mpsc::Receiver<Vec<u8>>) {
-        let (tx, rx) = mpsc::channel(capacity);
+    pub fn new(
+        socket: BoxedUdp,
+        guard: ConnectionGuard,
+        outer_dst: SocketAddr,
+        target_host: String,
+        target_port: u16,
+        endpoint_independent: bool,
+        queue_capacity: usize,
+    ) -> (Self, mpsc::Receiver<UdpDatagram>) {
+        let (sender, receiver) = mpsc::channel(queue_capacity);
+        let (cancel, _) = watch::channel(false);
+        let mut destinations = HashMap::with_capacity(2);
+        destinations.insert(
+            outer_dst,
+            UdpDestination {
+                target_host,
+                target_port,
+            },
+        );
         (
-            Arc::new(Self {
-                sender: tx,
-                last_seen: Mutex::new(Instant::now()),
-            }),
-            rx,
+            Self {
+                socket,
+                guard,
+                destinations: RwLock::new(destinations),
+                endpoint_independent,
+                sender,
+                cancel,
+                last_seen: AtomicU64::new(activity_tick()),
+            },
+            receiver,
         )
     }
 
-    pub fn try_send(&self, payload: Vec<u8>) -> Result<(), mpsc::error::TrySendError<Vec<u8>>> {
-        self.sender.try_send(payload)?;
+    pub fn touch(&self) {
+        self.last_seen.store(activity_tick(), Ordering::Relaxed);
+    }
+
+    fn last_seen(&self) -> u64 {
+        self.last_seen.load(Ordering::Relaxed)
+    }
+
+    pub fn destination(&self, outer_dst: SocketAddr) -> Option<(String, u16)> {
+        self.destinations
+            .read()
+            .get(&outer_dst)
+            .map(|destination| (destination.target_host.clone(), destination.target_port))
+    }
+
+    pub fn try_send(
+        &self,
+        datagram: UdpDatagram,
+    ) -> Result<(), mpsc::error::TrySendError<UdpDatagram>> {
+        self.sender.try_send(datagram)?;
         self.touch();
         Ok(())
     }
 
-    pub fn touch(&self) {
-        *self.last_seen.lock() = Instant::now();
+    pub fn cancel(&self) {
+        self.cancel.send_replace(true);
+        self.guard.cancel.notify_waiters();
     }
 
-    fn last_seen(&self) -> Instant {
-        *self.last_seen.lock()
+    pub fn cancel_receiver(&self) -> watch::Receiver<bool> {
+        self.cancel.subscribe()
+    }
+
+    pub fn register_destination(
+        &self,
+        outer_dst: SocketAddr,
+        target_host: String,
+        target_port: u16,
+    ) -> bool {
+        let mut destinations = self.destinations.write();
+        if !destinations.contains_key(&outer_dst) && destinations.len() >= UDP_EIM_DESTINATION_LIMIT
+        {
+            return false;
+        }
+        destinations.insert(
+            outer_dst,
+            UdpDestination {
+                target_host,
+                target_port,
+            },
+        );
+        true
+    }
+
+    /// Translate a carrier source back to the logical address visible in TUN.
+    ///
+    /// For direct/IP-aware carriers this is an exact endpoint match. Carriers
+    /// that cannot expose a source are safe only while the association has a
+    /// single logical destination; ambiguous multi-target replies fail closed.
+    pub fn logical_response_source(
+        &self,
+        transport_source: Option<SocketAddr>,
+    ) -> Option<SocketAddr> {
+        let destinations = self.destinations.read();
+        select_logical_response_source(&destinations, transport_source, self.endpoint_independent)
+    }
+
+    pub fn destination_count(&self) -> usize {
+        self.destinations.read().len()
     }
 }
 
+fn select_logical_response_source(
+    destinations: &HashMap<SocketAddr, UdpDestination>,
+    transport_source: Option<SocketAddr>,
+    endpoint_independent: bool,
+) -> Option<SocketAddr> {
+    if let Some(source) = transport_source {
+        if destinations.contains_key(&source) {
+            return Some(source);
+        }
+        if let Some((logical, _)) = destinations.iter().find(|(_, destination)| {
+            destination.target_port == source.port()
+                && parse_ip_literal(&destination.target_host) == Some(source.ip())
+        }) {
+            return Some(*logical);
+        }
+        let mut same_port = destinations
+            .iter()
+            .filter(|(_, destination)| destination.target_port == source.port())
+            .map(|(logical, _)| *logical);
+        if let Some(logical) = same_port.next()
+            && same_port.next().is_none()
+        {
+            // Fake-IP/domain targets do not expose their resolved address
+            // to capture. A unique destination port is still sufficient
+            // to restore the logical source without leaking the real IP.
+            return Some(logical);
+        }
+        if endpoint_independent {
+            return Some(source);
+        }
+        return None;
+    }
+    (destinations.len() == 1)
+        .then(|| destinations.keys().next().copied())
+        .flatten()
+}
+
+fn parse_ip_literal(host: &str) -> Option<IpAddr> {
+    host.trim()
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host.trim())
+        .parse()
+        .ok()
+}
+
+pub struct PendingUdpSession {
+    sender: mpsc::Sender<UdpDatagram>,
+    last_seen: AtomicU64,
+}
+
+impl PendingUdpSession {
+    fn new(capacity: usize) -> (Arc<Self>, mpsc::Receiver<UdpDatagram>) {
+        let (sender, receiver) = mpsc::channel(capacity);
+        (
+            Arc::new(Self {
+                sender,
+                last_seen: AtomicU64::new(activity_tick()),
+            }),
+            receiver,
+        )
+    }
+
+    pub fn try_send(
+        &self,
+        datagram: UdpDatagram,
+    ) -> Result<(), mpsc::error::TrySendError<UdpDatagram>> {
+        self.sender.try_send(datagram)?;
+        self.touch();
+        Ok(())
+    }
+
+    fn touch(&self) {
+        self.last_seen.store(activity_tick(), Ordering::Relaxed);
+    }
+
+    fn last_seen(&self) -> u64 {
+        self.last_seen.load(Ordering::Relaxed)
+    }
+}
+
+enum UdpSessionState {
+    Pending(Arc<PendingUdpSession>),
+    Established(Arc<UdpSession>),
+}
+
+pub enum UdpSessionReservation {
+    Pending(Arc<PendingUdpSession>),
+    Established(Arc<UdpSession>),
+    Created {
+        pending: Arc<PendingUdpSession>,
+        receiver: mpsc::Receiver<UdpDatagram>,
+    },
+}
+
 pub struct UdpSessionTable {
-    inner: DashMap<UdpFlowKey, Arc<UdpSession>>,
-    pending: DashMap<UdpFlowKey, Arc<PendingUdpSession>>,
-    idle: Duration,
+    inner: DashMap<UdpNatKey, UdpSessionState>,
+    idle_ticks: u64,
 }
 
 impl std::fmt::Debug for UdpSessionTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UdpSessionTable")
-            .field("len", &self.inner.len())
-            .field("pending_len", &self.pending.len())
-            .field("idle", &self.idle)
+            .field("len", &self.len())
+            .field("pending_len", &self.pending_len())
+            .field("idle_ms", &self.idle_ticks)
             .finish()
     }
 }
@@ -107,127 +300,286 @@ impl UdpSessionTable {
     pub fn new(idle: Duration) -> Self {
         Self {
             inner: DashMap::new(),
-            pending: DashMap::new(),
-            idle,
+            idle_ticks: duration_ticks(idle),
         }
     }
 
-    pub fn lookup(&self, key: &UdpFlowKey) -> Option<Arc<UdpSession>> {
-        self.inner.get(key).map(|e| e.value().clone())
-    }
-
-    pub fn insert(&self, key: UdpFlowKey, session: Arc<UdpSession>) {
-        self.inner.insert(key, session);
-    }
-
-    pub fn remove(&self, key: &UdpFlowKey) {
-        if let Some((_, session)) = self.inner.remove(key) {
-            session.guard.cancel.notify_waiters();
+    /// Atomically observe or reserve an association. Exactly one caller gets
+    /// `Created`, so packet bursts cannot start duplicate outbound dials.
+    pub fn reserve(&self, key: UdpNatKey, capacity: usize) -> UdpSessionReservation {
+        match self.inner.entry(key) {
+            Entry::Occupied(entry) => match entry.get() {
+                UdpSessionState::Pending(pending) => {
+                    UdpSessionReservation::Pending(pending.clone())
+                }
+                UdpSessionState::Established(session) => {
+                    UdpSessionReservation::Established(session.clone())
+                }
+            },
+            Entry::Vacant(entry) => {
+                let (pending, receiver) = PendingUdpSession::new(capacity);
+                entry.insert(UdpSessionState::Pending(pending.clone()));
+                UdpSessionReservation::Created { pending, receiver }
+            }
         }
     }
 
-    pub fn lookup_pending(&self, key: &UdpFlowKey) -> Option<Arc<PendingUdpSession>> {
-        self.pending.get(key).map(|e| e.value().clone())
+    pub fn promote(
+        &self,
+        key: UdpNatKey,
+        pending: &Arc<PendingUdpSession>,
+        session: Arc<UdpSession>,
+    ) -> bool {
+        let Entry::Occupied(mut entry) = self.inner.entry(key) else {
+            return false;
+        };
+        let matches = matches!(
+            entry.get(),
+            UdpSessionState::Pending(current) if Arc::ptr_eq(current, pending)
+        );
+        if matches {
+            entry.insert(UdpSessionState::Established(session));
+        }
+        matches
     }
 
-    pub fn insert_pending(&self, key: UdpFlowKey, session: Arc<PendingUdpSession>) {
-        self.pending.insert(key, session);
+    pub fn remove_pending_if(&self, key: UdpNatKey, pending: &Arc<PendingUdpSession>) {
+        if let Entry::Occupied(entry) = self.inner.entry(key)
+            && matches!(
+                entry.get(),
+                UdpSessionState::Pending(current) if Arc::ptr_eq(current, pending)
+            )
+        {
+            entry.remove();
+        }
     }
 
-    pub fn remove_pending(&self, key: &UdpFlowKey) {
-        self.pending.remove(key);
+    pub fn remove_session_if(&self, key: UdpNatKey, session: &Arc<UdpSession>) {
+        if let Entry::Occupied(entry) = self.inner.entry(key)
+            && matches!(
+                entry.get(),
+                UdpSessionState::Established(current) if Arc::ptr_eq(current, session)
+            )
+        {
+            entry.remove();
+            session.cancel();
+        }
     }
 
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.inner
+            .iter()
+            .filter(|entry| matches!(entry.value(), UdpSessionState::Established(_)))
+            .count()
     }
 
     pub fn pending_len(&self) -> usize {
-        self.pending.len()
+        self.inner
+            .iter()
+            .filter(|entry| matches!(entry.value(), UdpSessionState::Pending(_)))
+            .count()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty() && self.pending.is_empty()
+        self.inner.is_empty()
     }
 
-    /// 周期 GC：移除超过 idle 没活动的 session。返回移除条数。
-    /// 被移除的 session：
-    /// * `Arc<UdpSession>` 计数减 1；如果 reverse loop 持有的引用是最后一个，
-    ///   则 session drop 时连带 ConnectionGuard drop → ConnectionTable 自动清理。
-    /// * 实际调用方（reverse loop）下一次 recv_from 出错或被 cancel 唤醒时退出。
     pub fn purge(&self) -> usize {
-        let cutoff = Instant::now() - self.idle;
-        let sessions_to_remove: Vec<UdpFlowKey> = self
+        let cutoff = activity_tick().saturating_sub(self.idle_ticks);
+        let keys = self
             .inner
             .iter()
-            .filter_map(|e| {
-                let ls = *e.value().last_seen.lock();
-                if ls < cutoff { Some(*e.key()) } else { None }
+            .filter_map(|entry| {
+                let last_seen = match entry.value() {
+                    UdpSessionState::Pending(pending) => pending.last_seen(),
+                    UdpSessionState::Established(session) => session.last_seen(),
+                };
+                (last_seen <= cutoff).then_some(*entry.key())
             })
-            .collect();
-        let pending_to_remove: Vec<UdpFlowKey> = self
-            .pending
-            .iter()
-            .filter_map(|e| {
-                if e.value().last_seen() < cutoff {
-                    Some(*e.key())
-                } else {
-                    None
+            .collect::<Vec<_>>();
+        let mut removed = 0;
+        for key in keys {
+            if let Entry::Occupied(entry) = self.inner.entry(key) {
+                let last_seen = match entry.get() {
+                    UdpSessionState::Pending(pending) => pending.last_seen(),
+                    UdpSessionState::Established(session) => session.last_seen(),
+                };
+                if last_seen <= cutoff {
+                    let (_, state) = entry.remove_entry();
+                    if let UdpSessionState::Established(session) = state {
+                        session.cancel();
+                    }
+                    removed += 1;
                 }
-            })
-            .collect();
-        let n = sessions_to_remove.len() + pending_to_remove.len();
-        for k in sessions_to_remove {
-            // 触发 cancel 让 reverse loop 退出；从表移除。
-            if let Some((_, s)) = self.inner.remove(&k) {
-                s.guard.cancel.notify_waiters();
             }
         }
-        for k in pending_to_remove {
-            self.pending.remove(&k);
-        }
-        n
+        removed
     }
+
+    /// Cancel every association, for example after the physical outbound
+    /// interface changes and existing bound UDP sockets are no longer valid.
+    pub fn clear(&self) -> usize {
+        let keys = self
+            .inner
+            .iter()
+            .map(|entry| *entry.key())
+            .collect::<Vec<_>>();
+        let mut removed = 0;
+        for key in keys {
+            if let Some((_, state)) = self.inner.remove(&key) {
+                if let UdpSessionState::Established(session) = state {
+                    session.cancel();
+                }
+                removed += 1;
+            }
+        }
+        removed
+    }
+}
+
+fn activity_tick() -> u64 {
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    let elapsed = EPOCH.get_or_init(Instant::now).elapsed().as_millis();
+    elapsed.min(u64::MAX as u128) as u64 + 1
+}
+
+fn duration_ticks(duration: Duration) -> u64 {
+    duration.as_millis().max(1).min(u64::MAX as u128) as u64
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn fake_key(src_port: u16, dst_port: u16) -> UdpFlowKey {
-        UdpFlowKey {
-            src: format!("10.0.0.1:{src_port}").parse().unwrap(),
-            dst: format!("8.8.8.8:{dst_port}").parse().unwrap(),
-        }
+    fn key(src_port: u16, dst_port: u16, eim: bool) -> UdpNatKey {
+        UdpNatKey::new(
+            format!("10.0.0.1:{src_port}").parse().unwrap(),
+            format!("8.8.8.8:{dst_port}").parse().unwrap(),
+            eim,
+        )
     }
 
     #[test]
-    fn empty_table() {
-        let t = UdpSessionTable::new(Duration::from_secs(60));
-        assert!(t.is_empty());
-        assert_eq!(t.len(), 0);
-        assert!(t.lookup(&fake_key(1, 53)).is_none());
-        assert_eq!(t.purge(), 0);
+    fn eim_key_ignores_destination_but_symmetric_key_does_not() {
+        assert_eq!(key(5000, 53, true), key(5000, 443, true));
+        assert_ne!(key(5000, 53, false), key(5000, 443, false));
+    }
+
+    #[test]
+    fn reservation_is_atomic_and_reuses_pending_entry() {
+        let table = UdpSessionTable::new(Duration::from_secs(60));
+        let key = key(5000, 53, true);
+        let first = table.reserve(key, 2);
+        let second = table.reserve(key, 2);
+        let UdpSessionReservation::Created { pending, .. } = first else {
+            panic!("first reservation must create");
+        };
+        let UdpSessionReservation::Pending(existing) = second else {
+            panic!("second reservation must reuse pending");
+        };
+        assert!(Arc::ptr_eq(&pending, &existing));
+        assert_eq!(table.pending_len(), 1);
+    }
+
+    #[test]
+    fn concurrent_burst_has_exactly_one_dial_owner() {
+        let table = Arc::new(UdpSessionTable::new(Duration::from_secs(60)));
+        let key = key(5001, 3478, true);
+        let owners = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        std::thread::scope(|scope| {
+            for _ in 0..32 {
+                let table = table.clone();
+                let owners = owners.clone();
+                scope.spawn(move || {
+                    if matches!(
+                        table.reserve(key, UDP_PENDING_QUEUE_CAPACITY),
+                        UdpSessionReservation::Created { .. }
+                    ) {
+                        owners.fetch_add(1, Ordering::Relaxed);
+                    }
+                });
+            }
+        });
+        assert_eq!(owners.load(Ordering::Relaxed), 1);
+        assert_eq!(table.pending_len(), 1);
     }
 
     #[tokio::test]
-    async fn pending_queue_buffers_packets_until_dial_worker_establishes_session() {
-        let t = UdpSessionTable::new(Duration::from_secs(60));
-        let key = fake_key(50000, 443);
-        let (pending, mut rx) = super::PendingUdpSession::new(2);
-
-        t.insert_pending(key, pending.clone());
-        pending.try_send(vec![1, 2, 3]).unwrap();
-        pending.try_send(vec![4, 5, 6]).unwrap();
-
-        assert!(t.lookup_pending(&key).is_some());
-        assert_eq!(rx.recv().await.unwrap(), vec![1, 2, 3]);
-        assert_eq!(rx.recv().await.unwrap(), vec![4, 5, 6]);
-
-        t.remove_pending(&key);
-        assert!(t.lookup_pending(&key).is_none());
+    async fn pending_queue_buffers_packets() {
+        let table = UdpSessionTable::new(Duration::from_secs(60));
+        let key = key(5000, 443, false);
+        let UdpSessionReservation::Created {
+            pending,
+            mut receiver,
+        } = table.reserve(key, 2)
+        else {
+            panic!("must create");
+        };
+        pending
+            .try_send(UdpDatagram {
+                outer_dst: "8.8.8.8:443".parse().unwrap(),
+                payload: vec![1, 2, 3],
+            })
+            .unwrap();
+        assert_eq!(receiver.recv().await.unwrap().payload, vec![1, 2, 3]);
+        table.remove_pending_if(key, &pending);
+        assert!(table.is_empty());
     }
 
-    // 注：完整的 lookup/insert 单测需要构造 UdpSession（依赖 BoxedUdp + ConnectionGuard
-    // 的 mock）。整链路验证放在 tests/tun_udp_reuse.rs。这里只覆盖空表与 GC 边界。
+    #[test]
+    fn purge_expires_idle_pending_association() {
+        let table = UdpSessionTable::new(Duration::from_millis(5));
+        let _ = table.reserve(key(5002, 443, false), 1);
+        std::thread::sleep(Duration::from_millis(20));
+        assert_eq!(table.purge(), 1);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn clear_removes_pending_associations_immediately() {
+        let table = UdpSessionTable::new(Duration::from_secs(60));
+        let _ = table.reserve(key(5003, 443, true), 1);
+        assert_eq!(table.clear(), 1);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn endpoint_filtering_is_full_cone_only_in_eim_mode() {
+        let known: SocketAddr = "198.51.100.1:3478".parse().unwrap();
+        let unsolicited: SocketAddr = "203.0.113.7:5000".parse().unwrap();
+        let mut destinations = HashMap::new();
+        destinations.insert(
+            known,
+            UdpDestination {
+                target_host: known.ip().to_string(),
+                target_port: known.port(),
+            },
+        );
+        assert_eq!(
+            select_logical_response_source(&destinations, Some(unsolicited), true),
+            Some(unsolicited)
+        );
+        assert_eq!(
+            select_logical_response_source(&destinations, Some(unsolicited), false),
+            None
+        );
+    }
+
+    #[test]
+    fn fake_ip_response_is_restored_when_target_port_is_unambiguous() {
+        let fake: SocketAddr = "198.18.0.10:443".parse().unwrap();
+        let real: SocketAddr = "203.0.113.10:443".parse().unwrap();
+        let mut destinations = HashMap::new();
+        destinations.insert(
+            fake,
+            UdpDestination {
+                target_host: "example.test".into(),
+                target_port: 443,
+            },
+        );
+        assert_eq!(
+            select_logical_response_source(&destinations, Some(real), true),
+            Some(fake)
+        );
+    }
 }

--- a/crates/core-config/src/model.rs
+++ b/crates/core-config/src/model.rs
@@ -4856,10 +4856,14 @@ pub struct TunInboundOptions {
 
     /* ---- NAT / 性能 ---- */
     /// `endpoint_independent_nat` —— 全锥 NAT；UDP 打洞场景需开。
-    #[serde(default)]
+    #[serde(default, alias = "endpoint-independent-nat")]
     pub endpoint_independent_nat: bool,
     /// `udp_timeout` —— UDP NAT 老化（默认 5m）。
-    #[serde(default = "default_udp_timeout", with = "humantime_serde")]
+    #[serde(
+        default = "default_udp_timeout",
+        alias = "udp-timeout",
+        with = "humantime_serde"
+    )]
     pub udp_timeout: Duration,
     /// `exclude_mptcp` —— 透传 MPTCP 不接管。
     #[serde(default)]
@@ -5359,6 +5363,14 @@ fn default_tailscale_mode() -> TailscaleMode {
 #[cfg(test)]
 mod xhttp_config_tests {
     use super::*;
+
+    #[test]
+    fn tun_accepts_mihomo_kebab_case_nat_fields() {
+        let tun: TunInboundOptions =
+            serde_yaml::from_str("endpoint-independent-nat: true\nudp-timeout: 45s\n").unwrap();
+        assert!(tun.endpoint_independent_nat);
+        assert_eq!(tun.udp_timeout, Duration::from_secs(45));
+    }
 
     const FULL_XHTTP_YAML: &str = r#"
 host: cdn.example.com

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -21,6 +21,7 @@ core-grpc   = { workspace = true }
 tokio       = { workspace = true }
 async-trait = { workspace = true }
 bytes       = { workspace = true }
+dashmap     = { workspace = true }
 anyhow      = { workspace = true }
 thiserror   = { workspace = true }
 tracing     = { workspace = true }

--- a/crates/core-outbound/src/adapter.rs
+++ b/crates/core-outbound/src/adapter.rs
@@ -227,6 +227,19 @@ fn prepare_outbound_udp_socket_with(
 pub fn create_outbound_udp_socket(
     peer: std::net::SocketAddr,
 ) -> std::io::Result<(std::net::UdpSocket, crate::loopback::LoopbackUdpGuard)> {
+    let (sock, guard) = create_outbound_udp_association(peer)?;
+    sock.connect(peer)?;
+    if let Ok(local) = sock.local_addr() {
+        guard.observe_local_addr(local);
+    }
+    Ok((sock, guard))
+}
+
+/// Create an unconnected UDP association whose local endpoint is stable across
+/// destinations. Used by endpoint-independent TUN NAT.
+pub fn create_outbound_udp_association(
+    peer: std::net::SocketAddr,
+) -> std::io::Result<(std::net::UdpSocket, crate::loopback::LoopbackUdpGuard)> {
     let bind_addr: std::net::SocketAddr = if peer.is_ipv4() {
         "0.0.0.0:0".parse().unwrap()
     } else {
@@ -234,7 +247,6 @@ pub fn create_outbound_udp_socket(
     };
     let sock = std::net::UdpSocket::bind(bind_addr)?;
     let guard = prepare_outbound_udp_socket_for_addr(&sock, peer)?;
-    sock.connect(peer)?;
     if let Ok(local) = sock.local_addr() {
         guard.observe_local_addr(local);
     }
@@ -555,9 +567,9 @@ pub type BoxedStream = Pin<Box<dyn ProxyStream>>;
 ///
 /// `target` 是远端目标地址（域名或 IP）。
 ///
-/// 当前 `recv_from` ABI 只返回 payload 长度，无法把响应源地址交还给调用方。
-/// 因此基于 connected UDP socket 的实现必须对非初始目标 fail closed；在 ABI
-/// 扩展为返回 endpoint 之前，不能伪装支持一个 association 上的多目标转发。
+/// Multi-destination associations should override `recv_from_endpoint`; TUN
+/// EIM uses the returned source to restore the logical UDP peer and applies
+/// endpoint-dependent filtering when EIM is disabled.
 #[async_trait]
 pub trait UdpSocketLike: Send + Sync {
     async fn send_to(&self, buf: &[u8], target: &str, port: u16) -> std::io::Result<usize>;
@@ -575,6 +587,11 @@ pub trait UdpSocketLike: Send + Sync {
     /// Local transport endpoint when the carrier exposes it.
     fn local_addr(&self) -> std::io::Result<Option<std::net::SocketAddr>> {
         Ok(None)
+    }
+    /// Whether one association can safely address more than its dial target
+    /// and identify response sources.
+    fn supports_multi_target(&self) -> bool {
+        false
     }
     /// 关闭通道；某些协议需要发协议级断开。
     async fn close(&self) -> std::io::Result<()> {

--- a/crates/core-outbound/src/direct.rs
+++ b/crates/core-outbound/src/direct.rs
@@ -1,9 +1,7 @@
-use std::{
-    net::{IpAddr, SocketAddr},
-    sync::Arc,
-};
+use std::{net::SocketAddr, sync::Arc};
 
 use async_trait::async_trait;
+use dashmap::DashMap;
 use tokio::net::UdpSocket;
 
 use crate::{
@@ -67,11 +65,11 @@ impl OutboundAdapter for DirectOutbound {
                         local = %sock.local_addr().map(|v| v.to_string()).unwrap_or_else(|_| "-".into()),
                         "direct udp connected",
                     );
+                    let resolved = DashMap::new();
+                    resolved.insert(cache_key(&ctx.host, ctx.port), addr);
                     return Ok(Box::new(DirectUdp {
                         sock: Arc::new(sock),
-                        peer: addr,
-                        target_host: ctx.host.clone(),
-                        target_port: ctx.port,
+                        resolved,
                         loopback_guard,
                     }));
                 }
@@ -103,76 +101,127 @@ impl OutboundAdapter for DirectOutbound {
 
 struct DirectUdp {
     sock: Arc<UdpSocket>,
-    peer: SocketAddr,
-    target_host: String,
-    target_port: u16,
+    resolved: DashMap<(String, u16), SocketAddr>,
     loopback_guard: crate::loopback::LoopbackUdpGuard,
 }
 
 fn open_direct_udp_socket(
     peer: SocketAddr,
 ) -> std::io::Result<(UdpSocket, crate::loopback::LoopbackUdpGuard)> {
-    let (std_sock, guard) = crate::adapter::create_outbound_udp_socket(peer)?;
+    let (std_sock, guard) = crate::adapter::create_outbound_udp_association(peer)?;
     Ok((UdpSocket::from_std(std_sock)?, guard))
 }
 
 #[async_trait]
 impl UdpSocketLike for DirectUdp {
     async fn send_to(&self, buf: &[u8], target: &str, port: u16) -> std::io::Result<usize> {
-        if !self.matches_target(target, port) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "direct UDP association is connected to {}:{} ({}) and cannot send to \
-                     {target}:{port}; endpoint-aware UDP receive is required before one \
-                     association can safely serve multiple destinations",
-                    self.target_host, self.target_port, self.peer
-                ),
-            ));
+        let family_is_v4 = self.sock.local_addr()?.is_ipv4();
+        let key = cache_key(target, port);
+        if let Some(address) = self.resolved.get(&key).map(|entry| *entry)
+            && address.is_ipv4() == family_is_v4
+        {
+            match self.sock.send_to(buf, address).await {
+                Ok(length) => return Ok(length),
+                Err(_) => {
+                    self.resolved.remove(&key);
+                }
+            }
         }
-        self.sock.send(buf).await
+        let addresses = resolve_host_for_direct(target, port).await?;
+        let mut last_error = None;
+        for address in addresses
+            .into_iter()
+            .filter(|address| address.is_ipv4() == family_is_v4)
+        {
+            match self.sock.send_to(buf, address).await {
+                Ok(length) => {
+                    self.resolved.insert(key, address);
+                    return Ok(length);
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(last_error.unwrap_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                format!("no usable UDP address for {target}:{port}"),
+            )
+        }))
     }
 
     async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize> {
         let _ = &self.loopback_guard;
-        self.sock.recv(buf).await
+        self.sock.recv_from(buf).await.map(|(length, _)| length)
     }
 
     async fn recv_from_endpoint(
         &self,
         buf: &mut [u8],
     ) -> std::io::Result<(usize, Option<SocketAddr>)> {
-        let length = self.recv_from(buf).await?;
-        Ok((length, Some(self.peer)))
+        let (length, source) = self.sock.recv_from(buf).await?;
+        Ok((length, Some(source)))
     }
 
     fn local_addr(&self) -> std::io::Result<Option<SocketAddr>> {
         self.sock.local_addr().map(Some)
     }
-}
 
-impl DirectUdp {
-    fn matches_target(&self, target: &str, port: u16) -> bool {
-        if port != self.target_port {
-            return false;
-        }
-
-        if normalize_host(target).eq_ignore_ascii_case(normalize_host(&self.target_host)) {
-            return true;
-        }
-
-        parse_ip_literal(target) == Some(self.peer.ip())
+    fn supports_multi_target(&self) -> bool {
+        true
     }
 }
 
-fn normalize_host(host: &str) -> &str {
-    host.trim()
-        .strip_prefix('[')
-        .and_then(|host| host.strip_suffix(']'))
-        .unwrap_or_else(|| host.trim())
-        .trim_end_matches('.')
+fn cache_key(host: &str, port: u16) -> (String, u16) {
+    (
+        host.trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .trim_end_matches('.')
+            .to_ascii_lowercase(),
+        port,
+    )
 }
 
-fn parse_ip_literal(host: &str) -> Option<IpAddr> {
-    normalize_host(host).parse().ok()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn direct_udp_association_keeps_one_local_endpoint_for_multiple_targets() {
+        let first = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let second = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let first_addr = first.local_addr().unwrap();
+        let second_addr = second.local_addr().unwrap();
+        let outbound = DirectOutbound
+            .dial_udp(DialContext::udp("127.0.0.1", first_addr.port()))
+            .await
+            .unwrap();
+        let local = outbound.local_addr().unwrap().unwrap();
+
+        outbound
+            .send_to(b"one", "127.0.0.1", first_addr.port())
+            .await
+            .unwrap();
+        outbound
+            .send_to(b"two", "127.0.0.1", second_addr.port())
+            .await
+            .unwrap();
+
+        let mut buffer = [0u8; 8];
+        let (first_len, first_peer) = first.recv_from(&mut buffer).await.unwrap();
+        assert_eq!(&buffer[..first_len], b"one");
+        assert_eq!(first_peer.port(), local.port());
+        let (second_len, second_peer) = second.recv_from(&mut buffer).await.unwrap();
+        assert_eq!(&buffer[..second_len], b"two");
+        assert_eq!(second_peer.port(), local.port());
+        first.send_to(b"r1", first_peer).await.unwrap();
+        second.send_to(b"r2", second_peer).await.unwrap();
+
+        let mut sources = std::collections::HashSet::new();
+        for _ in 0..2 {
+            let (_, source) = outbound.recv_from_endpoint(&mut buffer).await.unwrap();
+            sources.insert(source.unwrap());
+        }
+        assert_eq!(sources, [first_addr, second_addr].into_iter().collect());
+    }
 }

--- a/crates/core-outbound/src/proto/shadowsocks.rs
+++ b/crates/core-outbound/src/proto/shadowsocks.rs
@@ -239,18 +239,26 @@ impl UdpSocketLike for ShadowsocksUdp {
     }
 
     async fn recv_from(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.recv_from_endpoint(buf).await.map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(&self, buf: &mut [u8]) -> io::Result<(usize, Option<SocketAddr>)> {
         // The encrypted datagram is larger than the caller's plaintext
         // buffer. Always receive into a full UDP packet buffer first, then
         // apply ordinary datagram truncation semantics to the destination.
         let mut packet = self.recv_buf.lock().await;
-        let (payload_len, _, _) = self
+        let (payload_len, source, _) = self
             .socket
             .recv(&mut packet)
             .await
             .map_err(io::Error::other)?;
         let copied = payload_len.min(buf.len());
         buf[..copied].copy_from_slice(&packet[..copied]);
-        Ok(copied)
+        let endpoint = match source {
+            Address::SocketAddress(address) => Some(address),
+            Address::DomainNameAddress(_, _) => None,
+        };
+        Ok((copied, endpoint))
     }
 
     fn local_addr(&self) -> io::Result<Option<SocketAddr>> {
@@ -260,6 +268,10 @@ impl UdpSocketLike for ShadowsocksUdp {
     async fn close(&self) -> io::Result<()> {
         let _ = &self.loopback_guard;
         Ok(())
+    }
+
+    fn supports_multi_target(&self) -> bool {
+        true
     }
 }
 

--- a/crates/core-outbound/src/proto/snell.rs
+++ b/crates/core-outbound/src/proto/snell.rs
@@ -58,7 +58,7 @@ use tokio::{
 
 use crate::{
     adapter::{BoxedStream, BoxedUdp, Capabilities, DialContext, OutboundAdapter, UdpSocketLike},
-    proto::addr::encode_socks_addr,
+    proto::addr::{decode_socks_addr, encode_socks_addr},
     transport::{Transport, tcp::TcpTransport},
 };
 
@@ -274,6 +274,13 @@ impl UdpSocketLike for SnellUdp {
     }
 
     async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.recv_from_endpoint(buf).await.map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        buf: &mut [u8],
+    ) -> std::io::Result<(usize, Option<std::net::SocketAddr>)> {
         let mut read = self.read.lock().await;
         let mut len = [0u8; 2];
         read.read_exact(&mut len).await?;
@@ -284,16 +291,25 @@ impl UdpSocketLike for SnellUdp {
         if body_len > 0 {
             read.read_exact(&mut packet[2..]).await?;
         }
-        let (_, _, payload) = decode_udp_packet(&packet)?;
+        let (_, address, payload) = decode_udp_packet(&packet)?;
+        let (host, port, _) = decode_socks_addr(address)?;
         let copy_len = payload.len().min(buf.len());
         buf[..copy_len].copy_from_slice(&payload[..copy_len]);
-        Ok(copy_len)
+        let endpoint = host
+            .parse::<std::net::IpAddr>()
+            .ok()
+            .map(|address| std::net::SocketAddr::new(address, port));
+        Ok((copy_len, endpoint))
     }
 
     async fn close(&self) -> std::io::Result<()> {
         let mut write = self.write.lock().await;
         let _ = write.shutdown().await;
         Ok(())
+    }
+
+    fn supports_multi_target(&self) -> bool {
+        true
     }
 }
 

--- a/crates/core-outbound/src/proto/trojan.rs
+++ b/crates/core-outbound/src/proto/trojan.rs
@@ -339,8 +339,15 @@ impl UdpSocketLike for TrojanUdp {
     }
 
     async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.recv_from_endpoint(buf).await.map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        buf: &mut [u8],
+    ) -> std::io::Result<(usize, Option<std::net::SocketAddr>)> {
         let mut read = self.read.lock().await;
-        let _ = read_socks_addr_async(&mut *read).await?;
+        let (host, port) = read_socks_addr_async(&mut *read).await?;
         let mut len = [0u8; 2];
         read.read_exact(&mut len).await?;
         let total = u16::from_be_bytes(len) as usize;
@@ -355,13 +362,21 @@ impl UdpSocketLike for TrojanUdp {
         }
         let copy_len = total.min(buf.len());
         buf[..copy_len].copy_from_slice(&payload[..copy_len]);
-        Ok(copy_len)
+        let endpoint = host
+            .parse::<std::net::IpAddr>()
+            .ok()
+            .map(|address| std::net::SocketAddr::new(address, port));
+        Ok((copy_len, endpoint))
     }
 
     async fn close(&self) -> std::io::Result<()> {
         let mut write = self.write.lock().await;
         let _ = write.shutdown().await;
         Ok(())
+    }
+
+    fn supports_multi_target(&self) -> bool {
+        true
     }
 }
 

--- a/crates/core-outbound/src/socks5.rs
+++ b/crates/core-outbound/src/socks5.rs
@@ -281,16 +281,27 @@ impl UdpSocketLike for Socks5Udp {
     }
 
     async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.recv_from_endpoint(buf).await.map(|(length, _)| length)
+    }
+
+    async fn recv_from_endpoint(
+        &self,
+        buf: &mut [u8],
+    ) -> std::io::Result<(usize, Option<SocketAddr>)> {
         let mut packet = vec![0u8; buf.len().saturating_add(512).max(1500)];
         let n = self.sock.recv(&mut packet).await?;
         if n < 3 || packet[0] != 0 || packet[1] != 0 || packet[2] != 0 {
             return Err(io_err("invalid socks5 udp header"));
         }
-        let (_, _, used) = decode_socks_addr(&packet[3..n])?;
+        let (host, port, used) = decode_socks_addr(&packet[3..n])?;
         let payload = &packet[3 + used..n];
         let copy_len = payload.len().min(buf.len());
         buf[..copy_len].copy_from_slice(&payload[..copy_len]);
-        Ok(copy_len)
+        let endpoint = host
+            .parse::<std::net::IpAddr>()
+            .ok()
+            .map(|address| SocketAddr::new(address, port));
+        Ok((copy_len, endpoint))
     }
 
     async fn close(&self) -> std::io::Result<()> {
@@ -300,6 +311,10 @@ impl UdpSocketLike for Socks5Udp {
         }
         let _ = &self.loopback_guard;
         Ok(())
+    }
+
+    fn supports_multi_target(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
## Summary

- harden Android, Linux, and Windows traffic interception and crash recovery
- use native platform networking APIs and add a resilient full-network control plane
- make endpoint-independent-nat effective in the production TUN UDP path
- add atomic UDP association reservation, bounded queues, idle GC, network-change invalidation, and stale-session-safe cleanup
- preserve UDP response endpoints and multi-target associations for Direct, SOCKS5, Shadowsocks, Trojan, and Snell
- restore Fake-IP logical sources, enforce symmetric filtering when EIM is disabled, and reject oversized UDP datagrams safely
- accept snake_case and Mihomo-compatible kebab-case NAT fields
- merge the latest main and resolve cross-platform capture build integration

## Validation

- cargo check -p core-capture --lib under WSL/Linux
- 8 UDP NAT/session concurrency and boundary tests
- Direct multi-target stable-local-endpoint UDP test
- IPv4/IPv6 UDP packet round-trip and oversized-datagram tests
- full TUN payload and kebab-case configuration parsing tests

All targeted checks passed.