### PR TITLE
feat(build): support selectable component tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,29 @@ on:
         required: false
         type: string
         default: ""
+      tags:
+        description: Exact comma-separated component tags; empty uses the standard build.
+        required: false
+        type: string
+        default: ""
       retention-days:
         description: Artifact retention period.
         required: false
         type: number
         default: 1
   workflow_dispatch:
+    inputs:
+      tags:
+        description: Exact component tags, for example with_quic,with_vless,with_grpc. Empty uses standard.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.ref }}
+  group: build-${{ github.workflow }}-${{ github.ref }}-${{ inputs.tags || 'standard' }}
   cancel-in-progress: true
 
 env:
@@ -70,6 +81,24 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
+      - name: Resolve component tags
+        shell: bash
+        env:
+          REQUESTED_TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          normalized="$(tr ' ;' ',,' <<< "$REQUESTED_TAGS" | sed -E 's/,+/,/g; s/^,//; s/,$//')"
+          if [ -n "$normalized" ] && [[ ! "$normalized" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]]; then
+            echo "::error::Component tags must be a comma/space-separated list of Cargo feature names."
+            exit 1
+          fi
+          echo "WUTHER_BUILD_TAGS=$normalized" >> "$GITHUB_ENV"
+          if [ -n "$normalized" ]; then
+            echo "WUTHER_BUILD_TAG_LABEL=$normalized" >> "$GITHUB_ENV"
+          else
+            echo "WUTHER_BUILD_TAG_LABEL=standard (default)" >> "$GITHUB_ENV"
+          fi
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -114,12 +143,22 @@ jobs:
       - name: Run Cargo NDK Build (Android)
         if: matrix.platform.is_android == true
         run: |
-          cargo ndk --target ${{ matrix.platform.target }} --platform 24 build --release --locked -p wuther-core
+          feature_args=()
+          if [ -n "$WUTHER_BUILD_TAGS" ]; then
+            feature_args=(--no-default-features --features "$WUTHER_BUILD_TAGS")
+          fi
+          cargo ndk --target ${{ matrix.platform.target }} --platform 24 \
+            build --release --locked -p wuther-core "${feature_args[@]}"
 
       - name: Run Cross Build (Non-Android)
         if: matrix.platform.is_android != true
         run: |
-          cross build --release --locked --target ${{ matrix.platform.target }} -p wuther-core
+          feature_args=()
+          if [ -n "$WUTHER_BUILD_TAGS" ]; then
+            feature_args=(--no-default-features --features "$WUTHER_BUILD_TAGS")
+          fi
+          cross build --release --locked --target ${{ matrix.platform.target }} \
+            -p wuther-core "${feature_args[@]}"
 
       - name: Package Artifacts
         env:
@@ -144,6 +183,11 @@ jobs:
           cp README.md LICENSE ./pkg_dir/
           cp third_party/xray-transport/LICENSE-MPL-2.0 ./pkg_dir/licenses/xray-transport-MPL-2.0.txt
           cp -R examples ./pkg_dir/
+          {
+            echo "version=${RELEASE_VERSION:-workspace}"
+            echo "target=${{ matrix.platform.target }}"
+            echo "tags=$WUTHER_BUILD_TAG_LABEL"
+          } > ./pkg_dir/BUILD-COMPONENTS.txt
 
           ARCHIVE_NAME="wuther-core-${PLATFORM_NAME}.zip"
           if [ -n "$RELEASE_VERSION" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,28 @@ on:
         required: false
         type: string
         default: ""
+      tags:
+        description: Exact component tags; empty validates the standard workspace.
+        required: false
+        type: string
+        default: ""
   pull_request:
     branches: ["main"]
   push:
     branches: ["main"]
   workflow_dispatch:
+    inputs:
+      tags:
+        description: Exact component tags, for example with_quic,with_vless,with_grpc. Empty uses standard.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ inputs.ref || github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ inputs.ref || github.event.pull_request.number || github.ref }}-${{ inputs.tags || 'standard' }}
   cancel-in-progress: true
 
 env:
@@ -73,8 +84,28 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+      - name: Resolve component tags
+        shell: bash
+        env:
+          REQUESTED_TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          normalized="$(tr ' ;' ',,' <<< "$REQUESTED_TAGS" | sed -E 's/,+/,/g; s/^,//; s/,$//')"
+          if [ -n "$normalized" ] && [[ ! "$normalized" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]]; then
+            echo "::error::Component tags must be a comma/space-separated list of Cargo feature names."
+            exit 1
+          fi
+          echo "WUTHER_BUILD_TAGS=$normalized" >> "$GITHUB_ENV"
+
       # Validate every Rust target without repeatedly linking the full workspace.
       # Feature-specific linking and artifact validation belong to their dedicated
       # workflows.
       - name: Check workspace
-        run: cargo check --workspace --all-targets --locked
+        shell: bash
+        run: |
+          if [ -n "$WUTHER_BUILD_TAGS" ]; then
+            cargo check -p wuther-core --all-targets --locked \
+              --no-default-features --features "$WUTHER_BUILD_TAGS"
+          else
+            cargo check --workspace --all-targets --locked
+          fi

--- a/.github/workflows/naive.yml
+++ b/.github/workflows/naive.yml
@@ -12,6 +12,12 @@ on:
       - "crates/core-outbound/**"
       - "crates/wuther-core/**"
   workflow_dispatch:
+    inputs:
+      tags:
+        description: Extra component tags to compile together with with_naive.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -59,9 +65,20 @@ jobs:
           echo "LD_LIBRARY_PATH=$RUNNER_TEMP/cronet-sdk/lib" >> "$GITHUB_ENV"
 
       - name: Check Naive feature
-        run: cargo check -p wuther-core --features naive --all-targets --locked
+        shell: bash
+        env:
+          EXTRA_TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          normalized="$(tr ' ;' ',,' <<< "$EXTRA_TAGS" | sed -E 's/,+/,/g; s/^,//; s/,$//')"
+          if [ -n "$normalized" ] && [[ ! "$normalized" =~ ^[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*$ ]]; then
+            echo "::error::Component tags must be a comma/space-separated list of Cargo feature names."
+            exit 1
+          fi
+          tags="with_naive${normalized:+,$normalized}"
+          cargo check -p wuther-core --no-default-features --features "$tags" --all-targets --locked
 
       - name: Test Naive URI and native tunnel
         run: |
           cargo test -p core-config parse_naive_h2_and_quic_links --locked
-          cargo test -p core-outbound --features naive naive --locked
+          cargo test -p core-outbound --no-default-features --features with_naive naive --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,11 @@ jobs:
           cp README.md LICENSE "$package_dir/"
           cp third_party/xray-transport/LICENSE-MPL-2.0 "$package_dir/licenses/xray-transport-MPL-2.0.txt"
           cp -R examples "$package_dir/"
+          {
+            echo "version=$RELEASE_VERSION"
+            echo "target=$TARGET"
+            echo "tags=standard (default)"
+          } > "$package_dir/BUILD-COMPONENTS.txt"
 
           cd "$package_dir"
           zip -X -r "../dist/$archive" .
@@ -226,6 +231,11 @@ jobs:
           Copy-Item README.md, LICENSE $packageDir
           Copy-Item examples (Join-Path $packageDir 'examples') -Recurse
           Copy-Item third_party/xray-transport/LICENSE-MPL-2.0 (Join-Path $licenseDir 'xray-transport-MPL-2.0.txt')
+          @(
+            "version=$env:RELEASE_VERSION"
+            "target=$env:TARGET"
+            "tags=standard (default)"
+          ) | Set-Content -Path (Join-Path $packageDir 'BUILD-COMPONENTS.txt') -Encoding UTF8
           Compress-Archive -Path (Join-Path $packageDir '*') -DestinationPath $archive -CompressionLevel Optimal
 
       - name: Upload artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,8 +168,8 @@ rtnetlink = "0.21.0"
 core-config   = { path = "crates/core-config" }
 core-fetch    = { path = "crates/core-fetch" }
 core-runtime  = { path = "crates/core-runtime" }
-core-inbound  = { path = "crates/core-inbound" }
-core-outbound = { path = "crates/core-outbound" }
+core-inbound  = { path = "crates/core-inbound", default-features = false }
+core-outbound = { path = "crates/core-outbound", default-features = false }
 core-grpc     = { path = "crates/core-grpc" }
 core-feeds    = { path = "crates/core-feeds" }
 core-store    = { path = "crates/core-store" }
@@ -177,7 +177,7 @@ core-ruleset  = { path = "crates/core-ruleset" }
 core-route    = { path = "crates/core-route" }
 core-resolver = { path = "crates/core-resolver" }
 core-smart    = { path = "crates/core-smart" }
-core-api      = { path = "crates/core-api" }
+core-api      = { path = "crates/core-api", default-features = false }
 core-capture  = { path = "crates/core-capture" }
 core-mesh     = { path = "crates/core-mesh" }
 core-observe  = { path = "crates/core-observe" }

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ sha256sum -c SHA256SUMS
 gh attestation verify <archive.zip> --repo MiChongs/WutherCore
 ```
 
-Young 构建需要 Mozilla NSS 原生库。Naive 构建需要 `naive` feature、Cronet 动态库和相应许可处理。各平台构建方式见 [构建脚本](scripts/README.md) 和 [发版指南](docs/RELEASING.md)。
+Young 构建需要 Mozilla NSS 原生库。Naive 构建需要 `with_naive` feature、Cronet 动态库和相应许可处理。协议与传输组件可以通过 `with_*` 编译标签精确裁剪，本地构建和 GitHub CI 使用同一套标签。完整标签表及各平台构建方式见 [构建脚本](scripts/README.md) 和 [发版指南](docs/RELEASING.md)。
 
 ## 文档
 

--- a/build.cmd
+++ b/build.cmd
@@ -8,6 +8,7 @@ REM   build.cmd                              default target matrix
 REM   build.cmd x86_64-pc-windows-msvc       single target
 REM   build.cmd --clean                      cargo clean before build
 REM   build.cmd android                      shorthand for aarch64-linux-android
+REM   build.cmd --tags "with_quic,with_vless" windows
 REM Other args are forwarded to scripts\build-all.ps1.
 
 set "SCRIPT_DIR=%~dp0"
@@ -41,7 +42,21 @@ if /I "%~1"=="--skip-checks" (
     goto parse
 )
 if /I "%~1"=="--profile" (
+    if "%~2"=="" (
+        echo ERROR: --profile requires a value.
+        exit /b 2
+    )
     set "EXTRA_ARGS=!EXTRA_ARGS! -Profile %~2"
+    shift
+    shift
+    goto parse
+)
+if /I "%~1"=="--tags" (
+    if "%~2"=="" (
+        echo ERROR: --tags requires a comma-separated value.
+        exit /b 2
+    )
+    set "EXTRA_ARGS=!EXTRA_ARGS! -Tags ""%~2"""
     shift
     shift
     goto parse

--- a/crates/core-api/Cargo.toml
+++ b/crates/core-api/Cargo.toml
@@ -4,12 +4,16 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = ["with_tun"]
+with_tun = ["dep:core-capture"]
+
 [dependencies]
 core-config  = { workspace = true }
 core-smart   = { workspace = true }
 core-runtime = { workspace = true }
 core-route   = { workspace = true }
-core-capture = { workspace = true }
+core-capture = { workspace = true, optional = true }
 core-mesh    = { workspace = true }
 core-feeds   = { workspace = true }
 core-observe = { workspace = true }

--- a/crates/core-api/src/native.rs
+++ b/crates/core-api/src/native.rs
@@ -19,6 +19,7 @@ pub struct NativeState {
     pub secret: Option<String>,
     pub urltest: Arc<UrlTester>,
     /// 由 main.rs 在 capture 启动后注入；为空时 /v1/capture/state 仅回静态配置。
+    #[cfg(feature = "with_tun")]
     pub capture: Option<Arc<core_capture::CaptureSupervisor>>,
     /// 统一组网监督器；`/v1/mesh/status` 只返回脱敏后的结构化快照。
     pub mesh: Option<Arc<core_mesh::MeshSupervisor>>,
@@ -46,6 +47,7 @@ impl NativeState {
             started_at: std::time::Instant::now(),
             secret: None,
             urltest,
+            #[cfg(feature = "with_tun")]
             capture: None,
             mesh: None,
             feeds,
@@ -253,6 +255,7 @@ async fn route_check(
 
 async fn capture_state(State(s): State<NativeState>) -> impl IntoResponse {
     let c = &s.runtime.plan.capture;
+    #[allow(unused_mut)]
     let mut body = json!({
         "on": c.on,
         "method": format!("{:?}", c.method).to_lowercase(),
@@ -277,9 +280,12 @@ async fn capture_state(State(s): State<NativeState>) -> impl IntoResponse {
             "loopback_address": c.tun.loopback_address.clone(),
         }
     });
-    if let Some(sup) = &s.capture {
-        if let Some(obj) = body.as_object_mut() {
-            obj.insert("runtime".into(), sup.report());
+    #[cfg(feature = "with_tun")]
+    {
+        if let Some(sup) = &s.capture {
+            if let Some(obj) = body.as_object_mut() {
+                obj.insert("runtime".into(), sup.report());
+            }
         }
     }
     Json(body)

--- a/crates/core-api/src/server.rs
+++ b/crates/core-api/src/server.rs
@@ -56,6 +56,7 @@ pub struct ApiServer {
     pub secret: Option<String>,
     pub clash_compat: bool,
     pub urltest: Arc<UrlTester>,
+    #[cfg(feature = "with_tun")]
     pub capture: Option<Arc<core_capture::CaptureSupervisor>>,
     /// 统一组网监督器；提供只读运行状态，不暴露认证材料。
     pub mesh: Option<Arc<core_mesh::MeshSupervisor>>,
@@ -77,6 +78,7 @@ impl ApiServer {
             started_at: std::time::Instant::now(),
             secret: self.secret.clone(),
             urltest: self.urltest.clone(),
+            #[cfg(feature = "with_tun")]
             capture: self.capture.clone(),
             mesh: self.mesh.clone(),
             feeds: self.feeds.clone(),

--- a/crates/core-capture/src/net_monitor_event.rs
+++ b/crates/core-capture/src/net_monitor_event.rs
@@ -90,7 +90,7 @@ mod windows_impl {
                 AF_UNSPEC as u16,
                 Some(route_callback),
                 ctx_ptr,
-                0,
+                false,
                 &mut route_handle,
             )
         };
@@ -99,7 +99,7 @@ mod windows_impl {
                 AF_UNSPEC as u16,
                 Some(iface_callback),
                 ctx_ptr,
-                0,
+                false,
                 &mut iface_handle,
             )
         };

--- a/crates/core-inbound/Cargo.toml
+++ b/crates/core-inbound/Cargo.toml
@@ -4,16 +4,44 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = ["standard"]
+standard = ["with_grpc", "with_reality", "with_shadowsocks", "with_xhttp"]
+with_grpc = ["dep:core-grpc", "with_reality", "tls_inbound"]
+with_reality = ["dep:core-reality"]
+with_shadowsocks = ["dep:shadowsocks"]
+with_xhttp = [
+    "tls_inbound",
+    "dep:h3",
+    "dep:h3-quinn",
+    "dep:quinn",
+]
+# Shared by gRPC TLS and XHTTP. This is kept separate so minimal/mixed-only
+# builds do not compile or link BoringSSL and the certificate toolchain.
+tls_inbound = [
+    "dep:boring",
+    "dep:boring-sys",
+    "dep:chrono",
+    "dep:ocsp-stapler",
+    "dep:rasn",
+    "dep:rasn-ocsp",
+    "dep:rasn-pkix",
+    "dep:rcgen",
+    "dep:sha1",
+    "dep:tokio-boring",
+    "dep:x509-parser",
+]
+
 [dependencies]
 core-config   = { workspace = true }
-core-grpc     = { workspace = true }
+core-grpc     = { workspace = true, optional = true }
 core-route    = { workspace = true }
 core-resolver = { workspace = true }
 core-outbound = { workspace = true }
 core-smart    = { workspace = true }
 core-runtime  = { workspace = true }
 core-observe  = { workspace = true }
-core-reality  = { workspace = true }
+core-reality  = { workspace = true, optional = true }
 tokio         = { workspace = true }
 tokio-util    = { workspace = true }
 async-trait   = { workspace = true }
@@ -30,7 +58,7 @@ uuid          = { workspace = true }
 subtle        = "2.6"
 rand          = { workspace = true }
 url           = { workspace = true }
-shadowsocks   = { workspace = true }
+shadowsocks   = { workspace = true, optional = true }
 
 # XHTTP/SplitHTTP inbound: HTTP/1.1 + HTTP/2 over TCP/TLS and HTTP/3 over QUIC.
 http           = "1"
@@ -41,20 +69,20 @@ http-body-util = "0.1"
 rustls         = { workspace = true }
 tokio-rustls   = { workspace = true }
 rustls-pemfile = "2"
-boring         = { workspace = true }
-boring-sys     = { workspace = true }
-tokio-boring   = { workspace = true }
-quinn          = { workspace = true }
-h3             = { workspace = true }
-h3-quinn       = { workspace = true }
-rcgen          = { version = "=0.14.8", features = ["pem", "x509-parser"] }
-ocsp-stapler   = { version = "=0.4.9", default-features = false }
-chrono         = { version = "0.4", default-features = false, features = ["clock"] }
-rasn           = "=0.28.13"
-rasn-ocsp      = "=0.28.13"
-rasn-pkix      = "=0.28.13"
-sha1           = "0.11"
-x509-parser    = { version = "=0.18.1", features = ["verify-aws"] }
+boring         = { workspace = true, optional = true }
+boring-sys     = { workspace = true, optional = true }
+tokio-boring   = { workspace = true, optional = true }
+quinn          = { workspace = true, optional = true }
+h3             = { workspace = true, optional = true }
+h3-quinn       = { workspace = true, optional = true }
+rcgen          = { version = "=0.14.8", features = ["pem", "x509-parser"], optional = true }
+ocsp-stapler   = { version = "=0.4.9", default-features = false, optional = true }
+chrono         = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+rasn           = { version = "=0.28.13", optional = true }
+rasn-ocsp      = { version = "=0.28.13", optional = true }
+rasn-pkix      = { version = "=0.28.13", optional = true }
+sha1           = { version = "0.11", optional = true }
+x509-parser    = { version = "=0.18.1", features = ["verify-aws"], optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd"))'.dependencies]
 nix = { version = "0.31", features = ["user", "fs"] }

--- a/crates/core-inbound/src/lib.rs
+++ b/crates/core-inbound/src/lib.rs
@@ -6,29 +6,42 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(feature = "with_grpc")]
 pub mod grpc;
 pub mod listener;
 pub mod mixed;
 pub mod privilege;
+#[cfg(feature = "with_reality")]
 pub mod reality;
+#[cfg(feature = "with_shadowsocks")]
 pub mod shadowsocks;
 pub mod vless;
+#[cfg(feature = "with_xhttp")]
 pub mod xhttp;
+#[cfg(feature = "with_xhttp")]
 mod xhttp_body_budget;
+#[cfg(feature = "with_xhttp")]
 mod xhttp_cors;
+#[cfg(feature = "with_xhttp")]
 pub mod xhttp_listener;
+#[cfg(feature = "tls_inbound")]
 mod xhttp_tls;
 
+#[cfg(feature = "with_grpc")]
 pub use grpc::{GrpcListener, run_grpc, run_grpc_with_cancellation};
 pub use listener::{bind_with_fallback, select_bind_addr};
 pub use mixed::{MixedListener, run_mixed};
 pub use privilege::{
     PrivilegeLevel, PrivilegeReport, ensure_best_effort_privilege, try_request_root_android,
 };
+#[cfg(feature = "with_reality")]
 pub use reality::{RealityListener, run_reality};
+#[cfg(feature = "with_shadowsocks")]
 pub use shadowsocks::{
     ShadowsocksListenerHandle, start_shadowsocks_listener, start_shadowsocks_listeners,
 };
 pub use vless::{VlessConnectionContext, VlessInboundConfig, serve_vless_stream};
+#[cfg(feature = "with_xhttp")]
 pub use xhttp_listener::{XhttpListenerHandle, start_xhttp_listener, start_xhttp_listeners};
+#[cfg(feature = "tls_inbound")]
 pub use xhttp_tls::{XrayServerTlsAcceptor, XrayServerTlsCarrier, XrayServerTlsStream};

--- a/crates/core-outbound/Cargo.toml
+++ b/crates/core-outbound/Cargo.toml
@@ -5,18 +5,79 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-default = []
+default = ["standard"]
+# Compile-time component tags. `standard` preserves the historical default
+# binary while individual `with_*` tags allow consumers to build a smaller,
+# purpose-specific core.
+standard = [
+    "with_anytls",
+    "with_grpc",
+    "with_hysteria",
+    "with_hysteria2",
+    "with_http",
+    "with_http_transport",
+    "with_mieru",
+    "with_quic",
+    "with_reality",
+    "with_shadowsocks",
+    "with_shadowsocksr",
+    "with_snell",
+    "with_socks",
+    "with_ssh",
+    "with_sudoku",
+    "with_trojan",
+    "with_trusttunnel",
+    "with_tuic",
+    "with_utls",
+    "with_vless",
+    "with_vmess",
+    "with_wireguard",
+    "with_ws",
+    "with_xhttp",
+    "with_young",
+]
+all_components = ["standard", "with_naive"]
+
+# Transport/capability tags.
+with_quic = []
+with_grpc = []
+with_reality = []
+with_utls = ["dep:boring", "dep:boring-sys", "dep:tokio-boring"]
+with_ws = []
+with_http_transport = []
+with_xhttp = ["with_quic"]
+
+# Outbound protocol tags.
+with_http = []
+with_socks = []
+with_shadowsocks = []
+with_shadowsocksr = []
+with_vmess = []
+with_vless = []
+with_trojan = []
 # NaiveProxy depends on the separately distributed SagerNet Cronet native
 # library. Keep it opt-in so ordinary MIT builds do not silently acquire a
 # GPL-3.0 runtime dependency.
-naive = ["dep:cronet"]
+with_naive = ["dep:cronet"]
+naive = ["with_naive"]
+with_snell = []
+with_anytls = []
+with_ssh = []
+with_hysteria = ["with_quic"]
+with_hysteria2 = ["with_quic"]
+with_tuic = ["with_quic"]
+with_wireguard = []
+with_mieru = []
+with_sudoku = []
+with_trusttunnel = []
+with_young = ["dep:core-young", "core-young/firefox-stack"]
 
 [dependencies]
 core-config = { workspace = true }
 core-reality = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
-core-young   = { workspace = true, features = ["firefox-stack"] }
+core-young   = { workspace = true, optional = true }
 core-grpc   = { workspace = true }
 tokio       = { workspace = true }
 async-trait = { workspace = true }
@@ -56,9 +117,9 @@ rustls-pki-types  = { workspace = true }
 webpki-roots      = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pemfile     = "2"
-boring             = { workspace = true }
-boring-sys         = { workspace = true }
-tokio-boring       = { workspace = true }
+boring             = { workspace = true, optional = true }
+boring-sys         = { workspace = true, optional = true }
+tokio-boring       = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true }
 uuid              = { workspace = true }
 rand              = { workspace = true }

--- a/crates/core-outbound/src/proto/mod.rs
+++ b/crates/core-outbound/src/proto/mod.rs
@@ -16,7 +16,7 @@ pub mod anytls;
 pub mod hysteria;
 pub mod hysteria2;
 pub mod mieru;
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_naive")]
 pub mod naive;
 pub mod shadowsocks;
 pub mod snell;
@@ -33,4 +33,5 @@ pub mod vmess_kdf;
 pub mod vmess_legacy;
 pub mod wireguard;
 pub mod xhttp;
+#[cfg(feature = "with_young")]
 pub mod young;

--- a/crates/core-outbound/src/registry.rs
+++ b/crates/core-outbound/src/registry.rs
@@ -15,9 +15,17 @@ use core_config::{
 };
 use uuid::Uuid;
 
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_http")]
+use crate::http::HttpOutbound;
+#[cfg(feature = "with_naive")]
 use crate::proto::naive::{NaiveOutbound, NaiveOutboundConfig};
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_young")]
+use crate::proto::young::YoungOutbound;
+#[cfg(feature = "with_socks")]
+use crate::socks5::Socks5Outbound;
+#[cfg(any(feature = "with_naive", feature = "with_young"))]
+use crate::stub::StubOutbound;
+#[cfg(feature = "with_naive")]
 use cronet::Header;
 
 use crate::{
@@ -25,7 +33,6 @@ use crate::{
     block::BlockOutbound,
     direct::DirectOutbound,
     dns_hijack::DnsHijackOutbound,
-    http::HttpOutbound,
     proto::{
         anytls::AnyTlsOutbound,
         hysteria::HysteriaOutbound,
@@ -47,17 +54,145 @@ use crate::{
             Config as XhttpConfig, DownloadRealitySettings, DownloadSettings,
             DownloadSocketSettings, DownloadTlsSettings, DownloadTransportSettings,
         },
-        young::YoungOutbound,
     },
     socket_policy::ConfiguredOutbound,
-    socks5::Socks5Outbound,
-    stub::StubOutbound,
     transport::{
         GrpcOptions, H2Options, HttpOptions, RealityOptions, TlsOptions, WsOptions, XhttpOptions,
     },
 };
 
 pub type ResolveFn = Arc<dyn Fn(&str) -> Option<SharedOutbound> + Send + Sync>;
+
+/// Canonical compile-time component tags accepted by `wuther-core`.
+pub const COMPONENT_TAGS: &[&str] = &[
+    "with_anytls",
+    "with_grpc",
+    "with_hysteria",
+    "with_hysteria2",
+    "with_http",
+    "with_http_transport",
+    "with_mieru",
+    "with_naive",
+    "with_quic",
+    "with_reality",
+    "with_shadowsocks",
+    "with_shadowsocksr",
+    "with_snell",
+    "with_socks",
+    "with_ssh",
+    "with_sudoku",
+    "with_trojan",
+    "with_trusttunnel",
+    "with_tuic",
+    "with_utls",
+    "with_vless",
+    "with_vmess",
+    "with_wireguard",
+    "with_ws",
+    "with_xhttp",
+    "with_young",
+];
+
+/// Return the build tag controlling one protocol. Direct, block and DNS are
+/// foundational and intentionally remain available in every build.
+pub fn protocol_component_tag(protocol: &NodeProtocol) -> Option<&'static str> {
+    match protocol {
+        NodeProtocol::Direct | NodeProtocol::Block | NodeProtocol::Dns => None,
+        NodeProtocol::Http => Some("with_http"),
+        NodeProtocol::Socks5 => Some("with_socks"),
+        NodeProtocol::Shadowsocks => Some("with_shadowsocks"),
+        NodeProtocol::ShadowsocksR => Some("with_shadowsocksr"),
+        NodeProtocol::Vmess => Some("with_vmess"),
+        NodeProtocol::Vless => Some("with_vless"),
+        NodeProtocol::Trojan => Some("with_trojan"),
+        NodeProtocol::Naive => Some("with_naive"),
+        NodeProtocol::Snell => Some("with_snell"),
+        NodeProtocol::AnyTls => Some("with_anytls"),
+        NodeProtocol::Ssh => Some("with_ssh"),
+        NodeProtocol::Hysteria => Some("with_hysteria"),
+        NodeProtocol::Hysteria2 => Some("with_hysteria2"),
+        NodeProtocol::Tuic => Some("with_tuic"),
+        NodeProtocol::Wireguard => Some("with_wireguard"),
+        NodeProtocol::Mieru => Some("with_mieru"),
+        NodeProtocol::Sudoku => Some("with_sudoku"),
+        NodeProtocol::TrustTunnel => Some("with_trusttunnel"),
+        NodeProtocol::Young => Some("with_young"),
+        NodeProtocol::Other(_) => None,
+    }
+}
+
+pub fn protocol_component_enabled(protocol: &NodeProtocol) -> bool {
+    match protocol {
+        NodeProtocol::Direct | NodeProtocol::Block | NodeProtocol::Dns => true,
+        NodeProtocol::Http => cfg!(feature = "with_http"),
+        NodeProtocol::Socks5 => cfg!(feature = "with_socks"),
+        NodeProtocol::Shadowsocks => cfg!(feature = "with_shadowsocks"),
+        NodeProtocol::ShadowsocksR => cfg!(feature = "with_shadowsocksr"),
+        NodeProtocol::Vmess => cfg!(feature = "with_vmess"),
+        NodeProtocol::Vless => cfg!(feature = "with_vless"),
+        NodeProtocol::Trojan => cfg!(feature = "with_trojan"),
+        NodeProtocol::Naive => cfg!(feature = "with_naive"),
+        NodeProtocol::Snell => cfg!(feature = "with_snell"),
+        NodeProtocol::AnyTls => cfg!(feature = "with_anytls"),
+        NodeProtocol::Ssh => cfg!(feature = "with_ssh"),
+        NodeProtocol::Hysteria => cfg!(feature = "with_hysteria"),
+        NodeProtocol::Hysteria2 => cfg!(feature = "with_hysteria2"),
+        NodeProtocol::Tuic => cfg!(feature = "with_tuic"),
+        NodeProtocol::Wireguard => cfg!(feature = "with_wireguard"),
+        NodeProtocol::Mieru => cfg!(feature = "with_mieru"),
+        NodeProtocol::Sudoku => cfg!(feature = "with_sudoku"),
+        NodeProtocol::TrustTunnel => cfg!(feature = "with_trusttunnel"),
+        NodeProtocol::Young => cfg!(feature = "with_young"),
+        NodeProtocol::Other(_) => true,
+    }
+}
+
+/// Fail closed when a configuration asks for code omitted by this build.
+pub fn validate_node_components(node: &ParsedNode) -> Result<(), String> {
+    if !protocol_component_enabled(&node.protocol) {
+        let tag = protocol_component_tag(&node.protocol).expect("disabled protocols have a tag");
+        return Err(format!(
+            "protocol `{}` is not compiled in; rebuild with `{tag}`",
+            node.protocol.as_str()
+        ));
+    }
+
+    let transport = node.transport.trim().to_ascii_lowercase();
+    let required_transport = match transport.as_str() {
+        "ws" | "websocket" => (!cfg!(feature = "with_ws")).then_some("with_ws"),
+        "http" | "h2" => (!cfg!(feature = "with_http_transport")).then_some("with_http_transport"),
+        "grpc" | "gun" => (!cfg!(feature = "with_grpc")).then_some("with_grpc"),
+        "xhttp" | "splithttp" => (!cfg!(feature = "with_xhttp")).then_some("with_xhttp"),
+        "quic" | "h3" => (!cfg!(feature = "with_quic")).then_some("with_quic"),
+        _ => None,
+    };
+    if let Some(tag) = required_transport {
+        return Err(format!(
+            "transport `{transport}` is not compiled in; rebuild with `{tag}`"
+        ));
+    }
+
+    if (node.reality.is_some() || node.reality_settings.is_some())
+        && !cfg!(feature = "with_reality")
+    {
+        return Err("REALITY is not compiled in; rebuild with `with_reality`".into());
+    }
+
+    let fingerprint = node
+        .tls_settings
+        .as_ref()
+        .and_then(|settings| settings.fingerprint.as_deref())
+        .or_else(|| node.params.get("fingerprint").map(String::as_str))
+        .unwrap_or_default()
+        .trim();
+    if !fingerprint.is_empty()
+        && !fingerprint.eq_ignore_ascii_case("unsafe")
+        && !cfg!(feature = "with_utls")
+    {
+        return Err("uTLS fingerprinting is not compiled in; rebuild with `with_utls`".into());
+    }
+    Ok(())
+}
 
 #[derive(Default)]
 pub struct OutboundRegistry {
@@ -146,41 +281,60 @@ pub fn register_nodes(reg: &mut OutboundRegistry, nodes: &[ParsedNode]) -> Resul
 }
 
 pub fn build_outbound(node: &ParsedNode) -> Result<SharedOutbound, String> {
+    validate_node_components(node)?;
+
+    macro_rules! compiled {
+        ($feature:literal, $expression:expr) => {{
+            #[cfg(feature = $feature)]
+            {
+                $expression
+            }
+            #[cfg(not(feature = $feature))]
+            {
+                unreachable!("component availability was validated before dispatch")
+            }
+        }};
+    }
+
     let outbound: SharedOutbound = match node.protocol {
         NodeProtocol::Direct => DirectOutbound::new(),
         NodeProtocol::Block => BlockOutbound::new(),
         NodeProtocol::Dns => DnsHijackOutbound::new(node.name.clone()),
-        NodeProtocol::Http => {
+        NodeProtocol::Http => compiled!("with_http", {
             let mut ob = HttpOutbound::new(&node.name, &node.host, node.port);
             if let (Some(u), Some(p)) = (node.user.clone(), node.password.clone()) {
                 ob = ob.with_auth(u, p);
             }
             ob.into_arc()
-        }
-        NodeProtocol::Socks5 => {
+        }),
+        NodeProtocol::Socks5 => compiled!("with_socks", {
             let mut ob = Socks5Outbound::new(&node.name, &node.host, node.port).with_udp(node.udp);
             if let (Some(u), Some(p)) = (node.user.clone(), node.password.clone()) {
                 ob = ob.with_auth(u, p);
             }
             ob.into_arc()
+        }),
+        NodeProtocol::Shadowsocks => {
+            compiled!("with_shadowsocks", build_shadowsocks(node)?)
         }
-        NodeProtocol::Shadowsocks => build_shadowsocks(node)?,
-        NodeProtocol::ShadowsocksR => build_ssr(node)?,
-        NodeProtocol::Vmess => return build_vmess(node),
-        NodeProtocol::Vless => return build_vless(node),
-        NodeProtocol::Trojan => Arc::new(build_trojan(node)?),
-        NodeProtocol::Naive => build_naive(node),
-        NodeProtocol::Snell => build_snell(node)?,
-        NodeProtocol::AnyTls => build_anytls(node)?,
-        NodeProtocol::Ssh => build_ssh(node)?,
-        NodeProtocol::Hysteria => build_hysteria_v1(node)?,
-        NodeProtocol::Hysteria2 => build_hysteria2(node)?,
-        NodeProtocol::Tuic => build_tuic(node)?,
-        NodeProtocol::Wireguard => build_wireguard(node)?,
-        NodeProtocol::Mieru => build_mieru(node),
-        NodeProtocol::Sudoku => build_sudoku(node)?,
-        NodeProtocol::TrustTunnel => build_trusttunnel(node),
-        NodeProtocol::Young => build_young(node),
+        NodeProtocol::ShadowsocksR => compiled!("with_shadowsocksr", build_ssr(node)?),
+        NodeProtocol::Vmess => compiled!("with_vmess", build_vmess(node)?),
+        NodeProtocol::Vless => compiled!("with_vless", build_vless(node)?),
+        NodeProtocol::Trojan => compiled!("with_trojan", Arc::new(build_trojan(node)?)),
+        NodeProtocol::Naive => compiled!("with_naive", build_naive(node)),
+        NodeProtocol::Snell => compiled!("with_snell", build_snell(node)?),
+        NodeProtocol::AnyTls => compiled!("with_anytls", build_anytls(node)?),
+        NodeProtocol::Ssh => compiled!("with_ssh", build_ssh(node)?),
+        NodeProtocol::Hysteria => compiled!("with_hysteria", build_hysteria_v1(node)?),
+        NodeProtocol::Hysteria2 => compiled!("with_hysteria2", build_hysteria2(node)?),
+        NodeProtocol::Tuic => compiled!("with_tuic", build_tuic(node)?),
+        NodeProtocol::Wireguard => compiled!("with_wireguard", build_wireguard(node)?),
+        NodeProtocol::Mieru => compiled!("with_mieru", build_mieru(node)),
+        NodeProtocol::Sudoku => compiled!("with_sudoku", build_sudoku(node)?),
+        NodeProtocol::TrustTunnel => {
+            compiled!("with_trusttunnel", build_trusttunnel(node))
+        }
+        NodeProtocol::Young => compiled!("with_young", build_young(node)),
         NodeProtocol::Other(ref protocol) => {
             return Err(format!("unsupported outbound protocol `{protocol}`"));
         }
@@ -193,7 +347,7 @@ pub fn try_build_outbound(node: &ParsedNode) -> Result<SharedOutbound, String> {
     build_outbound(node)
 }
 
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_naive")]
 fn build_naive(node: &ParsedNode) -> SharedOutbound {
     let mut config = NaiveOutboundConfig::new(&node.host, node.port);
     config.username = node.user.clone();
@@ -309,12 +463,7 @@ fn build_naive(node: &ParsedNode) -> SharedOutbound {
     }
 }
 
-#[cfg(not(feature = "naive"))]
-fn build_naive(node: &ParsedNode) -> SharedOutbound {
-    StubOutbound::new(node.name.clone(), "naive(feature-disabled)")
-}
-
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_naive")]
 fn param_bool(node: &ParsedNode, keys: &[&str], default: bool) -> bool {
     keys.iter()
         .find_map(|key| node.params.get(*key))
@@ -327,7 +476,7 @@ fn param_bool(node: &ParsedNode, keys: &[&str], default: bool) -> bool {
         .unwrap_or(default)
 }
 
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_naive")]
 fn param_usize(node: &ParsedNode, keys: &[&str], default: usize) -> usize {
     keys.iter()
         .find_map(|key| node.params.get(*key))
@@ -335,7 +484,7 @@ fn param_usize(node: &ParsedNode, keys: &[&str], default: usize) -> usize {
         .unwrap_or(default)
 }
 
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_naive")]
 fn param_u64(node: &ParsedNode, keys: &[&str], default: u64) -> u64 {
     keys.iter()
         .find_map(|key| node.params.get(*key))
@@ -343,7 +492,7 @@ fn param_u64(node: &ParsedNode, keys: &[&str], default: u64) -> u64 {
         .unwrap_or(default)
 }
 
-#[cfg(feature = "naive")]
+#[cfg(feature = "with_naive")]
 fn decode_config_blob(value: &str) -> Option<Vec<u8>> {
     use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
 
@@ -4052,6 +4201,7 @@ fn build_trusttunnel(node: &ParsedNode) -> SharedOutbound {
     Arc::new(ob)
 }
 
+#[cfg(feature = "with_young")]
 fn build_young(node: &ParsedNode) -> SharedOutbound {
     let encoded_key = node
         .user
@@ -4143,7 +4293,7 @@ fn decode_b64_32(s: &str) -> Option<[u8; 32]> {
     Some(out)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "standard"))]
 mod tests {
     use base64::Engine;
     use core_config::{
@@ -4153,7 +4303,7 @@ mod tests {
     };
     use uuid::Uuid;
 
-    #[cfg(feature = "naive")]
+    #[cfg(feature = "with_naive")]
     use super::decode_config_blob;
     use super::{
         DownloadTlsSettings, build_node_tls_options, build_outbound, build_trojan,
@@ -4165,7 +4315,7 @@ mod tests {
     const VALID_ECH_CONFIG_LIST: &str =
         "AD7+DQA6AAAgACC7Lynj4wV+BBnVL8X0QRh3b422HOpP33YHm5NgbFpiSAAIAAEAAQABAAMAB2VjaC5jb20AAA==";
 
-    #[cfg(feature = "naive")]
+    #[cfg(feature = "with_naive")]
     #[test]
     fn naive_registry_enables_uot_and_rejects_unsafe_combinations() {
         let mut node = ParsedNode::new("naive", NodeProtocol::Naive, "proxy.example", 443);
@@ -4191,7 +4341,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "naive")]
+    #[cfg(feature = "with_naive")]
     #[test]
     fn naive_registry_decodes_ech_config_formats() {
         assert_eq!(decode_config_blob("000102ff"), Some(vec![0, 1, 2, 255]));

--- a/crates/core-outbound/src/transport/mod.rs
+++ b/crates/core-outbound/src/transport/mod.rs
@@ -16,6 +16,7 @@ use core_config::model::XhttpDownloadTlsSettings;
 
 use crate::adapter::BoxedStream;
 
+#[cfg(feature = "with_utls")]
 pub(crate) mod boring_tls;
 mod browser_identity;
 pub(crate) mod ech;

--- a/crates/core-outbound/src/transport/tls.rs
+++ b/crates/core-outbound/src/transport/tls.rs
@@ -42,6 +42,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct TlsTransport {
     pub options: TlsOptions,
     config: Arc<OnceCell<Arc<ClientConfig>>>,
+    #[cfg(feature = "with_utls")]
     boring_config: Arc<OnceCell<Arc<boring::ssl::SslConnector>>>,
 }
 
@@ -50,6 +51,7 @@ impl TlsTransport {
         Self {
             options,
             config: Arc::new(OnceCell::new()),
+            #[cfg(feature = "with_utls")]
             boring_config: Arc::new(OnceCell::new()),
         }
     }
@@ -723,6 +725,7 @@ impl TlsTransport {
         host: &str,
         port: u16,
     ) -> std::io::Result<(BoxedStream, Option<Vec<u8>>)> {
+        #[cfg(feature = "with_utls")]
         if super::boring_tls::is_required(&self.options) {
             let connector = self
                 .boring_config

--- a/crates/wuther-core/Cargo.toml
+++ b/crates/wuther-core/Cargo.toml
@@ -12,8 +12,79 @@ keywords = ["proxy", "networking", "tun", "dns", "rust"]
 categories = ["command-line-utilities", "network-programming"]
 
 [features]
-default = []
-naive = ["core-outbound/naive"]
+default = ["standard"]
+# Standard keeps the pre-feature behavior (everything except GPL-linked
+# Naive/Cronet). Passing --no-default-features plus explicit `with_*` tags
+# produces an exact component build.
+standard = [
+    "with_api",
+    "with_tun",
+    "with_anytls",
+    "with_grpc",
+    "with_hysteria",
+    "with_hysteria2",
+    "with_http",
+    "with_http_transport",
+    "with_mieru",
+    "with_quic",
+    "with_reality",
+    "with_shadowsocks",
+    "with_shadowsocksr",
+    "with_snell",
+    "with_socks",
+    "with_ssh",
+    "with_sudoku",
+    "with_trojan",
+    "with_trusttunnel",
+    "with_tuic",
+    "with_utls",
+    "with_vless",
+    "with_vmess",
+    "with_wireguard",
+    "with_ws",
+    "with_xhttp",
+    "with_young",
+]
+all_components = ["standard", "with_naive"]
+
+# Runtime components.
+with_api = ["dep:core-api"]
+with_tun = ["dep:core-capture", "core-api?/with_tun"]
+
+# Transport/capability tags.
+with_quic = ["core-outbound/with_quic"]
+with_grpc = ["core-inbound/with_grpc", "core-outbound/with_grpc"]
+with_reality = ["core-inbound/with_reality", "core-outbound/with_reality"]
+with_utls = ["core-outbound/with_utls"]
+with_ws = ["core-outbound/with_ws"]
+with_http_transport = ["core-outbound/with_http_transport"]
+with_xhttp = ["with_quic", "core-inbound/with_xhttp", "core-outbound/with_xhttp"]
+
+# Protocol tags.
+with_http = ["core-outbound/with_http"]
+with_socks = ["core-outbound/with_socks"]
+with_shadowsocks = ["core-inbound/with_shadowsocks", "core-outbound/with_shadowsocks"]
+with_shadowsocksr = ["core-outbound/with_shadowsocksr"]
+with_vmess = ["core-outbound/with_vmess"]
+with_vless = ["core-outbound/with_vless"]
+with_trojan = ["core-outbound/with_trojan"]
+with_naive = ["core-outbound/with_naive"]
+naive = ["with_naive"]
+with_snell = ["core-outbound/with_snell"]
+with_anytls = ["core-outbound/with_anytls"]
+with_ssh = ["core-outbound/with_ssh"]
+with_hysteria = ["with_quic", "core-outbound/with_hysteria"]
+with_hysteria2 = ["with_quic", "core-outbound/with_hysteria2"]
+with_tuic = ["with_quic", "core-outbound/with_tuic"]
+with_wireguard = ["with_tun", "core-outbound/with_wireguard"]
+with_mieru = ["core-outbound/with_mieru"]
+with_sudoku = ["core-outbound/with_sudoku"]
+with_trusttunnel = ["core-outbound/with_trusttunnel"]
+with_young = [
+    "dep:core-young",
+    "core-young/firefox-stack",
+    "core-outbound/with_young",
+]
 
 [[bin]]
 name = "wuther-core"
@@ -25,16 +96,16 @@ core-runtime  = { workspace = true }
 core-feeds    = { workspace = true }
 core-store    = { workspace = true }
 core-ruleset  = { workspace = true }
-core-inbound  = { workspace = true }
-core-outbound = { workspace = true }
+core-inbound  = { workspace = true, default-features = false }
+core-outbound = { workspace = true, default-features = false }
 core-route    = { workspace = true }
 core-resolver = { workspace = true }
 core-smart    = { workspace = true }
-core-api      = { workspace = true }
-core-capture  = { workspace = true }
+core-api      = { workspace = true, optional = true, default-features = false }
+core-capture  = { workspace = true, optional = true }
 core-mesh     = { workspace = true }
 core-observe  = { workspace = true }
-core-young    = { workspace = true, features = ["firefox-stack"] }
+core-young    = { workspace = true, optional = true }
 clap          = { workspace = true }
 tokio         = { workspace = true }
 anyhow        = { workspace = true }

--- a/crates/wuther-core/src/main.rs
+++ b/crates/wuther-core/src/main.rs
@@ -13,14 +13,18 @@ use std::{path::PathBuf, sync::Arc};
 use anyhow::Context;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
+#[cfg(feature = "with_api")]
 use core_api::ApiServer;
 use core_config::loader::load_from_path;
 use core_feeds::{FeedDiskCache, FeedManager, FeedSink, FeedUpdate};
-use core_inbound::{
-    GrpcListener, MixedListener, ShadowsocksListenerHandle, XhttpListenerHandle,
-    ensure_best_effort_privilege, run_grpc, run_mixed, start_shadowsocks_listeners,
-    start_xhttp_listeners,
-};
+#[cfg(feature = "with_grpc")]
+use core_inbound::{GrpcListener, run_grpc};
+use core_inbound::{MixedListener, ensure_best_effort_privilege, run_mixed};
+#[cfg(feature = "with_shadowsocks")]
+use core_inbound::{ShadowsocksListenerHandle, start_shadowsocks_listeners};
+#[cfg(feature = "with_xhttp")]
+use core_inbound::{XhttpListenerHandle, start_xhttp_listeners};
+#[cfg(feature = "with_wireguard")]
 use core_outbound::proto::wireguard::{
     WireGuardServer, WireGuardServerConfig, WireGuardServerPeerConfig,
 };
@@ -77,6 +81,12 @@ enum Cmd {
     Ruleset {
         #[command(subcommand)]
         action: RulesetCmd,
+    },
+    /// 显示当前二进制实际编译进入的组件标签。
+    Components {
+        /// 以 JSON 输出，便于脚本和部署系统读取。
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -177,7 +187,128 @@ fn main() -> anyhow::Result<()> {
                 .build()?;
             rt.block_on(cmd_ruleset(action))
         }
+        Cmd::Components { json } => cmd_components(json),
     }
+}
+
+fn compiled_component_tags() -> Vec<&'static str> {
+    let mut tags = Vec::new();
+    macro_rules! push_tag {
+        ($feature:literal) => {
+            if cfg!(feature = $feature) {
+                tags.push($feature);
+            }
+        };
+    }
+    push_tag!("with_api");
+    push_tag!("with_tun");
+    push_tag!("with_anytls");
+    push_tag!("with_grpc");
+    push_tag!("with_hysteria");
+    push_tag!("with_hysteria2");
+    push_tag!("with_http");
+    push_tag!("with_http_transport");
+    push_tag!("with_mieru");
+    push_tag!("with_naive");
+    push_tag!("with_quic");
+    push_tag!("with_reality");
+    push_tag!("with_shadowsocks");
+    push_tag!("with_shadowsocksr");
+    push_tag!("with_snell");
+    push_tag!("with_socks");
+    push_tag!("with_ssh");
+    push_tag!("with_sudoku");
+    push_tag!("with_trojan");
+    push_tag!("with_trusttunnel");
+    push_tag!("with_tuic");
+    push_tag!("with_utls");
+    push_tag!("with_vless");
+    push_tag!("with_vmess");
+    push_tag!("with_wireguard");
+    push_tag!("with_ws");
+    push_tag!("with_xhttp");
+    push_tag!("with_young");
+    tags
+}
+
+fn cmd_components(json: bool) -> anyhow::Result<()> {
+    let tags = compiled_component_tags();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&tags)?);
+    } else if tags.is_empty() {
+        println!("minimal (no optional component tags)");
+    } else {
+        println!("{}", tags.join(","));
+    }
+    Ok(())
+}
+
+fn validate_compiled_components(
+    plan: &core_config::runtime_plan::RuntimePlan,
+) -> anyhow::Result<()> {
+    for node in &plan.nodes {
+        core_outbound::registry::validate_node_components(node).map_err(|error| {
+            anyhow::anyhow!(
+                "node `{}` requires an omitted component: {error}",
+                node.name
+            )
+        })?;
+    }
+
+    macro_rules! require_empty {
+        ($enabled:expr, $value:expr, $name:literal, $tag:literal) => {
+            if !$enabled && !$value.is_empty() {
+                anyhow::bail!(
+                    "{} is configured but not compiled in; rebuild with `{}`",
+                    $name,
+                    $tag
+                );
+            }
+        };
+    }
+    require_empty!(
+        cfg!(feature = "with_grpc"),
+        plan.listen.grpc,
+        "gRPC inbound",
+        "with_grpc"
+    );
+    require_empty!(
+        cfg!(feature = "with_xhttp"),
+        plan.listen.xhttp,
+        "XHTTP inbound",
+        "with_xhttp"
+    );
+    require_empty!(
+        cfg!(feature = "with_shadowsocks"),
+        plan.listen.shadowsocks,
+        "Shadowsocks inbound",
+        "with_shadowsocks"
+    );
+    require_empty!(
+        cfg!(feature = "with_wireguard"),
+        plan.listen.wireguard,
+        "WireGuard inbound",
+        "with_wireguard"
+    );
+    require_empty!(
+        cfg!(feature = "with_young"),
+        plan.listen.young,
+        "Young inbound",
+        "with_young"
+    );
+    require_empty!(
+        cfg!(feature = "with_reality"),
+        plan.listen.reality,
+        "REALITY inbound",
+        "with_reality"
+    );
+    if plan.capture.on && !cfg!(feature = "with_tun") {
+        anyhow::bail!("capture/TUN is configured but not compiled in; rebuild with `with_tun`");
+    }
+    if plan.ui.on && !cfg!(feature = "with_api") {
+        anyhow::bail!("API/UI is configured but not compiled in; rebuild with `with_api`");
+    }
+    Ok(())
 }
 
 async fn cmd_ruleset(action: RulesetCmd) -> anyhow::Result<()> {
@@ -417,7 +548,7 @@ async fn cmd_feeds(action: FeedsCmd) -> anyhow::Result<()> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "with_tun"))]
 mod tests {
     use core_config::model::{Log, LogFile, LogFormat, LogLevel};
 
@@ -642,6 +773,7 @@ nodes: []
         assert!(wait_for_mesh_fail_stop(&mut updates).await.is_none());
     }
 
+    #[cfg(feature = "with_xhttp")]
     #[tokio::test]
     async fn configured_xhttp_is_prebound_by_main_startup_path() {
         let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -695,6 +827,7 @@ route:
 
 fn cmd_check(config: PathBuf) -> anyhow::Result<()> {
     let plan = load_from_path(&config).map_err(|e| anyhow::anyhow!("{e}"))?;
+    validate_compiled_components(&plan)?;
     listener_resource_claims(&plan).context("listener resource validation failed")?;
     println!(
         "OK: {} 节点 / {} 分组 / {} 条规则",
@@ -707,6 +840,7 @@ fn cmd_check(config: PathBuf) -> anyhow::Result<()> {
 
 fn cmd_explain(config: PathBuf) -> anyhow::Result<()> {
     let plan = load_from_path(&config).map_err(|e| anyhow::anyhow!("{e}"))?;
+    validate_compiled_components(&plan)?;
     println!("{}", serde_json::to_string_pretty(&plan)?);
     Ok(())
 }
@@ -744,6 +878,7 @@ fn tracing_config_from_user_log(log: &core_config::model::Log) -> core_observe::
 }
 
 /// Attach the process-level host owner to capture's platform-specific claims.
+#[cfg(feature = "with_tun")]
 fn capture_resource_claims(plan: &core_capture::CapturePlan) -> Vec<core_mesh::HostResourceClaim> {
     use core_mesh::{HostResourceClaim, HostSubsystemId};
     let owner =
@@ -756,6 +891,7 @@ fn capture_resource_claims(plan: &core_capture::CapturePlan) -> Vec<core_mesh::H
 
 async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     let plan = load_from_path(&config).map_err(|e| anyhow::anyhow!("{e}"))?;
+    validate_compiled_components(&plan)?;
     if let Some(log) = &plan.log {
         core_observe::init_tracing_with_config(tracing_config_from_user_log(log), None);
     } else {
@@ -809,6 +945,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
 
     // 诊断 capture / mesh
+    #[cfg(feature = "with_tun")]
     match core_capture::diagnose(&plan.capture, &plan.mesh) {
         Ok(report) => info!(target: "capture", report = ?report, "diagnose"),
         Err(e) => warn!(target: "capture", error = %e, "diagnose failed"),
@@ -820,10 +957,17 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     // 后续具体产品后端按独立 PR 加入 registry。即使 registry 为空，保留资源也会
     // 出现在 /v1/mesh/status，且同一条事务路径已经覆盖未来后端的
     // probe -> preflight -> reconcile。
-    let mut capture_plan = core_capture::CapturePlan::from_config(&plan.capture)
-        .map_err(|error| anyhow::anyhow!("capture resource declaration failed: {error}"))?;
-    capture_plan.ipv6_enabled = plan.resolver.ipv6;
+    #[cfg(feature = "with_tun")]
+    let capture_plan = {
+        let mut capture_plan = core_capture::CapturePlan::from_config(&plan.capture)
+            .map_err(|error| anyhow::anyhow!("capture resource declaration failed: {error}"))?;
+        capture_plan.ipv6_enabled = plan.resolver.ipv6;
+        capture_plan
+    };
+    #[cfg(feature = "with_tun")]
     let mut host_claims = capture_resource_claims(&capture_plan);
+    #[cfg(not(feature = "with_tun"))]
+    let mut host_claims = Vec::new();
     host_claims.extend(listener_resource_claims(&plan)?);
     let mesh_supervisor = Arc::new(core_mesh::MeshSupervisor::new(
         core_mesh::BackendRegistry::new(),
@@ -864,8 +1008,10 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     );
     // XHTTP 的证书/ALPN 与 TCP/UDP socket 必须在宣告进程启动前全部准备完成。
     // 任何一项失败都会关闭已启动的同类监听并直接返回 cmd_run。
+    #[cfg(feature = "with_xhttp")]
     let mut xhttp_listener_handles =
         start_configured_xhttp_inbounds(&plan, runtime.clone()).await?;
+    #[cfg(feature = "with_shadowsocks")]
     let mut shadowsocks_listener_handles =
         start_configured_shadowsocks_inbounds(&plan, runtime.clone()).await?;
 
@@ -943,161 +1089,171 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     // 启动 capture supervisor（如果配置开启）—— 复用上面建好的 ruleset_index。
     // auto_route / auto_redirect 会改系统路由：启动失败必须 fail-closed，
     // 不能 warn 后继续跑“半透明代理”状态。
+    #[cfg(feature = "with_tun")]
     let mut capture_handle: Option<Arc<core_capture::CaptureSupervisor>> = None;
-    let capture_fail_closed = plan.capture.on
-        && (plan.capture.tun.auto_route
-            || plan.capture.tun.auto_redirect
-            || matches!(
-                plan.capture.method,
-                core_config::model::CaptureMethod::Tproxy
-                    | core_config::model::CaptureMethod::Redirect
-            ));
-    match core_capture::CaptureSupervisor::build(&plan.capture, &plan.mesh, plan.resolver.ipv6) {
-        Ok(Some(sup)) => {
-            // 注入 IpSetProvider，把 ruleset 的 cidr_v4/cidr_v6 暴露给 supervisor.allow_ip。
-            sup.set_ip_set_provider(Arc::new(RulesetIpSetProvider {
-                index: ruleset_index.clone(),
-            }));
-            if let Err(e) = sup.start(runtime.clone()).await {
+    #[cfg(feature = "with_tun")]
+    {
+        let capture_fail_closed = plan.capture.on
+            && (plan.capture.tun.auto_route
+                || plan.capture.tun.auto_redirect
+                || matches!(
+                    plan.capture.method,
+                    core_config::model::CaptureMethod::Tproxy
+                        | core_config::model::CaptureMethod::Redirect
+                ));
+        match core_capture::CaptureSupervisor::build(&plan.capture, &plan.mesh, plan.resolver.ipv6)
+        {
+            Ok(Some(sup)) => {
+                // 注入 IpSetProvider，把 ruleset 的 cidr_v4/cidr_v6 暴露给 supervisor.allow_ip。
+                sup.set_ip_set_provider(Arc::new(RulesetIpSetProvider {
+                    index: ruleset_index.clone(),
+                }));
+                if let Err(e) = sup.start(runtime.clone()).await {
+                    if capture_fail_closed {
+                        // 尽力停掉可能半装好的状态，再把错误抛给 CLI。
+                        let _ = sup.stop().await;
+                        let _ = mesh_supervisor.stop().await;
+                        runtime.shutdown().await;
+                        anyhow::bail!(
+                            "capture supervisor start failed under auto_route/tproxy/redirect \
+                         (fail-closed): {e}"
+                        );
+                    }
+                    warn!(target: "capture", error = %e, "capture supervisor start failed");
+                    // start() 已尝试一次事务回滚；若平台 pre_stop/stop 当次失败，
+                    // supervisor 会保留 CleanupFailed 账本。调用方必须显式重试，
+                    // 否则 drop supervisor 会同时丢失路由/fwmark 的恢复入口。
+                    if let Err(cleanup_error) = sup.stop().await {
+                        return Err(anyhow::anyhow!(
+                            "capture start failed ({e}); cleanup retry also failed \
+                         ({cleanup_error}); refusing to continue with possibly active \
+                         transparent-capture state"
+                        ));
+                    }
+                } else {
+                    capture_handle = Some(sup);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
                 if capture_fail_closed {
-                    // 尽力停掉可能半装好的状态，再把错误抛给 CLI。
-                    let _ = sup.stop().await;
                     let _ = mesh_supervisor.stop().await;
                     runtime.shutdown().await;
                     anyhow::bail!(
-                        "capture supervisor start failed under auto_route/tproxy/redirect \
-                         (fail-closed): {e}"
+                        "capture supervisor build failed under auto_route/tproxy/redirect \
+                     (fail-closed): {e}"
                     );
                 }
-                warn!(target: "capture", error = %e, "capture supervisor start failed");
-                // start() 已尝试一次事务回滚；若平台 pre_stop/stop 当次失败，
-                // supervisor 会保留 CleanupFailed 账本。调用方必须显式重试，
-                // 否则 drop supervisor 会同时丢失路由/fwmark 的恢复入口。
-                if let Err(cleanup_error) = sup.stop().await {
-                    return Err(anyhow::anyhow!(
-                        "capture start failed ({e}); cleanup retry also failed \
-                         ({cleanup_error}); refusing to continue with possibly active \
-                         transparent-capture state"
-                    ));
-                }
-            } else {
-                capture_handle = Some(sup);
+                warn!(target: "capture", error = %e, "capture supervisor build failed");
             }
-        }
-        Ok(None) => {}
-        Err(e) => {
-            if capture_fail_closed {
-                let _ = mesh_supervisor.stop().await;
-                runtime.shutdown().await;
-                anyhow::bail!(
-                    "capture supervisor build failed under auto_route/tproxy/redirect \
-                     (fail-closed): {e}"
-                );
-            }
-            warn!(target: "capture", error = %e, "capture supervisor build failed");
         }
     }
 
     let mut handles = Vec::new();
+    #[cfg(feature = "with_wireguard")]
     let mut wireguard_inbounds: Vec<(
         Arc<WireGuardServer>,
         core_capture::NetstackDispatcherHandles,
     )> = Vec::new();
 
-    // WireGuard 服务端入站。WireGuardServer 负责 NoiseIK、cookie/MAC、重放保护、
-    // roaming 与多 peer 路由；WireGuardTunIo 把认证后的裸 IP 包接入与系统 TUN
-    // 共用的 netstack dispatcher，因此 TCP 与 UDP 最终都经过同一 Runtime 路由。
-    for (index, listener) in plan.listen.wireguard.iter().enumerate() {
-        let peers = listener
-            .peers
-            .iter()
-            .map(|peer| WireGuardServerPeerConfig {
-                public_key: peer.public_key,
-                preshared_key: peer.preshared_key,
-                allowed_ips: peer.allowed_ips.clone(),
-                reserved: peer.reserved,
-                persistent_keepalive: peer.persistent_keepalive,
+    #[cfg(feature = "with_wireguard")]
+    {
+        // WireGuard 服务端入站。WireGuardServer 负责 NoiseIK、cookie/MAC、重放保护、
+        // roaming 与多 peer 路由；WireGuardTunIo 把认证后的裸 IP 包接入与系统 TUN
+        // 共用的 netstack dispatcher，因此 TCP 与 UDP 最终都经过同一 Runtime 路由。
+        for (index, listener) in plan.listen.wireguard.iter().enumerate() {
+            let peers = listener
+                .peers
+                .iter()
+                .map(|peer| WireGuardServerPeerConfig {
+                    public_key: peer.public_key,
+                    preshared_key: peer.preshared_key,
+                    allowed_ips: peer.allowed_ips.clone(),
+                    reserved: peer.reserved,
+                    persistent_keepalive: peer.persistent_keepalive,
+                })
+                .collect();
+            let server = match WireGuardServer::bind(WireGuardServerConfig {
+                bind: listener.bind,
+                private_key: listener.private_key,
+                peers,
+                mtu: listener.mtu,
+                packet_queue: listener.packet_queue,
+                handshake_rate_limit: listener.handshake_rate_limit,
             })
-            .collect();
-        let server = match WireGuardServer::bind(WireGuardServerConfig {
-            bind: listener.bind,
-            private_key: listener.private_key,
-            peers,
-            mtu: listener.mtu,
-            packet_queue: listener.packet_queue,
-            handshake_rate_limit: listener.handshake_rate_limit,
-        })
-        .await
-        .with_context(|| {
-            format!(
-                "bind WireGuard inbound listen.wireguard[{index}] at {}",
-                listener.bind
-            )
-        }) {
-            Ok(server) => Arc::new(server),
-            Err(error) => {
-                // A later listener can fail after earlier listeners already started their
-                // netstack tasks. Roll every subsystem back explicitly instead of relying
-                // on runtime teardown or detached Tokio task drops.
-                for (server, dispatcher) in wireguard_inbounds.drain(..) {
-                    dispatcher.stop();
-                    server.close().await;
-                }
-                if let Some(supervisor) = capture_handle.as_ref() {
-                    if let Err(cleanup_error) = supervisor.stop().await {
+            .await
+            .with_context(|| {
+                format!(
+                    "bind WireGuard inbound listen.wireguard[{index}] at {}",
+                    listener.bind
+                )
+            }) {
+                Ok(server) => Arc::new(server),
+                Err(error) => {
+                    // A later listener can fail after earlier listeners already started their
+                    // netstack tasks. Roll every subsystem back explicitly instead of relying
+                    // on runtime teardown or detached Tokio task drops.
+                    for (server, dispatcher) in wireguard_inbounds.drain(..) {
+                        dispatcher.stop();
+                        server.close().await;
+                    }
+                    if let Some(supervisor) = capture_handle.as_ref() {
+                        if let Err(cleanup_error) = supervisor.stop().await {
+                            warn!(
+                                target: "capture",
+                                error = %cleanup_error,
+                                "capture stop failed while rolling back WireGuard startup"
+                            );
+                        }
+                    }
+                    if let Err(cleanup_error) = mesh_supervisor.stop().await {
                         warn!(
-                            target: "capture",
+                            target: "mesh",
                             error = %cleanup_error,
-                            "capture stop failed while rolling back WireGuard startup"
+                            "mesh stop failed while rolling back WireGuard startup"
                         );
                     }
+                    feed_mgr_handle.stop();
+                    runtime.shutdown().await;
+                    return Err(error);
                 }
-                if let Err(cleanup_error) = mesh_supervisor.stop().await {
-                    warn!(
-                        target: "mesh",
-                        error = %cleanup_error,
-                        "mesh stop failed while rolling back WireGuard startup"
-                    );
-                }
-                feed_mgr_handle.stop();
-                runtime.shutdown().await;
-                return Err(error);
-            }
-        };
-        let mut dispatcher_plan = capture_plan.clone();
-        dispatcher_plan.mtu = std::num::NonZeroU16::new(
-            u16::try_from(listener.mtu).expect("validated WireGuard MTU always fits into u16"),
-        )
-        .expect("validated WireGuard MTU is non-zero");
-        dispatcher_plan.ipv6_enabled = plan.resolver.ipv6;
-        dispatcher_plan.allow_loopback_destination = true;
-        let fake_pool = runtime
-            .resolver
-            .fake_pool()
-            .unwrap_or_else(|| Arc::new(core_resolver::FakeIpPool::default()));
-        let dispatcher = Arc::new(core_capture::NetstackDispatcher::new(
-            dispatcher_plan.clone(),
-            Arc::new(core_capture::NatTable::default()),
-            Arc::new(core_capture::EimNatTable::new(dispatcher_plan.udp_timeout)),
-            fake_pool,
-            runtime.dns_service.clone(),
-            core_capture::noop_ipset_provider(),
-        ));
-        let device = Arc::new(core_capture::WireGuardTunIo::new(
-            server.clone(),
-            format!("wireguard-inbound-{index}"),
-            u32::from(dispatcher_plan.mtu.get()),
-        ));
-        let dispatcher_handles = dispatcher.start(device, runtime.clone());
-        info!(
-            target: "inbound::wireguard",
-            addr = %server.local_addr().unwrap_or(listener.bind),
-            peers = listener.peers.len(),
-            mtu = listener.mtu,
-            "WireGuard inbound ready (TCP+UDP)"
-        );
-        wireguard_inbounds.push((server, dispatcher_handles));
+            };
+            let mut dispatcher_plan = capture_plan.clone();
+            dispatcher_plan.mtu = std::num::NonZeroU16::new(
+                u16::try_from(listener.mtu).expect("validated WireGuard MTU always fits into u16"),
+            )
+            .expect("validated WireGuard MTU is non-zero");
+            dispatcher_plan.ipv6_enabled = plan.resolver.ipv6;
+            dispatcher_plan.allow_loopback_destination = true;
+            let fake_pool = runtime
+                .resolver
+                .fake_pool()
+                .unwrap_or_else(|| Arc::new(core_resolver::FakeIpPool::default()));
+            let dispatcher = Arc::new(core_capture::NetstackDispatcher::new(
+                dispatcher_plan.clone(),
+                Arc::new(core_capture::NatTable::default()),
+                Arc::new(core_capture::EimNatTable::new(dispatcher_plan.udp_timeout)),
+                fake_pool,
+                runtime.dns_service.clone(),
+                core_capture::noop_ipset_provider(),
+            ));
+            let device = Arc::new(core_capture::WireGuardTunIo::new(
+                server.clone(),
+                format!("wireguard-inbound-{index}"),
+                u32::from(dispatcher_plan.mtu.get()),
+            ));
+            let dispatcher_handles = dispatcher.start(device, runtime.clone());
+            info!(
+                target: "inbound::wireguard",
+                addr = %server.local_addr().unwrap_or(listener.bind),
+                peers = listener.peers.len(),
+                mtu = listener.mtu,
+                "WireGuard inbound ready (TCP+UDP)"
+            );
+            wireguard_inbounds.push((server, dispatcher_handles));
+        }
     }
+    #[cfg(feature = "with_young")]
     let mut young_server_handles = Vec::new();
 
     // Standalone DNS server —— mihomo `dns.listen` 等价。
@@ -1136,6 +1292,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
 
     // Young 原生入站：每个监听器由独立 current-thread runtime 驱动 Mozilla Neqo。
     // handle 持有关闭通道，必须存活到全局 shutdown。
+    #[cfg(feature = "with_young")]
     for listener in &plan.listen.young {
         let listen = listener
             .socket_addr()
@@ -1199,6 +1356,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
 
     // Xray gRPC（gun）入站。core-grpc 负责真实 tonic/prost Tun/TunMulti
     // framing，core-inbound 负责 VLESS TCP/UDP/mux 与统一路由运行时。
+    #[cfg(feature = "with_grpc")]
     for config in &plan.listen.grpc {
         let listener = GrpcListener::from_config(config)
             .map_err(|error| anyhow::anyhow!("gRPC listener configuration failed: {error}"))?;
@@ -1214,6 +1372,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
 
     // 控制面板/API
+    #[cfg(feature = "with_api")]
     if plan.ui.on {
         if let Some(panel) = &plan.listen.panel {
             let addr = panel.socket_addr().map_err(|e| anyhow::anyhow!("{e}"))?;
@@ -1223,6 +1382,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
                 secret: plan.ui.secret.clone(),
                 clash_compat: plan.ui.api.clash_compat,
                 urltest: urltest.clone(),
+                #[cfg(feature = "with_tun")]
                 capture: capture_handle.clone(),
                 mesh: Some(mesh_supervisor.clone()),
                 feeds: Some(feed_mgr_handle.clone()),
@@ -1262,11 +1422,13 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
             Ok(())
         }
     };
+    #[cfg(feature = "with_tun")]
     if let Some(sup) = capture_handle {
         if let Err(e) = sup.stop().await {
             warn!(target: "capture", error = %e, "capture stop failed");
         }
     }
+    #[cfg(feature = "with_wireguard")]
     for (server, dispatcher) in wireguard_inbounds {
         dispatcher.stop();
         server.close().await;
@@ -1276,6 +1438,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
     }
     feed_mgr_handle.stop();
     _ruleset_mgr_handle.stop();
+    #[cfg(feature = "with_shadowsocks")]
     for listener in &mut shadowsocks_listener_handles {
         if let Err(error) = listener.shutdown().await {
             warn!(
@@ -1286,6 +1449,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
             );
         }
     }
+    #[cfg(feature = "with_xhttp")]
     for listener in &mut xhttp_listener_handles {
         if let Err(error) = listener.shutdown().await {
             warn!(
@@ -1297,6 +1461,7 @@ async fn cmd_run(config: PathBuf) -> anyhow::Result<()> {
         }
     }
     runtime.shutdown().await;
+    #[cfg(feature = "with_young")]
     for server in &young_server_handles {
         if let Err(error) = server.shutdown() {
             warn!(target: "young", %error, "Young server shutdown failed");
@@ -1339,6 +1504,7 @@ async fn wait_for_mesh_fail_stop(
     }
 }
 
+#[cfg(feature = "with_xhttp")]
 async fn start_configured_xhttp_inbounds(
     plan: &core_config::runtime_plan::RuntimePlan,
     runtime: Arc<Runtime>,
@@ -1348,6 +1514,7 @@ async fn start_configured_xhttp_inbounds(
         .context("XHTTP 入站启动失败")
 }
 
+#[cfg(feature = "with_shadowsocks")]
 async fn start_configured_shadowsocks_inbounds(
     plan: &core_config::runtime_plan::RuntimePlan,
     runtime: Arc<Runtime>,
@@ -1362,10 +1529,12 @@ async fn start_configured_shadowsocks_inbounds(
 /// `route_address_set: ["geoip-cn"]` → 查 ruleset_index 的 `geoip-cn`，
 /// 命中 cidr_v4 / cidr_v6 即视为白/黑名单元素。
 #[derive(Debug)]
+#[cfg(feature = "with_tun")]
 struct RulesetIpSetProvider {
     index: Arc<core_ruleset::RulesetIndex>,
 }
 
+#[cfg(feature = "with_tun")]
 impl core_capture::IpSetProvider for RulesetIpSetProvider {
     fn contains(&self, name: &str, ip: std::net::IpAddr) -> bool {
         let Some(matcher) = self.index.get(name) else {
@@ -1405,6 +1574,7 @@ impl core_capture::IpSetProvider for RulesetIpSetProvider {
     }
 }
 
+#[cfg(feature = "with_tun")]
 fn map_ruleset_prefix_snapshot(
     snapshot: core_ruleset::RulesetIpPrefixSnapshot,
 ) -> core_capture::IpSetPrefixSnapshot {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -105,3 +105,8 @@ gh attestation verify .\wuther-core-0.4.0-windows-amd64-msvc.zip --repo MiChongs
 在 GitHub Actions 的 `Release` 工作流中选择 `Run workflow`，填写一个已经存在的标签。通常保持 `channel = auto`；显式选择 `prerelease` 或 `release` 时，选择必须与标签格式一致，否则工作流会拒绝执行。
 
 手动运行用于恢复失败的 Draft Release，不用于绕过版本、标签或 CI 校验。
+
+需要验证裁剪构建时，在 `CI` 或 `Build Matrix` 工作流中选择 `Run workflow`，
+并在 `tags` 中填写逗号分隔的组件标签，例如
+`with_quic,with_vless,with_grpc,with_utls`。留空执行标准组件集。标签含义、
+本地等价命令和许可边界见[构建脚本](../scripts/README.md#按组件标签编译)。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,10 +17,78 @@ build.cmd linux
 :: 多目标 + 先清理
 build.cmd --clean windows linux
 
+:: 精确组件构建（指定 --tags 后不会隐式加入 standard）
+build.cmd --tags "with_quic,with_vless,with_grpc,with_utls" windows
+
 :: 强制使用某个后端
 pwsh -File scripts/build-all.ps1 -Backend zigbuild -Targets "x86_64-unknown-linux-musl"
 pwsh -File scripts/build-all.ps1 -Backend cross    -Targets "aarch64-linux-android"
 ```
+
+## 按组件标签编译
+
+WutherCore 使用 Cargo features 提供与 Go `-tags` 等价的编译期组件裁剪。未指定
+`--tags` 时使用 `standard`，行为与引入组件标签前一致（除需单独许可的 Naive
+外全部启用）。一旦指定 `--tags`，脚本会自动添加 `--no-default-features`，只有
+列出的标签及其依赖会进入构建。
+
+```cmd
+:: VLESS + gRPC + uTLS，只构建 Windows x64
+build.cmd --tags "with_vless,with_grpc,with_utls" windows
+
+:: Hysteria 2 会自动带上 with_quic
+build.cmd --tags "with_hysteria2" linux
+
+:: 完整标准集
+build.cmd --tags "standard" windows
+
+:: 标准集再加 GPL/Cronet Naive
+build.cmd --tags "all_components" windows
+```
+
+也可以直接使用 Cargo：
+
+```bash
+cargo build --release -p wuther-core \
+  --no-default-features \
+  --features "with_quic,with_vless,with_grpc,with_utls"
+
+# 检查一个二进制实际包含哪些组件
+wuther-core components
+wuther-core components --json
+```
+
+### 可用标签
+
+| 类别 | 标签 | 能力 |
+|---|---|---|
+| 预设 | `standard` | 默认标准组件集，不含 Naive/Cronet |
+| 预设 | `all_components` | `standard` 加 `with_naive` |
+| 运行组件 | `with_api` | 管理 API 与面板服务 |
+| 运行组件 | `with_tun` | TUN/TProxy/Redirect capture |
+| 传输 | `with_quic` | QUIC/H3 基础能力 |
+| 传输 | `with_grpc` | Xray gRPC 入站与出站传输 |
+| 传输 | `with_reality` | REALITY |
+| 传输 | `with_utls` | uTLS ClientHello 指纹 |
+| 传输 | `with_ws` | WebSocket 传输 |
+| 传输 | `with_http_transport` | HTTP/2 transport |
+| 传输 | `with_xhttp` | XHTTP/SplitHTTP（自动启用 `with_quic`） |
+| 协议 | `with_http`, `with_socks` | HTTP 与 SOCKS5 出站 |
+| 协议 | `with_shadowsocks`, `with_shadowsocksr` | Shadowsocks/2022 与 SSR |
+| 协议 | `with_vmess`, `with_vless`, `with_trojan` | VMess、VLESS、Trojan |
+| 协议 | `with_hysteria`, `with_hysteria2`, `with_tuic` | QUIC 协议（自动启用 `with_quic`） |
+| 协议 | `with_wireguard` | WireGuard 客户端与服务端 |
+| 协议 | `with_anytls`, `with_snell`, `with_ssh` | AnyTLS、Snell、SSH |
+| 协议 | `with_mieru`, `with_sudoku`, `with_trusttunnel` | Mieru、Sudoku、TrustTunnel |
+| 协议 | `with_young` | Young + Mozilla Neqo/NSS |
+| 协议 | `with_naive` | Naive + Cronet；需单独满足 GPL 与原生库要求 |
+
+`DIRECT`、`BLOCK` 与 DNS hijack 是路由运行时的基础能力，所有构建始终保留。
+若配置引用了未编译组件，`check` 和 `run` 会直接给出缺少的 `with_*` 标签，不会
+静默注册占位实现。每个本地和 CI 归档都包含 `BUILD-COMPONENTS.txt`。
+
+GitHub Actions 的 **Build Matrix** 和 **CI** 手动运行入口也提供 `tags` 输入，
+语义与本地 `--tags` 完全相同；留空使用 `standard`。
 
 ## 短别名
 

--- a/scripts/build-all.ps1
+++ b/scripts/build-all.ps1
@@ -20,6 +20,10 @@
 .PARAMETER Profile
   cargo profile，默认 release。
 
+.PARAMETER Tags
+  精确编译进入二进制的组件标签，逗号或空格分隔。指定后自动传递
+  --no-default-features；留空使用 Cargo 默认的 standard 组件集。
+
 .PARAMETER NoArchive
   跳过打包步骤，仅产出二进制。
 
@@ -35,12 +39,14 @@
 .EXAMPLE
   pwsh -File scripts/build-all.ps1
   pwsh -File scripts/build-all.ps1 -Targets "x86_64-pc-windows-msvc"
+  pwsh -File scripts/build-all.ps1 -Tags "with_quic,with_vless,with_grpc" -Targets "x86_64-pc-windows-msvc"
   pwsh -File scripts/build-all.ps1 -Backend zigbuild -Targets "x86_64-unknown-linux-musl"
 #>
 [CmdletBinding()]
 param(
     [string]$Targets = "",
     [string]$Profile = "release",
+    [string]$Tags = "",
     [switch]$NoArchive,
     [switch]$SkipChecks,
     [switch]$Clean,
@@ -66,6 +72,22 @@ function Write-Step ($msg) { Write-Host "[$(Get-Date -Format HH:mm:ss)] >>> $msg
 function Write-Ok   ($msg) { Write-Host "[$(Get-Date -Format HH:mm:ss)]  OK $msg"  -ForegroundColor Green }
 function Write-Warn2($msg) { Write-Host "[$(Get-Date -Format HH:mm:ss)] !!! $msg" -ForegroundColor Yellow }
 function Write-Err  ($msg) { Write-Host "[$(Get-Date -Format HH:mm:ss)] ERR $msg" -ForegroundColor Red }
+
+# ---------- 组件标签 ----------
+$ComponentTags = @(
+    $Tags -split '[,;\s]+' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -ne "" } |
+        Select-Object -Unique
+)
+foreach ($tag in $ComponentTags) {
+    if ($tag -notmatch '^[A-Za-z0-9_-]+$') {
+        throw "invalid component tag '$tag' (allowed: letters, digits, _ and -)"
+    }
+}
+$CargoFeatures = $ComponentTags -join ","
+$BuildTagLabel = if ($CargoFeatures) { $CargoFeatures } else { "standard (default)" }
+Write-Step "组件标签: $BuildTagLabel"
 
 # ---------- 默认目标 ----------
 $DefaultTargets = @(
@@ -547,6 +569,9 @@ foreach ($target in $TargetList) {
                 $args = @("ndk", "--target", $abi, "--platform", "33", "build", "--$Profile", "-p", $BinaryName, "--target", $target, "--locked")
             }
         }
+        if ($CargoFeatures) {
+            $args += @("--no-default-features", "--features", $CargoFeatures)
+        }
         Write-Step "$cmd $($args -join ' ')"
         & $cmd @args
         if ($LASTEXITCODE -ne 0) { throw "$cmd build failed (exit $LASTEXITCODE)" }
@@ -564,6 +589,11 @@ foreach ($target in $TargetList) {
         Copy-Item (Join-Path $RepoRoot "README.md") $stageDir
         Copy-Item (Join-Path $RepoRoot "RP内核设计文档.md") $stageDir -ErrorAction SilentlyContinue
         Copy-Item (Join-Path $RepoRoot "examples") (Join-Path $stageDir "examples") -Recurse
+        @(
+            "version=$Version"
+            "target=$target"
+            "tags=$BuildTagLabel"
+        ) | Set-Content -Path (Join-Path $stageDir "BUILD-COMPONENTS.txt") -Encoding UTF8
 
         if (-not $NoArchive) {
             $archiveBase = "$BinaryName-$Version-$target"
@@ -591,6 +621,7 @@ foreach ($target in $TargetList) {
             $Summary += [pscustomobject]@{
                 Target  = $target
                 Backend = $useBackend
+                Tags    = $BuildTagLabel
                 Path    = $archive
                 SizeMB  = [math]::Round((Get-Item $archive).Length / 1MB, 2)
                 SHA256  = $sha
@@ -599,6 +630,7 @@ foreach ($target in $TargetList) {
             $Summary += [pscustomobject]@{
                 Target  = $target
                 Backend = $useBackend
+                Tags    = $BuildTagLabel
                 Path    = $stageDir
                 SizeMB  = [math]::Round($size / 1MB, 2)
                 SHA256  = ""
@@ -624,7 +656,7 @@ Android 推荐改用 cargo-ndk：
 Write-Host ""
 Write-Step "构建完成总结"
 if ($Summary.Count -gt 0) {
-    $Summary | Format-Table Target, Backend, Path, SizeMB, SHA256 -AutoSize
+    $Summary | Format-Table Target, Backend, Tags, Path, SizeMB, SHA256 -AutoSize
 } else {
     Write-Warn2 "没有成功构建的目标。"
 }

--- a/tests-e2e/Cargo.toml
+++ b/tests-e2e/Cargo.toml
@@ -11,14 +11,14 @@ path = "src/lib.rs"
 [dependencies]
 core-config  = { workspace = true }
 core-runtime = { workspace = true }
-core-inbound = { workspace = true }
-core-outbound = { workspace = true }
+core-inbound = { workspace = true, features = ["standard"] }
+core-outbound = { workspace = true, features = ["standard"] }
 core-smart   = { workspace = true }
 
 [dev-dependencies]
 base64       = { workspace = true }
 core-grpc     = { workspace = true }
-core-outbound = { workspace = true }
+core-outbound = { workspace = true, features = ["standard"] }
 core-reality  = { workspace = true }
 futures       = { workspace = true }
 hex          = { workspace = true }


### PR DESCRIPTION
## What

- 增加与 sing-box `-tags` 等价的 Cargo `with_*` 编译标签，以及 `standard` / `all_components` 预设
- 本地 `build.cmd --tags`、`scripts/build-all.ps1 -Tags` 支持精确组件构建；显式 tags 会自动关闭默认 features
- Build Matrix、CI、Naive 工作流支持手动选择 tags，并在构建归档写入 `BUILD-COMPONENTS.txt`
- API、TUN、入站、uTLS/BoringSSL、Young/NSS、Naive/Cronet 等重组件按 feature 条件编译
- `wuther-core components [--json]` 可查询二进制实际包含的组件
- `check` / `explain` / `run` 对配置引用的未编译组件 fail-closed，并提示缺失标签

## Why

此前协议和重运行组件大多固定进入默认构建，本地脚本与 CI 也没有统一的组件选择入口，无法按部署场景裁剪二进制及原生依赖。

## Compatibility / impact

- 不传 tags 时继续使用 `standard`，保持历史默认能力（Naive/Cronet 仍为许可敏感的显式 opt-in）
- `naive` 旧 feature 保留为 `with_naive` 的兼容别名
- `DIRECT`、`BLOCK` 与 DNS hijack 始终保留
- 修正 windows-sys 新签名要求的两个 `BOOL` 实参，保证包含 TUN 的 Windows Rust 检查可通过

## Validation

- `cargo check -p wuther-core --no-default-features --features with_http,with_socks --locked`
- `cargo check -p wuther-core --no-default-features --features with_anytls --locked`
- 包含 API/TUN/WireGuard/QUIC 及多数协议的组合 `cargo check`
- `cargo run ... -- components --json` 精确输出 `with_http`、`with_socks`
- 未编译组件配置的 `check` 返回非零并提示所需 `with_*`
- `cargo fmt --all --check`
- `cargo metadata --locked`
- `python scripts/check-repository.py`
- workflow YAML lint + actionlint
- PowerShell AST 与 `build.cmd --tags` 缺参校验

本机默认全集检查受现有 Young/NSS 的 libclang 环境和 BoringSSL/MSVC+NASM CMake 环境要求阻断；对应平台构建由 GitHub Actions 继续验证。
